### PR TITLE
[CELEBORN-1354][FOLLOWUP] Split rpc_app into rpc_app_lifecyclemanager and rpc_app_client

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -190,7 +190,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     rpcEnv =
         RpcEnv.create(
             RpcNameConstants.SHUFFLE_CLIENT_SYS,
-            TransportModuleConstants.RPC_APP_MODULE,
+            TransportModuleConstants.RPC_APP_CLIENT_MODULE,
             Utils.localHostName(conf),
             0,
             conf,

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -160,7 +160,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   // init driver celeborn LifecycleManager rpc service
   override val rpcEnv: RpcEnv = RpcEnv.create(
     RpcNameConstants.LIFECYCLE_MANAGER_SYS,
-    TransportModuleConstants.RPC_APP_MODULE,
+    TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE,
     lifecycleHost,
     conf.shuffleManagerPort,
     conf,

--- a/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
@@ -91,6 +91,15 @@ public class TransportContext implements Closeable {
     this.channelsLimiter = channelsLimiter;
     this.enableHeartbeat = enableHeartbeat;
     this.source = source;
+
+    if (null != this.sslFactory) {
+      logger.info(
+          "SSL factory created for module {}, has keys ? {}",
+          conf.getModuleName(),
+          this.sslFactory.hasKeyManagers());
+    } else {
+      logger.info("SSL not enabled for module = {}", conf.getModuleName());
+    }
   }
 
   public TransportContext(

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
@@ -244,8 +244,8 @@ public class TransportConf {
   }
 
   public boolean autoSslEnabled() {
-    // auto_ssl_enable is supported only for RPC_APP_MODULE
-    if (!TransportModuleConstants.RPC_APP_MODULE.equals(module)) return false;
+    // auto_ssl_enable is supported only for RPC_LIFECYCLEMANAGER_MODULE
+    if (!TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE.equals(module)) return false;
 
     // auto ssl must be enabled, and there should be no keystore or trust store configured
     boolean autoSslEnabled = celebornConf.isAutoSslEnabled(module);

--- a/common/src/main/java/org/apache/celeborn/common/protocol/TransportModuleConstants.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/TransportModuleConstants.java
@@ -24,10 +24,20 @@ public class TransportModuleConstants {
 
   // RPC module used by the application components to communicate with each other
   // This is used only at the application side.
+  // This is interally further split into RPC_LIFECYCLEMANAGER_MODULE and
+  // RPC_APP_CLIENT_MODULE - both of which inherit from RPC_APP_MODULE
+  // So for users, there is only RPC_APP_MODULE
   public static final String RPC_APP_MODULE = "rpc_app";
   // RPC module used to communicate with/between server components
   // This is used both at server (master/worker) and application side.
   public static final String RPC_SERVICE_MODULE = "rpc_service";
+
+  // See RPC_APP_MODULE for details - both RPC_LIFECYCLEMANAGER_MODULE and RPC_APP_CLIENT_MODULE
+  // are internal modules, and transport configs are not expected for these.
+  // For example, auto-ssl requires both RPC_LIFECYCLEMANAGER_MODULE and RPC_APP_CLIENT_MODULE
+  // to be in sync, though it is enabled only in RPC_LIFECYCLEMANAGER_MODULE
+  public static final String RPC_LIFECYCLEMANAGER_MODULE = "rpc_app_lifecyclemanager";
+  public static final String RPC_APP_CLIENT_MODULE = "rpc_app_client";
 
   // Both RPC_APP and RPC_SERVER fallsback to earlier RPC_MODULE for backward
   // compatibility

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -90,7 +90,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   private def warnIfInternalTransportModule(module: String, key: String): Unit = {
     // for now, assert false to test
     if (INTERNAL_TRANSPORT_MODULES.contains(module)) {
-      log.warn(s"$key configured for internal an transport module $module, " +
+      log.warn(s"$key configured for internal transport module $module, " +
         s"should be using ${INTERNAL_TRANSPORT_MODULES(module)} instead")
     }
   }
@@ -1409,7 +1409,8 @@ object CelebornConf extends Logging {
     // only for testing
     "test_child_module" -> "test_parent_module")
 
-  // These modules are internal to Celeborn, and users are not expected to directly configure them
+  // The keys are modules are internal to Celeborn, and users are not expected to directly
+  // configure them. The values give the user exposed module.
   val INTERNAL_TRANSPORT_MODULES: Map[String, String] = Map(
     TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE -> TransportModuleConstants.RPC_APP_MODULE,
     TransportModuleConstants.RPC_APP_CLIENT_MODULE -> TransportModuleConstants.RPC_APP_MODULE)

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -88,7 +88,6 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   }
 
   private def warnIfInternalTransportModule(module: String, key: String): Unit = {
-    // for now, assert false to test
     if (INTERNAL_TRANSPORT_MODULES.contains(module)) {
       log.warn(s"$key configured for internal transport module $module, " +
         s"should be using ${INTERNAL_TRANSPORT_MODULES(module)} instead")

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -198,7 +198,6 @@ private[celeborn] case class RpcEnvConfig(
 
 object RpcEnvConfig {
   private val VALID_TRANSPORT_MODULES = Set(
-    // These two are mainly for testing
     TransportModuleConstants.RPC_APP_MODULE,
     TransportModuleConstants.RPC_MODULE,
     TransportModuleConstants.RPC_APP_CLIENT_MODULE,

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -193,7 +193,15 @@ private[celeborn] case class RpcEnvConfig(
     port: Int,
     numUsableCores: Int,
     securityContext: Option[RpcSecurityContext]) {
-  assert(TransportModuleConstants.RPC_APP_MODULE == transportModule ||
-    TransportModuleConstants.RPC_SERVICE_MODULE == transportModule ||
-    TransportModuleConstants.RPC_MODULE == transportModule)
+  assert(RpcEnvConfig.VALID_TRANSPORT_MODULES.contains(transportModule))
+}
+
+object RpcEnvConfig {
+  private val VALID_TRANSPORT_MODULES = Set(
+    // These two are mainly for testing
+    TransportModuleConstants.RPC_APP_MODULE,
+    TransportModuleConstants.RPC_MODULE,
+    TransportModuleConstants.RPC_APP_CLIENT_MODULE,
+    TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE,
+    TransportModuleConstants.RPC_SERVICE_MODULE)
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -494,10 +494,19 @@ object Utils extends Logging {
     // assuming we have all the machine's cores).
     // NB: Only set if serverThreads/clientThreads not already set.
     val numThreads = defaultNumThreads(numUsableCores)
-    conf.setIfMissing(s"celeborn.$module.io.serverThreads", numThreads.toString)
-    conf.setIfMissing(s"celeborn.$module.io.clientThreads", numThreads.toString)
+    conf.setTransportConfIfMissing(
+      module,
+      CelebornConf.NETWORK_IO_SERVER_THREADS,
+      numThreads.toString)
+    conf.setTransportConfIfMissing(
+      module,
+      CelebornConf.NETWORK_IO_CLIENT_THREADS,
+      numThreads.toString)
     if (TransportModuleConstants.PUSH_MODULE == module) {
-      conf.setIfMissing(s"celeborn.$module.io.numConnectionsPerPeer", numThreads.toString)
+      conf.setTransportConfIfMissing(
+        module,
+        CelebornConf.NETWORK_IO_NUM_CONNECTIONS_PER_PEER,
+        numThreads.toString)
     }
 
     new TransportConf(module, conf)

--- a/common/src/test/java/org/apache/celeborn/common/network/AutoSSLRpcIntegrationSuite.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/AutoSSLRpcIntegrationSuite.java
@@ -30,12 +30,16 @@ import org.apache.celeborn.common.protocol.TransportModuleConstants;
 public class AutoSSLRpcIntegrationSuite extends RpcIntegrationSuiteJ {
   @BeforeClass
   public static void setUp() throws Exception {
-    // change it to client module
-    RpcIntegrationSuiteJ.TEST_MODULE = TransportModuleConstants.RPC_APP_MODULE;
+    // change it to lifecycle manager module
+    RpcIntegrationSuiteJ.TEST_MODULE = TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE;
     // set up SSL for TEST_MODULE
     RpcIntegrationSuiteJ.initialize(
         TestHelper.updateCelebornConfWithMap(
-            new CelebornConf(), SslSampleConfigs.createAutoSslConfigForModule(TEST_MODULE)));
+            new CelebornConf(),
+            // to validate, we are using TransportModuleConstants.RPC_APP_MODULE, to mirror how
+            // users will configure
+            SslSampleConfigs.createAutoSslConfigForModule(
+                TransportModuleConstants.RPC_APP_MODULE)));
   }
 
   @AfterClass

--- a/common/src/test/java/org/apache/celeborn/common/network/ssl/SslConnectivitySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/ssl/SslConnectivitySuiteJ.java
@@ -317,6 +317,7 @@ public class SslConnectivitySuiteJ {
 
     testSuccessfulConnectivity(
         TEST_MODULE,
+        TEST_MODULE,
         enableSsl,
         primaryConfigForServer,
         primaryConfigForClient,
@@ -325,7 +326,8 @@ public class SslConnectivitySuiteJ {
   }
 
   private void testSuccessfulConnectivity(
-      String module,
+      String serverModule,
+      String clientModule,
       boolean enableSsl,
       boolean primaryConfigForServer,
       boolean primaryConfigForClient,
@@ -336,9 +338,9 @@ public class SslConnectivitySuiteJ {
             new TestTransportState(
                 DEFAULT_HANDLER,
                 createTransportConf(
-                    module, enableSsl, primaryConfigForServer, postProcessServerConf),
+                    serverModule, enableSsl, primaryConfigForServer, postProcessServerConf),
                 createTransportConf(
-                    module, enableSsl, primaryConfigForClient, postProcessClientConf));
+                    clientModule, enableSsl, primaryConfigForClient, postProcessClientConf));
         TransportClient client = state.createClient()) {
 
       String msg = " hi ";
@@ -396,11 +398,11 @@ public class SslConnectivitySuiteJ {
 
   @Test
   public void testAutoSslConnectivity() throws Exception {
-    String module = TransportModuleConstants.RPC_MODULE;
 
-    final Function<CelebornConf, CelebornConf> updateConf =
+    final Function<CelebornConf, CelebornConf> updateServerConf =
         conf -> {
           // return a new config
+          String module = TransportModuleConstants.RPC_APP_MODULE;
           CelebornConf celebornConf = new CelebornConf();
           celebornConf.set("celeborn.ssl." + module + ".enabled", "true");
           celebornConf.set("celeborn.ssl." + module + ".protocol", "TLSv1.2");
@@ -408,9 +410,25 @@ public class SslConnectivitySuiteJ {
           return celebornConf;
         };
 
+    final Function<CelebornConf, CelebornConf> updateClientConf =
+        conf -> {
+          // return a new config
+          String module = TransportModuleConstants.RPC_APP_MODULE;
+          CelebornConf celebornConf = new CelebornConf();
+          celebornConf.set("celeborn.ssl." + module + ".enabled", "true");
+          celebornConf.set("celeborn.ssl." + module + ".protocol", "TLSv1.2");
+          return celebornConf;
+        };
+
     // checking nettyssl == false at both client and server does not make sense in this context
     // it is the same cert for both :)
     testSuccessfulConnectivity(
-        TransportModuleConstants.RPC_APP_MODULE, true, true, true, updateConf, updateConf);
+        TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE,
+        TransportModuleConstants.RPC_APP_CLIENT_MODULE,
+        true,
+        true,
+        true,
+        updateServerConf,
+        updateClientConf);
   }
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/ssl/SslConnectivitySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/ssl/SslConnectivitySuiteJ.java
@@ -299,8 +299,6 @@ public class SslConnectivitySuiteJ {
           return conf;
         };
 
-    // checking nettyssl == false at both client and server does not make sense in this context
-    // it is the same cert for both :)
     testSuccessfulConnectivity(true, true, true, updateConf, updateConf);
     testSuccessfulConnectivity(true, true, false, updateConf, updateConf);
     testSuccessfulConnectivity(true, false, true, updateConf, updateConf);
@@ -399,6 +397,10 @@ public class SslConnectivitySuiteJ {
   @Test
   public void testAutoSslConnectivity() throws Exception {
 
+    // Mirror how user will configure - so configure module based on RPC_APP_MODULE
+    // while create the server transport config for lifecycle manager (to match driver),
+    // and client to app_client similar to executors
+
     final Function<CelebornConf, CelebornConf> updateServerConf =
         conf -> {
           // return a new config
@@ -420,8 +422,6 @@ public class SslConnectivitySuiteJ {
           return celebornConf;
         };
 
-    // checking nettyssl == false at both client and server does not make sense in this context
-    // it is the same cert for both :)
     testSuccessfulConnectivity(
         TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE,
         TransportModuleConstants.RPC_APP_CLIENT_MODULE,

--- a/common/src/test/java/org/apache/celeborn/common/network/util/TransportConfSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/util/TransportConfSuiteJ.java
@@ -114,7 +114,7 @@ public class TransportConfSuiteJ {
     // for rpc_app module, it can be enabled.
     TransportConf conf =
         new TransportConf(
-            TransportModuleConstants.RPC_APP_MODULE,
+            TransportModuleConstants.RPC_LIFECYCLEMANAGER_MODULE,
             TestHelper.updateCelebornConfWithMap(
                 new CelebornConf(),
                 SslSampleConfigs.createAutoSslConfigForModule(

--- a/common/src/test/scala/org/apache/celeborn/common/rpc/RpcEnvSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/rpc/RpcEnvSuite.scala
@@ -666,7 +666,9 @@ abstract class RpcEnvSuite extends CelebornFunSuite {
   test("port conflict") {
     val anotherEnv = createRpcEnv(createCelebornConf(), "remote", env.address.port)
     try {
-      assert(anotherEnv.address.port != env.address.port)
+      assert(
+        anotherEnv.address.port != env.address.port,
+        s"new port = ${anotherEnv.address.port}, env port = ${env.address.port}")
     } finally {
       anotherEnv.shutdown()
       anotherEnv.awaitTermination()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Based on [review feedback here](https://github.com/apache/celeborn/pull/2469#discussion_r1573228448), split `rpc_app` module into two internal transport modules - `rpc_app_lifecyclemanager` and `rpc_app_client`.
These are not directly configured by users - but internally allow us to differentiate between lifecycle manager and executor

### Why are the changes needed?

auto ssl is to be configured only at lifecycle manager - doing it at executors is beneign, but not very useful (it results in creation of local files, etc).
Avoid this by handling it specifically only for lifecyclemanager.

This is based on [review feedback](https://github.com/apache/celeborn/pull/2469#discussion_r1573228448).


### Does this PR introduce _any_ user-facing change?
No, the modules are all internal and not user visible.


### How was this patch tested?
Unit tests were updated
