### PR TITLE
[CELEBORN-1317][FOLLOWUP] Remove Incubating from REST API Documentation

### DIFF
--- a/service/src/main/resources/org/apache/celeborn/swagger/index.html
+++ b/service/src/main/resources/org/apache/celeborn/swagger/index.html
@@ -19,7 +19,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Apache Celeborn(Incubating) REST API Documentation</title>
+    <title>Apache Celeborn REST API Documentation</title>
         <link rel="stylesheet" type="text/css" href="../swagger-static/swagger-ui.css" />
         <link rel="icon" type="image/png" href="../swagger-static/favicon-32x32.png" sizes="32x32" />
         <link rel="icon" type="image/png" href="../swagger-static/favicon-16x16.png" sizes="16x16" />

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
@@ -85,7 +85,7 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
     val apiUrl = s"http://${httpService.connectionUrl}/"
     openApi.info(
       new Info().title(
-        s"Apache Celeborn (Incubating) REST API Documentation")
+        s"Apache Celeborn REST API Documentation")
         .description(s"Role: ${httpService.serviceName}")
         .license(
           new License().name("Apache License 2.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove `Incubating` from REST API Documentation.

### Why are the changes needed?

The ASF board has approved a resolution to graduate Celeborn into a full Top Level Project. The REST API Documentation should remove `Incubating`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.