### PR TITLE
[CELEBORN-1406] Use Files. getLastModifiedTime to find last modified time instead of file.lastModified

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManager.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
@@ -220,9 +219,7 @@ public class ReloadingX509TrustManager implements X509TrustManager, Runnable {
 
   private static long getFileLastModified(File file) {
     try {
-      BasicFileAttributes attributes =
-          Files.readAttributes(file.toPath(), BasicFileAttributes.class);
-      return attributes.lastModifiedTime().toMillis();
+      return Files.getLastModifiedTime(file.toPath()).toMillis();
     } catch (IOException ioEx) {
       // fallback
       logger.info("Unable to read attributes for {}", file, ioEx);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `Files.readAttributes` instead of `File.lastModified`.
`File.lastModified` has been observed to have issues in some of our build boxes - which got addressed when moving to `Files.readAttributes`

### Why are the changes needed?

Make reloading more reliable and fix flakey tests


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests.
