### PR TITLE
[CELEBORN-1370] Exception with authentication is enabled when creating send-application-meta thread pool

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -4813,7 +4813,7 @@ object CelebornConf extends Logging {
       .doc("Number of threads used by the Master to send ApplicationMeta to Workers.")
       .version("0.5.0")
       .intConf
-      .checkValue(v => v > 0, "number of threads should be positive")
+      .checkValue(_ > 0, "number of threads should be positive")
       .createWithDefault(8)
 
   val WORKER_APPLICATION_REGISTRY_CACHE_SIZE: ConfigEntry[Int] =

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -4813,6 +4813,7 @@ object CelebornConf extends Logging {
       .doc("Number of threads used by the Master to send ApplicationMeta to Workers.")
       .version("0.5.0")
       .intConf
+      .checkValue(v => v > 0, "number of threads should be positive")
       .createWithDefault(8)
 
   val WORKER_APPLICATION_REGISTRY_CACHE_SIZE: ConfigEntry[Int] =

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -78,6 +78,9 @@ private[celeborn] class Master(
 
   private val authEnabled = conf.authEnabled
   private val secretRegistry = new MasterSecretRegistryImpl()
+  private val sendApplicationMetaThreads = conf.masterSendApplicationMetaThreads
+  // Send ApplicationMeta to workers
+  private var sendApplicationMetaExecutor: ExecutorService = _
 
   override val rpcEnv: RpcEnv =
     if (!authEnabled) {
@@ -258,9 +261,6 @@ private[celeborn] class Master(
       internalRpcEndpoint)
   }
 
-  private val sendApplicationMetaThreads = conf.masterSendApplicationMetaThreads
-  // Send ApplicationMeta to workers
-  private var sendApplicationMetaExecutor: ExecutorService = _
   // Maintains the mapping for the workers assigned to each application
   private val workersAssignedToApp
       : util.concurrent.ConcurrentHashMap[String, util.Set[WorkerInfo]] =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Change the initialization order, so that `sendApplicationMetaThreads` has been initialized before the dispatcher initalizes for master.
Currently it ends up being `0` as `onStart` ends up getting called as part of object creation - before `sendApplicationMetaThreads` has been initialized (and so ends up with default value of `0`).


### Why are the changes needed?

Ensure `sendApplicationMetaExecutor` is created when auth is enabled, and rest of `Master.onStart` completes.


### Does this PR introduce _any_ user-facing change?

No, fixes a bug in master.

### How was this patch tested?

Local deployment, existing unit tests.