### PR TITLE
[CELEBORN-1450] MRAppMasterWithCeleborn should get FileSystem via mapreduce.job.dir for HDFS federation

### DIFF
--- a/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
+++ b/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
@@ -81,9 +81,9 @@ public class MRAppMasterWithCeleborn extends MRAppMaster {
   private void writeLifecycleManagerConfToTask(JobConf conf, JobConf lmConf)
       throws CelebornIOException {
     try {
-      FileSystem fs = FileSystem.get(conf);
       String jobDirStr = conf.get(MRJobConfig.MAPREDUCE_JOB_DIR);
       Path celebornConfPath = new Path(jobDirStr, HadoopUtils.MR_CELEBORN_CONF);
+      FileSystem fs = celebornConfPath.getFileSystem(conf);
 
       try (FSDataOutputStream out =
           FileSystem.create(


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MRAppMasterWithCeleborn` gets `FileSystem` via `mapreduce.job.dir` for HDFS federation.

### Why are the changes needed?

`MRAppMasterWithCeleborn` should get `FileSystem` via `mapreduce.job.dir` for HDFS federation. Otherwise, the Celeborn conf path of `celeborn.xml` is wrong for the following example configuration:

```
<property>
   <name>fs.defaultFS</name>
   <value>viewfs://bigdata-cluster</value>
</property>
<property>
   <name>fs.viewfs.mounttable.bigdata-cluster.link./application</name>
   <value>hdfs://bigdata-proxy-ns/application</value>
</property>
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Cluster test.