### PR TITLE
[CELEBORN-1428] WrappedRpcResponseCallback should stop timer of PrimaryPushDataTime and ReplicaPushDataTime for failure

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -1093,6 +1093,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     }
 
     override def onFailure(e: Throwable): Unit = {
+      workerSource.stopTimer(workerSourceTime, s"$requestId")
       if (location != null) {
         logError(s"[handle$messageType.onFailure] partitionLocation: $location")
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`WrappedRpcResponseCallback` stops timer of `PrimaryPushDataTime` and `ReplicaPushDataTime` for failure.

### Why are the changes needed?

`WrappedRpcResponseCallback` does not stop timer of `PrimaryPushDataTime` and `ReplicaPushDataTime` for failure, which causes that the value of metric `PrimaryPushDataTime` and `ReplicaPushDataTime` is incorrect when failing to push data.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.