### PR TITLE
[CELEBORN-1360] Ensure that a client cannot push or fetch data belonging to a different application

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -354,7 +354,8 @@ public class TransportClient implements Closeable {
    * <p>Trying to set a different client ID after it's been set will result in an exception.
    */
   public void setClientId(String id) {
-    Preconditions.checkState(clientId == null, "Client ID has already been set.");
+    Preconditions.checkState(
+        clientId == null || clientId.equals(id), "Client ID has already been set.");
     this.clientId = id;
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
@@ -37,6 +37,8 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.celeborn.common.network.client.TransportClient;
+
 /**
  * A SASL Server for Celeborn which simply keeps track of the state of a single SASL session, from
  * the initial state to the "authenticated" state. (It is not a server in the sense of accepting
@@ -106,6 +108,7 @@ public class CelebornSaslServer {
    */
   static class DigestCallbackHandler implements CallbackHandler {
     private final SecretRegistry secretRegistry;
+    private final TransportClient client;
 
     /**
      * The use of 'volatile' is not necessary here because the 'handle' invocation includes both the
@@ -114,7 +117,8 @@ public class CelebornSaslServer {
      */
     private String userName = null;
 
-    DigestCallbackHandler(SecretRegistry secretRegistry) {
+    DigestCallbackHandler(TransportClient client, SecretRegistry secretRegistry) {
+      this.client = Preconditions.checkNotNull(client);
       this.secretRegistry = Preconditions.checkNotNull(secretRegistry);
     }
 
@@ -129,6 +133,7 @@ public class CelebornSaslServer {
             throw new SaslException("No username provided by client");
           }
           userName = decodeIdentifier(encodedName);
+          client.setClientId(userName);
         } else if (callback instanceof PasswordCallback) {
           logger.trace("SASL server callback: setting password");
           PasswordCallback pc = (PasswordCallback) callback;

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslRpcHandler.java
@@ -94,7 +94,7 @@ public class SaslRpcHandler extends AbstractAuthRpcHandler {
             new CelebornSaslServer(
                 DIGEST_MD5,
                 DEFAULT_SASL_SERVER_PROPS,
-                new CelebornSaslServer.DigestCallbackHandler(secretRegistry));
+                new CelebornSaslServer.DigestCallbackHandler(client, secretRegistry));
       }
       byte[] response = saslServer.response(saslMessage.getPayload().toByteArray());
       callback.onSuccess(ByteBuffer.wrap(response));

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationClientBootstrap.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationClientBootstrap.java
@@ -112,6 +112,7 @@ public class RegistrationClientBootstrap implements TransportClientBootstrap {
       register(client);
       LOG.info("Registration for {}", appId);
       registrationInfo.setRegistrationState(RegistrationInfo.RegistrationState.REGISTERED);
+      client.setClientId(appId);
     } catch (IOException | CelebornException e) {
       throw new RuntimeException(e);
     } finally {

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationRpcHandler.java
@@ -181,6 +181,7 @@ public class RegistrationRpcHandler extends BaseMessageHandler {
         LOG.trace("Application registration started {}", registerApplicationRequest.getId());
         processRegisterApplicationRequest(registerApplicationRequest, callback);
         registrationState = RegistrationState.REGISTERED;
+        client.setClientId(registerApplicationRequest.getId());
         LOG.info(
             "Application registered: appId {} rpcId {}",
             registerApplicationRequest.getId(),

--- a/common/src/main/java/org/apache/celeborn/common/network/server/BaseMessageHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BaseMessageHandler.java
@@ -46,4 +46,12 @@ public class BaseMessageHandler {
   public void channelInactive(TransportClient client) {}
 
   public void exceptionCaught(Throwable cause, TransportClient client) {}
+
+  protected void checkAuth(TransportClient client, String appId) {
+    if (client.getClientId() != null && !client.getClientId().equals(appId)) {
+      throw new SecurityException(
+          String.format(
+              "Client for %s not authorized for application %s.", client.getClientId(), appId));
+    }
+  }
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
@@ -40,12 +40,13 @@ public class CelebornSaslSuiteJ extends SaslTestBase {
             DIGEST_MD5,
             DEFAULT_SASL_CLIENT_PROPS,
             new CelebornSaslClient.ClientCallbackHandler(TEST_USER, TEST_SECRET));
+    TransportClient transportClient = mock(TransportClient.class);
     CelebornSaslServer server =
         new CelebornSaslServer(
             DIGEST_MD5,
             DEFAULT_SASL_SERVER_PROPS,
             new CelebornSaslServer.DigestCallbackHandler(
-                mock(TransportClient.class), secretRegistry));
+                transportClient, secretRegistry));
 
     assertFalse(client.isComplete());
     assertFalse(server.isComplete());
@@ -56,6 +57,7 @@ public class CelebornSaslSuiteJ extends SaslTestBase {
       clientMessage = client.response(server.response(clientMessage));
     }
     assertTrue(server.isComplete());
+    verify(transportClient, times(1)).setClientId(TEST_USER);
 
     // Disposal should invalidate
     server.dispose();

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
@@ -45,8 +45,7 @@ public class CelebornSaslSuiteJ extends SaslTestBase {
         new CelebornSaslServer(
             DIGEST_MD5,
             DEFAULT_SASL_SERVER_PROPS,
-            new CelebornSaslServer.DigestCallbackHandler(
-                transportClient, secretRegistry));
+            new CelebornSaslServer.DigestCallbackHandler(transportClient, secretRegistry));
 
     assertFalse(client.isComplete());
     assertFalse(server.isComplete());

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import org.junit.Test;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.server.BaseMessageHandler;
 import org.apache.celeborn.common.network.util.TransportConf;
 
@@ -43,7 +44,8 @@ public class CelebornSaslSuiteJ extends SaslTestBase {
         new CelebornSaslServer(
             DIGEST_MD5,
             DEFAULT_SASL_SERVER_PROPS,
-            new CelebornSaslServer.DigestCallbackHandler(secretRegistry));
+            new CelebornSaslServer.DigestCallbackHandler(
+                mock(TransportClient.class), secretRegistry));
 
     assertFalse(client.isComplete());
     assertFalse(server.isComplete());
@@ -73,7 +75,8 @@ public class CelebornSaslSuiteJ extends SaslTestBase {
         new CelebornSaslServer(
             DIGEST_MD5,
             DEFAULT_SASL_SERVER_PROPS,
-            new CelebornSaslServer.DigestCallbackHandler(secretRegistry));
+            new CelebornSaslServer.DigestCallbackHandler(
+                mock(TransportClient.class), secretRegistry));
 
     assertFalse(client.isComplete());
     assertFalse(server.isComplete());

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -147,7 +147,7 @@ class FetchHandler(
         val endIndices = openStreamList.getEndIndexList
         val readLocalFlags = openStreamList.getReadLocalShuffleList
         val pbOpenStreamListResponse = PbOpenStreamListResponse.newBuilder()
-
+        checkAuth(client, Utils.splitShuffleKey(shuffleKey)._1)
         0 until files.size() foreach { idx =>
           val pbStreamHandlerOpt = handleReduceOpenStreamInternal(
             client,
@@ -319,6 +319,7 @@ class FetchHandler(
       isLegacy: Boolean,
       readLocalShuffle: Boolean = false,
       callback: RpcResponseCallback): Unit = {
+    checkAuth(client, Utils.splitShuffleKey(shuffleKey)._1)
     workerSource.recordAppActiveConnection(client, shuffleKey)
     workerSource.startTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
     try {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -119,6 +119,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           client,
           pushData,
           pushData.requestId,
+          pushData.shuffleKey,
           () => {
             val partitionType =
               shufflePartitionType.getOrDefault(pushData.shuffleKey, PartitionType.REDUCE)
@@ -143,6 +144,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           client,
           pushMergedData,
           pushMergedData.requestId,
+          pushMergedData.shuffleKey,
           () =>
             handlePushMergedData(
               pushMergedData,
@@ -748,8 +750,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       client: TransportClient,
       message: RequestMessage,
       requestId: Long,
+      shuffleKey: String,
       handler: () => Unit,
       callback: RpcResponseCallback): Unit = {
+    checkAuth(client, Utils.splitShuffleKey(shuffleKey)._1)
     try {
       handler()
     } catch {
@@ -843,6 +847,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       client,
       rpcRequest,
       requestId,
+      shuffleKey,
       () =>
         handleMapPartitionRpcRequestCore(
           requestId,

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java
@@ -323,7 +323,7 @@ public class FetchHandlerSuiteJ {
     return fetchHandler;
   }
 
-  private final String shuffleKey = "dummyShuffleKey";
+  private final String shuffleKey = "dummyShuffleKey-123";
   private final String fileName = "dummyFileName";
   private final long dummyRequestId = 0;
 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriterSuiteJ.java
@@ -206,7 +206,7 @@ public class ReducePartitionDataWriterSuiteJ {
         new TransportMessage(
             MessageType.OPEN_STREAM,
             PbOpenStream.newBuilder()
-                .setShuffleKey("shuffleKey")
+                .setShuffleKey("shuffleKey-123")
                 .setFileName("location")
                 .setStartIndex(0)
                 .setEndIndex(Integer.MAX_VALUE)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This ensures that an authenticated client is not trying to push or fetch data which belongs to another application.

### Why are the changes needed?
The changes are needed for authentication support.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
