### PR TITLE
[CELEBORN-1429] Use log level DEBUG instead of TRACE to avoid revent excessive CPU consumption

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -183,7 +183,7 @@ class ChangePartitionManager(
         })
 
       if (newEntry) {
-        logTrace(s"[handleRequestPartitionLocation] For $shuffleId, request for same partition" +
+        logDebug(s"[handleRequestPartitionLocation] For $shuffleId, request for same partition" +
           s"$partitionId-$oldEpoch exists, register context.")
       } else {
         getLatestPartition(shuffleId, partitionId, oldEpoch).foreach { latestLoc =>

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -372,7 +372,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       val partitionId = pb.getPartitionId
       val epoch = pb.getEpoch
       val oldPartition = PbSerDeUtils.fromPbPartitionLocation(pb.getOldPartition)
-      logTrace(s"Received split request, " +
+      logDebug(s"Received split request, " +
         s"$shuffleId, $partitionId, $epoch, $oldPartition")
       changePartitionManager.handleRequestPartitionLocation(
         ChangeLocationsCallContext(context, 1),
@@ -382,7 +382,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         oldPartition)
 
     case MapperEnd(shuffleId, mapId, attemptId, numMappers, partitionId) =>
-      logTrace(s"Received MapperEnd TaskEnd request, " +
+      logDebug(s"Received MapperEnd TaskEnd request, " +
         s"${Utils.makeMapKey(shuffleId, mapId, attemptId)}")
       val partitionType = getPartitionType(shuffleId)
       partitionType match {

--- a/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
@@ -84,7 +84,7 @@ class ReleasePartitionManager(
                               lifecycleManager.destroySlotsWithRetry(
                                 shuffleId,
                                 destroyResource)
-                              logTrace(s"Destroyed partition resource for shuffle $shuffleId $destroyResource")
+                              logDebug(s"Destroyed partition resource for shuffle $shuffleId $destroyResource")
                             }
                         }
                       }
@@ -125,7 +125,7 @@ class ReleasePartitionManager(
 
       if (!destroyResource.isEmpty) {
         lifecycleManager.destroySlotsWithRetry(shuffleId, destroyResource)
-        logTrace(
+        logDebug(
           s"Destroyed partition resource for partition $shuffleId-$partitionId, $destroyResource")
       }
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -179,7 +179,7 @@ public class TransportClientFactory implements Closeable {
       logger.warn(
           "DNS resolution {} for {} took {} ms", resolveMsg, resolvedAddress, hostResolveTimeMs);
     } else {
-      logger.trace(
+      logger.debug(
           "DNS resolution {} for {} took {} ms", resolveMsg, resolvedAddress, hostResolveTimeMs);
     }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/MessageDecoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/MessageDecoder.java
@@ -44,7 +44,7 @@ public final class MessageDecoder extends MessageToMessageDecoder<ByteBuf> {
     Message.Type msgType = Message.Type.decode(in);
     Message decoded = Message.decode(msgType, in);
     assert decoded.type() == msgType;
-    logger.trace("Received message {}: {}", msgType, decoded);
+    logger.debug("Received message {}: {}", msgType, decoded);
     out.add(decoded);
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslClient.java
@@ -144,15 +144,15 @@ public class CelebornSaslClient {
 
       for (Callback callback : callbacks) {
         if (callback instanceof NameCallback) {
-          logger.trace("SASL client callback: setting username");
+          logger.debug("SASL client callback: setting username");
           NameCallback nc = (NameCallback) callback;
           nc.setName(encodeIdentifier(id));
         } else if (callback instanceof PasswordCallback) {
-          logger.trace("SASL client callback: setting password");
+          logger.debug("SASL client callback: setting password");
           PasswordCallback pc = (PasswordCallback) callback;
           pc.setPassword(encodePassword(password));
         } else if (callback instanceof RealmCallback) {
-          logger.trace("SASL client callback: setting realm");
+          logger.debug("SASL client callback: setting realm");
           RealmCallback rc = (RealmCallback) callback;
           rc.setText(rc.getDefaultText());
         } else if (callback instanceof RealmChoiceCallback) {

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
@@ -126,7 +126,7 @@ public class CelebornSaslServer {
     public void handle(Callback[] callbacks) throws UnsupportedCallbackException, SaslException {
       for (Callback callback : callbacks) {
         if (callback instanceof NameCallback) {
-          logger.trace("SASL server callback: setting username");
+          logger.debug("SASL server callback: setting username");
           NameCallback nc = (NameCallback) callback;
           String encodedName = nc.getName() != null ? nc.getName() : nc.getDefaultName();
           if (encodedName == null) {
@@ -135,7 +135,7 @@ public class CelebornSaslServer {
           userName = decodeIdentifier(encodedName);
           client.setClientId(userName);
         } else if (callback instanceof PasswordCallback) {
-          logger.trace("SASL server callback: setting password");
+          logger.debug("SASL server callback: setting password");
           PasswordCallback pc = (PasswordCallback) callback;
           String secret = secretRegistry.getSecretKey(userName);
           if (secret == null) {
@@ -143,7 +143,7 @@ public class CelebornSaslServer {
           }
           pc.setPassword(encodePassword(secret));
         } else if (callback instanceof RealmCallback) {
-          logger.trace("SASL server callback: setting realm");
+          logger.debug("SASL server callback: setting realm");
           RealmCallback rc = (RealmCallback) callback;
           rc.setText(rc.getDefaultText());
         } else if (callback instanceof AuthorizeCallback) {

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationRpcHandler.java
@@ -114,7 +114,7 @@ public class RegistrationRpcHandler extends BaseMessageHandler {
     // The message is delegated either if the client is already authenticated or if the connection
     // is authenticated.
     if (registrationState == RegistrationState.REGISTERED || saslHandler.isAuthenticated()) {
-      LOG.trace("Already authenticated. Delegating {}", client.getClientId());
+      LOG.debug("Already authenticated. Delegating {}", client.getClientId());
       delegate.receive(client, message, callback);
     } else {
       RpcRequest rpcRequest = (RpcRequest) message;
@@ -153,32 +153,32 @@ public class RegistrationRpcHandler extends BaseMessageHandler {
         checkRequestAllowed(RegistrationState.NONE);
         respondToAuthInitialization(callback);
         registrationState = RegistrationState.INIT;
-        LOG.trace("Authentication initialization completed: rpcId {}", message.requestId);
+        LOG.debug("Authentication initialization completed: rpcId {}", message.requestId);
         break;
       case SASL_REQUEST_VALUE:
         PbSaslRequest saslRequest = pbMsg.getParsedPayload();
         if (saslRequest.getAuthType().equals(PbAuthType.CLIENT_AUTH)) {
-          LOG.trace("Received Sasl Message for client authentication");
+          LOG.debug("Received Sasl Message for client authentication");
           checkRequestAllowed(RegistrationState.INIT);
           authenticateClient(saslRequest, callback);
           if (saslServer.isComplete()) {
             LOG.debug("SASL authentication successful for channel {}", client);
             complete();
             registrationState = RegistrationState.AUTHENTICATED;
-            LOG.trace("Client authenticated: rpcId {}", message.requestId);
+            LOG.debug("Client authenticated: rpcId {}", message.requestId);
           }
         } else {
           // It is a SASL message to authenticate the connection. If the application hasn't
           // registered, then
           // saslHandler will throw an exception that the app hasn't registered.
-          LOG.trace("Delegating to sasl handler: rpcId {}", message.requestId);
+          LOG.debug("Delegating to sasl handler: rpcId {}", message.requestId);
           saslHandler.receive(client, message, callback);
         }
         break;
       case REGISTER_APPLICATION_REQUEST_VALUE:
         PbRegisterApplicationRequest registerApplicationRequest = pbMsg.getParsedPayload();
         checkRequestAllowed(RegistrationState.AUTHENTICATED);
-        LOG.trace("Application registration started {}", registerApplicationRequest.getId());
+        LOG.debug("Application registration started {}", registerApplicationRequest.getId());
         processRegisterApplicationRequest(registerApplicationRequest, callback);
         registrationState = RegistrationState.REGISTERED;
         client.setClientId(registerApplicationRequest.getId());

--- a/common/src/main/java/org/apache/celeborn/common/network/server/AbstractAuthRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/AbstractAuthRpcHandler.java
@@ -52,7 +52,7 @@ public abstract class AbstractAuthRpcHandler extends BaseMessageHandler {
   public final void receive(
       TransportClient client, RequestMessage message, RpcResponseCallback callback) {
     if (isAuthenticated) {
-      LOG.trace("Already authenticated. Delegating {}", client.getClientId());
+      LOG.debug("Already authenticated. Delegating {}", client.getClientId());
       delegate.receive(client, message, callback);
     } else {
       isAuthenticated = doAuthChallenge(client, message, callback);

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportRequestHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportRequestHandler.java
@@ -92,7 +92,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
 
   private void processRpcRequest(final RpcRequest req) {
     try {
-      logger.trace("Process rpc request {}", req.requestId);
+      logger.debug("Process rpc request {}", req.requestId);
       msgHandler.receive(
           reverseClient,
           req,
@@ -117,7 +117,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
 
   private void processOneWayMessage(OneWayMessage req) {
     try {
-      logger.trace("Process one way request");
+      logger.debug("Process one way request");
       msgHandler.receive(reverseClient, req);
     } catch (Exception e) {
       logger.error("Error while invoking handler#receive() for one-way message.", e);
@@ -128,7 +128,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
 
   private void processOtherMessages(RequestMessage req) {
     try {
-      logger.trace("delegating to handler to process other request");
+      logger.debug("delegating to handler to process other request");
       msgHandler.receive(reverseClient, req);
     } catch (Exception e) {
       logger.error("Error while invoking handler#receive() for other message.", e);
@@ -167,7 +167,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
         .addListener(
             future -> {
               if (future.isSuccess()) {
-                logger.trace("Sent result {} to client {}", result, remoteAddress);
+                logger.debug("Sent result {} to client {}", result, remoteAddress);
               } else {
                 logger.warn(
                     String.format(

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -454,7 +454,7 @@ private[celeborn] class Master(
       context.reply(ReleaseSlotsResponse(StatusCode.SUCCESS))
 
     case requestSlots @ RequestSlots(applicationId, _, _, _, _, _, _, _, _, _, _, _) =>
-      logTrace(s"Received RequestSlots request $requestSlots.")
+      logDebug(s"Received RequestSlots request $requestSlots.")
       checkAuth(context, applicationId)
       executeWithLeaderChecker(context, handleRequestSlots(context, requestSlots))
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -1200,7 +1200,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       softSplit: AtomicBoolean,
       callback: RpcResponseCallback): Boolean = {
     val diskFull = checkDiskFull(fileWriter)
-    logTrace(
+    logDebug(
       s"""
          |CheckDiskFullAndSplit in
          |diskFull:$diskFull,
@@ -1217,7 +1217,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       } else {
         workerSource.incCounter(WorkerSource.WRITE_DATA_HARD_SPLIT_COUNT)
         callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
-        logTrace(
+        logDebug(
           s"""
              |CheckDiskFullAndSplit hardSplit
              |diskFull:$diskFull,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use log level `DEBUG` instead of `TRACE` to avoid revent excessive CPU consumption.

### Why are the changes needed?

Use log level `DEBUG` instead of `TRACE` when `TRACE` is disabled. The log level `TRACE` causes the excessive CPU consumption.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.