### PR TITLE
[CELEBORN-1441] RocksDBLogger uses Logger#Logger(InfoLogLevel) instead of deprecated constructor of o.rocksdb.Logger

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBProvider.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBProvider.java
@@ -138,7 +138,7 @@ public class RocksDBProvider {
     private static final Logger LOG = LoggerFactory.getLogger(RocksDBLogger.class);
 
     RocksDBLogger(Options options) {
-      super(options);
+      super(options.infoLogLevel());
     }
 
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

`RocksDBLogger` uses `Logger#Logger(InfoLogLevel)` instead of deprecated constructor of `o.rocksdb.Logger` to clean up the use of deprecated APIs related to `o.rocksdb.Logger`.

### Why are the changes needed?

`RocksDBLogger` uses `Logger#Logger(InfoLogLevel)` instead of deprecated constructor of `o.rocksdb.Logger` that refers to [Logger.java#L39-L54](https://github.com/facebook/rocksdb/blob/5c2be544f5509465957706c955b6d623e889ac4e/java/src/main/java/org/rocksdb/Logger.java#L39-L54).

```
/**
  * <p>AbstractLogger constructor.</p>
  *
  * <p><strong>Important:</strong> the log level set within
  * the {@link org.rocksdb.Options} instance will be used as
  * maximum log level of RocksDB.</p>
  *
  * @param options {@link org.rocksdb.Options} instance.
  *
  * @deprecated Use {@link Logger#Logger(InfoLogLevel)} instead, e.g. {@code new
  *     Logger(options.infoLogLevel())}.
  */
@Deprecated
public Logger(final Options options) {
    this(options.infoLogLevel());
}
```

Backport https://github.com/apache/spark/pull/46436.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.