### PR TITLE
[CELEBORN-1372] Update ControlMessages to handle ApplicationMeta and ApplicationMetaRequest

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -891,6 +891,12 @@ object ControlMessages extends Logging {
 
     case pb: PbCheckWorkersAvailableResponse =>
       new TransportMessage(MessageType.CHECK_WORKERS_AVAILABLE_RESPONSE, pb.toByteArray)
+
+    case pb: PbApplicationMeta =>
+      new TransportMessage(MessageType.APPLICATION_META, pb.toByteArray)
+
+    case pb: PbApplicationMetaRequest =>
+      new TransportMessage(MessageType.APPLICATION_META_REQUEST, pb.toByteArray)
   }
 
   // TODO change return type to GeneratedMessageV3
@@ -1238,6 +1244,12 @@ object ControlMessages extends Logging {
 
       case CHECK_WORKERS_AVAILABLE_RESPONSE_VALUE =>
         PbCheckWorkersAvailableResponse.parseFrom(message.getPayload)
+
+      case APPLICATION_META_VALUE =>
+        PbApplicationMeta.parseFrom(message.getPayload)
+
+      case APPLICATION_META_REQUEST_VALUE =>
+        PbApplicationMetaRequest.parseFrom(message.getPayload)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

With authentication enabled, rpc requests from executors to driver and vice versa fail when trying to send/receive `ApplicationMeta` and `ApplicationMetaRequest`.


### Why are the changes needed?

Executor is unable to communicate with the driver with auth enabled.


### Does this PR introduce _any_ user-facing change?

No, bug fix for feature introduced in 0.5


### How was this patch tested?

Tested with spark 3.1 against a patched version of Celeborn (pre-reqs: #2445, #2446)