### PR TITLE
[CELEBORN-1236][FOLLOWUP] Gauge is_terminating, is_terminated and is_shutdown should represent a single numerical value

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/ThreadPoolSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/ThreadPoolSource.scala
@@ -83,25 +83,25 @@ class ThreadPoolSource(
     addGauge(
       "is_terminating",
       label,
-      new Gauge[Boolean] {
-        override def getValue: Boolean = {
-          threadPoolExecutor.isTerminating
+      new Gauge[Int] {
+        override def getValue: Int = {
+          if (threadPoolExecutor.isTerminating) 1 else 0
         }
       })
     addGauge(
       "is_terminated",
       label,
-      new Gauge[Boolean] {
-        override def getValue: Boolean = {
-          threadPoolExecutor.isTerminated
+      new Gauge[Int] {
+        override def getValue: Int = {
+          if (threadPoolExecutor.isTerminated) 1 else 0
         }
       })
     addGauge(
       "is_shutdown",
       label,
-      new Gauge[Boolean] {
-        override def getValue: Boolean = {
-          threadPoolExecutor.isShutdown
+      new Gauge[Int] {
+        override def getValue: Int = {
+          if (threadPoolExecutor.isShutdown) 1 else 0
         }
       })
   }
@@ -129,7 +129,7 @@ class ThreadPoolSource(
       label,
       new Gauge[Int] {
         override def getValue: Int = {
-          threads.size
+          threads.length
         }
       })
     addGauge(

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -141,6 +141,9 @@ These metrics are exposed by Celeborn master.
     - is_terminating
     - is_terminated
     - is_shutdown
+    - thread_count
+    - thread_is_terminated_count
+    - thread_is_shutdown_count
 
 #### Worker
 These metrics are exposed by Celeborn worker.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Gauge `is_terminating`, `is_terminated` and `is_shutdown` should represent a single numerical value instead of boolean value.

### Why are the changes needed?

A gauge is a metric that represents a single numerical value that can arbitrarily go up and down. The value type of `is_terminating`, `is_terminated` and `is_shutdown` should be numerical, otherwise `AbstractSource#addGauge` would warn the failed log as follows:

```
2024-04-12 20:04:12,438 [WARN] [main] - org.apache.celeborn.common.metrics.source.ThreadPoolSource -Logging.scala(55) -Add gauge is_terminating failed, the value type class java.lang.Boolean is not a number
2024-04-12 20:04:12,438 [WARN] [main] - org.apache.celeborn.common.metrics.source.ThreadPoolSource -Logging.scala(55) -Add gauge is_terminated failed, the value type class java.lang.Boolean is not a number
2024-04-12 20:04:12,438 [WARN] [main] - org.apache.celeborn.common.metrics.source.ThreadPoolSource -Logging.scala(55) -Add gauge is_shutdown failed, the value type class java.lang.Boolean is not a number
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.