### PR TITLE
[CELEBORN-1380][FOLLOWUP] Add org.openlabtesting.leveldbjni in BSD 3-clause of LICENSE-binary

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -302,7 +302,7 @@ BSD 3-clause
 See licenses/LICENSE-protobuf.txt for details.
 com.google.protobuf:protobuf-java
 See licenses/LICENSE-leveldbjni.txt for details.
-org.fusesource.leveldbjni:leveldbjni-all
+org.openlabtesting.leveldbjni:leveldbjni-all
 
 
 Common Development and Distribution License (CDDL) 1.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `org.openlabtesting.leveldbjni` in BSD 3-clause of LICENSE-binary instead of `org.fusesource.leveldbjni`.

### Why are the changes needed?

BSD 3-clause of LICENSE-binary includes `org.fusesource.leveldbjni` which has been already changed to `org.openlabtesting.leveldbjni`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.