### PR TITLE
[CELEBORN-1317][FOLLOWUP] ServerConnector supports celeborn.master.http.stopTimeout and celeborn.worker.http.stopTimeout

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -125,6 +125,7 @@ object HttpServer {
     connector.setPort(port)
     connector.setReuseAddress(!SystemUtils.IS_OS_WINDOWS)
     connector.setAcceptQueueSize(math.min(connector.getAcceptors, 8))
+    connector.setStopTimeout(stopTimeout)
 
     new HttpServer(role, server, connector, collection)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ServerConnector` supports `celeborn.master.http.stopTimeout` and `celeborn.worker.http.stopTimeout`.

### Why are the changes needed?

Jetty `Server` supports `celeborn.master.http.stopTimeout` and `celeborn.worker.http.stopTimeout`, but `ServerConnector` does not support, which default stop timeout is 5min.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local test.