### PR TITLE
[CELEBORN-1398] Support return leader ip to client

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class MasterNotLeaderException extends IOException {
 
@@ -34,13 +35,19 @@ public class MasterNotLeaderException extends IOException {
 
   public MasterNotLeaderException(
       String currentPeer, String suggestedLeaderPeer, @Nullable Throwable cause) {
-    this(currentPeer, suggestedLeaderPeer, suggestedLeaderPeer, cause);
+    this(
+        currentPeer,
+        Pair.of(suggestedLeaderPeer, suggestedLeaderPeer),
+        Pair.of(suggestedLeaderPeer, suggestedLeaderPeer),
+        false,
+        cause);
   }
 
   public MasterNotLeaderException(
       String currentPeer,
-      String suggestedLeaderPeer,
-      String suggestedInternalLeaderPeer,
+      Pair<String, String> suggestedLeaderPeer,
+      Pair<String, String> suggestedInternalLeaderPeer,
+      boolean bindPreferIp,
       @Nullable Throwable cause) {
     super(
         String.format(
@@ -55,8 +62,11 @@ public class MasterNotLeaderException extends IOException {
                 ? StringUtils.EMPTY
                 : String.format(" Exception:%s.", cause.getMessage())),
         cause);
-    this.leaderPeer = suggestedLeaderPeer;
-    this.internalLeaderPeer = suggestedInternalLeaderPeer;
+    this.leaderPeer = bindPreferIp ? suggestedLeaderPeer.getKey() : suggestedLeaderPeer.getValue();
+    this.internalLeaderPeer =
+        bindPreferIp
+            ? suggestedInternalLeaderPeer.getKey()
+            : suggestedInternalLeaderPeer.getValue();
   }
 
   public String getSuggestedLeaderAddress() {

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -21,8 +21,9 @@ import java.io.IOException;
 
 import javax.annotation.Nullable;
 
+import scala.Tuple2;
+
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 
 public class MasterNotLeaderException extends IOException {
 
@@ -37,23 +38,23 @@ public class MasterNotLeaderException extends IOException {
       String currentPeer, String suggestedLeaderPeer, @Nullable Throwable cause) {
     this(
         currentPeer,
-        Pair.of(suggestedLeaderPeer, suggestedLeaderPeer),
-        Pair.of(suggestedLeaderPeer, suggestedLeaderPeer),
+        Tuple2.apply(suggestedLeaderPeer, suggestedLeaderPeer),
+        Tuple2.apply(suggestedLeaderPeer, suggestedLeaderPeer),
         false,
         cause);
   }
 
   public MasterNotLeaderException(
       String currentPeer,
-      Pair<String, String> suggestedLeaderPeer,
-      Pair<String, String> suggestedInternalLeaderPeer,
+      Tuple2<String, String> suggestedLeaderPeer,
+      Tuple2<String, String> suggestedInternalLeaderPeer,
       boolean bindPreferIp,
       @Nullable Throwable cause) {
     super(
         String.format(
             "Master:%s is not the leader.%s%s",
             currentPeer,
-            currentPeer.equals(suggestedLeaderPeer)
+            currentPeer.equals(suggestedLeaderPeer._1)
                 ? StringUtils.EMPTY
                 : String.format(
                     " Suggested leader is Master:%s (%s).",
@@ -62,11 +63,9 @@ public class MasterNotLeaderException extends IOException {
                 ? StringUtils.EMPTY
                 : String.format(" Exception:%s.", cause.getMessage())),
         cause);
-    this.leaderPeer = bindPreferIp ? suggestedLeaderPeer.getKey() : suggestedLeaderPeer.getValue();
+    this.leaderPeer = bindPreferIp ? suggestedLeaderPeer._1 : suggestedLeaderPeer._2;
     this.internalLeaderPeer =
-        bindPreferIp
-            ? suggestedInternalLeaderPeer.getKey()
-            : suggestedInternalLeaderPeer.getValue();
+        bindPreferIp ? suggestedInternalLeaderPeer._1 : suggestedInternalLeaderPeer._2;
   }
 
   public String getSuggestedLeaderAddress() {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -448,11 +448,9 @@ object Utils extends Logging {
 
   // Convert address (ip:port or host:port) to (ip:port, host:port) pair
   def addressToIpHostAddressPair(address: String): (String, String) = {
-    val hostPort = Utils.parseHostPort(address)
-    val internalIpHostAddressPair = Utils.getIpHostAddressPair(hostPort._1)
-    (
-      internalIpHostAddressPair._1 + ":" + hostPort._2,
-      internalIpHostAddressPair._2 + ":" + hostPort._2)
+    val (host, port) = Utils.parseHostPort(address)
+    val (_ip, _host) = Utils.getIpHostAddressPair(host)
+    (_ip + ":" + port, _host + ":" + port)
   }
 
   def checkHostPort(hostPort: String): Unit = {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -432,6 +432,20 @@ object Utils extends Logging {
     }
   }
 
+  def getIpHostAddressPair(host: String): (String, String) = {
+    try {
+      val inetAddress = InetAddress.getByName(host)
+      val hostAddress = inetAddress.getHostAddress
+      if (host.equals(hostAddress)) {
+        (hostAddress, inetAddress.getCanonicalHostName)
+      } else {
+        (hostAddress, host)
+      }
+    } catch {
+      case _: Throwable => (host, host) // return original input
+    }
+  }
+
   def checkHostPort(hostPort: String): Unit = {
     if (hostPort != null && hostPort.split(":").length > 2) {
       assert(

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -432,7 +432,7 @@ object Utils extends Logging {
     }
   }
 
-  def getIpHostAddressPair(host: String): (String, String) = {
+  private def getIpHostAddressPair(host: String): (String, String) = {
     try {
       val inetAddress = InetAddress.getByName(host)
       val hostAddress = inetAddress.getHostAddress
@@ -444,6 +444,15 @@ object Utils extends Logging {
     } catch {
       case _: Throwable => (host, host) // return original input
     }
+  }
+
+  // Convert address (ip:port or host:port) to (ip:port, host:port) pair
+  def addressToIpHostAddressPair(address: String): (String, String) = {
+    val hostPort = Utils.parseHostPort(address)
+    val internalIpHostAddressPair = Utils.getIpHostAddressPair(hostPort._1)
+    (
+      internalIpHostAddressPair._1 + ":" + hostPort._2,
+      internalIpHostAddressPair._2 + ":" + hostPort._2)
   }
 
   def checkHostPort(hostPort: String): Unit = {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -31,6 +31,7 @@ import scala.Tuple2;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
@@ -55,6 +56,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.client.MasterClient;
 import org.apache.celeborn.common.exception.CelebornRuntimeException;
 import org.apache.celeborn.common.util.ThreadUtils;
+import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.ResourceResponse;
 
@@ -72,6 +74,7 @@ public class HARaftServer {
     return CALL_ID_COUNTER.getAndIncrement() & Long.MAX_VALUE;
   }
 
+  private final MasterNode localNode;
   private final InetSocketAddress ratisAddr;
   private final String rpcEndpoint;
   private final String internalRpcEndpoint;
@@ -90,7 +93,8 @@ public class HARaftServer {
   private long roleCheckIntervalMs;
   private final ReentrantReadWriteLock roleCheckLock = new ReentrantReadWriteLock();
   private Optional<RaftProtos.RaftPeerRole> cachedPeerRole = Optional.empty();
-  private Optional<Tuple2<String, String>> cachedLeaderPeerRpcEndpoints = Optional.empty();
+  private Optional<LeaderPeerEndpoints> cachedLeaderPeerRpcEndpoints = Optional.empty();
+
   private final CelebornConf conf;
   private long workerTimeoutDeadline;
   private long appTimeoutDeadline;
@@ -100,7 +104,7 @@ public class HARaftServer {
    *
    * @param conf configuration
    * @param localRaftPeerId raft peer id of this Ratis server
-   * @param ratisAddr address of the ratis server
+   * @param localNode local node of this Ratis server
    * @param raftPeers peer nodes in the raft ring
    * @throws IOException
    */
@@ -108,15 +112,14 @@ public class HARaftServer {
       MetaHandler metaHandler,
       CelebornConf conf,
       RaftPeerId localRaftPeerId,
-      InetSocketAddress ratisAddr,
-      String rpcEndpoint,
-      String internalRpcEndpoint,
+      MasterNode localNode,
       List<RaftPeer> raftPeers)
       throws IOException {
     this.metaHandler = metaHandler;
-    this.ratisAddr = ratisAddr;
-    this.rpcEndpoint = rpcEndpoint;
-    this.internalRpcEndpoint = internalRpcEndpoint;
+    this.localNode = localNode;
+    this.ratisAddr = localNode.ratisAddr();
+    this.rpcEndpoint = localNode.rpcEndpoint();
+    this.internalRpcEndpoint = localNode.internalRpcEndpoint();
     this.raftPeerId = localRaftPeerId;
     this.raftGroup = RaftGroup.valueOf(RAFT_GROUP_ID, raftPeers);
     this.masterStateMachine = getStateMachine();
@@ -201,14 +204,8 @@ public class HARaftServer {
           // Add other nodes belonging to the same service to the Ratis ring
           raftPeers.add(raftPeer);
         });
-    return new HARaftServer(
-        metaHandler,
-        conf,
-        localRaftPeerId,
-        ratisAddr,
-        localNode.rpcEndpoint(),
-        localNode.internalRpcEndpoint(),
-        raftPeers);
+
+    return new HARaftServer(metaHandler, conf, localRaftPeerId, localNode, raftPeers);
   }
 
   public ResourceResponse submitRequest(ResourceProtos.ResourceRequest request)
@@ -436,9 +433,9 @@ public class HARaftServer {
   /**
    * Get the suggested leader peer id.
    *
-   * @return RaftPeerId of the suggested leader node - Tuple2(rpc endpoint, internal rpc endpoint)
+   * @return RaftPeerId of the suggested leader node - Optional<LeaderPeerEndpoints>
    */
-  public Optional<Tuple2<String, String>> getCachedLeaderPeerRpcEndpoint() {
+  public Optional<LeaderPeerEndpoints> getCachedLeaderPeerRpcEndpoint() {
     this.roleCheckLock.readLock().lock();
     try {
       return cachedLeaderPeerRpcEndpoints;
@@ -457,21 +454,26 @@ public class HARaftServer {
       RaftProtos.RaftPeerRole thisNodeRole = roleInfoProto.getRole();
 
       if (thisNodeRole.equals(RaftProtos.RaftPeerRole.LEADER)) {
-        setServerRole(thisNodeRole, getRpcEndpoint(), getInternalRpcEndpoint());
+        setServerRole(
+            thisNodeRole,
+            Pair.of(localNode.rpcIpEndpoint(), localNode.rpcEndpoint()),
+            Pair.of(localNode.internalRpcIpEndpoint(), localNode.internalRpcEndpoint()));
       } else if (thisNodeRole.equals(RaftProtos.RaftPeerRole.FOLLOWER)) {
         ByteString leaderNodeId = roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getId();
         // There may be a chance, here we get leaderNodeId as null. For
         // example, in 3 node Ratis, if 2 nodes are down, there will
         // be no leader.
-        String leaderPeerRpcEndpoint = null;
-        String leaderPeerInternalRpcEndpoint = null;
+        Pair<String, String> leaderPeerRpcEndpoint = null;
+        Pair<String, String> leaderPeerInternalRpcEndpoint = null;
         if (leaderNodeId != null && !leaderNodeId.isEmpty()) {
-          leaderPeerRpcEndpoint =
+          String clientAddress =
               roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getClientAddress();
+          leaderPeerRpcEndpoint = addressToIpHostAddressPair(clientAddress);
           // We use admin address to host the internal rpc address
           if (conf.internalPortEnabled()) {
-            leaderPeerInternalRpcEndpoint =
+            String adminAddress =
                 roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getAdminAddress();
+            leaderPeerInternalRpcEndpoint = addressToIpHostAddressPair(adminAddress);
           } else {
             leaderPeerInternalRpcEndpoint = leaderPeerRpcEndpoint;
           }
@@ -492,11 +494,19 @@ public class HARaftServer {
     }
   }
 
+  public Pair<String, String> addressToIpHostAddressPair(String address) {
+    Tuple2<String, Object> hostPort = Utils.parseHostPort(address);
+    Tuple2<String, String> internalIpHostAddressPair = Utils.getIpHostAddressPair(hostPort._1);
+    return Pair.of(
+        internalIpHostAddressPair._1 + ":" + hostPort._2,
+        internalIpHostAddressPair._2 + ":" + hostPort._2);
+  }
+
   /** Set the current server role and the leader peer rpc endpoint. */
   private void setServerRole(
       RaftProtos.RaftPeerRole currentRole,
-      String leaderPeerRpcEndpoint,
-      String leaderPeerInternalRpcEndpoint) {
+      Pair<String, String> leaderPeerRpcEndpoint,
+      Pair<String, String> leaderPeerInternalRpcEndpoint) {
     this.roleCheckLock.writeLock().lock();
     try {
       boolean leaderChanged = false;
@@ -518,7 +528,8 @@ public class HARaftServer {
       this.cachedPeerRole = Optional.ofNullable(currentRole);
       if (null != leaderPeerRpcEndpoint) {
         this.cachedLeaderPeerRpcEndpoints =
-            Optional.of(Tuple2.apply(leaderPeerRpcEndpoint, leaderPeerInternalRpcEndpoint));
+            Optional.of(
+                new LeaderPeerEndpoints(leaderPeerRpcEndpoint, leaderPeerInternalRpcEndpoint));
       } else {
         this.cachedLeaderPeerRpcEndpoints = Optional.empty();
       }
@@ -577,5 +588,19 @@ public class HARaftServer {
 
   public long getAppTimeoutDeadline() {
     return appTimeoutDeadline;
+  }
+
+  public static class LeaderPeerEndpoints {
+    // the rpcEndpoints pair (ip:port, host:port)
+    public final Pair<String, String> rpcEndpoints;
+
+    // the rpcInternalEndpoints pair (ip:port, host:port)
+    public final Pair<String, String> rpcInternalEndpoints;
+
+    public LeaderPeerEndpoints(
+        Pair<String, String> rpcEndpoints, Pair<String, String> rpcInternalEndpoints) {
+      this.rpcEndpoints = rpcEndpoints;
+      this.rpcInternalEndpoints = rpcInternalEndpoints;
+    }
   }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -76,6 +76,7 @@ private[celeborn] class Master(
   metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_MASTER))
   metricsSystem.registerSource(new SystemMiscSource(conf, MetricsSystem.ROLE_MASTER))
 
+  private val bindPreferIP: Boolean = conf.bindPreferIP
   private val authEnabled = conf.authEnabled
   private val secretRegistry = new MasterSecretRegistryImpl()
   private val sendApplicationMetaThreads = conf.masterSendApplicationMetaThreads
@@ -358,12 +359,12 @@ private[celeborn] class Master(
   }
 
   def executeWithLeaderChecker[T](context: RpcCallContext, f: => T): Unit =
-    if (HAHelper.checkShouldProcess(context, statusSystem)) {
+    if (HAHelper.checkShouldProcess(context, statusSystem, bindPreferIP)) {
       try {
         f
       } catch {
         case e: Exception =>
-          HAHelper.sendFailure(context, HAHelper.getRatisServer(statusSystem), e)
+          HAHelper.sendFailure(context, HAHelper.getRatisServer(statusSystem), e, bindPreferIP)
       }
     }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -40,7 +40,11 @@ case class MasterNode(
 
   def rpcEndpoint: String = rpcHost + ":" + rpcPort
 
+  def rpcIpEndpoint: String = rpcAddr.getAddress.getHostAddress + ":" + rpcPort
+
   def internalRpcEndpoint: String = rpcHost + ":" + internalRpcPort
+
+  def internalRpcIpEndpoint: String = rpcAddr.getAddress.getHostAddress + ":" + rpcPort
 
   lazy val ratisAddr = MasterNode.createSocketAddr(ratisHost, ratisPort)
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
-import scala.Tuple2;
-
 import org.junit.*;
 import org.mockito.Mockito;
 
@@ -180,7 +178,7 @@ public class RatisMasterStatusSystemSuiteJ {
   }
 
   @Test
-  public void testLeaderAvaiable() {
+  public void testLeaderAvailable() {
     boolean hasLeader =
         RATISSERVER1.isLeader() || RATISSERVER2.isLeader() || RATISSERVER3.isLeader();
     Assert.assertTrue(hasLeader);
@@ -198,12 +196,15 @@ public class RatisMasterStatusSystemSuiteJ {
     boolean isFollowerCurrentLeader = follower.isLeader();
     Assert.assertFalse(isFollowerCurrentLeader);
 
-    Optional<Tuple2<String, String>> cachedLeaderPeerRpcEndpoint =
+    Optional<HARaftServer.LeaderPeerEndpoints> cachedLeaderPeerRpcEndpoint =
         follower.getCachedLeaderPeerRpcEndpoint();
 
     Assert.assertTrue(cachedLeaderPeerRpcEndpoint.isPresent());
-    Assert.assertEquals(leader.getRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get()._1());
-    Assert.assertEquals(leader.getInternalRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get()._2());
+    Assert.assertEquals(
+        leader.getRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get().rpcEndpoints.getValue());
+    Assert.assertEquals(
+        leader.getInternalRpcEndpoint(),
+        cachedLeaderPeerRpcEndpoint.get().rpcInternalEndpoints.getValue());
   }
 
   private static final String HOSTNAME1 = "host1";

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import scala.Tuple2;
+
 import org.junit.*;
 import org.mockito.Mockito;
 
@@ -200,11 +202,18 @@ public class RatisMasterStatusSystemSuiteJ {
         follower.getCachedLeaderPeerRpcEndpoint();
 
     Assert.assertTrue(cachedLeaderPeerRpcEndpoint.isPresent());
-    Assert.assertEquals(
-        leader.getRpcEndpoint(), cachedLeaderPeerRpcEndpoint.get().rpcEndpoints.getValue());
-    Assert.assertEquals(
-        leader.getInternalRpcEndpoint(),
-        cachedLeaderPeerRpcEndpoint.get().rpcInternalEndpoints.getValue());
+
+    Tuple2<String, String> rpcEndpointsPair = cachedLeaderPeerRpcEndpoint.get().rpcEndpoints;
+    Tuple2<String, String> rpcInternalEndpointsPair =
+        cachedLeaderPeerRpcEndpoint.get().rpcInternalEndpoints;
+
+    // rpc endpoint may use custom host name then this ut need check ever ip/host
+    Assert.assertTrue(
+        leader.getRpcEndpoint().equals(rpcEndpointsPair._1)
+            || leader.getRpcEndpoint().equals(rpcEndpointsPair._2));
+    Assert.assertTrue(
+        leader.getInternalRpcEndpoint().equals(rpcInternalEndpointsPair._1)
+            || leader.getRpcEndpoint().equals(rpcInternalEndpointsPair._2));
   }
 
   private static final String HOSTNAME1 = "host1";


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title


### Why are the changes needed?
Currently, if accessing services of a Celeborn cluster across Kubernetes clusters, one may encounter DNS resolution issues. However, connectivity may be achieved through IP addresses when combined with the Kubernetes setting hostNetwork=true for clients from different clusters. At present, the `celeborn.network.bind.preferIpAddress` configuration is only effective on worker nodes. This PR will enable the feature of returning the leader's IP when accessing the master node.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA
