### PR TITLE
[CELEBORN-1397] Fix compilation error on branch-0.4

### DIFF
--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -316,7 +316,7 @@ public class MasterClientSuiteJ {
         .when(rpcEnv)
         .setupEndpointRef(Mockito.any(RpcAddress.class), Mockito.anyString());
 
-    MasterClient client = new MasterClient(rpcEnv, conf, false);
+    MasterClient client = new MasterClient(rpcEnv, conf);
     HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
 
     HeartbeatFromWorkerResponse response = null;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix MasterClient construct method use in MasterClientSuiteJ.


### Why are the changes needed?
MasterClient's construct method has changed by https://github.com/apache/celeborn/pull/2281 on main. It's a feature to support authentication on branch-0.5.

https://github.com/apache/celeborn/pull/2466 's backport on branch-0.4 here caused a conflict in MasterClientSuiteJ.java:319.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Local compile test.
