### PR TITLE
[CELEBORN-1405][BUILD] SBT allows using credential without a realm

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -273,10 +273,12 @@ object CelebornCommonSettings {
       }.get
 
       Credentials(
-        "Sonatype Nexus Repository Manager",
+        // Credentials matching is done using both: realm and host keys, sbt/sbt#2366 allows using
+        // credential without a realm by providing an empty string for realm.
+        "" /* realm */,
         host,
         sys.env.getOrElse("ASF_USERNAME", ""),
-        sys.env.getOrElse("ASF_PASSWORD", "")),
+        sys.env.getOrElse("ASF_PASSWORD", ""))
     },
     publishTo := {
       if (isSnapshot.value) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Change SBT publish credential's realm from hardcoded "Sonatype Nexus Repository Manager" to "".

### Why are the changes needed?

According to [SBT docs](https://www.scala-sbt.org/1.x/docs/Publishing.html#Credentials):

> Credentials matching is done using both: `realm` and `host` keys. 

https://github.com/sbt/sbt/issues/2366 allows using credential without a realm by providing an empty string for realm, that's what we wanted exactly.

### Does this PR introduce _any_ user-facing change?

Yes, before this change, when I tried to publish the artifacts to a private corp nexus, it failed with 401 even with corrected `ASF_USERNAME` and `ASF_PASSWORD`. The publication works well after this change.

### How was this patch tested?

Manually tests.