### PR TITLE
[CELEBORN-1430] TransportClientFactory should check whether handler is null when creating client

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -154,8 +154,10 @@ public class TransportClientFactory implements Closeable {
       // this code was able to update things.
       TransportChannelHandler handler =
           cachedClient.getChannel().pipeline().get(TransportChannelHandler.class);
-      synchronized (handler) {
-        handler.getResponseHandler().updateTimeOfLastRequest();
+      if (handler != null) {
+        synchronized (handler) {
+          handler.getResponseHandler().updateTimeOfLastRequest();
+        }
       }
 
       if (cachedClient.isActive()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TransportClientFactory` checks whether `handler` is null when creating client.

### Why are the changes needed?

There is a case that `cachedClient.isActive()` may return true and may return false when checked for the second time when another thread is closing the channel, which causes that the `handler` may be null. Therefore, `TransportClientFactory` should check whether handler is null when creating client.

Backport https://github.com/apache/spark/pull/46506.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.