### PR TITLE
[CELEBORN-1404][BUILD] Disable SBT ANSI color on extracting info from output

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -247,9 +247,9 @@ function build_mr_client {
 #########################
 
 function sbt_build_service {
-  VERSION=$("$SBT" "Show / version" | awk '/\[info\]/{ver=$2} END{print ver}')
+  VERSION=$("$SBT" -no-colors "Show / version" | awk '/\[info\]/{ver=$2} END{print ver}')
 
-  SCALA_VERSION=$("$SBT" "Show / scalaBinaryVersion" | awk '/\[info\]/{ver=$2} END{print ver}')
+  SCALA_VERSION=$("$SBT" -no-colors "Show / scalaBinaryVersion" | awk '/\[info\]/{ver=$2} END{print ver}')
 
   echo "Celeborn version is $VERSION"
   echo "Making apache-celeborn-$VERSION-$NAME.tgz"
@@ -288,9 +288,9 @@ function sbt_build_service {
 function sbt_build_client {
   PROFILE="$1"
   # get the client shaded project
-  CLIENT_PROJECT=$("$SBT" "$PROFILE" projects | grep shaded | awk '{print$2}')
+  CLIENT_PROJECT=$("$SBT" -no-colors "$PROFILE" projects | grep shaded | awk '{print$2}')
   # get the shaded jar file path
-  ASSEMBLY_OUTPUT_PATH=$("$SBT" "$PROFILE" "show $CLIENT_PROJECT/assembly/assemblyOutputPath" | awk '/\[info\]/{ver=$2} END{print ver}')
+  ASSEMBLY_OUTPUT_PATH=$("$SBT" -no-colors "$PROFILE" "show $CLIENT_PROJECT/assembly/assemblyOutputPath" | awk '/\[info\]/{ver=$2} END{print ver}')
   # build the shaded jar
   $SBT $PROFILE "clean;$CLIENT_PROJECT/assembly"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Disable SBT ANSI color with option `-no-colors` on extracting info from the output, to recover the binary tarball package on the CI environment. 

### Why are the changes needed?

Most CI tools like GHA and GitLab CI export env `CI=true` on the building environment. I found an interesting thing: an sbt command with/without env `CI=true` outputs look same, but actually not.

```
$ build/sbt "Show / scalaBinaryVersion"
[info] 	2.12
[info] celeborn-service / Show / scalaBinaryVersion
[info] 	2.12
[info] celeborn-client / Show / scalaBinaryVersion
[info] 	2.12
[info] celeborn-master / Show / scalaBinaryVersion
[info] 	2.12
[info] Show / scalaBinaryVersion
[info] 	2.12
```

```
$ CI=true build/sbt "Show / scalaBinaryVersion"
[info] 	2.12
[info] celeborn-service / Show / scalaBinaryVersion
[info] 	2.12
[info] celeborn-client / Show / scalaBinaryVersion
[info] 	2.12
[info] celeborn-master / Show / scalaBinaryVersion
[info] 	2.12
[info] Show / scalaBinaryVersion
[info] 	2.12
```

```
$ build/sbt "Show / scalaBinaryVersion" | awk '/\[info\]/{ver=$2} END{print ver}'
2.12
```

```
$ CI=true build/sbt "Show / scalaBinaryVersion" | awk '/\[info\]/{ver=$2} END{print ver}'

```

finally I found when `CI=true`, the sbt output has ASCII colors

```
Using /Users/chengpan/.sdkman/candidates/java/17.0.8-zulu as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mwelcome to sbt 1.9.4 (Azul Systems, Inc. Java 17.0.8)^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mloading global plugins from /Users/chengpan/.sbt/1.0/plugins^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mloading settings for project ne-celeborn-build from plugins.sbt ...^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mloading project definition from /Users/chengpan/Projects/ne-celeborn/project^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mloading settings for project ne-celeborn from version.sbt ...^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mset current project to ne-celeborn (in build file:/Users/chengpan/Projects/ne-celeborn/)^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mceleborn-worker / Show / scalaBinaryVersion^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0m   2.12^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mceleborn-common / Show / scalaBinaryVersion^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0m   2.12^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mceleborn-service / Show / scalaBinaryVersion^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0m   2.12^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mceleborn-client / Show / scalaBinaryVersion^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0m   2.12^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mceleborn-master / Show / scalaBinaryVersion^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0m   2.12^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mShow / scalaBinaryVersion^[[0m
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0m   2.12^[[0m
^[[0J
```

### Does this PR introduce _any_ user-facing change?

No for users who do not have such issues.

### How was this patch tested?

Manually test.