### PR TITLE
[CELEBORN-1337] Optimize WorkerInfo in WorkerStatusTracker by removing unused fields

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1522,7 +1522,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       ids: util.ArrayList[Integer]): RequestSlotsResponse = {
     val excludedWorkerSet =
       if (excludedWorkersFilter) {
-        workerStatusTracker.excludedWorkers.asScala.keys.map(WorkerInfo.fromWorkerSummary).toSet
+        workerStatusTracker.excludedWorkers.asScala.keys.map(WorkerInfo.fromWorkerId).toSet
       } else {
         Set.empty[WorkerInfo]
       }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1522,7 +1522,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       ids: util.ArrayList[Integer]): RequestSlotsResponse = {
     val excludedWorkerSet =
       if (excludedWorkersFilter) {
-        workerStatusTracker.excludedWorkers.asScala.keys.toSet
+        workerStatusTracker.excludedWorkers.asScala.keys.map(WorkerInfo.fromWorkerSummary).toSet
       } else {
         Set.empty[WorkerInfo]
       }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -134,8 +134,7 @@ class WorkerStatusTracker(
       failedWorkers.asScala.map(e => (WorkerId.fromWorkerInfo(e._1), e._2)).foreach {
         case (workerId, (StatusCode.WORKER_SHUTDOWN, _)) =>
           shuttingWorkers.add(workerId)
-        case (workerId, (statusCode, registerTime))
-            if !excludedWorkers.containsKey(workerId) =>
+        case (workerId, (statusCode, registerTime)) if !excludedWorkers.containsKey(workerId) =>
           excludedWorkers.put(workerId, (statusCode, registerTime))
         case (workerId, (statusCode, _))
             if statusCode == StatusCode.NO_AVAILABLE_WORKING_DIR ||

--- a/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
@@ -37,10 +37,10 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
 
     val registerTime = System.currentTimeMillis()
     statusTracker.excludedWorkers.put(
-      mockSummary("host1"),
+      mockId("host1"),
       (StatusCode.WORKER_UNKNOWN, registerTime))
     statusTracker.excludedWorkers.put(
-      mockSummary("host2"),
+      mockId("host2"),
       (StatusCode.WORKER_SHUTDOWN, registerTime))
 
     // test reserve (only statusCode list in handleHeartbeatResponse)
@@ -49,9 +49,9 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
 
     // only reserve host1
     Assert.assertEquals(
-      statusTracker.excludedWorkers.get(mockSummary("host1")),
+      statusTracker.excludedWorkers.get(mockId("host1")),
       (StatusCode.WORKER_UNKNOWN, registerTime))
-    Assert.assertFalse(statusTracker.excludedWorkers.containsKey(mockSummary("host2")))
+    Assert.assertFalse(statusTracker.excludedWorkers.containsKey(mockId("host2")))
 
     // add shutdown/excluded worker
     val response1 = buildResponse(Array("host0"), Array("host1", "host3"), Array("host4"))
@@ -59,33 +59,33 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
 
     // test keep Unknown register time
     Assert.assertEquals(
-      statusTracker.excludedWorkers.get(mockSummary("host1")),
+      statusTracker.excludedWorkers.get(mockId("host1")),
       (StatusCode.WORKER_UNKNOWN, registerTime))
 
     // test new added workers
-    Assert.assertTrue(statusTracker.excludedWorkers.containsKey(mockSummary("host0")))
-    Assert.assertTrue(statusTracker.excludedWorkers.containsKey(mockSummary("host3")))
-    Assert.assertTrue(!statusTracker.excludedWorkers.containsKey(mockSummary("host4")))
-    Assert.assertTrue(statusTracker.shuttingWorkers.contains(mockSummary("host4")))
+    Assert.assertTrue(statusTracker.excludedWorkers.containsKey(mockId("host0")))
+    Assert.assertTrue(statusTracker.excludedWorkers.containsKey(mockId("host3")))
+    Assert.assertTrue(!statusTracker.excludedWorkers.containsKey(mockId("host4")))
+    Assert.assertTrue(statusTracker.shuttingWorkers.contains(mockId("host4")))
 
     // test re heartbeat with shutdown workers
     val response3 = buildResponse(Array.empty, Array.empty, Array("host4"))
     statusTracker.handleHeartbeatResponse(response3)
-    Assert.assertTrue(!statusTracker.excludedWorkers.containsKey(mockSummary("host4")))
-    Assert.assertTrue(statusTracker.shuttingWorkers.contains(mockSummary("host4")))
+    Assert.assertTrue(!statusTracker.excludedWorkers.containsKey(mockId("host4")))
+    Assert.assertTrue(statusTracker.shuttingWorkers.contains(mockId("host4")))
 
     // test remove
     val workers = new util.HashSet[WorkerInfo]
     workers.add(mock("host3"))
     statusTracker.removeFromExcludedWorkers(workers)
-    Assert.assertFalse(statusTracker.excludedWorkers.containsKey(mockSummary("host3")))
+    Assert.assertFalse(statusTracker.excludedWorkers.containsKey(mockId("host3")))
 
     // test register time elapsed
     Thread.sleep(3000)
     val response2 = buildResponse(Array.empty, Array("host5", "host6"), Array.empty)
     statusTracker.handleHeartbeatResponse(response2)
     Assert.assertEquals(statusTracker.excludedWorkers.size(), 2)
-    Assert.assertFalse(statusTracker.excludedWorkers.containsKey(mockSummary("host1")))
+    Assert.assertFalse(statusTracker.excludedWorkers.containsKey(mockId("host1")))
   }
 
   private def buildResponse(
@@ -112,7 +112,7 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
     new WorkerInfo(host, -1, -1, -1, -1)
   }
 
-  private def mockSummary(host: String): WorkerId = {
+  private def mockId(host: String): WorkerId = {
     WorkerId.fromWorkerInfo(mock(host))
   }
 }

--- a/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
@@ -24,7 +24,7 @@ import org.junit.Assert
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.CLIENT_EXCLUDED_WORKER_EXPIRE_TIMEOUT
-import org.apache.celeborn.common.meta.{WorkerInfo, WorkerSummary}
+import org.apache.celeborn.common.meta.{WorkerId, WorkerInfo}
 import org.apache.celeborn.common.protocol.message.ControlMessages.HeartbeatFromApplicationResponse
 import org.apache.celeborn.common.protocol.message.StatusCode
 
@@ -112,7 +112,7 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
     new WorkerInfo(host, -1, -1, -1, -1)
   }
 
-  private def mockSummary(host: String): WorkerSummary = {
-    WorkerSummary.fromWorkerInfo(mock(host))
+  private def mockSummary(host: String): WorkerId = {
+    WorkerId.fromWorkerInfo(mock(host))
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -339,4 +339,14 @@ object WorkerInfo {
       workerId.fetchPort,
       workerId.replicatePort)
   }
+
+  def toPrunedWorkerInfo(workerInfo: WorkerInfo): WorkerInfo = {
+    new WorkerInfo(
+      workerInfo.host,
+      workerInfo.rpcPort,
+      workerInfo.pushPort,
+      workerInfo.fetchPort,
+      workerInfo.replicatePort,
+      workerInfo.internalPort)
+  }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -32,7 +32,7 @@ import org.apache.celeborn.common.rpc.RpcEndpointRef
 import org.apache.celeborn.common.rpc.netty.NettyRpcEndpointRef
 import org.apache.celeborn.common.util.{JavaUtils, Utils}
 
-class WorkerSummary(
+class WorkerId(
     val host: String,
     val rpcPort: Int,
     val pushPort: Int,
@@ -59,7 +59,7 @@ class WorkerSummary(
   }
 
   override def equals(other: Any): Boolean = other match {
-    case that: WorkerInfo =>
+    case that: WorkerId =>
       host == that.host &&
         rpcPort == that.rpcPort &&
         pushPort == that.pushPort &&
@@ -78,9 +78,9 @@ class WorkerSummary(
   }
 }
 
-object WorkerSummary {
-  def fromWorkerInfo(workerInfo: WorkerInfo): WorkerSummary = {
-    new WorkerSummary(
+object WorkerId {
+  def fromWorkerInfo(workerInfo: WorkerInfo): WorkerId = {
+    new WorkerId(
       workerInfo.host,
       workerInfo.rpcPort,
       workerInfo.pushPort,
@@ -98,7 +98,7 @@ class WorkerInfo(
     override val replicatePort: Int,
     override val internalPort: Int,
     _diskInfos: util.Map[String, DiskInfo],
-    _userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption]) extends WorkerSummary(
+    _userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption]) extends WorkerId(
     host,
     rpcPort,
     pushPort,
@@ -331,7 +331,7 @@ object WorkerInfo {
     new WorkerInfo(host, rpcPort.toInt, pushPort.toInt, fetchPort.toInt, replicatePort.toInt)
   }
 
-  def fromWorkerSummary(summary: WorkerSummary): WorkerInfo = {
+  def fromWorkerSummary(summary: WorkerId): WorkerInfo = {
     new WorkerInfo(
       summary.host,
       summary.rpcPort,

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -331,12 +331,12 @@ object WorkerInfo {
     new WorkerInfo(host, rpcPort.toInt, pushPort.toInt, fetchPort.toInt, replicatePort.toInt)
   }
 
-  def fromWorkerSummary(summary: WorkerId): WorkerInfo = {
+  def fromWorkerId(workerId: WorkerId): WorkerInfo = {
     new WorkerInfo(
-      summary.host,
-      summary.rpcPort,
-      summary.pushPort,
-      summary.fetchPort,
-      summary.replicatePort)
+      workerId.host,
+      workerId.rpcPort,
+      workerId.pushPort,
+      workerId.fetchPort,
+      workerId.replicatePort)
   }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1000,12 +1000,16 @@ private[celeborn] class Master(
     // unknown workers will retain in needCheckedWorkerList
     needCheckedWorkerList.removeAll(workersSnapShot)
     if (shouldResponse) {
+      val excludedList =
+        (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
+          .map(WorkerInfo.toPrunedWorkerInfo).asJava
+      val shutdownList = shutdownWorkerSnapshot.asScala
+        .map(WorkerInfo.toPrunedWorkerInfo).asJava
       context.reply(HeartbeatFromApplicationResponse(
         StatusCode.SUCCESS,
-        new util.ArrayList(
-          (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala).asJava),
+        new util.ArrayList(excludedList),
         needCheckedWorkerList,
-        shutdownWorkerSnapshot))
+        new util.ArrayList(shutdownList)))
     } else {
       context.reply(OneWayMessageResponse)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
WorkerSummary is added as parent of WorkerInfo to be used in WorkerStatusTracker to reduce memory footprint 

### Why are the changes needed?
In our 1000+ nodes cluster, over 500 workers got excluded by master due to high disk usage, then master encountered severe gc pressure with app heartbeat. We found needCheckedWorkerList in HeartbeatFromApplication message can as large as 5M, and WorkerInfo contains lots of information that is not used by LifeCycleManager. The extra information(_diskInfos/_userResourceConsumption) can be removed to reduce message size


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

