### PR TITLE
[CELEBORN-1408] workerShuffleCommitTimeout should use millisecond units

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -583,12 +583,12 @@ private[deploy] class Controller(
           override def run(timeout: Timeout): Unit = {
             if (result.get() != null) {
               result.get().cancel(true)
-              logWarning(s"After waiting $shuffleCommitTimeout s, cancel all commit file jobs.")
+              logWarning(s"After waiting $shuffleCommitTimeout ms, cancel all commit file jobs.")
             }
           }
         },
         shuffleCommitTimeout,
-        TimeUnit.SECONDS)
+        TimeUnit.MILLISECONDS)
 
       result.set(future.handleAsync(
         new BiFunction[Void, Throwable, Unit] {
@@ -604,7 +604,7 @@ private[deploy] class Controller(
                   Thread.currentThread().interrupt()
                   throw ie
                 case _: TimeoutException =>
-                  logWarning(s"While handling commitFiles, timeout after $shuffleCommitTimeout s.")
+                  logWarning(s"While handling commitFiles, timeout after $shuffleCommitTimeout ms.")
                 case throwable: Throwable =>
                   logError("While handling commitFiles, exception occurs.", throwable)
               }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix workerShuffleCommitTimeout use millisecond units.

### Why are the changes needed?
The unit of `workerShuffleCommitTimeout` is milliseconds, but it is used as seconds in the worker.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GA

