### PR TITLE
[CELEBORN-1317][FOLLOWUP] Retry to setup mini cluster if the cause is BindException

### DIFF
--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResourceSuite.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.master
+package org.apache.celeborn.service.deploy.master.http.api
 
 import javax.ws.rs.core.MediaType
 
@@ -25,6 +25,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 import org.apache.celeborn.server.common.HttpService
 import org.apache.celeborn.server.common.http.ApiBaseResourceSuite
+import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 
 class ApiMasterResourceSuite extends ApiBaseResourceSuite {
   private var master: Master = _

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -51,6 +51,7 @@ private[celeborn] case class HttpServer(
 
   def stop(exitCode: Int): Unit = synchronized {
     if (isStarted) {
+
       stopInternal(exitCode)
     }
   }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -51,7 +51,6 @@ private[celeborn] case class HttpServer(
 
   def stop(exitCode: Int): Unit = synchronized {
     if (isStarted) {
-
       stopInternal(exitCode)
     }
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.service.deploy
 
+import java.io.IOException
 import java.net.BindException
 import java.nio.file.Files
 import java.util.concurrent.locks.{Lock, ReentrantLock}
@@ -70,7 +71,9 @@ trait MiniClusterFeature extends Logging {
         workers = w
         created = true
       } catch {
-        case e: BindException =>
+        case e: IOException
+            if e.isInstanceOf[BindException] || Option(e.getCause).exists(
+              _.isInstanceOf[BindException]) =>
           logError(s"failed to setup mini cluster, retrying (retry count: $retryCount)", e)
           retryCount += 1
           if (retryCount == 3) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
To fix the UT for http server port already in use issue.

For Jetty HttpServer, if failed to bind port, the exception is IOException and the cause is BindException, we should retry for that.

Before:
```
    case e: BindException => // retry to setup mini cluster
```

Now:
```
    case e: IOException
         if e.isInstanceOf[BindException] || Option(e.getCause).exists(
           _.isInstanceOf[BindException]) =>  // retry to setup mini cluster
```

### Why are the changes needed?

To fix the UT for http server port already in use issue.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Will trigger GA for 3 three times.