### PR TITLE
[CELEBORN-1411] Change default log level to INFO when there is no log4j2 config file

### DIFF
--- a/sbin/start-master.sh
+++ b/sbin/start-master.sh
@@ -46,6 +46,7 @@ CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.nio.ch=ALL-UNN
 CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.nio.cs=ALL-UNNAMED"
 CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.security.action=ALL-UNNAMED"
 CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS -Dorg.apache.logging.log4j.level=INFO"
 export CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS"
 
 exec "${CELEBORN_HOME}/sbin/celeborn-daemon.sh" start org.apache.celeborn.service.deploy.master.Master 1 "$@"

--- a/sbin/start-worker.sh
+++ b/sbin/start-worker.sh
@@ -51,6 +51,7 @@ CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.nio.ch=ALL-UNN
 CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.nio.cs=ALL-UNNAMED"
 CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.security.action=ALL-UNNAMED"
 CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS --add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS -Dorg.apache.logging.log4j.level=INFO"
 export CELEBORN_JAVA_OPTS="$CELEBORN_JAVA_OPTS"
 
 if [ "$WORKER_INSTANCE" = "" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?
To output logs if there is no log4j2 config file.


### Why are the changes needed?

This makes the log to console work out-of-box without `log4j2.xml`

### Does this PR introduce _any_ user-facing change?

NO.

### How was this patch tested?

GA.
