### PR TITLE
[CELEBORN-1457] Avoid NPE during shuffle data cleanup

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -232,8 +232,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       reloadAndCleanFileInfos(this.db)
     } catch {
       case e: Exception =>
-        logError("Init level DB failed:", e)
-        this.db = null
+        throw new IllegalStateException("Enable workerGracefulShutdown but failed to initialize db for recovery", e)
     }
     saveCommittedFileInfosExecutor =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor(
@@ -574,7 +573,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         }
         if (workerGracefulShutdown) {
           committedFileInfos.remove(shuffleKey)
-          if (cleanDB && null != db) {
+          if (cleanDB) {
             db.delete(dbShuffleKey(shuffleKey))
           }
         }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -232,7 +232,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       reloadAndCleanFileInfos(this.db)
     } catch {
       case e: Exception =>
-        throw new IllegalStateException("Enable workerGracefulShutdown but failed to initialize db for recovery", e)
+        throw new IllegalStateException(
+          "Failed to initialize db for recovery during graceful worker shutdown.",
+          e)
     }
     saveCommittedFileInfosExecutor =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -574,7 +574,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         }
         if (workerGracefulShutdown) {
           committedFileInfos.remove(shuffleKey)
-          if (cleanDB) {
+          if (cleanDB && null != db) {
             db.delete(dbShuffleKey(shuffleKey))
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Avoid NPE during shuffle data cleanup by checking for null LevelDB.


### Why are the changes needed?
If the LevelDB in StorageManager fails to initialize, the db will be null. This will cause a java.lang.NullPointerException when storageManager.cleanupExpiredShuffleKey(expiredShuffleKeys) is called, and the shuffle data in expiredShuffleKeys will not be cleaned up. The worker's disk may be filled up as a result.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual Testing
