### PR TITLE
[CELEBORN-1431][HELM] Expose release_name in PodMonitor

### DIFF
--- a/charts/celeborn/templates/master/podmonitor.yaml
+++ b/charts/celeborn/templates/master/podmonitor.yaml
@@ -29,6 +29,9 @@ spec:
     port: {{ .Values.podMonitor.podMetricsEndpoint.portName | quote }}
     scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
     path: {{ get .Values.celeborn "celeborn.metrics.prometheus.path" | default "/metrics/prometheus" }}
+    relabelings:
+    - targetLabel: release_name
+      replacement: {{ .Release.Name }}
   jobLabel: celeborn-master-podmonitor
   namespaceSelector:
     matchNames:

--- a/charts/celeborn/templates/worker/podmonitor.yaml
+++ b/charts/celeborn/templates/worker/podmonitor.yaml
@@ -29,6 +29,9 @@ spec:
     port: {{ .Values.podMonitor.podMetricsEndpoint.portName | quote }}
     scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
     path: {{ get .Values.celeborn "celeborn.metrics.prometheus.path" | default "/metrics/prometheus" }}
+    relabelings:
+    - targetLabel: release_name
+      replacement: {{ .Release.Name }}
   jobLabel: celeborn-worker-podmonitor
   namespaceSelector:
     matchNames:

--- a/charts/celeborn/tests/master/podmonitor_test.yaml
+++ b/charts/celeborn/tests/master/podmonitor_test.yaml
@@ -45,6 +45,21 @@ tests:
           kind: PodMonitor
           name: celeborn-master-podmonitor
 
+  - it: Should use release name as custom label release_name's value
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints[0].relabelings
+          content:
+            targetLabel: release_name
+            replacement: celeborn
+          count: 1
+
   - it: Should use the specified pod metrics endpoints
     capabilities:
       apiVersions:
@@ -64,6 +79,9 @@ tests:
             port: test-port
             scheme: http
             path: /metrics/prometheus
+            relabelings:
+              - targetLabel: release_name
+                replacement: celeborn
           count: 1
 
   - it: Should respect `celeborn.metrics.prometheus.path`
@@ -83,4 +101,7 @@ tests:
             port: metrics
             scheme: http
             path: custom-metrics-path
+            relabelings:
+              - targetLabel: release_name
+                replacement: celeborn
           count: 1

--- a/charts/celeborn/tests/worker/podmonitor_test.yaml
+++ b/charts/celeborn/tests/worker/podmonitor_test.yaml
@@ -45,6 +45,21 @@ tests:
           kind: PodMonitor
           name: celeborn-worker-podmonitor
 
+  - it: Should use release name as custom label release_name's value
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints[0].relabelings
+          content:
+            targetLabel: release_name
+            replacement: celeborn
+          count: 1
+
   - it: Should use the specified pod metrics endpoints
     capabilities:
       apiVersions:
@@ -64,6 +79,9 @@ tests:
             port: test-port
             scheme: http
             path: /metrics/prometheus
+            relabelings:
+              - targetLabel: release_name
+                replacement: celeborn
           count: 1
 
   - it: Should respect `celeborn.metrics.prometheus.path`
@@ -83,4 +101,7 @@ tests:
             port: metrics
             scheme: http
             path: custom-metrics-path
+            relabelings:
+              - targetLabel: release_name
+                replacement: celeborn
           count: 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This PR modifies the Helm chart to expose the release_name as a label in Prometheus metrics.

### Why are the changes needed?

To distinguish different Celeboarn cluster's metrics when deploying multiple Celeborn releases in the same K8s cluster and the same namespace.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New UTs are added