### PR TITLE
[CELEBORN-1390] ServletContextHandler should allow null path info to avoid redirection

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpUtils.scala
@@ -75,7 +75,6 @@ private[celeborn] object HttpUtils extends Logging {
   def createStaticHandler(
       resourceBase: String,
       contextPath: String): ServletContextHandler = {
-    val contextHandler = new ServletContextHandler()
     val holder = new ServletHolder(classOf[DefaultServlet])
     Option(Thread.currentThread().getContextClassLoader.getResource(resourceBase)) match {
       case Some(res) =>
@@ -83,17 +82,12 @@ private[celeborn] object HttpUtils extends Logging {
       case None =>
         throw new CelebornException("Could not find resource path for Web UI: " + resourceBase)
     }
-    contextHandler.setContextPath(contextPath)
-    contextHandler.addServlet(holder, "/")
-    contextHandler
+    createContextHandler(contextPath, holder)
   }
 
   def createServletHandler(contextPath: String, servlet: HttpServlet): ServletContextHandler = {
-    val handler = new ServletContextHandler()
     val holder = new ServletHolder(servlet)
-    handler.setContextPath(contextPath)
-    handler.addServlet(holder, "/")
-    handler
+    createContextHandler(contextPath, holder)
   }
 
   def createRedirectHandler(src: String, dest: String): ServletContextHandler = {
@@ -124,5 +118,15 @@ private[celeborn] object HttpUtils extends Logging {
     }
 
     createServletHandler(src, redirectedServlet)
+  }
+
+  def createContextHandler(
+      contextPath: String,
+      servletHolder: ServletHolder): ServletContextHandler = {
+    val contextHandler = new ServletContextHandler()
+    contextHandler.setContextPath(contextPath)
+    contextHandler.addServlet(servletHolder, "/")
+    contextHandler.setAllowNullPathInfo(true)
+    contextHandler
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ServletContextHandler` allows null path info to avoid redirection via `setAllowNullPathInfo(true)`. 

### Why are the changes needed?

`ServletContextHandler` does not allow null path info which causes that `celeborn.metrics.prometheus.path` and `celeborn.metrics.json.path` could not access without redirection. For example:

```
celeborn@celeborn-test:/data/service/celeborn$ curl http://localhost:9096/metrics/prometheus
celeborn@celeborn-test:/data/service/celeborn$ curl http://localhost:9096/metrics/prometheus/
metrics_WriteDataHardSplitCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataWriteFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataConnectionExceptionCount_Count{role="Worker"} 0 1713182689795
metrics_FetchChunkFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataCreateConnectionFailCount_Count{role="Worker"} 0 1713182689795
metrics_WriteDataSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_FetchChunkSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataFailCount_Count{role="Worker"} 0 1713182689795
metrics_RegionStartFailCount_Count{role="Worker"} 0 1713182689795
metrics_RegionFinishFailCount_Count{role="Worker"} 0 1713182689795
metrics_ActiveConnectionCount_Count{role="Worker"} 0 1713182689795
metrics_SlotsAllocated_Count{role="Worker"} 0 1713182689795
metrics_OpenStreamSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_WriteDataFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataFailNonCriticalCauseCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataTimeoutCount_Count{role="Worker"} 0 1713182689795
metrics_PushDataHandshakeFailCount_Count{role="Worker"} 0 1713182689795
metrics_OpenStreamFailCount_Count{role="Worker"} 0 1713182689795
```

`ServletContextHandler` should allow null path info to avoid redirection via `setAllowNullPathInfo(true)`. `setAllowNullPathInfo()` sets true if `/context` is not redirected to `/context/`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `ApiMasterResourceSuite`
- `ApiWorkerResourceSuite`

```
celeborn@celeborn-test:/data/service/celeborn$ curl http://localhost:9096/metrics/prometheus
metrics_WriteDataHardSplitCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataWriteFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataConnectionExceptionCount_Count{role="Worker"} 0 1713182689795
metrics_FetchChunkFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataCreateConnectionFailCount_Count{role="Worker"} 0 1713182689795
metrics_WriteDataSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_FetchChunkSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataFailCount_Count{role="Worker"} 0 1713182689795
metrics_RegionStartFailCount_Count{role="Worker"} 0 1713182689795
metrics_RegionFinishFailCount_Count{role="Worker"} 0 1713182689795
metrics_ActiveConnectionCount_Count{role="Worker"} 0 1713182689795
metrics_SlotsAllocated_Count{role="Worker"} 0 1713182689795
metrics_OpenStreamSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_WriteDataFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataFailNonCriticalCauseCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataTimeoutCount_Count{role="Worker"} 0 1713182689795
metrics_PushDataHandshakeFailCount_Count{role="Worker"} 0 1713182689795
metrics_OpenStreamFailCount_Count{role="Worker"} 0 1713182689795
celeborn@celeborn-test:/data/service/celeborn$ curl http://localhost:9096/metrics/prometheus/
metrics_WriteDataHardSplitCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataWriteFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataConnectionExceptionCount_Count{role="Worker"} 0 1713182689795
metrics_FetchChunkFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataCreateConnectionFailCount_Count{role="Worker"} 0 1713182689795
metrics_WriteDataSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_FetchChunkSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataFailCount_Count{role="Worker"} 0 1713182689795
metrics_RegionStartFailCount_Count{role="Worker"} 0 1713182689795
metrics_RegionFinishFailCount_Count{role="Worker"} 0 1713182689795
metrics_ActiveConnectionCount_Count{role="Worker"} 0 1713182689795
metrics_SlotsAllocated_Count{role="Worker"} 0 1713182689795
metrics_OpenStreamSuccessCount_Count{role="Worker"} 0 1713182689795
metrics_WriteDataFailCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataFailNonCriticalCauseCount_Count{role="Worker"} 0 1713182689795
metrics_ReplicateDataTimeoutCount_Count{role="Worker"} 0 1713182689795
metrics_PushDataHandshakeFailCount_Count{role="Worker"} 0 1713182689795
metrics_OpenStreamFailCount_Count{role="Worker"} 0 1713182689795