### PR TITLE
[CELEBORN-1376] Push data failed should always release request body

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -284,7 +284,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      client.pushData(pushData, pushDataTimeout, callback, closeCallBack);
+      client.pushData(pushData, pushDataTimeout, callback, closeCallBack, null);
     } catch (Exception e) {
       logger.error(
           "Exception raised while pushing data byteBuf for shuffle {} map {} attempt {} partitionId {} batch {} location {}.",

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -284,8 +284,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      client.pushData(
-          pushData, pushDataTimeout, callback, closeCallBack, () -> pushData.body().release());
+      client.pushData(pushData, pushDataTimeout, callback, closeCallBack);
     } catch (Exception e) {
       logger.error(
           "Exception raised while pushing data byteBuf for shuffle {} map {} attempt {} partitionId {} batch {} location {}.",

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -284,7 +284,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      client.pushData(pushData, pushDataTimeout, callback, closeCallBack, null);
+      client.pushData(pushData, pushDataTimeout, callback, closeCallBack);
     } catch (Exception e) {
       logger.error(
           "Exception raised while pushing data byteBuf for shuffle {} map {} attempt {} partitionId {} batch {} location {}.",

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -284,7 +284,8 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      client.pushData(pushData, pushDataTimeout, callback, closeCallBack, null);
+      client.pushData(
+          pushData, pushDataTimeout, callback, closeCallBack, () -> pushData.body().release());
     } catch (Exception e) {
       logger.error(
           "Exception raised while pushing data byteBuf for shuffle {} map {} attempt {} partitionId {} batch {} location {}.",

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -111,7 +111,7 @@ public class FlinkShuffleClientImplSuiteJ {
   @Test
   public void testPushDataByteBufFail() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    when(client.pushData(any(), anyLong(), any(), any()))
+    when(client.pushData(any(), anyLong(), any(), any(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback = t.getArgument(1, RpcResponseCallback.class);

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -216,13 +216,14 @@ public class TransportClient implements Closeable {
       long pushDataTimeout,
       RpcResponseCallback callback,
       Runnable rpcSendoutCallback) {
-    Runnable rpcFailureCallback = () -> {
-      try {
-        pushData.body().release();
-      } catch (Throwable e) {
-        logger.error("Error release buffer for PUSH_DATA request " + pushData.requestId, e);
-      }
-    };
+    Runnable rpcFailureCallback =
+        () -> {
+          try {
+            pushData.body().release();
+          } catch (Throwable e) {
+            logger.error("Error release buffer for PUSH_DATA request " + pushData.requestId, e);
+          }
+        };
     return pushData(pushData, pushDataTimeout, callback, rpcSendoutCallback, rpcFailureCallback);
   }
 
@@ -250,15 +251,16 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcFailureCallback = () -> {
-      try {
-        pushMergedData.body().release();
-      } catch (Throwable e) {
-        logger.error("Error release buffer for PUSH_MERGED_DATA request " + pushMergedData.requestId, e);
-      }
-    };
-    return pushMergedData(
-        pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
+    Runnable rpcFailureCallback =
+        () -> {
+          try {
+            pushMergedData.body().release();
+          } catch (Throwable e) {
+            logger.error(
+                "Error release buffer for PUSH_MERGED_DATA request " + pushMergedData.requestId, e);
+          }
+        };
+    return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
   public ChannelFuture pushMergedData(

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -207,14 +207,15 @@ public class TransportClient implements Closeable {
   }
 
   public ChannelFuture pushData(
-      PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcFailureCallback =
-        new Runnable() {
-          @Override
-          public void run() {
-            pushData.body().release();
-          }
-        };
+      PushData pushData,
+      long pushDataTimeout,
+      RpcResponseCallback callback) {
+    Runnable rpcFailureCallback = new Runnable() {
+      @Override
+      public void run() {
+        pushData.body().release();
+      }
+    };
     return pushData(pushData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
@@ -241,14 +242,15 @@ public class TransportClient implements Closeable {
   }
 
   public ChannelFuture pushMergedData(
-      PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcFailureCallback =
-        new Runnable() {
-          @Override
-          public void run() {
-            pushMergedData.body().release();
-          }
-        };
+      PushMergedData pushMergedData,
+      long pushDataTimeout,
+      RpcResponseCallback callback) {
+    Runnable rpcFailureCallback = new Runnable() {
+      @Override
+      public void run() {
+        pushMergedData.body().release();
+      }
+    };
     return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
@@ -450,7 +452,9 @@ public class TransportClient implements Closeable {
     }
 
     PushChannelListener(
-        long pushRequestId, Runnable rpcSendOutCallback, Runnable rpcFailureCallback) {
+        long pushRequestId,
+        Runnable rpcSendOutCallback,
+        Runnable rpcFailureCallback) {
       super("PUSH " + pushRequestId);
       this.pushRequestId = pushRequestId;
       this.rpcSendOutCallback = rpcSendOutCallback;
@@ -468,7 +472,7 @@ public class TransportClient implements Closeable {
     @Override
     protected void handleFailure(String errorMsg, Throwable cause) {
       handler.handlePushFailure(pushRequestId, errorMsg, cause);
-      if (rpcFailureCallback != null) {
+      if(rpcFailureCallback != null) {
         rpcFailureCallback.run();
       }
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -208,14 +208,7 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushData(
       PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcFailureCallback =
-        new Runnable() {
-          @Override
-          public void run() {
-            pushData.body().release();
-          }
-        };
-    return pushData(pushData, pushDataTimeout, callback, null, rpcFailureCallback);
+    return pushData(pushData, pushDataTimeout, callback, null, () -> pushData.body().release());
   }
 
   public ChannelFuture pushData(
@@ -242,14 +235,8 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcFailureCallback =
-        new Runnable() {
-          @Override
-          public void run() {
-            pushMergedData.body().release();
-          }
-        };
-    return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
+    return pushMergedData(
+        pushMergedData, pushDataTimeout, callback, null, () -> pushMergedData.body().release());
   }
 
   public ChannelFuture pushMergedData(

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -208,13 +208,12 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushData(
       PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcSendoutCallback =
-        new Runnable() {
-          @Override
-          public void run() {
-            pushData.body().release();
-          }
-        };
+    Runnable rpcSendoutCallback = new Runnable() {
+      @Override
+      public void run() {
+        pushData.body().release();
+      }
+    };
     return pushData(pushData, pushDataTimeout, callback, rpcSendoutCallback);
   }
 
@@ -240,13 +239,12 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcSendoutCallback =
-        new Runnable() {
-          @Override
-          public void run() {
-            pushMergedData.body().release();
-          }
-        };
+    Runnable rpcSendoutCallback = new Runnable() {
+      @Override
+      public void run() {
+        pushMergedData.body().release();
+      }
+    };
     return pushMergedData(pushMergedData, pushDataTimeout, callback, rpcSendoutCallback);
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -208,13 +208,7 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushData(
       PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcSendoutCallback = new Runnable() {
-      @Override
-      public void run() {
-        pushData.body().release();
-      }
-    };
-    return pushData(pushData, pushDataTimeout, callback, rpcSendoutCallback);
+    return pushData(pushData, pushDataTimeout, callback, null);
   }
 
   public ChannelFuture pushData(
@@ -239,20 +233,6 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcSendoutCallback = new Runnable() {
-      @Override
-      public void run() {
-        pushMergedData.body().release();
-      }
-    };
-    return pushMergedData(pushMergedData, pushDataTimeout, callback, rpcSendoutCallback);
-  }
-
-  public ChannelFuture pushMergedData(
-      PushMergedData pushMergedData,
-      long pushDataTimeout,
-      RpcResponseCallback callback,
-      Runnable rpcSendoutCallback) {
     if (logger.isTraceEnabled()) {
       logger.trace("Pushing merged data to {}", NettyUtils.getRemoteAddress(channel));
     }
@@ -263,7 +243,7 @@ public class TransportClient implements Closeable {
     handler.addPushRequest(requestId, info);
     pushMergedData.requestId = requestId;
 
-    PushChannelListener listener = new PushChannelListener(requestId, rpcSendoutCallback);
+    PushChannelListener listener = new PushChannelListener(requestId);
     ChannelFuture channelFuture = channel.writeAndFlush(pushMergedData).addListener(listener);
     info.setChannelFuture(channelFuture);
     return channelFuture;

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -257,7 +257,9 @@ public class TransportClient implements Closeable {
             pushMergedData.body().release();
           } catch (Throwable e) {
             logger.error(
-                "Error release buffer for PUSH_MERGED_DATA request {}", pushMergedData.requestId, e);
+                "Error release buffer for PUSH_MERGED_DATA request {}",
+                pushMergedData.requestId,
+                e);
           }
         };
     return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -215,13 +215,14 @@ public class TransportClient implements Closeable {
             pushData.body().release();
           }
         };
-    return pushData(pushData, pushDataTimeout, callback, rpcFailureCallback);
+    return pushData(pushData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
   public ChannelFuture pushData(
       PushData pushData,
       long pushDataTimeout,
       RpcResponseCallback callback,
+      Runnable rpcSendoutCallback,
       Runnable rpcFailureCallback) {
     if (logger.isTraceEnabled()) {
       logger.trace("Pushing data to {}", NettyUtils.getRemoteAddress(channel));
@@ -232,7 +233,8 @@ public class TransportClient implements Closeable {
     PushRequestInfo info = new PushRequestInfo(dueTime, callback);
     handler.addPushRequest(requestId, info);
     pushData.requestId = requestId;
-    PushChannelListener listener = new PushChannelListener(requestId, rpcFailureCallback);
+    PushChannelListener listener =
+        new PushChannelListener(requestId, rpcSendoutCallback, rpcFailureCallback);
     ChannelFuture channelFuture = channel.writeAndFlush(pushData).addListener(listener);
     info.setChannelFuture(channelFuture);
     return channelFuture;
@@ -247,13 +249,14 @@ public class TransportClient implements Closeable {
             pushMergedData.body().release();
           }
         };
-    return pushMergedData(pushMergedData, pushDataTimeout, callback, rpcFailureCallback);
+    return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData,
       long pushDataTimeout,
       RpcResponseCallback callback,
+      Runnable rpcSendoutCallback,
       Runnable rpcFailureCallback) {
     if (logger.isTraceEnabled()) {
       logger.trace("Pushing merged data to {}", NettyUtils.getRemoteAddress(channel));
@@ -265,7 +268,8 @@ public class TransportClient implements Closeable {
     handler.addPushRequest(requestId, info);
     pushMergedData.requestId = requestId;
 
-    PushChannelListener listener = new PushChannelListener(requestId, rpcFailureCallback);
+    PushChannelListener listener =
+        new PushChannelListener(requestId, rpcSendoutCallback, rpcFailureCallback);
     ChannelFuture channelFuture = channel.writeAndFlush(pushMergedData).addListener(listener);
     info.setChannelFuture(channelFuture);
     return channelFuture;
@@ -437,21 +441,28 @@ public class TransportClient implements Closeable {
 
   private class PushChannelListener extends StdChannelListener {
     final long pushRequestId;
+    Runnable rpcSendOutCallback;
+
     Runnable rpcFailureCallback;
 
     PushChannelListener(long pushRequestId) {
-      this(pushRequestId, null);
+      this(pushRequestId, null, null);
     }
 
-    PushChannelListener(long pushRequestId, Runnable rpcFailureCallback) {
+    PushChannelListener(
+        long pushRequestId, Runnable rpcSendOutCallback, Runnable rpcFailureCallback) {
       super("PUSH " + pushRequestId);
       this.pushRequestId = pushRequestId;
+      this.rpcSendOutCallback = rpcSendOutCallback;
       this.rpcFailureCallback = rpcFailureCallback;
     }
 
     @Override
     public void operationComplete(Future<? super Void> future) throws Exception {
       super.operationComplete(future);
+      if (rpcSendOutCallback != null) {
+        rpcSendOutCallback.run();
+      }
     }
 
     @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -207,15 +207,14 @@ public class TransportClient implements Closeable {
   }
 
   public ChannelFuture pushData(
-      PushData pushData,
-      long pushDataTimeout,
-      RpcResponseCallback callback) {
-    Runnable rpcFailureCallback = new Runnable() {
-      @Override
-      public void run() {
-        pushData.body().release();
-      }
-    };
+      PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
+    Runnable rpcFailureCallback =
+        new Runnable() {
+          @Override
+          public void run() {
+            pushData.body().release();
+          }
+        };
     return pushData(pushData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
@@ -242,15 +241,14 @@ public class TransportClient implements Closeable {
   }
 
   public ChannelFuture pushMergedData(
-      PushMergedData pushMergedData,
-      long pushDataTimeout,
-      RpcResponseCallback callback) {
-    Runnable rpcFailureCallback = new Runnable() {
-      @Override
-      public void run() {
-        pushMergedData.body().release();
-      }
-    };
+      PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
+    Runnable rpcFailureCallback =
+        new Runnable() {
+          @Override
+          public void run() {
+            pushMergedData.body().release();
+          }
+        };
     return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
   }
 
@@ -452,9 +450,7 @@ public class TransportClient implements Closeable {
     }
 
     PushChannelListener(
-        long pushRequestId,
-        Runnable rpcSendOutCallback,
-        Runnable rpcFailureCallback) {
+        long pushRequestId, Runnable rpcSendOutCallback, Runnable rpcFailureCallback) {
       super("PUSH " + pushRequestId);
       this.pushRequestId = pushRequestId;
       this.rpcSendOutCallback = rpcSendOutCallback;
@@ -472,7 +468,7 @@ public class TransportClient implements Closeable {
     @Override
     protected void handleFailure(String errorMsg, Throwable cause) {
       handler.handlePushFailure(pushRequestId, errorMsg, cause);
-      if(rpcFailureCallback != null) {
+      if (rpcFailureCallback != null) {
         rpcFailureCallback.run();
       }
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -208,12 +208,13 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushData(
       PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcSendoutCallback = new Runnable() {
-      @Override
-      public void run() {
-        pushData.body().release();
-      }
-    };
+    Runnable rpcSendoutCallback =
+        new Runnable() {
+          @Override
+          public void run() {
+            pushData.body().release();
+          }
+        };
     return pushData(pushData, pushDataTimeout, callback, rpcSendoutCallback);
   }
 
@@ -239,12 +240,13 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcSendoutCallback = new Runnable() {
-      @Override
-      public void run() {
-        pushMergedData.body().release();
-      }
-    };
+    Runnable rpcSendoutCallback =
+        new Runnable() {
+          @Override
+          public void run() {
+            pushMergedData.body().release();
+          }
+        };
     return pushMergedData(pushMergedData, pushDataTimeout, callback, rpcSendoutCallback);
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -221,7 +221,7 @@ public class TransportClient implements Closeable {
           try {
             pushData.body().release();
           } catch (Throwable e) {
-            logger.error("Error release buffer for PUSH_DATA request " + pushData.requestId, e);
+            logger.error("Error release buffer for PUSH_DATA request {}", pushData.requestId, e);
           }
         };
     return pushData(pushData, pushDataTimeout, callback, rpcSendoutCallback, rpcFailureCallback);
@@ -257,7 +257,7 @@ public class TransportClient implements Closeable {
             pushMergedData.body().release();
           } catch (Throwable e) {
             logger.error(
-                "Error release buffer for PUSH_MERGED_DATA request " + pushMergedData.requestId, e);
+                "Error release buffer for PUSH_MERGED_DATA request {}", pushMergedData.requestId, e);
           }
         };
     return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Worker netty not release
<img width="1729" alt="截屏2024-04-07 17 26 40" src="https://github.com/apache/celeborn/assets/46485123/5774f735-570b-448e-ab94-4c78661717f5">

Many push failed
<img width="767" alt="截屏2024-04-07 17 27 46" src="https://github.com/apache/celeborn/assets/46485123/41866bd0-d634-4dbf-8518-b474c8d1faad">



1. For spark shuffle client, enable it release push data body when rpc failure
2. For flink client, since it use wrapped bytbuf, we need release push data body when rpc failure and release origin body when rpc completed.
3. For worker replicate, we should enable it release push data body when rpc failure.


### Why are the changes needed?
Avoid worker netty memory leak


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

