### PR TITLE
[CELEBORN-1419] Avoid adding shuffle id repeatedly

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -137,7 +137,7 @@ public class SparkShuffleManager implements ShuffleManager {
 
   @Override
   public boolean unregisterShuffle(int appShuffleId) {
-    if (sortShuffleIds.contains(appShuffleId)) {
+    if (sortShuffleIds.remove(appShuffleId)) {
       return sortShuffleManager().unregisterShuffle(appShuffleId);
     }
     // For Spark driver side trigger unregister shuffle.

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -214,7 +214,6 @@ public class SparkShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
-        sortShuffleIds.add(handle.shuffleId());
         return sortShuffleManager().getWriter(handle, mapId, context);
       }
     } catch (IOException e) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -293,7 +293,6 @@ public class SparkShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
-        sortShuffleIds.add(handle.shuffleId());
         return sortShuffleManager().getWriter(handle, mapId, context, metrics);
       }
     } catch (IOException e) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -190,7 +190,7 @@ public class SparkShuffleManager implements ShuffleManager {
 
   @Override
   public boolean unregisterShuffle(int appShuffleId) {
-    if (sortShuffleIds.contains(appShuffleId)) {
+    if (sortShuffleIds.remove(appShuffleId)) {
       return sortShuffleManager().unregisterShuffle(appShuffleId);
     }
     // For Spark driver side trigger unregister shuffle.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Avoid adding shuffle id repeatedly


### Why are the changes needed?
`registerShuffle` has added the shuffle id to `sortShuffleIds`, and there is no need to add it repeatedly when calling `getWriter`



### Does this PR introduce _any_ user-facing change?
None


### How was this patch tested?

