### PR TITLE
[CELEBORN-1445] handle NPE when open stream

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -36,8 +36,8 @@ public class ExceptionUtils {
     }
   }
 
-  public static Throwable wrapIOExceptionToUnRetryable(Throwable throwable) {
-    if (throwable instanceof IOException) {
+  public static Throwable wrapExceptionToUnRetryable(Throwable throwable) {
+    if (throwable instanceof IOException || throwable instanceof NullPointerException) {
       return new PartitionUnRetryAbleException(throwable.getMessage(), throwable);
     } else {
       return throwable;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
@@ -419,7 +419,7 @@ public class MapPartitionDataReader implements Comparable<MapPartitionDataReader
       // And do not close channel because multiple streams are using the very same channel.
       // wrapIOException to PartitionUnRetryAbleException, client may choose regenerate the data.
       this.associatedChannel.writeAndFlush(
-          new TransportableError(streamId, ExceptionUtils.wrapIOExceptionToUnRetryable(throwable)));
+          new TransportableError(streamId, ExceptionUtils.wrapExceptionToUnRetryable(throwable)));
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In some case, celeborn may lost the shuffle key, and when client try to open the stream with this shuffle key. Celeborn worker will throw NPE and won't reply the open stream request.

Client will wait(hang) until reach the fetch chunk time out, so let's fast fail with return the PartitionUnRetryAbleException.


### Why are the changes needed?
As the above.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add IT