### PR TITLE
[CELEBORN-1384] Manually excluding workers should not depend on whether the workers are alive

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -684,10 +684,7 @@ private[celeborn] class Master(
       workersToAdd: util.List[WorkerInfo],
       workersToRemove: util.List[WorkerInfo],
       requestId: String): Unit = {
-    statusSystem.handleWorkerExclude(
-      workersToAdd.asScala.filter(workersSnapShot.contains(_)).asJava,
-      workersToRemove.asScala.filter(workersSnapShot.contains(_)).asJava,
-      requestId)
+    statusSystem.handleWorkerExclude(workersToAdd, workersToRemove, requestId)
     if (context != null) {
       context.reply(WorkerExcludeResponse(true))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Manually excluding workers should not depend on whether the workers are alive or not for master.

### Why are the changes needed?

When the workers are offline, master could not add or remove workers through manually excluding workers. Therefore, master should support manually excluding workers no matter whether the workers are alive or not.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.