### PR TITLE
[CELEBORN-1425][HELM] Add helm chart unit tests to ensure manifests are rendered as expected  Edit  Add comment

### DIFF
--- a/charts/celeborn/tests/configmap_test.yaml
+++ b/charts/celeborn/tests/configmap_test.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn configmap
+
+templates:
+  - configmap.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should create configmap
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ConfigMap
+          name: celeborn-conf
+
+  - it: Should have correct data fields
+    asserts:
+      - exists:
+          path: data["celeborn-defaults.conf"]
+      - exists:
+          path: data["celeborn-env.sh"]
+      - exists:
+          path: data["log4j2.xml"]

--- a/charts/celeborn/tests/master/podmonitor_test.yaml
+++ b/charts/celeborn/tests/master/podmonitor_test.yaml
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master pod monitor
+
+templates:
+  - master/podmonitor.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should not create master pod monitor as default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create master pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create master pod monitor if `podMonitor.enable` is true and api version `monitoring.coreos.com/v1/PodMonitor` exists
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - containsDocument:
+          apiVersion: monitoring.coreos.com/v1
+          kind: PodMonitor
+          name: celeborn-master-podmonitor
+
+  - it: Should use the specified pod metrics endpoints
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+        podMetricsEndpoint:
+          scheme: http
+          interval: 3s
+          portName: test-port
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 3s
+            port: test-port
+            scheme: http
+            path: /metrics/prometheus
+          count: 1
+
+  - it: Should respect `celeborn.metrics.prometheus.path`
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      celeborn:
+        celeborn.metrics.prometheus.path: custom-metrics-path
+      podMonitor:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 5s
+            port: metrics
+            scheme: http
+            path: custom-metrics-path
+          count: 1

--- a/charts/celeborn/tests/master/priorityclass_test.yaml
+++ b/charts/celeborn/tests/master/priorityclass_test.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master priority class
+
+templates:
+  - master/priorityclass.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should not create master priority as default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create master priority class if `priorityClass.master.create` is true
+    set:
+      priorityClass:
+        master:
+          create: true
+    asserts:
+      - containsDocument:
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          name: celeborn-master-priority-class
+
+  - it: Should use the specified priority class value
+    set:
+      priorityClass:
+        master:
+          create: true
+          value: 1000
+    asserts:
+      - equal:
+          path: value
+          value: 1000

--- a/charts/celeborn/tests/master/service_test.yaml
+++ b/charts/celeborn/tests/master/service_test.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master service
+
+templates:
+  - master/service.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should create master service
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: celeborn-master-svc
+
+  - it: Should have label selectors for master
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/role"]
+          value: master
+
+  - it: Should create master service with the specified service type and port
+    set:
+      service:
+        type: NodePort
+        port: 9097
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 9097
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9097

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -1,0 +1,198 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master statefulset
+
+templates:
+  - master/statefulset.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should add extra pod annotations if `podAnnotations` is specified
+    set:
+      podAnnotations:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should use the specified image if `image.repository` and `image.tag` is set
+    set:
+      image:
+        repository: test-repository
+        tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: test-repository:test-tag
+
+  - it: Should use the specified image pull policy if `image.pullPolicy` is set
+    set:
+      image:
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: Should add secrets if `imagePullSecrets` is set
+    set:
+      imagePullSecrets:
+        - name: test-secret1
+        - name: test-secret2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: test-secret1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: test-secret2
+
+  - it: Should add node selector if `nodeSelector` is set
+    set:
+      nodeSelector:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add tolerations if `tolerations` is set
+    set:
+      tolerations:
+        - key: key1
+          operator: Equal
+          value: value1
+          effect: NoSchedule
+        - key: key2
+          operator: Exists
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified affinity if `affinity.master` is set
+    set:
+      affinity:
+        master:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity
+          value:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+
+  - it: Should use the specified priority class name if `priorityClass.master.name` is set
+    set:
+      priorityClass:
+        master:
+          name: test-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should use the specified dns policy if `dnsPolicy` is set
+    set:
+      dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: Should enable host network if `hostNetwork` is set to true
+    set:
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: Should use the specified security context if `podSecurityContext` is set
+    set:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: Should use the specified replicas if `masterReplicas` is set
+    set:
+      masterReplicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10

--- a/charts/celeborn/tests/worker/podmonitor_test.yaml
+++ b/charts/celeborn/tests/worker/podmonitor_test.yaml
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker pod monitor
+
+templates:
+  - worker/podmonitor.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should not create worker pod monitor as default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create worker pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create worker pod monitor if `podMonitor.enable` is true and api version `monitoring.coreos.com/v1/PodMonitor` exists
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - containsDocument:
+          apiVersion: monitoring.coreos.com/v1
+          kind: PodMonitor
+          name: celeborn-worker-podmonitor
+
+  - it: Should use the specified pod metrics endpoints
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+        podMetricsEndpoint:
+          scheme: http
+          interval: 3s
+          portName: test-port
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 3s
+            port: test-port
+            scheme: http
+            path: /metrics/prometheus
+          count: 1
+
+  - it: Should respect `celeborn.metrics.prometheus.path`
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      celeborn:
+        celeborn.metrics.prometheus.path: custom-metrics-path
+      podMonitor:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 5s
+            port: metrics
+            scheme: http
+            path: custom-metrics-path
+          count: 1

