### PR TITLE
[CELEBORN-1380] Change default recoverDbBackend to ROCKSDB to support arm devices

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2917,12 +2917,12 @@ object CelebornConf extends Logging {
   val WORKER_GRACEFUL_SHUTDOWN_RECOVER_DB_BACKEND: ConfigEntry[String] =
     buildConf("celeborn.worker.graceful.shutdown.recoverDbBackend")
       .categories("worker")
-      .doc("Specifies a disk-based store used in local db. LEVELDB or ROCKSDB.")
+      .doc("Specifies a disk-based store used in local db. LEVELDB or ROCKSDB. If you are using arm devices, use ROCKSDB.")
       .version("0.4.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(Set("LEVELDB", "ROCKSDB"))
-      .createWithDefault("LEVELDB")
+      .createWithDefault("ROCKSDB")
 
   val WORKER_PARTITION_SORTER_SHUTDOWN_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout")

--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -316,7 +316,7 @@ public class MasterClientSuiteJ {
         .when(rpcEnv)
         .setupEndpointRef(Mockito.any(RpcAddress.class), Mockito.anyString());
 
-    MasterClient client = new MasterClient(rpcEnv, conf, false);
+    MasterClient client = new MasterClient(rpcEnv, conf);
     HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
 
     HeartbeatFromWorkerResponse response = null;

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -63,7 +63,7 @@ license: |
 | celeborn.worker.graceful.shutdown.checkSlotsFinished.timeout | 480s | The wait time of waiting for the released slots to be committed or destroyed during worker graceful shutdown. | 0.2.0 |  | 
 | celeborn.worker.graceful.shutdown.enabled | false | When true, during worker shutdown, the worker will wait for all released slots to be committed or destroyed. | 0.2.0 |  | 
 | celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout | 120s | The wait time of waiting for sorting partition files during worker graceful shutdown. | 0.2.0 |  | 
-| celeborn.worker.graceful.shutdown.recoverDbBackend | LEVELDB | Specifies a disk-based store used in local db. LEVELDB or ROCKSDB. | 0.4.0 |  | 
+| celeborn.worker.graceful.shutdown.recoverDbBackend | ROCKSDB | Specifies a disk-based store used in local db. LEVELDB or ROCKSDB. If you are using arm devices, use ROCKSDB. | 0.4.0 |  | 
 | celeborn.worker.graceful.shutdown.recoverPath | &lt;tmp&gt;/recover | The path to store DB. | 0.2.0 |  | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.interval | 5s | Interval for a Celeborn worker to flush committed file infos into Level DB. | 0.3.1 |  | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync | false | Whether to call sync method to save committed file infos into Level DB to handle OS crash. | 0.3.1 |  | 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBProviderSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBProviderSuiteJ.java
@@ -1,4 +1,3 @@
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change default recoverDbBackend to ROCKSDB to support arm devices.


### Why are the changes needed?
LEVELDB as the default value of recoverDbBackend will cause worker failed to start on arm devices.


### Does this PR introduce _any_ user-facing change?
Yes, this change should be mentioned in release note.


### How was this patch tested?
GA and cluster.
