### PR TITLE
[CELEBORN-1200][CORE][WIP] Scheduler Spark Reduce Task Locality with Celeborn Worker

### DIFF
--- a/assets/spark-patch/Celeborn_Reduce_Task_Locality_spark3_3.patch
+++ b/assets/spark-patch/Celeborn_Reduce_Task_Locality_spark3_3.patch
@@ -1,0 +1,186 @@
+diff --git a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+index b1974948430..69c5923b032 100644
+--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
++++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+@@ -1026,24 +1026,19 @@ private[spark] class MapOutputTrackerMaster(
+       if (preferredLoc.nonEmpty) {
+         preferredLoc
+       } else {
+-        if (shuffleLocalityEnabled && dep.rdd.partitions.length < SHUFFLE_PREF_MAP_THRESHOLD &&
+-          dep.partitioner.numPartitions < SHUFFLE_PREF_REDUCE_THRESHOLD) {
+-          val blockManagerIds = getLocationsWithLargestOutputs(dep.shuffleId, partitionId,
+-            dep.partitioner.numPartitions, REDUCER_PREF_LOCS_FRACTION)
+-          if (blockManagerIds.nonEmpty) {
+-            blockManagerIds.get.map(_.host)
+-          } else {
+-            Nil
+-          }
+-        } else {
+-          Nil
+-        }
++        // allow custom shuffle manager to specify locations of preferred locations
++        dep.shuffleHandle.getReduceTaskPreferLocation(this, dep, partitionId)
+       }
+     } else {
+       Nil
+     }
+   }
+ 
++  def shouldGetLocationsWithLargestOutputs(mapTaskNum: Int, reduceTaskNum: Int): Boolean = {
++    shuffleLocalityEnabled && mapTaskNum < SHUFFLE_PREF_MAP_THRESHOLD &&
++       reduceTaskNum < SHUFFLE_PREF_REDUCE_THRESHOLD
++  }
++
+   /**
+    * Return a list of locations that each have fraction of map output greater than the specified
+    * threshold.
+@@ -1058,7 +1053,7 @@ private[spark] class MapOutputTrackerMaster(
+       shuffleId: Int,
+       reducerId: Int,
+       numReducers: Int,
+-      fractionThreshold: Double)
++      fractionThreshold: Double = REDUCER_PREF_LOCS_FRACTION)
+     : Option[Array[BlockManagerId]] = {
+ 
+     val shuffleStatus = shuffleStatuses.get(shuffleId).orNull
+@@ -1127,6 +1122,22 @@ private[spark] class MapOutputTrackerMaster(
+     }
+   }
+ 
++  // Called by ShuffledRowRDD, call shuffle handler to get the map output locations.
++  def getMapLocation(
++      dep: ShuffleDependency[_, _, _],
++      startMapIndex: Int,
++      endMapIndex: Int,
++      startPartition: Int,
++      endPartition: Int): Seq[String] = {
++    dep.shuffleHandle.getMapLocation(
++      this,
++      dep,
++      startMapIndex,
++      endMapIndex,
++      startPartition,
++      endPartition)
++  }
++
+   def incrementEpoch(): Unit = {
+     epochLock.synchronized {
+       epoch += 1
+diff --git a/core/src/main/scala/org/apache/spark/shuffle/BaseShuffleHandle.scala b/core/src/main/scala/org/apache/spark/shuffle/BaseShuffleHandle.scala
+index 6fe183c0780..2d6e9b97a04 100644
+--- a/core/src/main/scala/org/apache/spark/shuffle/BaseShuffleHandle.scala
++++ b/core/src/main/scala/org/apache/spark/shuffle/BaseShuffleHandle.scala
+@@ -17,6 +17,7 @@
+ 
+ package org.apache.spark.shuffle
+ 
++import org.apache.spark.MapOutputTrackerMaster
+ import org.apache.spark.ShuffleDependency
+ 
+ /**
+@@ -25,4 +26,33 @@ import org.apache.spark.ShuffleDependency
+ private[spark] class BaseShuffleHandle[K, V, C](
+     shuffleId: Int,
+     val dependency: ShuffleDependency[K, V, C])
+-  extends ShuffleHandle(shuffleId)
++  extends ShuffleHandle(shuffleId) {
++
++  def getReduceTaskPreferLocation(
++      tracker: MapOutputTrackerMaster,
++      dep: ShuffleDependency[_, _, _],
++      partitionId: Int): Seq[String] = {
++    if (tracker.shouldGetLocationsWithLargestOutputs(
++      dep.rdd.partitions.length,
++      dep.partitioner.numPartitions)) {
++      val blockManagerIds = tracker.getLocationsWithLargestOutputs(
++        dep.shuffleId,
++        partitionId,
++        dep.partitioner.numPartitions)
++      if (blockManagerIds.nonEmpty) {
++        return blockManagerIds.get.map(_.host)
++      }
++    }
++    Nil
++  }
++
++  def getMapLocation(
++      tracker: MapOutputTrackerMaster,
++      dep: ShuffleDependency[_, _, _],
++      startMapIndex: Int,
++      endMapIndex: Int,
++      startPartition: Int,
++      endPartition: Int): Seq[String] = {
++    tracker.getMapLocation(dep, startMapIndex, endMapIndex)
++  }
++}
+diff --git a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+index e04c97fe618..bcc308a1547 100644
+--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
++++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+@@ -17,6 +17,7 @@
+ 
+ package org.apache.spark.shuffle
+ 
++import org.apache.spark.{MapOutputTrackerMaster, ShuffleDependency}
+ import org.apache.spark.annotation.DeveloperApi
+ 
+ /**
+@@ -25,4 +26,18 @@ import org.apache.spark.annotation.DeveloperApi
+  * @param shuffleId ID of the shuffle
+  */
+ @DeveloperApi
+-abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {}
++abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {
++
++  def getReduceTaskPreferLocation(
++      tracker: MapOutputTrackerMaster,
++      dep: ShuffleDependency[_, _, _],
++      partitionId: Int): Seq[String]
++
++  def getMapLocation(
++      tracker: MapOutputTrackerMaster,
++      dep: ShuffleDependency[_, _, _],
++      startMapIndex: Int,
++      endMapIndex: Int,
++      startPartition: Int,
++      endPartition: Int): Seq[String]
++}
+diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
+index 47d61196fe8..be1cae5b70f 100644
+--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
++++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
+@@ -182,14 +182,29 @@ class ShuffledRowRDD(
+           tracker.getPreferredLocationsForShuffle(dependency, reducerIndex)
+         }
+ 
+-      case PartialReducerPartitionSpec(_, startMapIndex, endMapIndex, _) =>
+-        tracker.getMapLocation(dependency, startMapIndex, endMapIndex)
++      case PartialReducerPartitionSpec(reducerIndex, startMapIndex, endMapIndex, _) =>
++        tracker.getMapLocation(
++          dependency,
++          startMapIndex,
++          endMapIndex,
++          reducerIndex,
++          reducerIndex + 1)
+ 
+-      case PartialMapperPartitionSpec(mapIndex, _, _) =>
+-        tracker.getMapLocation(dependency, mapIndex, mapIndex + 1)
++      case PartialMapperPartitionSpec(mapIndex, startReducerIndex, endReducerIndex) =>
++        tracker.getMapLocation(
++          dependency,
++          mapIndex,
++          mapIndex + 1,
++          startReducerIndex,
++          endReducerIndex)
+ 
+       case CoalescedMapperPartitionSpec(startMapIndex, endMapIndex, numReducers) =>
+-        tracker.getMapLocation(dependency, startMapIndex, endMapIndex)
++        tracker.getMapLocation(
++          dependency,
++          startMapIndex,
++          endMapIndex,
++          0,
++          numReducers)
+     }
+   }
+ 

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -128,6 +128,10 @@ spec:
           - name: {{ $key }}
             value: {{ $val | quote }}
           {{- end}}
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
       terminationGracePeriodSeconds: 30
       volumes:
         - configMap:

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -182,7 +182,7 @@ public class SparkShuffleManager implements ShuffleManager {
           celebornConf.clientFetchThrowsFetchFailure(),
           dependency.rdd().getNumPartitions(),
           dependency,
-          null, null,
+          null,
           lifecycleManager.self());
     }
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -90,10 +90,7 @@ public class SparkShuffleManager implements ShuffleManager {
 
   public SparkShuffleManager(SparkConf conf, boolean isDriver) {
     if (conf.getBoolean(SQLConf.LOCAL_SHUFFLE_READER_ENABLED().key(), true)) {
-      logger.warn(
-          "Detected {} (default is true) is enabled, it's highly recommended to disable it when "
-              + "use Celeborn as Remote Shuffle Service to avoid performance degradation.",
-          SQLConf.LOCAL_SHUFFLE_READER_ENABLED().key());
+      SparkUtils.printSparkAQELocalShuffleReadRecommend();
     }
     if ((Boolean) conf.get(package$.MODULE$.DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED())) {
       String key = package$.MODULE$.DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED().key();
@@ -184,7 +181,9 @@ public class SparkShuffleManager implements ShuffleManager {
           shuffleId,
           celebornConf.clientFetchThrowsFetchFailure(),
           dependency.rdd().getNumPartitions(),
-          dependency);
+          dependency,
+          null, null,
+          lifecycleManager.self());
     }
   }
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -34,6 +34,7 @@ import org.apache.spark.shuffle.ShuffleWriteMetricsReporter;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.apache.spark.sql.execution.UnsafeRowSerializer;
 import org.apache.spark.sql.execution.metric.SQLMetric;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.storage.BlockManagerId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -272,5 +273,12 @@ public class SparkUtils {
     }
     throw new UnsupportedOperationException(
         "unexpected! neither methods unregisterAllMapAndMergeOutput/unregisterAllMapOutput are found in MapOutputTrackerMaster");
