### PR TITLE
[CELEBORN-1388] Use finer grained locks in changePartitionManager

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -49,7 +49,7 @@ class ChangePartitionManager(
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Integer, JSet[ChangePartitionRequest]]]()
 
   // shuffleId -> locks
-  private val locks = JavaUtils.newConcurrentHashMap[Int,Array[AnyRef]]()
+  private val locks = JavaUtils.newConcurrentHashMap[Int, Array[AnyRef]]()
   private val lockBucketSize = conf.batchHandleChangePartitionBuckets
 
   // shuffleId -> set of partition id
@@ -140,7 +140,7 @@ class ChangePartitionManager(
         ConcurrentHashMap.newKeySet[Int]()
     }
 
-  private val locksRegisterFunc =  new util.function.Function[Int, Array[AnyRef]] {
+  private val locksRegisterFunc = new util.function.Function[Int, Array[AnyRef]] {
     override def apply(t: Int): Array[AnyRef] = {
       Array.fill(lockBucketSize)(new AnyRef())
     }

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -87,7 +87,7 @@ class ChangePartitionManager(
                         requests.asScala.map { case (partitionId, request) =>
                           locks(partitionId % locks.length).synchronized {
                             if (!requestSet.contains(partitionId)) {
-                              requestSet.put(partitionId, Unit)
+                              requestSet.put(partitionId, ())
                               Some(request.asScala.toArray.maxBy(_.epoch))
                             } else {
                               None

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -47,7 +47,7 @@ class ChangePartitionManager(
   // shuffleId -> (partitionId -> set of ChangePartition)
   private val changePartitionRequests =
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Integer, JSet[ChangePartitionRequest]]]()
-  private val locks = Array.fill(conf.batchHandleChangePartitionParallelism)(new AnyRef())
+  private val locks = Array.fill(conf.batchHandleChangePartitionBuckets)(new AnyRef())
 
   // shuffleId -> set of partition id
   private val inBatchPartitions =

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -159,7 +159,8 @@ class ChangePartitionManager(
 
     locks(partitionId % locks.length).synchronized {
       var newEntry = false
-      val set = requests.computeIfAbsent(partitionId,
+      val set = requests.computeIfAbsent(
+        partitionId,
         (_: Integer) => {
           newEntry = true
           new util.HashSet[ChangePartitionRequest]()

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -161,9 +161,11 @@ class ChangePartitionManager(
       var newEntry = false
       val set = requests.computeIfAbsent(
         partitionId,
-        (_: Integer) => {
-          newEntry = true
-          new util.HashSet[ChangePartitionRequest]()
+        new java.util.function.Function[Integer, util.Set[ChangePartitionRequest]] {
+          override def apply(t: Integer): util.Set[ChangePartitionRequest] = {
+            newEntry = true
+            new util.HashSet[ChangePartitionRequest]()
+          }
         })
 
       if (newEntry) {

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -85,7 +85,7 @@ class ChangePartitionManager(
                         val requestSet = inBatchPartitions.get(shuffleId)
                         requests.asScala.map { case (partitionId, request) =>
                           locks(partitionId % locks.length).synchronized {
-                            if (!inBatchPartitions.contains(partitionId)) {
+                            if (!requestSet.contains(partitionId)) {
                               requestSet.add(partitionId)
                               Some(request.asScala.toArray.maxBy(_.epoch))
                             } else {

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -51,7 +51,7 @@ class ChangePartitionManager(
 
   // shuffleId -> set of partition id
   private val inBatchPartitions =
-    JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap.KeySetView[Int, Unit]]()
+    JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap.KeySetView[Int, java.lang.Boolean]]()
 
   private val batchHandleChangePartitionEnabled = conf.batchHandleChangePartitionEnabled
   private val batchHandleChangePartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
@@ -131,9 +131,9 @@ class ChangePartitionManager(
     }
 
   private val inBatchShuffleIdRegisterFunc =
-    new util.function.Function[Int, ConcurrentHashMap.KeySetView[Int, Unit]]() {
-      override def apply(s: Int): ConcurrentHashMap.KeySetView[Int, Unit] =
-        JavaUtils.newConcurrentHashMap[Int, Unit]().keySet()
+    new util.function.Function[Int, ConcurrentHashMap.KeySetView[Int, java.lang.Boolean]]() {
+      override def apply(s: Int): ConcurrentHashMap.KeySetView[Int, java.lang.Boolean] =
+        ConcurrentHashMap.newKeySet[Int]()
     }
 
   def handleRequestPartitionLocation(

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -3904,8 +3904,7 @@ object CelebornConf extends Logging {
   val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM: ConfigEntry[Int] =
     buildConf("celeborn.client.shuffle.batchHandleChangePartition.parallelism")
       .categories("client")
-      .internal
-      .doc("max number of change partition requests which can be concurrently processed ")
+      .doc("Max number of change partition requests which can be concurrently processed ")
       .version("0.5.0")
       .intConf
       .createWithDefault(256)

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -914,6 +914,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     PartitionSplitMode.valueOf(get(SHUFFLE_PARTITION_SPLIT_MODE))
   def shufflePartitionSplitThreshold: Long = get(SHUFFLE_PARTITION_SPLIT_THRESHOLD)
   def batchHandleChangePartitionEnabled: Boolean = get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_ENABLED)
+  def batchHandleChangePartitionParallelism: Int =
+    get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM)
   def batchHandleChangePartitionNumThreads: Int = get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_THREADS)
   def batchHandleChangePartitionRequestInterval: Long =
     get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_INTERVAL)
@@ -3898,6 +3900,15 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .booleanConf
       .createWithDefault(true)
+
+  val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM: ConfigEntry[Int] =
+    buildConf("celeborn.client.shuffle.batchHandleChangePartition.parallelism")
+      .categories("client")
+      .internal
+      .doc("max number of change partition requests which can be concurrently processed ")
+      .version("0.5.0")
+      .intConf
+      .createWithDefault(256)
 
   val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.client.shuffle.batchHandleChangePartition.threads")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -914,8 +914,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     PartitionSplitMode.valueOf(get(SHUFFLE_PARTITION_SPLIT_MODE))
   def shufflePartitionSplitThreshold: Long = get(SHUFFLE_PARTITION_SPLIT_THRESHOLD)
   def batchHandleChangePartitionEnabled: Boolean = get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_ENABLED)
-  def batchHandleChangePartitionParallelism: Int =
-    get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM)
+  def batchHandleChangePartitionBuckets: Int =
+    get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_BUCKETS)
   def batchHandleChangePartitionNumThreads: Int = get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_THREADS)
   def batchHandleChangePartitionRequestInterval: Long =
     get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_INTERVAL)
@@ -3901,8 +3901,8 @@ object CelebornConf extends Logging {
       .booleanConf
       .createWithDefault(true)
 
-  val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM: ConfigEntry[Int] =
-    buildConf("celeborn.client.shuffle.batchHandleChangePartition.parallelism")
+  val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_BUCKETS: ConfigEntry[Int] =
+    buildConf("celeborn.client.shuffle.batchHandleChangePartition.partitionBuckets")
       .categories("client")
       .doc("Max number of change partition requests which can be concurrently processed ")
       .version("0.5.0")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -81,6 +81,7 @@ license: |
 | celeborn.client.rpc.reserveSlots.askTimeout | &lt;value of celeborn.rpc.askTimeout&gt; | false | Timeout for LifecycleManager request reserve slots. | 0.3.0 |  | 
 | celeborn.client.rpc.shared.threads | 16 | false | Number of shared rpc threads in LifecycleManager. | 0.3.2 |  | 
 | celeborn.client.shuffle.batchHandleChangePartition.interval | 100ms | false | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.3.0 | celeborn.shuffle.batchHandleChangePartition.interval | 
+| celeborn.client.shuffle.batchHandleChangePartition.parallelism | 256 | false | Max number of change partition requests which can be concurrently processed  | 0.5.0 |  | 
 | celeborn.client.shuffle.batchHandleChangePartition.threads | 8 | false | Threads number for LifecycleManager to handle change partition request in batch. | 0.3.0 | celeborn.shuffle.batchHandleChangePartition.threads | 
 | celeborn.client.shuffle.batchHandleCommitPartition.interval | 5s | false | Interval for LifecycleManager to schedule handling commit partition requests in batch. | 0.3.0 | celeborn.shuffle.batchHandleCommitPartition.interval | 
 | celeborn.client.shuffle.batchHandleCommitPartition.threads | 8 | false | Threads number for LifecycleManager to handle commit partition request in batch. | 0.3.0 | celeborn.shuffle.batchHandleCommitPartition.threads | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -81,7 +81,7 @@ license: |
 | celeborn.client.rpc.reserveSlots.askTimeout | &lt;value of celeborn.rpc.askTimeout&gt; | false | Timeout for LifecycleManager request reserve slots. | 0.3.0 |  | 
 | celeborn.client.rpc.shared.threads | 16 | false | Number of shared rpc threads in LifecycleManager. | 0.3.2 |  | 
 | celeborn.client.shuffle.batchHandleChangePartition.interval | 100ms | false | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.3.0 | celeborn.shuffle.batchHandleChangePartition.interval | 
-| celeborn.client.shuffle.batchHandleChangePartition.parallelism | 256 | false | Max number of change partition requests which can be concurrently processed  | 0.5.0 |  | 
+| celeborn.client.shuffle.batchHandleChangePartition.partitionBuckets | 256 | false | Max number of change partition requests which can be concurrently processed  | 0.5.0 |  | 
 | celeborn.client.shuffle.batchHandleChangePartition.threads | 8 | false | Threads number for LifecycleManager to handle change partition request in batch. | 0.3.0 | celeborn.shuffle.batchHandleChangePartition.threads | 
 | celeborn.client.shuffle.batchHandleCommitPartition.interval | 5s | false | Interval for LifecycleManager to schedule handling commit partition requests in batch. | 0.3.0 | celeborn.shuffle.batchHandleCommitPartition.interval | 
 | celeborn.client.shuffle.batchHandleCommitPartition.threads | 8 | false | Threads number for LifecycleManager to handle commit partition request in batch. | 0.3.0 | celeborn.shuffle.batchHandleCommitPartition.threads | 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

this PR proposes to use finer grained lock in  changePartitionManager when handling requests for different partitions

### Why are the changes needed?

we observed the intensive competition of locks when there are many partition got split. most of  change-partition-executor threads are competing for the concurrenthashmap used in ChangePartitionManager...this concurrentHashMap is holding request per partition but we are lock at the whole map instead of per partition level, 

with this change, the driver memory footprint is significantly reduced due to the increased processing throughput... 

### Does this PR introduce _any_ user-facing change?

one more configs

### How was this patch tested?

prod