### PR TITLE
[CELEBORN-1420] Fix mapreduce job will throw an exit exception after it succeeded

### DIFF
--- a/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
+++ b/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
@@ -152,11 +152,13 @@ public class MRAppMasterWithCeleborn extends MRAppMaster {
               rmAppConf);
 
       // set this flag to avoid exit exception
-      Field field = MRAppMaster.class.getDeclaredField("mainStarted");
-      if (field != null) {
+      try {
+        Field field = MRAppMaster.class.getDeclaredField("mainStarted");
         field.setAccessible(true);
         field.setBoolean(null, true);
         field.setAccessible(false);
+      } catch (NoSuchFieldException e) {
+        // ignore it for compatibility
       }
 
       ShutdownHookManager.get()

--- a/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
+++ b/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.mapreduce.v2.app;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -149,6 +150,13 @@ public class MRAppMasterWithCeleborn extends MRAppMaster {
               Integer.parseInt(nodeHttpPortString),
               appSubmitTime,
               rmAppConf);
+
+      // set this flag to avoid exit exception
+      Field field = MRAppMaster.class.getDeclaredField("mainStarted");
+      field.setAccessible(true);
+      field.setBoolean(null, true);
+      field.setAccessible(false);
+
       ShutdownHookManager.get()
           .addShutdownHook(
               () -> {

--- a/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
+++ b/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
@@ -153,9 +153,11 @@ public class MRAppMasterWithCeleborn extends MRAppMaster {
 
       // set this flag to avoid exit exception
       Field field = MRAppMaster.class.getDeclaredField("mainStarted");
-      field.setAccessible(true);
-      field.setBoolean(null, true);
-      field.setAccessible(false);
+      if (field != null) {
+        field.setAccessible(true);
+        field.setBoolean(null, true);
+        field.setAccessible(false);
+      }
 
       ShutdownHookManager.get()
           .addShutdownHook(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set the correct flag to remove a redundant exception.


### Why are the changes needed?
To remove a redundant exception.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
Manually test.
