### PR TITLE
[INFRA][FOLLOWUP] Fix copyright of mkdocs.yml for graduation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,11 @@ extra:
 
 copyright: >
   <br>
-  Copyright © 2024 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.
+  Copyright © 2022-2024 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.
   <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy<a/><br>
+  <br>
+  Apache Celeborn™, Apache, the Apache feather logo are trademarks or registered trademarks of The Apache Software Foundation.<br>
+  <br>
   Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<br>
   <br>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ copyright: >
   Copyright © 2022-2024 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.
   <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy<a/><br>
   <br>
-  Apache Celeborn™, Apache, the Apache feather logo are trademarks or registered trademarks of The Apache Software Foundation.<br>
+  Apache Celeborn™, Apache, and the Apache feather logo are trademarks or registered trademarks of The Apache Software Foundation.<br>
   <br>
   Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<br>
   <br>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `copyright` of `mkdocs.yml` for graduation.

### Why are the changes needed?

Follow https://github.com/apache/celeborn-website/pull/44#discussion_r1540556944.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.