--- a/charts/celeborn/tests/worker/priorityclass_test.yaml
+++ b/charts/celeborn/tests/worker/priorityclass_test.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker priority class
+
+templates:
+  - worker/priorityclass.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should not create worker priority as default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create worker priority class if `priorityClass.worker.create` is true
+    set:
+      priorityClass:
+        worker:
+          create: true
+    asserts:
+      - containsDocument:
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          name: celeborn-worker-priority-class
+
+  - it: Should use the specified priority class value
+    set:
+      priorityClass:
+        worker:
+          create: true
+          value: 1000
+    asserts:
+      - equal:
+          path: value
+          value: 1000

--- a/charts/celeborn/tests/worker/service_test.yaml
+++ b/charts/celeborn/tests/worker/service_test.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker service
+
+templates:
+  - worker/service.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should create worker service
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: celeborn-worker-svc
+
+  - it: Should have label selectors for worker
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/role"]
+          value: worker
+
+  - it: Should create worker service with the specified service type
+    set:
+      service:
+        type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -1,0 +1,198 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker statefulset
+
+templates:
+  - worker/statefulset.yaml
+
+release:
+  name: celeborn
+
+tests:
+  - it: Should add extra pod annotations if `podAnnotations` is specified
+    set:
+      podAnnotations:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should use the specified image if `image.repository` and `image.tag` is set
+    set:
+      image:
+        repository: test-repository
+        tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: test-repository:test-tag
+
+  - it: Should use the specified image pull policy if `image.pullPolicy` is set
+    set:
+      image:
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: Should add secrets if `imagePullSecrets` is set
+    set:
+      imagePullSecrets:
+        - name: test-secret1
+        - name: test-secret2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: test-secret1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: test-secret2
+
+  - it: Should add node selector if `nodeSelector` is set
+    set:
+      nodeSelector:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add tolerations if `tolerations` is set
+    set:
+      tolerations:
+        - key: key1
+          operator: Equal
+          value: value1
+          effect: NoSchedule
+        - key: key2
+          operator: Exists
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified affinity if `affinity.worker` is specified
+    set:
+      affinity:
+        worker:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity
+          value:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+
+  - it: Should use the specified priority class name if `priorityClass.worker.name` is set
+    set:
+      priorityClass:
+        worker:
+          name: test-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should use the specified dns policy if `dnsPolicy` is set
+    set:
+      dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: Should enable host network if `hostNetwork` is set to true
+    set:
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: Should use the specified security context if `podSecurityContext` is set
+    set:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: Should use the specified replicas if `workerReplicas` is set
+    set:
+      workerReplicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Add helm chart unit tests to ensure manifests are rendered as expected.

### Why are the changes needed?

To achieve better robustness and availability.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I had added some unit test files in `charts/celeborn/tests`. Detailed information about how to run helm chart unit tests can be found here [helm-unittest/helm-unittest](https://github.com/helm-unittest/helm-unittest). First, you need to install helm unit test plugin:

```shell
helm plugin install https://github.com/helm-unittest/helm-unittest.git
```

Then, run helm chart unitt tests as follows:

```shell
$ helm unittest charts/celeborn  --file "tests/**/*_test.yaml" --strict --debug
load_plugins.go:110: [info] file (/Users/chenyi/Library/helm/plugins/helm-acr/completion.yaml) not provided by plugin. No plugin auto-completion possible

### Chart [ celeborn ] charts/celeborn

 PASS  Test Celeborn configmap  charts/celeborn/tests/configmap_test.yaml
 PASS  Test Celeborn master pod monitor charts/celeborn/tests/master/podmonitor_test.yaml
 PASS  Test Celeborn master priority class      charts/celeborn/tests/master/priorityclass_test.yaml
 PASS  Test Celeborn master service     charts/celeborn/tests/master/service_test.yaml
 PASS  Test Celeborn master statefulset charts/celeborn/tests/master/statefulset_test.yaml
 PASS  Test Celeborn worker pod monitor charts/celeborn/tests/worker/podmonitor_test.yaml
 PASS  Test Celeborn worker priority class      charts/celeborn/tests/worker/priorityclass_test.yaml
 PASS  Test Celeborn worker service     charts/celeborn/tests/worker/service_test.yaml
 PASS  Test Celeborn worker statefulset charts/celeborn/tests/worker/statefulset_test.yaml

Charts:      1 passed, 1 total
Test Suites: 9 passed, 9 total
Tests:       46 passed, 46 total
Snapshot:    0 passed, 0 total
Time:        180.841209ms
```