### PR TITLE
[CELEBORN-1310][FOLLOWUP] License check add flink-1.19 profile

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -47,6 +47,7 @@ jobs:
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.15
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.17
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.18
+          build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.19
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,spark-2.4
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,spark-3.3
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,mr


### PR DESCRIPTION
### What changes were proposed in this pull request?

License check add `flink-1.19` profile.

### Why are the changes needed?

There is no license check of `flink-1.19` profile in CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.