### PR TITLE
[CELEBORN-1379] Catch Throwable for ReadBufferDispatcher thread.

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
@@ -91,8 +91,7 @@ public class ReadBufferDispatcher extends Thread {
             } else {
               try {
                 // If dispatcher can not allocate requested buffers, it will wait here until
-                // necessary
-                // buffers are get.
+                // necessary buffers are get.
                 Thread.sleep(this.readBufferAllocationWait);
               } catch (InterruptedException e) {
                 logger.info("Buffer dispatcher is closing");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Catch throwable and release unused buffers.


### Why are the changes needed?
When the BufferAllocator tries to allocate a new ByteBuf, it may throw an OutOfDirectMemoryError. We should catch Throwable in ReadBufferDispatcher to avoid the thread from exiting.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA
