### PR TITLE
[CELEBORN-1448] Use static regex Pattern instances in JavaUtils.timeStringAs and JavaUtils.byteStringAs

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/JavaUtils.java
@@ -242,6 +242,8 @@ public class JavaUtils {
           .put("pi", ByteUnit.PiB)
           .build();
 
+  private static final Pattern TIME_STRING_PATTERN = Pattern.compile("(-?[0-9]+)([a-z]+)?");
+
   /**
    * Convert a passed time string (e.g. 50s, 100ms, or 250us) to a time count in the given unit. The
    * unit is also considered the default if the given string does not specify a unit.
@@ -250,7 +252,7 @@ public class JavaUtils {
     String lower = str.toLowerCase(Locale.ROOT).trim();
 
     try {
-      Matcher m = Pattern.compile("(-?[0-9]+)([a-z]+)?").matcher(lower);
+      Matcher m = TIME_STRING_PATTERN.matcher(lower);
       if (!m.matches()) {
         throw new NumberFormatException("Failed to parse time string: " + str);
       }
@@ -291,6 +293,10 @@ public class JavaUtils {
     return timeStringAs(str, TimeUnit.SECONDS);
   }
 
+  private static final Pattern BYTE_STRING_PATTERN = Pattern.compile("([0-9]+)([a-z]+)?");
+  private static final Pattern BYTE_STRING_FRACTION_PATTERN =
+      Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?");
+
   /**
    * Convert a passed byte string (e.g. 50b, 100kb, or 250mb) to the given. If no suffix is
    * provided, a direct conversion to the provided unit is attempted.
@@ -299,8 +305,8 @@ public class JavaUtils {
     String lower = str.toLowerCase(Locale.ROOT).trim();
 
     try {
-      Matcher m = Pattern.compile("([0-9]+)([a-z]+)?").matcher(lower);
-      Matcher fractionMatcher = Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?").matcher(lower);
+      Matcher m = BYTE_STRING_PATTERN.matcher(lower);
+      Matcher fractionMatcher = BYTE_STRING_FRACTION_PATTERN.matcher(lower);
 
       if (m.matches()) {
         long val = Long.parseLong(m.group(1));


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?

[SPARK-48496](https://issues.apache.org/jira/browse/SPARK-48496)[CORE] Use static regex Pattern instances in JavaUtils.timeStringAs and JavaUtils.byteStringAs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
