### PR TITLE
[CELEBORN-1389] Bump Dropwizard version from 3.2.6 to 4.2.25

### DIFF
--- a/assets/grafana/celeborn-jvm-dashboard.json
+++ b/assets/grafana/celeborn-jvm-dashboard.json
@@ -1245,6 +1245,42 @@
           "legendFormat": "daemon_${baseLegend}",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_peak_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "peak_${baseLegend}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_total_started_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "total_started_${baseLegend}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_deadlock_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "deadlock_${baseLegend}",
+          "range": true,
+          "refId": "F"
         }
       ],
       "title": "Thread Counts",
@@ -1400,18 +1436,6 @@
           "legendFormat": "terminated_${baseLegend}",
           "range": true,
           "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "metrics_jvm_thread_deadlock_count_Value{instance=~\"${instance}\"}",
-          "hide": false,
-          "legendFormat": "deadlock_${baseLegend}",
-          "range": true,
-          "refId": "G"
         }
       ],
       "title": "Thread States",

--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-flink-1.19
+++ b/dev/deps/dependencies-client-flink-1.19
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -17,6 +17,7 @@
 
 HikariCP-java7/2.4.12//HikariCP-java7-2.4.12.jar
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 aopalliance/1.0//aopalliance-1.0.jar
 asm-commons/9.4//asm-commons-9.4.jar
 asm-tree/9.4//asm-tree-9.4.jar
@@ -136,9 +137,9 @@ kotlin-stdlib/1.4.10//kotlin-stdlib-1.4.10.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 mssql-jdbc/6.2.1.jre7//mssql-jdbc-6.2.1.jre7.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.4.0//lz4-java-1.4.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -16,6 +16,7 @@
 #
 
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
@@ -34,9 +35,9 @@ jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar
 netty-buffer/4.1.107.Final//netty-buffer-4.1.107.Final.jar
 netty-codec-dns/4.1.107.Final//netty-codec-dns-4.1.107.Final.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -17,6 +17,7 @@
 
 HikariCP/4.0.3//HikariCP-4.0.3.jar
 RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
+amqp-client/5.20.0//amqp-client-5.20.0.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar
 ap-loader-all/3.0-8//ap-loader-all-3.0-8.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
@@ -75,9 +76,9 @@ log4j-core/2.17.2//log4j-core-2.17.2.jar
 log4j-slf4j-impl/2.17.2//log4j-slf4j-impl-2.17.2.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
-metrics-core/3.2.6//metrics-core-3.2.6.jar
-metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar
-metrics-jvm/3.2.6//metrics-jvm-3.2.6.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 mimepull/1.9.15//mimepull-1.9.15.jar
 mybatis/3.5.15//mybatis-3.5.15.jar
 netty-all/4.1.107.Final//netty-all-4.1.107.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <!-- use hadoop-3 as default  -->
     <hadoop.version>3.3.6</hadoop.version>
 
-    <codahale.metrics.version>3.2.6</codahale.metrics.version>
+    <codahale.metrics.version>4.2.25</codahale.metrics.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-io.version>2.13.0</commons-io.version>
     <commons-crypto.version>1.0.0</commons-crypto.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -53,7 +53,7 @@ object Dependencies {
   val leveldbJniVersion = "1.8"
   val log4j2Version = "2.17.2"
   val jdkToolsVersion = "0.1"
-  val metricsVersion = "3.2.6"
+  val metricsVersion = "4.2.25"
   val mockitoVersion = "4.11.0"
   val nettyVersion = "4.1.107.Final"
   val ratisVersion = "2.5.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Dropwizard version from 3.2.6 to 4.2.25. Meanwhile, introduce `metrics_jvm_thread_peak_count_Value` and `metrics_jvm_thread_total_started_count_Value` in `celeborn-jvm-dashboard.json`.

### Why are the changes needed?

Dropwizard metrics has released v4.2.25 including some bugfixes and improvements including:

* [JVM] Fix maximum/total memory calculation: https://github.com/dropwizard/metrics/pull/3125
* [Thread] Add peak and total started thread count to `ThreadStatesGaugeSet`: https://github.com/dropwizard/metrics/pull/1601

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.