### PR TITLE
[CELEBORN-1335] RpcTimeoutException should inherit from CelebornIOException

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcTimeout.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcTimeout.scala
@@ -23,13 +23,14 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.exception.CelebornIOException
 import org.apache.celeborn.common.util.{ThreadUtils, Utils}
 
 /**
  * An exception thrown if RpcTimeout modifies a `TimeoutException`.
  */
 private[celeborn] class RpcTimeoutException(message: String, cause: TimeoutException)
-  extends TimeoutException(message) { initCause(cause) }
+  extends CelebornIOException(message, cause)
 
 /**
  * Associates a timeout with a description so that a when a TimeoutException occurs, additional

--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -31,6 +31,7 @@ import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.metrics.source.ThreadPoolSource
+import org.apache.celeborn.common.rpc.RpcTimeoutException
 
 object ThreadUtils {
 
@@ -316,6 +317,8 @@ object ThreadUtils {
       awaitable.result(atMost)(awaitPermission)
     } catch {
       // TimeoutException is thrown in the current thread, so not need to warp the exception.
+      case e: RpcTimeoutException =>
+        throw e
       case NonFatal(t) if !t.isInstanceOf[TimeoutException] =>
         throw new CelebornException("Exception thrown in awaitResult: ", t)
       case e: Throwable =>
@@ -339,6 +342,8 @@ object ThreadUtils {
       awaitable.ready(atMost)(awaitPermission)
     } catch {
       // TimeoutException is thrown in the current thread, so not need to warp the exception.
+      case e: RpcTimeoutException =>
+        throw e
       case NonFatal(t) if !t.isInstanceOf[TimeoutException] =>
         throw new CelebornException("Exception thrown in awaitResult: ", t)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We meet a case Spark task throw `RpcTimeoutException`, then causing all executor excluded when enable
`spark.excludeOnFailure.application.fetchFailure.enabled`.
Even we have ignore `CelebornIOException` in spark side.
`RpcTimeoutException` should also inherit from `CelebornIOException`



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