+  }
+
+  public static void printSparkAQELocalShuffleReadRecommend() {
+    LOG.warn(
+        "Detected {} (default is true) is enabled, it's highly recommended to disable it when "
+            + "use Celeborn as Remote Shuffle Service to avoid performance degradation.",
+        SQLConf.LOCAL_SHUFFLE_READER_ENABLED().key());
   }
 }

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.celeborn
 
+import org.apache.spark.MapOutputTrackerMaster
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.shuffle.BaseShuffleHandle
 
@@ -38,8 +39,6 @@ class CelebornShuffleHandle[K, V, C](
     @transient lifecycleManagerRef: RpcEndpointRef = null)
   extends BaseShuffleHandle(shuffleId, dependency) {
 
-  import org.apache.spark.MapOutputTrackerMaster
-
   def this(
       appUniqueId: String,
       lifecycleManagerHost: String,
@@ -60,7 +59,7 @@ class CelebornShuffleHandle[K, V, C](
     null,
     null)
 
-  // will be called by MapOutputTrackerMaster
+  // will be called by MapOutputTrackerMaster, return partition location
   def getReduceTaskPreferLocation(
       tracker: MapOutputTrackerMaster,
       dep: ShuffleDependency[_, _, _],

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -35,7 +35,6 @@ class CelebornShuffleHandle[K, V, C](
     val numMappers: Int,
     dependency: ShuffleDependency[K, V, C],
     val extension: Array[Byte],
-    val ioCryptoInitializationVector: Array[Byte],
     @transient lifecycleManagerRef: RpcEndpointRef = null)
   extends BaseShuffleHandle(shuffleId, dependency) {
 
@@ -56,7 +55,6 @@ class CelebornShuffleHandle[K, V, C](
     throwsFetchFailure,
     numMappers,
     dependency,
-    null,
     null)
 
   // will be called by MapOutputTrackerMaster, return partition location

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -21,6 +21,8 @@ import org.apache.spark.ShuffleDependency
 import org.apache.spark.shuffle.BaseShuffleHandle
 
 import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.protocol.message.ControlMessages.{GetPartitionLocation, GetPartitionLocationResponse}
+import org.apache.celeborn.common.rpc.RpcEndpointRef
 
 class CelebornShuffleHandle[K, V, C](
     val appUniqueId: String,
@@ -31,8 +33,13 @@ class CelebornShuffleHandle[K, V, C](
     val throwsFetchFailure: Boolean,
     val numMappers: Int,
     dependency: ShuffleDependency[K, V, C],
-    val extension: Array[Byte])
+    val extension: Array[Byte],
+    val ioCryptoInitializationVector: Array[Byte],
+    @transient lifecycleManagerRef: RpcEndpointRef = null)
   extends BaseShuffleHandle(shuffleId, dependency) {
+
+  import org.apache.spark.MapOutputTrackerMaster
+
   def this(
       appUniqueId: String,
       lifecycleManagerHost: String,
@@ -50,5 +57,40 @@ class CelebornShuffleHandle[K, V, C](
     throwsFetchFailure,
     numMappers,
     dependency,
+    null,
     null)
+
+  // will be called by MapOutputTrackerMaster
+  def getReduceTaskPreferLocation(
+      tracker: MapOutputTrackerMaster,
+      dep: ShuffleDependency[_, _, _],
+      partitionId: Int): Seq[String] = {
+    if (lifecycleManagerRef == null) {
+      return Seq.empty
+    }
+    try {
+      val res = lifecycleManagerRef.askSync[GetPartitionLocationResponse](GetPartitionLocation(
+        shuffleId,
+        partitionId))
+      res.hosts
+    } catch {
+      case _: Exception =>
+        Seq.empty
+    }
+  }
+
+  def getMapLocation(
+      tracker: MapOutputTrackerMaster,
+      dep: ShuffleDependency[_, _, _],
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int): Seq[String] = {
+    // endPartition - startPartition != 1 means enabled AQE local shuffle read
+    if (endPartition - startPartition != 1) {
+      SparkUtils.printSparkAQELocalShuffleReadRecommend()
+      return Seq.empty
+    }
+    getReduceTaskPreferLocation(tracker, dep, startPartition)
+  }
 }

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -267,6 +267,10 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
     getCommitHandler(shuffleId).handleGetReducerFileGroup(context, shuffleId)
   }
 
+  def handleGetPartitionLocation(shuffleId: Int, partitionId: Int): Seq[String] = {
+    getCommitHandler(shuffleId).handleGetPartitionLocation(shuffleId, partitionId)
+  }
+
   // exposed for test
   def getCommitHandler(shuffleId: Int): CommitHandler = {
     val partitionType = lifecycleManager.getPartitionType(shuffleId)

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -357,8 +357,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       val appShuffleId = pb.getAppShuffleId
       val appShuffleIdentifier = pb.getAppShuffleIdentifier
       val isWriter = pb.getIsShuffleWriter
-      logDebug(s"Received GetShuffleId request, appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier" +
-        s" isWriter $isWriter.")
+      logDebug(s"Received GetShuffleId request, appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier isWriter $isWriter.")
       handleGetShuffleIdForApp(context, appShuffleId, appShuffleIdentifier, isWriter)
 
     case pb: PbReportShuffleFetchFailure =>
@@ -725,8 +724,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       context: RpcCallContext,
       shuffleId: Int): Unit = {
     if (!registeredShuffle.contains(shuffleId)) {
-      logWarning(s"[handleGetReducerFileGroup] shuffle $shuffleId not registered, maybe no shuffle data within this " +
-        s"stage.")
+      logWarning(s"[handleGetReducerFileGroup] shuffle $shuffleId not registered, maybe no shuffle data within this stage.")
       context.reply(GetReducerFileGroupResponse(
         StatusCode.SHUFFLE_NOT_REGISTERED,
         JavaUtils.newConcurrentHashMap(),
@@ -751,8 +749,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             override def apply(id: Int)
                 : scala.collection.mutable.LinkedHashMap[String, (Int, Boolean)] = {
               val newShuffleId = shuffleIdGenerator.getAndIncrement()
-              logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier " +
-                s"$appShuffleIdentifier")
+              logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
               scala.collection.mutable.LinkedHashMap(appShuffleIdentifier -> (newShuffleId, true))
             }
           })
@@ -790,13 +787,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
               val shuffleId: Integer =
                 if (determinate && candidateShuffle.isDefined) {
                   val id = candidateShuffle.get._1
-                  logInfo(s"reuse existing shuffleId $id for appShuffleId $appShuffleId appShuffleIdentifier " +
-                    s"$appShuffleIdentifier")
+                  logInfo(s"reuse existing shuffleId $id for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
                   id
                 } else {
                   val newShuffleId = shuffleIdGenerator.getAndIncrement()
-                  logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier " +
-                    s"$appShuffleIdentifier")
+                  logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
                   shuffleIds.put(appShuffleIdentifier, (newShuffleId, true))
                   newShuffleId
                 }
@@ -812,8 +807,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
           case Some(shuffleId) =>
             val pbGetShuffleIdResponse = {
               logDebug(
-                s"get shuffleId $shuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier " +
-                  s"isWriter $isWriter")
+                s"get shuffleId $shuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier isWriter $isWriter")
               PbGetShuffleIdResponse.newBuilder().setShuffleId(shuffleId).build()
             }
             context.reply(pbGetShuffleIdResponse)
@@ -1148,8 +1142,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             } catch {
               case t: Throwable =>
                 logError(
-                  s"Init rpc client failed for $shuffleId on ${destroyWorkerInfo.readableAddress()} during release " +
-                    s"peer partition.",
+                  s"Init rpc client failed for $shuffleId on ${destroyWorkerInfo.readableAddress()} during release peer partition.",
                   t)
                 destroyWorkerInfo = null
             }
@@ -1442,15 +1435,13 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             case scala.util.Success(res) =>
               if (res.status != StatusCode.SUCCESS && retryTimes < rpcMaxRetires) {
                 logError(
-                  s"Request $message to ${futureWithStatus.endpoint} return ${res.status} for $shuffleKey " +
-                    s"$retryTimes/$rpcMaxRetires, " +
+                  s"Request $message to ${futureWithStatus.endpoint} return ${res.status} for $shuffleKey $retryTimes/$rpcMaxRetires, " +
                     "will retry.")
                 retryDestroy(futureWithStatus, currentTime)
               } else {
                 if (res.status != StatusCode.SUCCESS && retryTimes == rpcMaxRetires) {
                   logError(
-                    s"Request $message to ${futureWithStatus.endpoint} return ${res.status} for $shuffleKey " +
-                      s"$retryTimes/$rpcMaxRetires, " +
+                    s"Request $message to ${futureWithStatus.endpoint} return ${res.status} for $shuffleKey $retryTimes/$rpcMaxRetires, " +
                       "will not retry.")
                 }
                 iter.remove()
@@ -1458,15 +1449,13 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             case scala.util.Failure(e) =>
               if (retryTimes < rpcMaxRetires) {
                 logError(
-                  s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for " +
-                    s"$shuffleKey, reason: $e, " +
+                  s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for $shuffleKey, reason: $e, " +
                     "will retry.")
                 retryDestroy(futureWithStatus, currentTime)
               } else {
                 if (retryTimes == rpcMaxRetires) {
                   logError(
-                    s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for " +
-                      s"$shuffleKey, reason: $e, " +
+                    s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for $shuffleKey, reason: $e, " +
                       "will not retry.")
                 }
                 iter.remove()
@@ -1475,15 +1464,13 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         } else if (currentTime - futureWithStatus.startTime > timeout) {
           if (retryTimes < rpcMaxRetires) {
             logError(
-              s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for $shuffleKey, " +
-                s"reason: Timeout, " +
+              s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for $shuffleKey, reason: Timeout, " +
                 "will retry.")
             retryDestroy(futureWithStatus, currentTime)
           } else {
             if (retryTimes == rpcMaxRetires) {
               logError(
-                s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for $shuffleKey," +
-                  s" reason: Timeout, " +
+                s"Request $message to ${futureWithStatus.endpoint} failed $retryTimes/$rpcMaxRetires for $shuffleKey, reason: Timeout, " +
                   "will retry.")
             }
             iter.remove()

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -99,12 +99,17 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   private val rpcCacheExpireTime = conf.clientRpcCacheExpireTime
   private val rpcMaxRetires = conf.clientRpcMaxRetries
 
+  private val shuffleClientCacheSize = conf.clientShuffleClientCacheSize
+  private val shuffleClientCacheConcurrencyLevel = conf.clientShuffleClientCacheConcurrencyLevel
+  private val shuffleClientCacheExpireTime = conf.clientShuffleClientCacheExpireTime
+
   private val excludedWorkersFilter = conf.registerShuffleFilterExcludedWorkerEnabled
 
+  // here to avoid memory leak, due to executor OOM
   private val registerShuffleClientCache = CacheBuilder.newBuilder()
-    .concurrencyLevel(rpcCacheConcurrencyLevel)
-    .expireAfterAccess(rpcCacheExpireTime, TimeUnit.MILLISECONDS)
-    .maximumSize(rpcCacheSize)
+    .concurrencyLevel(shuffleClientCacheConcurrencyLevel)
+    .expireAfterAccess(shuffleClientCacheExpireTime, TimeUnit.MILLISECONDS)
+    .maximumSize(shuffleClientCacheSize)
     .build[String, Set[String]]
 
   private val registerShuffleResponseRpcCache: Cache[Int, ByteBuffer] = CacheBuilder.newBuilder()

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -175,6 +175,11 @@ abstract class CommitHandler(
    */
   def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit
 
+  /**
+   * Call to get list of Worker's topologyLocation where hold the partition file
+   */
+  def handleGetPartitionLocation(shuffleId: Int, partitionId: Int): Seq[String]
+
   def removeExpiredShuffle(shuffleId: Int): Unit = {
     reducerFileGroupsMap.remove(shuffleId)
   }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -224,6 +224,21 @@ class MapPartitionCommitHandler(
       succeedPartitionIds))
   }
 
+  override def handleGetPartitionLocation(
+      shuffleId: Int,
+      partitionId: Int): Seq[String] = {
+    val partitionMap = reducerFileGroupsMap.get(shuffleId)
+    if (partitionMap == null) {
+      Seq.empty
+    }
+    val locSet = partitionMap.get(partitionId)
+    if (locSet == null) {
+      Seq.empty
+    }
+    val hosts = locSet.asScala.map(loc => loc.getTopologyLocation).toSeq
+    hosts
+  }
+
   override def releasePartitionResource(shuffleId: Int, partitionId: Int): Unit = {
     val succeedPartitionIds = shuffleSucceedPartitionIds.get(shuffleId)
     if (succeedPartitionIds != null) {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -316,6 +316,21 @@ class ReducePartitionCommitHandler(
     }
   }
 
+  override def handleGetPartitionLocation(
+      shuffleId: Int,
+      partitionId: Int): Seq[String] = {
+    val partitionMap = reducerFileGroupsMap.get(shuffleId)
+    if (partitionMap == null) {
+      return Seq.empty
+    }
+    val locSet = partitionMap.get(partitionId)
+    if (locSet == null) {
+      return Seq.empty
+    }
+    val hosts = locSet.asScala.map(loc => loc.getTopologyLocation).toSeq
+    hosts
+  }
+
   override def waitStageEnd(shuffleId: Int): (Boolean, Long) = {
     var timeout = stageEndTimeout
     val delta = 100

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -172,7 +172,7 @@ public class DummyShuffleClient extends ShuffleClient {
     List<PartitionLocation> partitionLocationList = new ArrayList<>();
     for (int i = 0; i < workerNum; i++) {
       partitionLocationList.add(
-          new PartitionLocation(0, 0, host, 1000 + i, 2000 + i, 3000 + i, 4000 + i, PRIMARY));
+          new PartitionLocation(0, 0, host, 1000 + i, 2000 + i, 3000 + i, 4000 + i, PRIMARY, host));
     }
     for (int i = 0; i < numPartitions; i++) {
       map.put(i, partitionLocationList.get(i % workerNum));

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -65,7 +65,8 @@ public abstract class ShuffleClientBaseSuiteJ {
           PRIMARY_PUSH_PORT,
           PRIMARY_FETCH_PORT,
           PRIMARY_REPLICATE_PORT,
-          PartitionLocation.Mode.PRIMARY);
+          PartitionLocation.Mode.PRIMARY,
+          "localhost");
   protected static final PartitionLocation replicaLocation =
       new PartitionLocation(
           0,
@@ -75,7 +76,8 @@ public abstract class ShuffleClientBaseSuiteJ {
           REPLICA_PUSH_PORT,
           REPLICA_FETCH_PORT,
           REPLICA_REPLICATE_PORT,
-          PartitionLocation.Mode.REPLICA);
+          PartitionLocation.Mode.REPLICA,
+          "localhost");
 
   protected final int BATCH_HEADER_SIZE = 4 * 4;
   protected ChannelFuture mockedFuture = mock(ChannelFuture.class);

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -74,7 +74,8 @@ public class ShuffleClientSuiteJ {
           PRIMARY_PUSH_PORT,
           PRIMARY_FETCH_PORT,
           PRIMARY_REPLICATE_PORT,
-          PartitionLocation.Mode.PRIMARY);
+          PartitionLocation.Mode.PRIMARY,
+          "localhost");
   private static final PartitionLocation replicaLocation =
       new PartitionLocation(
           0,
@@ -84,7 +85,8 @@ public class ShuffleClientSuiteJ {
           REPLICA_PUSH_PORT,
           REPLICA_FETCH_PORT,
           REPLICA_REPLICATE_PORT,
-          PartitionLocation.Mode.REPLICA);
+          PartitionLocation.Mode.REPLICA,
+          "localhost");
 
   private static final byte[] TEST_BUF1 = "hello world".getBytes(StandardCharsets.UTF_8);
   private final int BATCH_HEADER_SIZE = 4 * 4;

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -50,12 +50,12 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
   }
 
   override protected def afterEach() {
-    if (lifecycleManager != null) {
-      lifecycleManager.stop()
-    }
-
+    // [CELEBORN-1200] should call shuffle client shut down first
     if (shuffleClient != null) {
       shuffleClient.shutdown()
+    }
+    if (lifecycleManager != null) {
+      lifecycleManager.stop()
     }
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -272,9 +272,7 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
-  /**
-   * @see PartitionLocation#getFileName
-   */
+  /** @see PartitionLocation#getFileName */
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
   }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -92,6 +92,30 @@ public class PartitionLocation implements Serializable {
       int pushPort,
       int fetchPort,
       int replicatePort,
+      Mode mode) {
+    this(
+        id,
+        epoch,
+        host,
+        rpcPort,
+        pushPort,
+        fetchPort,
+        replicatePort,
+        mode,
+        null,
+        new StorageInfo(),
+        new RoaringBitmap(),
+        host);
+  }
+
+  public PartitionLocation(
+      int id,
+      int epoch,
+      String host,
+      int rpcPort,
+      int pushPort,
+      int fetchPort,
+      int replicatePort,
       Mode mode,
       String topologyLocation) {
     this(
@@ -248,7 +272,9 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
-  /** @see PartitionLocation#getFileName */
+  /**
+   * @see PartitionLocation#getFileName
+   */
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
   }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -63,6 +63,7 @@ public class PartitionLocation implements Serializable {
   private PartitionLocation peer;
   private StorageInfo storageInfo;
   private RoaringBitmap mapIdBitMap;
+  private String topologyLocation;
   private transient String _hostPushPort;
   private transient String _hostFetchPort;
 
@@ -78,6 +79,7 @@ public class PartitionLocation implements Serializable {
     this.peer = loc.peer;
     this.storageInfo = loc.storageInfo;
     this.mapIdBitMap = loc.mapIdBitMap;
+    this.topologyLocation = loc.topologyLocation;
     this._hostPushPort = host + ":" + pushPort;
     this._hostFetchPort = host + ":" + fetchPort;
   }
@@ -90,7 +92,8 @@ public class PartitionLocation implements Serializable {
       int pushPort,
       int fetchPort,
       int replicatePort,
-      Mode mode) {
+      Mode mode,
+      String topologyLocation) {
     this(
         id,
         epoch,
@@ -102,7 +105,8 @@ public class PartitionLocation implements Serializable {
         mode,
         null,
         new StorageInfo(),
-        new RoaringBitmap());
+        new RoaringBitmap(),
+        topologyLocation);
   }
 
   public PartitionLocation(
@@ -126,7 +130,8 @@ public class PartitionLocation implements Serializable {
         mode,
         peer,
         new StorageInfo(),
-        new RoaringBitmap());
+        new RoaringBitmap(),
+        host);
   }
 
   public PartitionLocation(
@@ -140,7 +145,8 @@ public class PartitionLocation implements Serializable {
       Mode mode,
       PartitionLocation peer,
       StorageInfo hint,
-      RoaringBitmap mapIdBitMap) {
+      RoaringBitmap mapIdBitMap,
+      String topologyLocation) {
     this.id = id;
     this.epoch = epoch;
     this.host = host;
@@ -152,6 +158,7 @@ public class PartitionLocation implements Serializable {
     this.peer = peer;
     this.storageInfo = hint;
     this.mapIdBitMap = mapIdBitMap;
+    this.topologyLocation = topologyLocation;
     this._hostPushPort = host + ":" + pushPort;
     this._hostFetchPort = host + ":" + fetchPort;
   }
@@ -331,5 +338,13 @@ public class PartitionLocation implements Serializable {
 
   public void setMapIdBitMap(RoaringBitmap mapIdBitMap) {
     this.mapIdBitMap = mapIdBitMap;
+  }
+
+  public String getTopologyLocation() {
+    return topologyLocation;
+  }
+
+  public void setTopologyLocation(String topologyLocation) {
+    this.topologyLocation = topologyLocation;
   }
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -96,6 +96,8 @@ enum MessageType {
   AUTHENTICATION_INITIATION_RESPONSE = 73;
   REGISTER_APPLICATION_REQUEST = 74;
   REGISTER_APPLICATION_RESPONSE = 75;
+  REGISTER_SHUFFLE_CLIENT = 76;
+  UNREGISTER_SHUFFLE_CLIENT = 77;
 }
 
 enum StreamType {
@@ -127,6 +129,7 @@ message PbPartitionLocation {
   PbPartitionLocation peer = 9;
   PbStorageInfo storageInfo = 10;
   bytes mapIdBitmap = 11;
+  string topologyLocation = 12;
 }
 
 message PbWorkerResource {
@@ -153,6 +156,7 @@ message PbWorkerInfo {
   int32 replicatePort = 5;
   repeated PbDiskInfo disks = 6;
   map<string, PbResourceConsumption> userResourceConsumption = 7;
+  string topologyLocation = 8;
 }
 
 message PbFileGroup {
@@ -168,6 +172,7 @@ message PbRegisterWorker {
   repeated PbDiskInfo disks = 6;
   string requestId = 9;
   map<string, PbResourceConsumption> userResourceConsumption = 8;
+  string topologyLocation = 10;
 }
 
 message PbHeartbeatFromWorker {
@@ -193,6 +198,16 @@ message PbRegisterShuffle {
   int32 shuffleId = 1;
   int32 numMappers = 2;
   int32 numPartitions = 3;
+}
+
+message PbRegisterShuffleClient {
+  string topologyLocation = 1;
+  string bindAddress = 2;
+}
+
+message PbUnRegisterShuffleClient {
+  string topologyLocation = 1;
+  string bindAddress = 2;
 }
 
 message PbRegisterMapPartitionTask {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -780,6 +780,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     new RpcTimeout(
       get(CLIENT_RESERVE_SLOTS_RPC_TIMEOUT).milli,
       CLIENT_RESERVE_SLOTS_RPC_TIMEOUT.key)
+  def clientShuffleClientCacheSize: Int = get(CLIENT_SHUFFLE_CLIENT_CACHE_SIZE)
+  def clientShuffleClientCacheConcurrencyLevel: Int =
+    get(CLIENT_SHUFFLE_CLIENT_CACHE_CONCURRENCY_LEVEL)
+  def clientShuffleClientCacheExpireTime: Long = get(CLIENT_SHUFFLE_CLIENT_CACHE_EXPIRE_TIME)
 
   def clientRpcRegisterShuffleRpcAskTimeout: RpcTimeout =
     new RpcTimeout(
@@ -3824,6 +3828,30 @@ object CelebornConf extends Logging {
       .doc("The time before a cache item is removed.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("15s")
+
+  val CLIENT_SHUFFLE_CLIENT_CACHE_SIZE: ConfigEntry[Int] =
+    buildConf("celeborn.client.shuffleClient.cache.size")
+      .categories("client")
+      .version("0.5.0")
+      .doc("The max cache items count for register shuffle client.")
+      .intConf
+      .createWithDefault(2048)
+
+  val CLIENT_SHUFFLE_CLIENT_CACHE_CONCURRENCY_LEVEL: ConfigEntry[Int] =
+    buildConf("celeborn.client.shuffleClient.cache.concurrencyLevel")
+      .categories("client")
+      .version("0.5.0")
+      .doc("The number of write locks to update register shuffle client cache.")
+      .intConf
+      .createWithDefault(32)
+
+  val CLIENT_SHUFFLE_CLIENT_CACHE_EXPIRE_TIME: ConfigEntry[Long] =
+    buildConf("celeborn.client.shuffleClient.cache.expireTime")
+      .categories("client")
+      .version("0.5.0")
+      .doc("The time before a register shuffle client cache item is removed.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("1h")
 
   val CLIENT_RPC_SHARED_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.client.rpc.shared.threads")

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationSuiteJ.java
@@ -41,7 +41,8 @@ public class PartitionLocationSuiteJ {
           pushPort,
           fetchPort,
           replicatePort,
-          PartitionLocation.Mode.REPLICA);
+          PartitionLocation.Mode.REPLICA,
+          host);
 
   @Test
   public void testGetCorrectMode() {
@@ -176,7 +177,7 @@ public class PartitionLocationSuiteJ {
   public void testToStringOutput() {
     PartitionLocation location1 =
         new PartitionLocation(
-            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode, host);
     PartitionLocation location2 =
         new PartitionLocation(
             partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode, peer);
@@ -201,7 +202,8 @@ public class PartitionLocationSuiteJ {
             mode,
             peer,
             storageInfo,
-            bitmap);
+            bitmap,
+            host);
 
     String exp1 =
         "PartitionLocation[\n"

--- a/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
@@ -88,7 +88,8 @@ class ShufflePartitionLocationInfoSuite extends CelebornFunSuite {
       -1,
       -1,
       -1,
-      PartitionLocation.Mode.PRIMARY)
+      PartitionLocation.Mode.PRIMARY,
+      "mock")
   }
 
 }

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -198,7 +198,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
   }
 
   test("WorkerInfo toString output") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, "topology")
     val worker2 = new WorkerInfo("h2", 20001, 20002, 20003, 2000, null, null)
 
     val worker3 = new WorkerInfo(

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -192,7 +192,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
   }
 
   test("WorkerInfo equals when endpoint different") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, "topology")
     val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
     assertEquals(worker1, worker2)
   }
@@ -245,6 +245,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |LastHeartbeat: 0
            |Disks: empty
            |UserResourceConsumption: empty
+           |TopologyLocation: topology
            |WorkerRef: null
            |""".stripMargin
 
@@ -259,6 +260,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
           |LastHeartbeat: 0
           |Disks: empty
           |UserResourceConsumption: empty
+          |TopologyLocation: h2
           |WorkerRef: null
           |""".stripMargin
       val exp3 =
@@ -272,6 +274,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |LastHeartbeat: 0
            |Disks: empty
            |UserResourceConsumption: empty
+           |TopologyLocation: h3
            |WorkerRef: null
            |""".stripMargin
       val exp4 =
@@ -289,6 +292,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |  DiskInfo2: DiskInfo(maxSlots: 0, committed shuffles 0, running applications 0, shuffleAllocations: Map(), mountPoint: disk2, usableSpace: 2048.0 MiB, avgFlushTime: 2 ns, avgFetchTime: 2 ns, activeSlots: 20, storageType: SSD) status: HEALTHY dirs $placeholder
            |UserResourceConsumption: $placeholder
            |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MiB, diskFileCount: 1, hdfsBytesWritten: 50.0 MiB, hdfsFileCount: 1)
+           |TopologyLocation: h4
            |WorkerRef: null
            |""".stripMargin;
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfoSuite.scala
@@ -73,6 +73,7 @@ class WorkerPartitionLocationInfoSuite extends CelebornFunSuite {
       -1,
       -1,
       -1,
-      PartitionLocation.Mode.PRIMARY)
+      PartitionLocation.Mode.PRIMARY,
+      "mock")
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -83,12 +83,12 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
     new WorkerInfo("localhost", 2001, 2002, 2003, 2004, diskInfos, userResourceConsumption)
 
   val partitionLocation1 =
-    new PartitionLocation(0, 0, "host1", 10, 9, 8, 14, PartitionLocation.Mode.REPLICA)
+    new PartitionLocation(0, 0, "host1", 10, 9, 8, 14, PartitionLocation.Mode.REPLICA, "host1")
   val partitionLocation2 =
-    new PartitionLocation(1, 1, "host2", 20, 19, 18, 24, PartitionLocation.Mode.REPLICA)
+    new PartitionLocation(1, 1, "host2", 20, 19, 18, 24, PartitionLocation.Mode.REPLICA, "host2")
 
   val partitionLocation3 =
-    new PartitionLocation(2, 2, "host3", 30, 29, 28, 27, PartitionLocation.Mode.PRIMARY)
+    new PartitionLocation(2, 2, "host3", 30, 29, 28, 27, PartitionLocation.Mode.PRIMARY, "host3")
   val partitionLocation4 =
     new PartitionLocation(
       3,
@@ -106,7 +106,8 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
         false,
         "filePath",
         StorageInfo.LOCAL_DISK_MASK),
-      null)
+      null,
+      "host4")
 
   val workerResource = new WorkerResource()
   workerResource.put(

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -189,7 +189,8 @@ class UtilsSuite extends CelebornFunSuite {
         1000,
         1001,
         100,
-        PartitionLocation.Mode.PRIMARY))
+        PartitionLocation.Mode.PRIMARY,
+        "host"))
     }
     partitionSet
   }

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -100,6 +100,9 @@ license: |
 | celeborn.client.shuffle.partitionSplit.threshold | 1G | Shuffle file size threshold, if file size exceeds this, trigger split. | 0.3.0 | 
 | celeborn.client.shuffle.rangeReadFilter.enabled | false | If a spark application have skewed partition, this value can set to true to improve performance. | 0.2.0 | 
 | celeborn.client.shuffle.register.filterExcludedWorker.enabled | false | Whether to filter excluded worker when register shuffle. | 0.4.0 | 
+| celeborn.client.shuffleClient.cache.concurrencyLevel | 32 | The number of write locks to update register shuffle client cache. | 0.5.0 | 
+| celeborn.client.shuffleClient.cache.expireTime | 1h | The time before a register shuffle client cache item is removed. | 0.5.0 | 
+| celeborn.client.shuffleClient.cache.size | 2048 | The max cache items count for register shuffle client. | 0.5.0 | 
 | celeborn.client.slot.assign.maxWorkers | 10000 | Max workers that slots of one shuffle can be allocated on. Will choose the smaller positive one from Master side and Client side, see `celeborn.master.slot.assign.maxWorkers`. | 0.3.1 | 
 | celeborn.client.spark.fetch.throwsFetchFailure | false | client throws FetchFailedException instead of CelebornIOException | 0.4.0 | 
 | celeborn.client.spark.push.dynamicWriteMode.enabled | false | Whether to dynamically switch push write mode based on conditions.If true, shuffle mode will be only determined by partition count | 0.5.0 | 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -625,7 +625,8 @@ public class SlotsAllocator {
         isPrimary ? PartitionLocation.Mode.PRIMARY : PartitionLocation.Mode.REPLICA,
         peer,
         storageInfo,
-        new RoaringBitmap());
+        new RoaringBitmap(),
+        workerInfo.topologyLocation());
   }
 
   public static Map<WorkerInfo, Map<String, Integer>> slotsToDiskAllocations(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -201,10 +201,18 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       int fetchPort,
       int replicatePort,
       Map<String, DiskInfo> disks,
-      Map<UserIdentifier, ResourceConsumption> userResourceConsumption) {
+      Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      String topologyLocation) {
     WorkerInfo workerInfo =
         new WorkerInfo(
-            host, rpcPort, pushPort, fetchPort, replicatePort, disks, userResourceConsumption);
+            host,
+            rpcPort,
+            pushPort,
+            fetchPort,
+            replicatePort,
+            disks,
+            userResourceConsumption,
+            topologyLocation);
     workerInfo.lastHeartbeat_$eq(System.currentTimeMillis());
     workerInfo.networkLocation_$eq(rackResolver.resolve(host).getNetworkLocation());
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -63,6 +63,27 @@ public interface IMetadataHandler {
       boolean highWorkload,
       String requestId);
 
+  default void handleRegisterWorker(
+      String host,
+      int rpcPort,
+      int pushPort,
+      int fetchPort,
+      int replicatePort,
+      Map<String, DiskInfo> disks,
+      Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      String requestId) {
+    handleRegisterWorker(
+        host,
+        rpcPort,
+        pushPort,
+        fetchPort,
+        replicatePort,
+        disks,
+        userResourceConsumption,
+        host,
+        requestId);
+  }
+
   void handleRegisterWorker(
       String host,
       int rpcPort,
@@ -71,6 +92,7 @@ public interface IMetadataHandler {
       int replicatePort,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      String topologyLocation,
       String requestId);
 
   void handleReportWorkerUnavailable(List<WorkerInfo> failedNodes, String requestId);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/MetaUtil.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/MetaUtil.java
@@ -37,7 +37,8 @@ public class MetaUtil {
         address.getRpcPort(),
         address.getPushPort(),
         address.getFetchPort(),
-        address.getReplicatePort());
+        address.getReplicatePort(),
+        address.getTopologyLocation());
   }
 
   public static ResourceProtos.WorkerAddress infoToAddr(WorkerInfo info) {
@@ -47,6 +48,7 @@ public class MetaUtil {
         .setPushPort(info.pushPort())
         .setFetchPort(info.fetchPort())
         .setReplicatePort(info.replicatePort())
+        .setTopologyLocation(info.topologyLocation())
         .build();
   }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -128,9 +128,17 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
       int replicatePort,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      String topologyLocation,
       String requestId) {
     updateRegisterWorkerMeta(
-        host, rpcPort, pushPort, fetchPort, replicatePort, disks, userResourceConsumption);
+        host,
+        rpcPort,
+        pushPort,
+        fetchPort,
+        replicatePort,
+        disks,
+        userResourceConsumption,
+        topologyLocation);
   }
 
   @Override

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -285,6 +285,7 @@ public class HAMasterMetaManager extends AbstractMetaManager {
       int replicatePort,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      String topologyLocation,
       String requestId) {
     try {
       ratisServer.submitRequest(
@@ -301,6 +302,7 @@ public class HAMasterMetaManager extends AbstractMetaManager {
                       .putAllDisks(MetaUtil.toPbDiskInfos(disks))
                       .putAllUserResourceConsumption(
                           MetaUtil.toPbUserResourceConsumption(userResourceConsumption))
+                      .setTopologyLocation(topologyLocation)
                       .build())
               .build());
     } catch (CelebornRuntimeException e) {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -97,6 +97,8 @@ public class MetaHandler {
       int replicatePort;
       Map<String, DiskInfo> diskInfos;
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption;
+      String topologyLocation;
+      List<Map<String, Integer>> slots = new ArrayList<>();
       Map<String, Long> estimatedAppDiskUsage = new HashMap<>();
       switch (cmdType) {
         case RequestSlots:
@@ -207,15 +209,17 @@ public class MetaHandler {
           userResourceConsumption =
               MetaUtil.fromPbUserResourceConsumption(
                   request.getRegisterWorkerRequest().getUserResourceConsumptionMap());
+          topologyLocation = request.getRegisterWorkerRequest().getTopologyLocation();
           LOG.debug(
-              "Handle worker register for {} {} {} {} {} {} {}",
+              "Handle worker register for {} {} {} {} {} {} {} {}",
               host,
               rpcPort,
               pushPort,
               fetchPort,
               replicatePort,
               diskInfos,
-              userResourceConsumption);
+              userResourceConsumption,
+              topologyLocation);
           metaSystem.updateRegisterWorkerMeta(
               host,
               rpcPort,
@@ -223,7 +227,8 @@ public class MetaHandler {
               fetchPort,
               replicatePort,
               diskInfos,
-              userResourceConsumption);
+              userResourceConsumption,
+              topologyLocation);
           break;
 
         case ReportWorkerUnavailable:

--- a/master/src/main/proto/Resource.proto
+++ b/master/src/main/proto/Resource.proto
@@ -142,6 +142,7 @@ message RegisterWorkerRequest {
   required int32 replicatePort = 5;
   map<string, DiskInfo> disks = 6;
   map<string, ResourceConsumption> userResourceConsumption = 7;
+  required string topologyLocation = 8;
 }
 
 message ReportWorkerUnavailableRequest {
@@ -158,6 +159,7 @@ message WorkerAddress {
   required int32 pushPort = 3;
   required int32 fetchPort = 4;
   required int32 replicatePort = 5;
+  required string topologyLocation = 6;
 }
 
 message UserIdentifier {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -138,9 +138,15 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         disks3,
         userResourceConsumption3,
+        "topologyLocation",
         getNewReqeustId());
 
     assertEquals(3, statusSystem.workers.size());
+    assertEquals(
+        1,
+        statusSystem.workers.stream()
+            .filter(w -> "topologyLocation".equals(w.topologyLocation()))
+            .count());
   }
 
   @Test

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -271,6 +271,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         disks3,
         userResourceConsumption3,
+        "topologyLocation",
         getNewReqeustId());
     Thread.sleep(3000L);
 
@@ -278,6 +279,12 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
     Assert.assertEquals(3, STATUSSYSTEM2.workers.size());
     Assert.assertEquals(3, STATUSSYSTEM3.workers.size());
+
+    Assert.assertEquals(
+        1,
+        statusSystem.workers.stream()
+            .filter(worker -> "topologyLocation".equals(worker.topologyLocation()))
+            .count());
   }
 
   @Test

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -77,6 +77,7 @@ private[celeborn] class Worker(
   private val host = rpcEnv.address.host
   private val rpcPort = rpcEnv.address.port
   Utils.checkHost(host)
+  private val topologyLocation = Option(System.getenv("KUBERNETES_NODE_NAME")).getOrElse(host)
 
   private val WORKER_SHUTDOWN_PRIORITY = 100
   val shutdown = new AtomicBoolean(false)
@@ -226,7 +227,8 @@ private[celeborn] class Worker(
       fetchPort,
       replicatePort,
       diskInfos,
-      userResourceConsumption)
+      userResourceConsumption,
+      topologyLocation)
 
   // whether this Worker registered to Master successfully
   val registered = new AtomicBoolean(false)
@@ -508,6 +510,7 @@ private[celeborn] class Worker(
               // StorageManager have update the disk info.
               workerInfo.diskInfos.asScala.toMap,
               handleResourceConsumption().asScala.toMap,
+              topologyLocation,
               MasterClient.genRequestId()),
             classOf[PbRegisterWorkerResponse])
         } catch {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/WorkingPartitionSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/WorkingPartitionSuiteJ.java
@@ -35,9 +35,10 @@ public class WorkingPartitionSuiteJ {
     List<WorkingPartition> list = new ArrayList<>();
 
     PartitionLocation p1 =
-        new PartitionLocation(0, 0, "host1", 10, 9, 8, 14, PartitionLocation.Mode.REPLICA);
+        new PartitionLocation(0, 0, "host1", 10, 9, 8, 14, PartitionLocation.Mode.REPLICA, "host1");
     PartitionLocation p2 =
-        new PartitionLocation(1, 1, "host1", 11, 12, 13, 15, PartitionLocation.Mode.REPLICA);
+        new PartitionLocation(
+            1, 1, "host1", 11, 12, 13, 15, PartitionLocation.Mode.REPLICA, "host1");
 
     WorkingPartition pd1 = new WorkingPartition(p1, null);
     WorkingPartition pd2 = new WorkingPartition(p2, null);
@@ -54,7 +55,7 @@ public class WorkingPartitionSuiteJ {
     map.put(pd2, pd2);
 
     PartitionLocation p =
-        new PartitionLocation(0, 0, "host1", 10, 9, 8, 11, PartitionLocation.Mode.REPLICA);
+        new PartitionLocation(0, 0, "host1", 10, 9, 8, 11, PartitionLocation.Mode.REPLICA, "host1");
     assertTrue(map.containsKey(p));
 
     map.remove(p1);
@@ -66,12 +67,28 @@ public class WorkingPartitionSuiteJ {
     PartitionLocation p3 =
         new WorkingPartition(
             new PartitionLocation(
-                2, 1, "30.225.12.48", 9096, 9097, 9098, 9099, PartitionLocation.Mode.PRIMARY),
+                2,
+                1,
+                "30.225.12.48",
+                9096,
+                9097,
+                9098,
+                9099,
+                PartitionLocation.Mode.PRIMARY,
+                "30.225.12.48"),
             null);
     map2.put(p3, p3);
     PartitionLocation p4 =
         new PartitionLocation(
-            2, 1, "30.225.12.48", 9096, 9097, 9098, 9099, PartitionLocation.Mode.REPLICA);
+            2,
+            1,
+            "30.225.12.48",
+            9096,
+            9097,
+            9098,
+            9099,
+            PartitionLocation.Mode.REPLICA,
+            "30.225.12.48");
     assertTrue(map2.containsKey(p4));
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
@@ -58,8 +58,8 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
     conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, tmpFile.toString)
     worker = new Worker(conf, workerArgs)
 
-    val pl1 = new PartitionLocation(0, 0, "12", 0, 0, 0, 0, PartitionLocation.Mode.PRIMARY)
-    val pl2 = new PartitionLocation(1, 0, "12", 0, 0, 0, 0, PartitionLocation.Mode.REPLICA)
+    val pl1 = new PartitionLocation(0, 0, "12", 0, 0, 0, 0, PartitionLocation.Mode.PRIMARY, "12")
+    val pl2 = new PartitionLocation(1, 0, "12", 0, 0, 0, 0, PartitionLocation.Mode.REPLICA, "12")
 
     worker.storageManager.createPartitionDataWriter(
       "1",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

For now, Spark submit job with Celeborn can’t schedule Reduce Task to correct node, due to following parts:
Celeborn Shuffle Write submit MapStatus with Executor Info, but all shuffle data is store in Celeborn Worker
Spark Framework only call MapOutputTrackerMaster to get ShuffledRDD or ShuffledRowRDD prefer location.

Based on the above issues, we modified Celeborn and small part of Spark:
Make Celeborn Master aware Celeborn Worker Topology Location(for now Topology Location means which node to be deployed)
Make Celeborn LifecycleManager aware spark Executor Topology Location
Spark Framework should open the interface to allow the custom shuffle service to provide prefer location info

See mode detail in design doc: [CELEBORN-1200 Spark Reduce Task aware locality with Celeborn Cluster](https://docs.google.com/document/d/1hO_W5eaqrOPfuCJsy_5jg_PtTw1-OW0aO1vcbWEIt5U/edit?usp=sharing)

```mermaid
sequenceDiagram 
Celeborn Worker->>Celeborn Master : Register self with TopologyLocation

Celeborn Master->>LifecycleManager: Reply Request Slots with TopologyLocation

LifecycleManager->>LifecycleManager: Handle Commit File to Build PartitionLocation with TopologyLocation

CelebornShuffleClient->>LifecycleManager:  Register Shuffle Client with TopologyLocation and Client Address when set up LifecycleManagerRef

SparkDAGScheduler->> MapOutputTrackerMaster: Call to get Seq of host to allocate reduce task

MapOutputTrackerMaster->>ShuffleHandler(CelebornShuffleHandler): Get Seq of host

CelebornShuffleHandler->>LifecycleManager: Get Seq of host

LifecycleManager->>LifecycleManager: Get Partition File TopologyLocation and Find Corresponding Shuffle Client Address
```

### Why are the changes needed?

Based on production practices, when Celeborn Worker and Spark Executor operate on the same batch of Kubernetes nodes and both mount disks using `hostPath`, we have observed that under limited network IO, the Shuffle Fetch Wait Time is significantly extended.

We expect the Spark Reduce Task to be scheduled to the executor on the corresponding node holding the partition data by simply moving the computing rather than moving the data idea.

So, we propose this PR to make the Celeborn cluster running on Kubernetes aware of the Topology Info (node information for the current implementation) of the Celeborn Worker, Then, simply depend the Spark RDD Prefer Location feature to schedule Reduce tasks to nodes with data.

### Does this PR introduce _any_ user-facing change?

No, the specific task assignment logic change is not perceived by the user, but the Task Locality Level change is clearly visible on the spark UI.

### How was this patch tested?
- ✅ Pass CI & Unit Test
- ✅ Functional Test
- 🚧 Performance Test