### PR TITLE
[CELEBORN-1399][FOLLOWUP] MR CelebornMapOutputCollector should check exception after flush

### DIFF
--- a/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
+++ b/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
@@ -177,9 +177,7 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
     conf.set("mapreduce.job.user.classpath.first", "true")
 
     conf.set("mapreduce.job.reduce.slowstart.completedmaps", "1")
-    conf.set(
-      "mapreduce.celeborn.master.endpoints",
-      s"errorhost:${master.conf.get(CelebornConf.MASTER_PORT)}")
+    conf.set("mapreduce.celeborn.master.endpoints", "errorhost:9097")
     conf.set(
       MRJobConfig.MAP_OUTPUT_COLLECTOR_CLASS_ATTR,
       "org.apache.hadoop.mapred.CelebornMapOutputCollector")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix compilation error on `WordCountTest` for MR of branch-0.4.

### Why are the changes needed?

MR `WordCountTest` compiles error, which should be fixed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.