### PR TITLE
[CELEBORN-1422] Remove tmpRecords array when collecting written count metrics

### DIFF
--- a/client-spark/spark-3-columnar-shuffle/src/main/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriter.java
+++ b/client-spark/spark-3-columnar-shuffle/src/main/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriter.java
@@ -127,7 +127,7 @@ public class ColumnarHashBasedShuffleWriter<K, V, C> extends HashBasedShuffleWri
         }
         celebornBatchBuilders[partitionId].newBuilders();
       }
-      incRecordsWritten(partitionId);
+      tmpRecordsWritten++;
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
For spark3 client, use a long variable to help to count written records instead of a `tmpRecords` array.


### Why are the changes needed?
There is no need to use a array for spark3.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Cluster test. Both shuffle writer count records correctly.
