### PR TITLE
[CELEBORN-1371] Update ratis with internal port endpoint address as well

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -175,7 +175,8 @@ public class MasterClient {
     // 'CelebornException: Exception thrown in awaitResult'
     if (e.getCause() instanceof MasterNotLeaderException) {
       MasterNotLeaderException exception = (MasterNotLeaderException) e.getCause();
-      String leaderAddr = exception.getSuggestedLeaderAddress();
+      String leaderAddr = isWorker ? exception.getSuggestedInternalLeaderAddress():
+              exception.getSuggestedLeaderAddress();
       if (!leaderAddr.equals(MasterNotLeaderException.LEADER_NOT_PRESENTED)) {
         setRpcEndpointRef(leaderAddr);
       } else {

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -175,8 +175,10 @@ public class MasterClient {
     // 'CelebornException: Exception thrown in awaitResult'
     if (e.getCause() instanceof MasterNotLeaderException) {
       MasterNotLeaderException exception = (MasterNotLeaderException) e.getCause();
-      String leaderAddr = isWorker ? exception.getSuggestedInternalLeaderAddress():
-              exception.getSuggestedLeaderAddress();
+      String leaderAddr =
+          isWorker
+              ? exception.getSuggestedInternalLeaderAddress()
+              : exception.getSuggestedLeaderAddress();
       if (!leaderAddr.equals(MasterNotLeaderException.LEADER_NOT_PRESENTED)) {
         setRpcEndpointRef(leaderAddr);
       } else {

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -37,15 +37,19 @@ public class MasterNotLeaderException extends IOException {
     this(currentPeer, suggestedLeaderPeer, suggestedLeaderPeer, cause);
   }
 
-  public MasterNotLeaderException(String currentPeer,
-      String suggestedLeaderPeer, String suggestedInternalLeaderPeer, @Nullable Throwable cause) {
+  public MasterNotLeaderException(
+      String currentPeer,
+      String suggestedLeaderPeer,
+      String suggestedInternalLeaderPeer,
+      @Nullable Throwable cause) {
     super(
         String.format(
             "Master:%s is not the leader.%s%s",
             currentPeer,
             currentPeer.equals(suggestedLeaderPeer)
                 ? StringUtils.EMPTY
-                : String.format(" Suggested leader is Master:%s (%s).",
+                : String.format(
+                    " Suggested leader is Master:%s (%s).",
                     suggestedLeaderPeer, suggestedInternalLeaderPeer),
             cause == null
                 ? StringUtils.EMPTY

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -28,26 +28,38 @@ public class MasterNotLeaderException extends IOException {
   private static final long serialVersionUID = -2552475565785098271L;
 
   private final String leaderPeer;
+  private final String internalLeaderPeer;
 
   public static final String LEADER_NOT_PRESENTED = "leader is not present";
 
   public MasterNotLeaderException(
       String currentPeer, String suggestedLeaderPeer, @Nullable Throwable cause) {
+    this(currentPeer, suggestedLeaderPeer, suggestedLeaderPeer, cause);
+  }
+
+  public MasterNotLeaderException(String currentPeer,
+      String suggestedLeaderPeer, String suggestedInternalLeaderPeer, @Nullable Throwable cause) {
     super(
         String.format(
             "Master:%s is not the leader.%s%s",
             currentPeer,
             currentPeer.equals(suggestedLeaderPeer)
                 ? StringUtils.EMPTY
-                : String.format(" Suggested leader is Master:%s.", suggestedLeaderPeer),
+                : String.format(" Suggested leader is Master:%s (%s).",
+                    suggestedLeaderPeer, suggestedInternalLeaderPeer),
             cause == null
                 ? StringUtils.EMPTY
                 : String.format(" Exception:%s.", cause.getMessage())),
         cause);
     this.leaderPeer = suggestedLeaderPeer;
+    this.internalLeaderPeer = suggestedInternalLeaderPeer;
   }
 
   public String getSuggestedLeaderAddress() {
     return leaderPeer;
+  }
+
+  public String getSuggestedInternalLeaderAddress() {
+    return internalLeaderPeer;
   }
 }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 
+import scala.Tuple2;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
@@ -31,7 +33,6 @@ import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.rpc.RpcCallContext;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
-import scala.Tuple2;
 
 public class HAHelper {
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.service.deploy.master.clustermeta.ha;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.protocol.Message;
@@ -30,6 +31,7 @@ import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.rpc.RpcCallContext;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
+import scala.Tuple2;
 
 public class HAHelper {
 
@@ -50,11 +52,13 @@ public class HAHelper {
       RpcCallContext context, HARaftServer ratisServer, Throwable cause) {
     if (context != null) {
       if (ratisServer != null) {
-        if (ratisServer.getCachedLeaderPeerRpcEndpoint().isPresent()) {
+        Optional<Tuple2<String, String>> leaderPeer = ratisServer.getCachedLeaderPeerRpcEndpoint();
+        if (leaderPeer.isPresent()) {
           context.sendFailure(
               new MasterNotLeaderException(
                   ratisServer.getRpcEndpoint(),
-                  ratisServer.getCachedLeaderPeerRpcEndpoint().get(),
+                  leaderPeer.get()._1(),
+                  leaderPeer.get()._2(),
                   cause));
         } else {
           context.sendFailure(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -202,8 +202,13 @@ public class HARaftServer {
           raftPeers.add(raftPeer);
         });
     return new HARaftServer(
-        metaHandler, conf, localRaftPeerId, ratisAddr, localNode.rpcEndpoint(),
-        localNode.internalRpcEndpoint(), raftPeers);
+        metaHandler,
+        conf,
+        localRaftPeerId,
+        ratisAddr,
+        localNode.rpcEndpoint(),
+        localNode.internalRpcEndpoint(),
+        raftPeers);
   }
 
   public ResourceResponse submitRequest(ResourceProtos.ResourceRequest request)
@@ -465,7 +470,8 @@ public class HARaftServer {
               roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getClientAddress();
           // We use admin address to host the internal rpc address
           if (conf.internalPortEnabled()) {
-            leaderPeerInternalRpcEndpoint = roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getAdminAddress();
+            leaderPeerInternalRpcEndpoint =
+                roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getAdminAddress();
           } else {
             leaderPeerInternalRpcEndpoint = leaderPeerRpcEndpoint;
           }
@@ -487,8 +493,10 @@ public class HARaftServer {
   }
 
   /** Set the current server role and the leader peer rpc endpoint. */
-  private void setServerRole(RaftProtos.RaftPeerRole currentRole,
-      String leaderPeerRpcEndpoint, String leaderPeerInternalRpcEndpoint) {
+  private void setServerRole(
+      RaftProtos.RaftPeerRole currentRole,
+      String leaderPeerRpcEndpoint,
+      String leaderPeerInternalRpcEndpoint) {
     this.roleCheckLock.writeLock().lock();
     try {
       boolean leaderChanged = false;
@@ -510,7 +518,7 @@ public class HARaftServer {
       this.cachedPeerRole = Optional.ofNullable(currentRole);
       if (null != leaderPeerRpcEndpoint) {
         this.cachedLeaderPeerRpcEndpoints =
-                Optional.of(Tuple2.apply(leaderPeerRpcEndpoint, leaderPeerInternalRpcEndpoint));
+            Optional.of(Tuple2.apply(leaderPeerRpcEndpoint, leaderPeerInternalRpcEndpoint));
       } else {
         this.cachedLeaderPeerRpcEndpoints = Optional.empty();
       }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterClusterInfo.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterClusterInfo.scala
@@ -43,13 +43,8 @@ object MasterClusterInfo extends Logging {
       val ratisPort = conf.haMasterRatisPort(nodeId)
       val rpcHost = conf.haMasterNodeHost(nodeId)
       val rpcPort = conf.haMasterNodePort(nodeId)
-      val internalPort = {
-        if (conf.internalPortEnabled) {
-          conf.haMasterNodeInternalPort(nodeId)
-        } else {
-          rpcPort
-        }
-      }
+      val internalPort =
+        if (conf.internalPortEnabled) conf.haMasterNodeInternalPort(nodeId) else rpcPort
       MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort, internalPort)
     }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterClusterInfo.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterClusterInfo.scala
@@ -43,7 +43,14 @@ object MasterClusterInfo extends Logging {
       val ratisPort = conf.haMasterRatisPort(nodeId)
       val rpcHost = conf.haMasterNodeHost(nodeId)
       val rpcPort = conf.haMasterNodePort(nodeId)
-      MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort)
+      val internalPort = {
+        if (conf.internalPortEnabled) {
+          conf.haMasterNodeInternalPort(nodeId)
+        } else {
+          rpcPort
+        }
+      }
+      MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort, internalPort)
     }
 
     val (localNodes, peerNodes) = localNodeIdOpt match {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -93,7 +93,8 @@ object MasterNode extends Logging {
       this
     }
 
-    def build: MasterNode = MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort, internalRpcPort)
+    def build: MasterNode =
+      MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort, internalRpcPort)
   }
 
   private def createSocketAddr(host: String, port: Int): InetSocketAddress = {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -29,7 +29,8 @@ case class MasterNode(
     ratisHost: String,
     ratisPort: Int,
     rpcHost: String,
-    rpcPort: Int) {
+    rpcPort: Int,
+    internalRpcPort: Int) {
 
   def isRatisHostUnresolved: Boolean = ratisAddr.isUnresolved
 
@@ -38,6 +39,8 @@ case class MasterNode(
   def ratisEndpoint: String = ratisHost + ":" + ratisPort
 
   def rpcEndpoint: String = rpcHost + ":" + rpcPort
+
+  def internalRpcEndpoint: String = rpcHost + ":" + internalRpcPort
 
   lazy val ratisAddr = MasterNode.createSocketAddr(ratisHost, ratisPort)
 
@@ -52,6 +55,7 @@ object MasterNode extends Logging {
     private var ratisPort = 0
     private var rpcHost: String = _
     private var rpcPort = 0
+    private var internalRpcPort = 0
 
     def setNodeId(nodeId: String): this.type = {
       this.nodeId = nodeId
@@ -84,7 +88,12 @@ object MasterNode extends Logging {
       this
     }
 
-    def build: MasterNode = MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort)
+    def setInternalRpcPort(internalRpcPort: Int): this.type = {
+      this.internalRpcPort = internalRpcPort
+      this
+    }
+
+    def build: MasterNode = MasterNode(nodeId, ratisHost, ratisPort, rpcHost, rpcPort, internalRpcPort)
   }
 
   private def createSocketAddr(host: String, port: Int): InetSocketAddress = {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import scala.Tuple2;
+
 import org.junit.*;
 import org.mockito.Mockito;
 
@@ -43,7 +45,6 @@ import org.apache.celeborn.common.rpc.netty.NettyRpcEndpointRef;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
-import scala.Tuple2;
 
 public class RatisMasterStatusSystemSuiteJ {
   protected static HARaftServer RATISSERVER1 = null;
@@ -186,11 +187,14 @@ public class RatisMasterStatusSystemSuiteJ {
 
     // Check if the rpc endpoint and internal rpc endpoint of the leader is as expected.
 
-    HARaftServer leader = RATISSERVER1.isLeader() ? RATISSERVER1 :
-        (RATISSERVER2.isLeader() ? RATISSERVER2 : RATISSERVER3);
+    HARaftServer leader =
+        RATISSERVER1.isLeader()
+            ? RATISSERVER1
+            : (RATISSERVER2.isLeader() ? RATISSERVER2 : RATISSERVER3);
     // one of them must be the follower given the three servers we have
     HARaftServer follower = RATISSERVER1.isLeader() ? RATISSERVER2 : RATISSERVER1;
-    Optional<Tuple2<String, String>> cachedLeaderPeerRpcEndpoint = follower.getCachedLeaderPeerRpcEndpoint();
+    Optional<Tuple2<String, String>> cachedLeaderPeerRpcEndpoint =
+        follower.getCachedLeaderPeerRpcEndpoint();
 
     Assert.assertTrue(cachedLeaderPeerRpcEndpoint.isPresent());
     Assert.assertEquals(leader.getRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get()._1());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -193,6 +193,11 @@ public class RatisMasterStatusSystemSuiteJ {
             : (RATISSERVER2.isLeader() ? RATISSERVER2 : RATISSERVER3);
     // one of them must be the follower given the three servers we have
     HARaftServer follower = RATISSERVER1.isLeader() ? RATISSERVER2 : RATISSERVER1;
+
+    // This is expected to be false, but as a side effect, updates getCachedLeaderPeerRpcEndpoint
+    boolean isFollowerCurrentLeader = follower.isLeader();
+    Assert.assertFalse(isFollowerCurrentLeader);
+
     Optional<Tuple2<String, String>> cachedLeaderPeerRpcEndpoint =
         follower.getCachedLeaderPeerRpcEndpoint();
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -43,6 +43,7 @@ import org.apache.celeborn.common.rpc.netty.NettyRpcEndpointRef;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
+import scala.Tuple2;
 
 public class RatisMasterStatusSystemSuiteJ {
   protected static HARaftServer RATISSERVER1 = null;
@@ -127,6 +128,7 @@ public class RatisMasterStatusSystemSuiteJ {
                 .setHost(Utils.localHostName(conf1))
                 .setRatisPort(ratisPort1)
                 .setRpcPort(ratisPort1)
+                .setInternalRpcPort(ratisPort1)
                 .setNodeId(id1)
                 .build();
         MasterNode masterNode2 =
@@ -134,6 +136,7 @@ public class RatisMasterStatusSystemSuiteJ {
                 .setHost(Utils.localHostName(conf2))
                 .setRatisPort(ratisPort2)
                 .setRpcPort(ratisPort2)
+                .setInternalRpcPort(ratisPort2)
                 .setNodeId(id2)
                 .build();
         MasterNode masterNode3 =
@@ -141,6 +144,7 @@ public class RatisMasterStatusSystemSuiteJ {
                 .setHost(Utils.localHostName(conf3))
                 .setRatisPort(ratisPort3)
                 .setRpcPort(ratisPort3)
+                .setInternalRpcPort(ratisPort3)
                 .setNodeId(id3)
                 .build();
 
@@ -179,6 +183,18 @@ public class RatisMasterStatusSystemSuiteJ {
     boolean hasLeader =
         RATISSERVER1.isLeader() || RATISSERVER2.isLeader() || RATISSERVER3.isLeader();
     Assert.assertTrue(hasLeader);
+
+    // Check if the rpc endpoint and internal rpc endpoint of the leader is as expected.
+
+    HARaftServer leader = RATISSERVER1.isLeader() ? RATISSERVER1 :
+        (RATISSERVER2.isLeader() ? RATISSERVER2 : RATISSERVER3);
+    // one of them must be the follower given the three servers we have
+    HARaftServer follower = RATISSERVER1.isLeader() ? RATISSERVER2 : RATISSERVER1;
+    Optional<Tuple2<String, String>> cachedLeaderPeerRpcEndpoint = follower.getCachedLeaderPeerRpcEndpoint();
+
+    Assert.assertTrue(cachedLeaderPeerRpcEndpoint.isPresent());
+    Assert.assertEquals(leader.getRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get()._1());
+    Assert.assertEquals(leader.getInternalRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get()._2());
   }
 
   private static final String HOSTNAME1 = "host1";


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MasterNotLeaderException` should include not just the rpc address for applications, but also the internal rpc address (based on internal port) for workers to connect to the leader.

I am leveraging `adminAddress` in order to persist this information in ratis state - and have client reconnect to the right rpc endpoint based on whether it is application or worker.

### Why are the changes needed?

Without this fix, workers connect to rpc endpoint which applications use (and not at internal port) when `MasterNotLeaderException` is thrown - resulting in failures.


### Does this PR introduce _any_ user-facing change?

No, bug fix.

### How was this patch tested?

Tested with a local deployment - 3 masters + 2 workers, with authentication and internal port enabled.
Without the fix, one or more worker fails to come up and fails with exception.

Additionally, existing tests pass and test updated.
