### PR TITLE
[CELEBORN-1434] Support MRAppMasterWithCeleborn to disable job recovery and job reduce slow start by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Meanwhile, configure the following settings in YARN and MapReduce config.
 -Dmapreduce.job.map.output.collector.class=org.apache.hadoop.mapred.CelebornMapOutputCollector
 -Dmapreduce.job.reduce.shuffle.consumer.plugin.class=org.apache.hadoop.mapreduce.task.reduce.CelebornShuffleConsumer
 ```
+**Note**: `MRAppMasterWithCeleborn` disables `yarn.app.mapreduce.am.job.recovery.enable` and sets `mapreduce.job.reduce.slowstart.completedmaps` to 1 by default.
 
 ### Best Practice
 If you want to set up a production-ready Celeborn cluster, your cluster should have at least 3 masters and at least 4 workers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,6 +207,8 @@ cp $CELEBORN_HOME/mr/<Celeborn Client Jar> <yarn.application.classpath>
     </property>
 </configuration>
 ```
+**Note**: `MRAppMasterWithCeleborn` disables `yarn.app.mapreduce.am.job.recovery.enable` and sets `mapreduce.job.reduce.slowstart.completedmaps` to 1 by default.
+
 Then deploy the example word count to the running cluster for verifying whether above configurations are correct.
 ```shell
 cd $HADOOP_HOME

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -243,3 +243,4 @@ Meanwhile, configure the following settings in YARN and MapReduce config.
 -Dmapreduce.job.map.output.collector.class=org.apache.hadoop.mapred.CelebornMapOutputCollector
 -Dmapreduce.job.reduce.shuffle.consumer.plugin.class=org.apache.hadoop.mapreduce.task.reduce.CelebornShuffleConsumer
 ```
+**Note**: `MRAppMasterWithCeleborn` disables `yarn.app.mapreduce.am.job.recovery.enable` and sets `mapreduce.job.reduce.slowstart.completedmaps` to 1 by default.

--- a/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
+++ b/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
@@ -109,7 +109,6 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
       try {
         val conf = new Configuration(yarnCluster.getConfig)
         // YARN config
-        conf.set("yarn.app.mapreduce.am.job.recovery.enable", "false")
         conf.set(
           "yarn.app.mapreduce.am.command-opts",
           "org.apache.celeborn.mapreduce.v2.app.MRAppMasterWithCeleborn")
@@ -118,7 +117,6 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
         conf.set("mapreduce.framework.name", "yarn")
         conf.set("mapreduce.job.user.classpath.first", "true")
 
-        conf.set("mapreduce.job.reduce.slowstart.completedmaps", "1")
         conf.set(
           "mapreduce.celeborn.master.endpoints",
           s"localhost:${master.conf.get(CelebornConf.MASTER_PORT)}")
@@ -196,7 +194,6 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
     var exitCode = false
     val conf = new Configuration(yarnCluster.getConfig)
     // YARN config
-    conf.set("yarn.app.mapreduce.am.job.recovery.enable", "false")
     conf.set(
       "yarn.app.mapreduce.am.command-opts",
       "org.apache.celeborn.mapreduce.v2.app.MRAppMasterWithCeleborn")
@@ -205,7 +202,6 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
     conf.set("mapreduce.framework.name", "yarn")
     conf.set("mapreduce.job.user.classpath.first", "true")
 
-    conf.set("mapreduce.job.reduce.slowstart.completedmaps", "1")
     conf.set(
       "mapreduce.celeborn.master.endpoints",
       s"errorhost:${master.conf.get(CelebornConf.MASTER_PORT)}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MRAppMasterWithCeleborn` disables `yarn.app.mapreduce.am.job.recovery.enable` and sets `mapreduce.job.reduce.slowstart.completedmaps` to 1 by default.

### Why are the changes needed?

MapReduce does not set the flag which indicates whether to keep containers across application attempts in ApplicationSubmissionContext. Meanwhile, make sure reduces are scheduled only after all map are completed. Therefore, `MRAppMasterWithCeleborn` could disable `yarn.app.mapreduce.am.job.recovery.enable` and set `mapreduce.job.reduce.slowstart.completedmaps` to 1 by default.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`WordCountTest`