### PR TITLE
[CELEBORN-1378] Call PartitionDataWriter#flush() before submitting to commitThreadPool

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -156,9 +156,9 @@ public abstract class PartitionDataWriter implements DeviceObserver {
     numPendingWrites.decrementAndGet();
   }
 
-  protected void flush(boolean finalFlush) throws IOException {
+  public void flush(boolean finalFlush) throws IOException {
     synchronized (flushLock) {
-      // flushBuffer == null here means writer already closed
+      // flushBuffer == null here means final flush already been called
       if (flushBuffer != null) {
         int numBytes = flushBuffer.readableBytes();
         if (numBytes != 0) {
@@ -416,12 +416,6 @@ public abstract class PartitionDataWriter implements DeviceObserver {
   @Override
   public String toString() {
     return diskFileInfo.getFilePath();
-  }
-
-  public void flushOnMemoryPressure() throws IOException {
-    synchronized (flushLock) {
-      flush(false);
-    }
   }
 
   public long getSplitThreshold() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriter.java
@@ -68,7 +68,7 @@ public final class ReducePartitionDataWriter extends PartitionDataWriter {
   }
 
   @Override
-  protected void flush(boolean finalFlush) throws IOException {
+  public void flush(boolean finalFlush) throws IOException {
     super.flush(finalFlush);
     maybeSetChunkOffsets(finalFlush);
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -671,7 +671,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           override def accept(file: String, writer: PartitionDataWriter): Unit = {
             if (writer.getException == null) {
               try {
-                writer.flushOnMemoryPressure()
+                writer.flush(false)
               } catch {
                 case t: Throwable =>
                   logError(
@@ -688,7 +688,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     })
     hdfsWriters.forEach(new BiConsumer[String, PartitionDataWriter] {
       override def accept(t: String, u: PartitionDataWriter): Unit = {
-        u.flushOnMemoryPressure()
+        u.flush(false)
       }
     })
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
There are high commit files latency in some production environments. This PR triggers flush before
calling close to avoid waiting in commitThreadPool.


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Passes GA.
