### PR TITLE
[CELEBORN-1382] Bump RoaringBitmap version from 0.9.32 to 1.0.5

### DIFF
--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-flink-1.19
+++ b/dev/deps/dependencies-client-flink-1.19
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -16,7 +16,7 @@
 #
 
 HikariCP-java7/2.4.12//HikariCP-java7-2.4.12.jar
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 aopalliance/1.0//aopalliance-1.0.jar
 asm-commons/9.4//asm-commons-9.4.jar
 asm-tree/9.4//asm-tree-9.4.jar
@@ -188,7 +188,6 @@ re2j/1.1//re2j-1.1.jar
 reload4j/1.2.22//reload4j-1.2.22.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 slf4j-reload4j/1.7.36//slf4j-reload4j-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.11.12//scala-library-2.11.12.jar
 scala-reflect/2.11.12//scala-reflect-2.11.12.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.10//scala-library-2.12.10.jar
 scala-reflect/2.12.10//scala-reflect-2.12.10.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.10//scala-library-2.12.10.jar
 scala-reflect/2.12.10//scala-reflect-2.12.10.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.15//scala-library-2.12.15.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.15//scala-library-2.12.15.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.17//scala-library-2.12.17.jar
 scala-reflect/2.12.17//scala-reflect-2.12.17.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -79,7 +79,6 @@ ratis-proto/2.5.1//ratis-proto-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -16,7 +16,7 @@
 #
 
 HikariCP/4.0.3//HikariCP-4.0.3.jar
-RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar
 ap-loader-all/3.0-8//ap-loader-all-3.0-8.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
@@ -131,7 +131,6 @@ reflections/0.10.2//reflections-0.10.2.jar
 rocksdbjni/8.11.3//rocksdbjni-8.11.3.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
-shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <ratis.version>2.5.1</ratis.version>
     <scalatest.version>3.2.16</scalatest.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <roaringbitmap.version>0.9.32</roaringbitmap.version>
+    <roaringbitmap.version>1.0.5</roaringbitmap.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <zstd-jni.version>1.5.2-1</zstd-jni.version>
     <kubernetes-client.version>6.7.0</kubernetes-client.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val mockitoVersion = "4.11.0"
   val nettyVersion = "4.1.107.Final"
   val ratisVersion = "2.5.1"
-  val roaringBitmapVersion = "0.9.32"
+  val roaringBitmapVersion = "1.0.5"
   val rocksdbJniVersion = "8.11.3"
   val jacksonVersion = "2.15.3"
   val scalatestMockitoVersion = "1.17.14"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump RoaringBitmap version from 0.9.32 to 1.0.5.

### Why are the changes needed?

RoaringBitmap has released v1.0.5, which release note refers to [1.0.5](https://github.com/RoaringBitmap/RoaringBitmap/releases/tag/1.0.5). This version includes some bugfixes and improvements including:

- Fix roaringbitmap - batchiterator's advanceIfNeeded to handle run lengths of zero.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.