### PR TITLE
[CELEBORN-1334][BUILD] Client side should not import unnecessary deps

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -122,11 +122,13 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-api</artifactId>
           <version>${hadoop.version}</version>
+          <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-runtime</artifactId>
           <version>${hadoop.version}</version>
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -142,6 +144,7 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
           <version>${hadoop.version}</version>
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1023,6 +1023,7 @@
     <profile>
       <id>hadoop-3</id>
       <activation>
+        <activeByDefault>true</activeByDefault>
         <property>
           <name>hadoop.version</name>
           <value>/^3\..*$/</value>
@@ -1036,11 +1037,13 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-api</artifactId>
           <version>${hadoop.version}</version>
+          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-runtime</artifactId>
           <version>${hadoop.version}</version>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1060,6 +1063,7 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
           <version>${hadoop.version}</version>
+          <scope>provided</scope>
           <exclusions>
             <exclusion>
               <groupId>org.apache.hadoop</groupId>
@@ -1212,18 +1216,12 @@
     <profile>
       <id>jdk-8</id>
       <activation>
+        <activeByDefault>true</activeByDefault>
         <jdk>1.8</jdk>
       </activation>
       <properties>
         <java.version>8</java.version>
       </properties>
-      <dependencies>
-        <dependency>
-          <groupId>com.github.olivergondza</groupId>
-          <artifactId>maven-jdk-tools-wrapper</artifactId>
-          <version>0.1</version>
-        </dependency>
-      </dependencies>
       <build>
         <plugins>
           <!-- Based on https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-8 -->

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -106,6 +106,51 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>jdk-8</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.olivergondza</groupId>
+          <artifactId>maven-jdk-tools-wrapper</artifactId>
+          <version>0.1</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hadoop-3</id>
+      <activation>
+        <property>
+          <name>hadoop-3-deps</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-api</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hadoop-2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current spark client pom import hadoop client jar and jdk tool jar
<img width="677" alt="image" src="https://github.com/apache/incubator-celeborn/assets/46485123/bafdb49e-5893-4b0b-9226-4a2d5e358f98">

Client side should not contain such pom deps


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

