### PR TITLE
[CELEBORN-1381] Avoid construct TransportConf when creating CelebornInputStream

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -216,9 +216,7 @@ public abstract class CelebornInputStream extends InputStream {
       } else {
         fetchChunkMaxRetry = conf.clientFetchMaxRetriesForEachReplica();
       }
-      TransportConf transportConf =
-          Utils.fromCelebornConf(conf, TransportModuleConstants.DATA_MODULE, 0);
-      retryWaitMs = transportConf.ioRetryWaitTimeMs();
+      this.retryWaitMs = conf.networkIoRetryWaitMs(TransportModuleConstants.DATA_MODULE);
       this.callback = metricsCallback;
       this.exceptionMaker = exceptionMaker;
       this.partitionId = partitionId;

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -38,7 +38,6 @@ import org.apache.celeborn.client.compress.Decompressor;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
-import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.*;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.ExceptionMaker;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Get retryWaitMs directly from conf when creating CelebornInputStream.


### Why are the changes needed?
It is unnecessary to construct TransportConf here.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test.
