### PR TITLE
[CELEBORN-1190][FOLLOWUP] Fix WARNING of error prone

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -60,7 +60,7 @@ import org.apache.celeborn.plugin.flink.utils.BufferUtils;
 public class RemoteShuffleInputGateDelegation {
   private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleInputGateDelegation.class);
   /** Lock to protect {@link #receivedBuffers} and {@link #cause} and {@link #closed}. */
-  private Object lock = new Object();
+  private final Object lock = new Object();
 
   /** Name of the corresponding computing task. */
   private String taskName;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfo.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfo.java
@@ -33,7 +33,7 @@ public class ShuffleTaskInfo {
   private ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, AtomicInteger>>
       shuffleIdMapAttemptIdIndex = JavaUtils.newConcurrentHashMap();
   // task shuffle id -> celeborn shuffle id
-  private ConcurrentHashMap<String, Integer> taskShuffleIdToShuffleId =
+  private final ConcurrentHashMap<String, Integer> taskShuffleIdToShuffleId =
       JavaUtils.newConcurrentHashMap();
   // celeborn shuffle id -> task shuffle id
   private ConcurrentHashMap<Integer, String> shuffleIdToTaskShuffleId =

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/TransferBufferPool.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/TransferBufferPool.java
@@ -182,16 +182,14 @@ public class TransferBufferPool implements BufferRecycler {
   private List<CreditAssignment> dispatchReservedCredits() {
     assert Thread.holdsLock(lock);
 
-    if (numAvailableBuffers < MIN_CREDITS_TO_NOTIFY || listeners.size() <= 0) {
-      return Collections.emptyList();
-    }
-
     List<CreditAssignment> creditAssignments = new ArrayList<>();
-    while (numAvailableBuffers > 0 && listeners.size() > 0) {
-      CreditListener creditListener = listeners.poll();
-      int numCredits = assignCredits(creditListener);
-      if (numCredits > 0) {
-        creditAssignments.add(new CreditAssignment(numCredits, creditListener));
+    if (numAvailableBuffers >= MIN_CREDITS_TO_NOTIFY && !listeners.isEmpty()) {
+      while (numAvailableBuffers > 0 && !listeners.isEmpty()) {
+        CreditListener creditListener = listeners.poll();
+        int numCredits = assignCredits(creditListener);
+        if (numCredits > 0) {
+          creditAssignments.add(new CreditAssignment(numCredits, creditListener));
+        }
       }
     }
     return creditAssignments;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
@@ -55,7 +55,7 @@ public class CelebornBufferStream {
   private FlinkShuffleClientImpl mapShuffleClient;
   private boolean isClosed;
   private boolean isOpenSuccess;
-  private Object lock = new Object();
+  private final Object lock = new Object();
   private Supplier<ByteBuf> bufferSupplier;
   private int initialCredit;
   private Consumer<RequestMessage> messageConsumer;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -17,10 +17,10 @@
 
 package org.apache.celeborn.plugin.flink.utils;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -31,19 +31,16 @@ import org.apache.celeborn.common.CelebornConf;
 public class FlinkUtils {
   private static final JobID ZERO_JOB_ID = new JobID(0, 0);
   public static final Set<String> pluginConfNames =
-      new HashSet<String>() {
-        {
-          add("remote-shuffle.job.min.memory-per-partition");
-          add("remote-shuffle.job.min.memory-per-gate");
-          add("remote-shuffle.job.concurrent-readings-per-gate");
-          add("remote-shuffle.job.memory-per-partition");
-          add("remote-shuffle.job.memory-per-gate");
-          add("remote-shuffle.job.support-floating-buffer-per-input-gate");
-          add("remote-shuffle.job.enable-data-compression");
-          add("remote-shuffle.job.support-floating-buffer-per-output-gate");
-          add("remote-shuffle.job.compression.codec");
-        }
-      };
+      ImmutableSet.of(
+          "remote-shuffle.job.min.memory-per-partition",
+          "remote-shuffle.job.min.memory-per-gate",
+          "remote-shuffle.job.concurrent-readings-per-gate",
+          "remote-shuffle.job.memory-per-partition",
+          "remote-shuffle.job.memory-per-gate",
+          "remote-shuffle.job.support-floating-buffer-per-input-gate",
+          "remote-shuffle.job.enable-data-compression",
+          "remote-shuffle.job.support-floating-buffer-per-output-gate",
+          "remote-shuffle.job.compression.codec");
 
   public static CelebornConf toCelebornConf(Configuration configuration) {
     CelebornConf tmpCelebornConf = new CelebornConf();

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/BufferPackSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/BufferPackSuiteJ.java
@@ -203,10 +203,7 @@ public class BufferPackSuiteJ {
     packer.process(buffers.get(0), 0);
     try {
       packer.drain();
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-    } catch (Exception e) {
-      throw e;
+    } catch (RuntimeException ignored) {
     }
 
     // this should never throw any exception

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -137,7 +137,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
 
   private List<SupplierWithException<BufferPool, IOException>> createBufferPoolFactory() {
     NetworkBufferPool networkBufferPool =
-        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofMillis(1000));
+        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofSeconds(1));
 
     int numBuffersPerPartition = 64 * 1024 / 32;
     int numForResultPartition = numBuffersPerPartition * 7 / 8;

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -137,7 +137,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
 
   private List<SupplierWithException<BufferPool, IOException>> createBufferPoolFactory() {
     NetworkBufferPool networkBufferPool =
-        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofMillis(1000));
+        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofSeconds(1));
 
     int numBuffersPerPartition = 64 * 1024 / 32;
     int numForResultPartition = numBuffersPerPartition * 7 / 8;

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -137,7 +137,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
 
   private List<SupplierWithException<BufferPool, IOException>> createBufferPoolFactory() {
     NetworkBufferPool networkBufferPool =
-        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofMillis(1000));
+        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofSeconds(1));
 
     int numBuffersPerPartition = 64 * 1024 / 32;
     int numForResultPartition = numBuffersPerPartition * 7 / 8;

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -137,7 +137,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
 
   private List<SupplierWithException<BufferPool, IOException>> createBufferPoolFactory() {
     NetworkBufferPool networkBufferPool =
-        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofMillis(1000));
+        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofSeconds(1));
 
     int numBuffersPerPartition = 64 * 1024 / 32;
     int numForResultPartition = numBuffersPerPartition * 7 / 8;

--- a/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -137,7 +137,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
 
   private List<SupplierWithException<BufferPool, IOException>> createBufferPoolFactory() {
     NetworkBufferPool networkBufferPool =
-        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofMillis(1000));
+        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofSeconds(1));
 
     int numBuffersPerPartition = 64 * 1024 / 32;
     int numForResultPartition = numBuffersPerPartition * 7 / 8;

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -117,7 +117,7 @@ public class SparkShuffleManager implements ShuffleManager {
 
     lifecycleManager.registerAppShuffleDeterminate(
         shuffleId,
-        dependency.rdd().getOutputDeterministicLevel() != DeterministicLevel.INDETERMINATE());
+        !DeterministicLevel.INDETERMINATE().equals(dependency.rdd().getOutputDeterministicLevel()));
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleDataIO.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleDataIO.java
@@ -62,6 +62,7 @@ class CelebornShuffleDriverComponents extends LocalDiskShuffleDriverComponents {
   }
 
   // Omitting @Override annotation to avoid compile error before Spark 3.5.0
+  @SuppressWarnings("MissingOverride")
   public boolean supportsReliableStorage() {
     return supportsReliableStorage;
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -160,7 +160,7 @@ public class SparkShuffleManager implements ShuffleManager {
 
     lifecycleManager.registerAppShuffleDeterminate(
         shuffleId,
-        dependency.rdd().getOutputDeterministicLevel() != DeterministicLevel.INDETERMINATE());
+        !DeterministicLevel.INDETERMINATE().equals(dependency.rdd().getOutputDeterministicLevel()));
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -113,7 +113,6 @@ public class ShuffleClientImpl extends ShuffleClient {
   protected final Map<String, PushState> pushStates = JavaUtils.newConcurrentHashMap();
 
   private final boolean pushExcludeWorkerOnFailureEnabled;
-  private final boolean shuffleCompressionEnabled;
   private final Set<String> pushExcludedWorkers = ConcurrentHashMap.newKeySet();
   private final ConcurrentHashMap<String, Long> fetchExcludedWorkers =
       JavaUtils.newConcurrentHashMap();
@@ -126,13 +125,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   private final boolean authEnabled;
   private final TransportConf dataTransportConf;
 
-  private final ThreadLocal<Compressor> compressorThreadLocal =
-      new ThreadLocal<Compressor>() {
-        @Override
-        protected Compressor initialValue() {
-          return Compressor.getCompressor(conf);
-        }
-      };
+  private ThreadLocal<Compressor> compressorThreadLocal;
 
   private final ReviveManager reviveManager;
 
@@ -178,7 +171,9 @@ public class ShuffleClientImpl extends ShuffleClient {
     testRetryRevive = conf.testRetryRevive();
     pushBufferMaxSize = conf.clientPushBufferMaxSize();
     pushExcludeWorkerOnFailureEnabled = conf.clientPushExcludeWorkerOnFailureEnabled();
-    shuffleCompressionEnabled = !conf.shuffleCompressionCodec().equals(CompressionCodec.NONE);
+    if (!CompressionCodec.NONE.equals(conf.shuffleCompressionCodec())) {
+      compressorThreadLocal = ThreadLocal.withInitial(() -> Compressor.getCompressor(conf));
+    }
     if (conf.clientPushReplicateEnabled()) {
       pushDataTimeout = conf.pushDataTimeoutMs() * 2;
     } else {
@@ -747,6 +742,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         case PUSH_DATA_TIMEOUT_REPLICA:
           pushExcludedWorkers.add(oldLocation.getPeer().hostAndPushPort());
           break;
+        default: // fall out
       }
     }
   }
@@ -938,7 +934,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     // increment batchId
     final int nextBatchId = pushState.nextBatchId();
 
-    if (shuffleCompressionEnabled) {
+    if (compressorThreadLocal != null) {
       // compress data
       final Compressor compressor = compressorThreadLocal.get();
       compressor.compress(data, offset, length);
@@ -1656,6 +1652,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                       "Request %s return %s for %s.",
                       getReducerFileGroup, response.status(), shuffleId);
               logger.warn(exceptionMsg);
+              break;
+            default: // fall out
           }
         }
       } catch (Exception e) {
@@ -1666,6 +1664,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
   }
 
+  @Override
   public ReduceFileGroups updateFileGroup(int shuffleId, int partitionId)
       throws CelebornIOException {
     Tuple2<ReduceFileGroups, String> fileGroupTuple =
@@ -1850,6 +1849,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   @VisibleForTesting
+  @Override
   public TransportClientFactory getDataClientFactory() {
     return dataClientFactory;
   }

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -51,7 +51,7 @@ import org.apache.celeborn.common.util.ThreadUtils;
 public class LocalPartitionReader implements PartitionReader {
 
   private static final Logger logger = LoggerFactory.getLogger(LocalPartitionReader.class);
-  private static volatile ThreadPoolExecutor readLocalShufflePool;
+  private volatile ThreadPoolExecutor readLocalShufflePool;
   private final LinkedBlockingQueue<ByteBuf> results;
   private final AtomicReference<IOException> exception = new AtomicReference<>();
   private final int fetchMaxReqsInFlight;

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -51,7 +51,7 @@ import org.apache.celeborn.common.util.ThreadUtils;
 public class LocalPartitionReader implements PartitionReader {
 
   private static final Logger logger = LoggerFactory.getLogger(LocalPartitionReader.class);
-  private volatile ThreadPoolExecutor readLocalShufflePool;
+  private static volatile ThreadPoolExecutor readLocalShufflePool;
   private final LinkedBlockingQueue<ByteBuf> results;
   private final AtomicReference<IOException> exception = new AtomicReference<>();
   private final int fetchMaxReqsInFlight;
@@ -69,6 +69,7 @@ public class LocalPartitionReader implements PartitionReader {
   private TransportClient client;
   private MetricsCallback metricsCallback;
 
+  @SuppressWarnings("StaticAssignmentInConstructor")
   public LocalPartitionReader(
       CelebornConf conf,
       String shuffleKey,

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -56,7 +56,7 @@ public abstract class FileInfo {
     return bytesFlushed;
   }
 
-  public void updateBytesFlushed(long bytes) {
+  public synchronized void updateBytesFlushed(long bytes) {
     bytesFlushed += bytes;
     if (isReduceFileMeta) {
       getReduceFileMeta().updateChunkOffset(bytesFlushed, false);

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientBootstrap.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientBootstrap.java
@@ -31,7 +31,6 @@ public interface TransportClientBootstrap {
    * Performs the bootstrapping operation, throwing an exception on failure.
    *
    * @param client the transport client to bootstrap
-   * @param channel the associated channel with the transport client
    * @throws RuntimeException
    */
   void doBootstrap(TransportClient client) throws RuntimeException;

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -63,11 +63,11 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   private final AtomicLong timeOfLastRequestNs;
 
   private final long pushTimeoutCheckerInterval;
-  private static ScheduledExecutorService pushTimeoutChecker = null;
+  private ScheduledExecutorService pushTimeoutChecker;
   private ScheduledFuture pushCheckerScheduleFuture;
 
   private final long fetchTimeoutCheckerInterval;
-  private static ScheduledExecutorService fetchTimeoutChecker = null;
+  private ScheduledExecutorService fetchTimeoutChecker;
   private ScheduledFuture fetchCheckerScheduleFuture;
 
   public TransportResponseHandler(TransportConf conf, Channel channel) {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -63,13 +63,14 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   private final AtomicLong timeOfLastRequestNs;
 
   private final long pushTimeoutCheckerInterval;
-  private ScheduledExecutorService pushTimeoutChecker;
+  private static ScheduledExecutorService pushTimeoutChecker = null;
   private ScheduledFuture pushCheckerScheduleFuture;
 
   private final long fetchTimeoutCheckerInterval;
-  private ScheduledExecutorService fetchTimeoutChecker;
+  private static ScheduledExecutorService fetchTimeoutChecker = null;
   private ScheduledFuture fetchCheckerScheduleFuture;
 
+  @SuppressWarnings("StaticAssignmentInConstructor")
   public TransportResponseHandler(TransportConf conf, Channel channel) {
     this.conf = conf;
     this.channel = channel;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -55,6 +55,7 @@ public abstract class Message implements Encodable {
     return false;
   }
 
+  @SuppressWarnings("NonOverridingEquals")
   protected boolean equals(Message other) {
     return Objects.equals(body, other.body);
   }

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslClientFactory.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.common.network.sasl.anonymous;
 
 import static org.apache.celeborn.common.network.sasl.SaslUtils.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -70,7 +71,7 @@ public class AnonymousSaslClientFactory implements SaslClientFactory {
     return new String[] {ANONYMOUS};
   }
 
-  class CelebornAnonymousSaslClient implements SaslClient {
+  static class CelebornAnonymousSaslClient implements SaslClient {
 
     private boolean isCompleted = false;
 
@@ -90,7 +91,7 @@ public class AnonymousSaslClientFactory implements SaslClientFactory {
         throw new IllegalStateException("Authentication has already completed.");
       }
       isCompleted = true;
-      return ANONYMOUS.getBytes();
+      return ANONYMOUS.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslServerFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslServerFactory.java
@@ -64,7 +64,7 @@ public class AnonymousSaslServerFactory implements SaslServerFactory {
     return new String[] {ANONYMOUS};
   }
 
-  class CelebornAnonymousSaslServer implements SaslServer {
+  static class CelebornAnonymousSaslServer implements SaslServer {
     private boolean isCompleted = false;
 
     @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManager.java
@@ -200,20 +200,22 @@ public class ReloadingX509TrustManager implements X509TrustManager, Runnable {
       } catch (InterruptedException e) {
         running = false;
       }
-      try {
-        if (running && needsReload()) {
-          try {
-            trustManagerRef.set(loadTrustManager());
-            this.reloadCount += 1;
-          } catch (Exception ex) {
-            logger.warn(
-                "Could not load truststore (keep using existing one) : " + ex.toString(), ex);
+      synchronized (this) {
+        try {
+          if (running && needsReload()) {
+            try {
+              trustManagerRef.set(loadTrustManager());
+              this.reloadCount += 1;
+            } catch (Exception ex) {
+              logger.warn(
+                  "Could not load truststore (keep using existing one) : " + ex.toString(), ex);
+            }
           }
+        } catch (IOException ex) {
+          logger.warn("Could not check whether truststore needs reloading: " + ex.toString(), ex);
         }
-      } catch (IOException ex) {
-        logger.warn("Could not check whether truststore needs reloading: " + ex.toString(), ex);
+        needsReloadCheckCounts++;
       }
-      needsReloadCheckCounts++;
     }
   }
 

--- a/common/src/test/java/org/apache/celeborn/common/network/SSLTransportClientFactorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/SSLTransportClientFactorySuiteJ.java
@@ -29,6 +29,7 @@ import org.apache.celeborn.common.network.ssl.SslSampleConfigs;
 public class SSLTransportClientFactorySuiteJ extends TransportClientFactorySuiteJ {
 
   @Before
+  @Override
   public void setUp() {
     // set up SSL for TEST_MODULE
     doSetup(
@@ -37,6 +38,7 @@ public class SSLTransportClientFactorySuiteJ extends TransportClientFactorySuite
   }
 
   @After
+  @Override
   public void tearDown() {
     super.tearDown();
   }

--- a/common/src/test/java/org/apache/celeborn/common/network/protocol/EncryptedMessageWithHeaderSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/protocol/EncryptedMessageWithHeaderSuiteJ.java
@@ -121,7 +121,7 @@ public class EncryptedMessageWithHeaderSuiteJ {
 
       // Validate we read data correctly
       assertEquals(bodyResult.readableBytes(), chunkSize);
-      assert (bodyResult.readableBytes() < (randomData.length - readIndex));
+      assertTrue(bodyResult.readableBytes() < (randomData.length - readIndex));
       while (bodyResult.readableBytes() > 0) {
         assertEquals(bodyResult.readByte(), randomData[readIndex++]);
       }

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
@@ -96,9 +96,7 @@ public class SaslTestBase {
           TimeUnit.MILLISECONDS.sleep(10);
         }
       }
-      if (error != null) {
-        throw error;
-      }
+      assertNull(error);
     }
   }
 

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
@@ -96,7 +96,9 @@ public class SaslTestBase {
           TimeUnit.MILLISECONDS.sleep(10);
         }
       }
-      assertNull(error);
+      if (error != null) {
+        throw error;
+      }
     }
   }
 

--- a/common/src/test/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManagerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManagerSuiteJ.java
@@ -101,15 +101,7 @@ public class ReloadingX509TrustManagerSuiteJ {
 
     assertThrows(
         IOException.class,
-        () -> {
-          ReloadingX509TrustManager tm =
-              new ReloadingX509TrustManager(KeyStore.getDefaultType(), trustStore, "password", 10);
-          try {
-            tm.init();
-          } finally {
-            tm.destroy();
-          }
-        });
+        () -> new ReloadingX509TrustManager(KeyStore.getDefaultType(), trustStore, "password", 10));
   }
 
   /**
@@ -127,17 +119,8 @@ public class ReloadingX509TrustManagerSuiteJ {
 
     assertThrows(
         IOException.class,
-        () -> {
-          ReloadingX509TrustManager tm =
-              new ReloadingX509TrustManager(
-                  KeyStore.getDefaultType(), corruptStore, "password", 10);
-          try {
-            tm.init();
-          } finally {
-            tm.destroy();
-            corruptStore.delete();
-          }
-        });
+        () ->
+            new ReloadingX509TrustManager(KeyStore.getDefaultType(), corruptStore, "password", 10));
   }
 
   /**

--- a/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java
@@ -149,7 +149,7 @@ public class SslSampleConfigs {
    *     be specified to use it
    * @return the signed certificate (signed using ca if provided, else self-signed)
    */
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("JavaUtilDate")
   public static X509Certificate generateCertificate(
       String dn,
       KeyPair pair,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -163,6 +163,7 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
     updateWorkerEventMeta(workerEventTypeValue, workerInfoList);
   }
 
+  @Override
   public void handleUpdatePartitionSize() {
     updatePartitionSize();
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -493,7 +493,7 @@ public class HARaftServer {
   /**
    * Get the suggested leader peer id.
    *
-   * @return RaftPeerId of the suggested leader node - Optional<LeaderPeerEndpoints>
+   * @return RaftPeerId of the suggested leader node - {@code Optional<LeaderPeerEndpoints>}
    */
   public Optional<LeaderPeerEndpoints> getCachedLeaderPeerRpcEndpoint() {
     this.roleCheckLock.readLock().lock();

--- a/pom.xml
+++ b/pom.xml
@@ -1135,14 +1135,18 @@
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne \
                 -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
-                -Xep:FutureReturnValueIgnored:OFF \
-                -Xep:TypeParameterUnusedInFormals:OFF \
-                -Xep:UnusedVariable:OFF \
-                -Xep:StringSplitter:OFF \
+                -Xep:BadImport:OFF \
                 -Xep:EmptyBlockTag:OFF \
+                -Xep:EmptyCatch:OFF \
                 -Xep:EqualsGetClass:OFF \
+                -Xep:FutureReturnValueIgnored:OFF \
+                -Xep:JdkObsolete:OFF \
                 -Xep:MissingSummary:OFF \
-                -Xep:BadImport:OFF</arg>
+                -Xep:MutableConstantField:OFF \
+                -Xep:StringSplitter:OFF \
+                -Xep:TypeParameterUnusedInFormals:OFF \
+                -Xep:UnnecessaryParentheses:OFF \
+                -Xep:UnusedVariable:OFF</arg>
             </compilerArgs>
             <annotationProcessorPaths>
               <path>
@@ -1493,14 +1497,18 @@
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
                   -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
-                  -Xep:FutureReturnValueIgnored:OFF \
-                  -Xep:TypeParameterUnusedInFormals:OFF \
-                  -Xep:UnusedVariable:OFF \
-                  -Xep:StringSplitter:OFF \
+                  -Xep:BadImport:OFF \
                   -Xep:EmptyBlockTag:OFF \
+                  -Xep:EmptyCatch:OFF \
                   -Xep:EqualsGetClass:OFF \
+                  -Xep:FutureReturnValueIgnored:OFF \
+                  -Xep:JdkObsolete:OFF \
                   -Xep:MissingSummary:OFF \
-                  -Xep:BadImport:OFF</arg>
+                  -Xep:MutableConstantField:OFF \
+                  -Xep:StringSplitter:OFF \
+                  -Xep:TypeParameterUnusedInFormals:OFF \
+                  -Xep:UnnecessaryParentheses:OFF \
+                  -Xep:UnusedVariable:OFF</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
@@ -1549,14 +1557,18 @@
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
                   -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
-                  -Xep:FutureReturnValueIgnored:OFF \
-                  -Xep:TypeParameterUnusedInFormals:OFF \
-                  -Xep:UnusedVariable:OFF \
-                  -Xep:StringSplitter:OFF \
+                  -Xep:BadImport:OFF \
                   -Xep:EmptyBlockTag:OFF \
+                  -Xep:EmptyCatch:OFF \
                   -Xep:EqualsGetClass:OFF \
+                  -Xep:FutureReturnValueIgnored:OFF \
+                  -Xep:JdkObsolete:OFF \
                   -Xep:MissingSummary:OFF \
-                  -Xep:BadImport:OFF</arg>
+                  -Xep:MutableConstantField:OFF \
+                  -Xep:StringSplitter:OFF \
+                  -Xep:TypeParameterUnusedInFormals:OFF \
+                  -Xep:UnnecessaryParentheses:OFF \
+                  -Xep:UnusedVariable:OFF</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DbConfigServiceImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DbConfigServiceImpl.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.celeborn.common.CelebornConf;
@@ -54,5 +55,10 @@ public class DbConfigServiceImpl extends BaseConfigServiceImpl implements Config
                 Collectors.toMap(
                     tenantConfig -> Pair.of(tenantConfig.getTenantId(), tenantConfig.getName()),
                     Function.identity())));
+  }
+
+  @VisibleForTesting
+  public IServiceManager getServiceManager() {
+    return iServiceManager;
   }
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/model/ClusterInfo.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/model/ClusterInfo.java
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.server.common.service.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 public class ClusterInfo {
 
@@ -25,8 +25,8 @@ public class ClusterInfo {
   private String name;
   private String namespace;
   private String endpoint;
-  private Date gmtCreate;
-  private Date gmtModify;
+  private Instant gmtCreate;
+  private Instant gmtModify;
 
   public Integer getId() {
     return id;
@@ -60,19 +60,19 @@ public class ClusterInfo {
     this.endpoint = endpoint;
   }
 
-  public Date getGmtCreate() {
+  public Instant getGmtCreate() {
     return gmtCreate;
   }
 
-  public void setGmtCreate(Date gmtCreate) {
+  public void setGmtCreate(Instant gmtCreate) {
     this.gmtCreate = gmtCreate;
   }
 
-  public Date getGmtModify() {
+  public Instant getGmtModify() {
     return gmtModify;
   }
 
-  public void setGmtModify(Date gmtModify) {
+  public void setGmtModify(Instant gmtModify) {
     this.gmtModify = gmtModify;
   }
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/model/ClusterSystemConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/model/ClusterSystemConfig.java
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.server.common.service.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 public class ClusterSystemConfig {
   private Integer id;
@@ -25,8 +25,8 @@ public class ClusterSystemConfig {
   private String configKey;
   private String configValue;
   private String type;
-  private Date gmtCreate;
-  private Date gmtModify;
+  private Instant gmtCreate;
+  private Instant gmtModify;
 
   public Integer getId() {
     return id;
@@ -68,19 +68,19 @@ public class ClusterSystemConfig {
     this.type = type;
   }
 
-  public Date getGmtCreate() {
+  public Instant getGmtCreate() {
     return gmtCreate;
   }
 
-  public void setGmtCreate(Date gmtCreate) {
+  public void setGmtCreate(Instant gmtCreate) {
     this.gmtCreate = gmtCreate;
   }
 
-  public Date getGmtModify() {
+  public Instant getGmtModify() {
     return gmtModify;
   }
 
-  public void setGmtModify(Date gmtModify) {
+  public void setGmtModify(Instant gmtModify) {
     this.gmtModify = gmtModify;
   }
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/model/ClusterTenantConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/model/ClusterTenantConfig.java
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.server.common.service.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,8 +32,8 @@ public class ClusterTenantConfig {
   private String configKey;
   private String configValue;
   private String type;
-  private Date gmtCreate;
-  private Date gmtModify;
+  private Instant gmtCreate;
+  private Instant gmtModify;
 
   public Integer getId() {
     return id;
@@ -99,19 +99,19 @@ public class ClusterTenantConfig {
     this.type = type;
   }
 
-  public Date getGmtCreate() {
+  public Instant getGmtCreate() {
     return gmtCreate;
   }
 
-  public void setGmtCreate(Date gmtCreate) {
+  public void setGmtCreate(Instant gmtCreate) {
     this.gmtCreate = gmtCreate;
   }
 
-  public Date getGmtModify() {
+  public Instant getGmtModify() {
     return gmtModify;
   }
 
-  public void setGmtModify(Date gmtModify) {
+  public void setGmtModify(Instant gmtModify) {
     this.gmtModify = gmtModify;
   }
 

--- a/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java
@@ -61,6 +61,7 @@ public class DbServiceManagerImpl implements IServiceManager {
     this.clusterId = createCluster(getClusterInfoFromEnv());
   }
 
+  @SuppressWarnings("JavaUtilDate")
   @Override
   public int createCluster(ClusterInfo clusterInfo) {
     ClusterInfo clusterInfoFromDB = getClusterInfo(clusterInfo.getName());

--- a/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java
@@ -18,8 +18,8 @@
 package org.apache.celeborn.server.common.service.store.db;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,15 +61,14 @@ public class DbServiceManagerImpl implements IServiceManager {
     this.clusterId = createCluster(getClusterInfoFromEnv());
   }
 
-  @SuppressWarnings("JavaUtilDate")
   @Override
   public int createCluster(ClusterInfo clusterInfo) {
     ClusterInfo clusterInfoFromDB = getClusterInfo(clusterInfo.getName());
     if (clusterInfoFromDB == null) {
       try (SqlSession sqlSession = sqlSessionFactory.openSession(true)) {
         ClusterInfoMapper mapper = sqlSession.getMapper(ClusterInfoMapper.class);
-        clusterInfo.setGmtCreate(new Date());
-        clusterInfo.setGmtModify(new Date());
+        clusterInfo.setGmtCreate(Instant.now());
+        clusterInfo.setGmtModify(Instant.now());
         mapper.insert(clusterInfo);
         LOG.info("Create cluster {} successfully.", JsonUtils.toJson(clusterInfo));
       } catch (Exception e) {

--- a/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java
@@ -67,8 +67,9 @@ public class DbServiceManagerImpl implements IServiceManager {
     if (clusterInfoFromDB == null) {
       try (SqlSession sqlSession = sqlSessionFactory.openSession(true)) {
         ClusterInfoMapper mapper = sqlSession.getMapper(ClusterInfoMapper.class);
-        clusterInfo.setGmtCreate(Instant.now());
-        clusterInfo.setGmtModify(Instant.now());
+        Instant now = Instant.now();
+        clusterInfo.setGmtCreate(now);
+        clusterInfo.setGmtModify(now);
         mapper.insert(clusterInfo);
         LOG.info("Create cluster {} successfully.", JsonUtils.toJson(clusterInfo));
       } catch (Exception e) {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -51,7 +51,7 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
     CacheLoader<String, String> cacheLoader =
         new CacheLoader<String, String>() {
           @Override
-          public String load(String appId) {
+          public String load(String appId) throws Exception {
             LOG.debug("Missing the secret for {}; fetching it from the master", appId);
             PbApplicationMetaRequest pbApplicationMetaRequest =
                 PbApplicationMetaRequest.newBuilder().setAppId(appId).build();
@@ -65,12 +65,10 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
               return pbApplicationMeta.getSecret();
             } catch (Throwable e) {
               // We catch Throwable here because masterClient.askSync declares it in its definition.
-              // If the secret is null, the authentication will fail so just logging the exception
-              // here.
               LOG.error(
                   "Failed to fetch the application meta info for {} from the master", appId, e);
+              throw new Exception(e);
             }
-            return null;
           }
         };
     secretCache = CacheBuilder.newBuilder().maximumSize(maxCacheSize).build(cacheLoader);

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -81,7 +81,8 @@ public class MemoryManager {
   private long readBufferThreshold;
   private long readBufferTarget;
   private ReadBufferDispatcher readBufferDispatcher;
-  private List<ReadBufferTargetChangeListener> readBufferTargetChangeListeners;
+  private final List<ReadBufferTargetChangeListener> readBufferTargetChangeListeners =
+      new ArrayList<>();
   private long lastNotifiedTarget = 0;
   private final ScheduledExecutorService readBufferTargetUpdateService =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor(
@@ -190,7 +191,6 @@ public class MemoryManager {
     if (readBufferThreshold > 0) {
       // if read buffer threshold is zero means that there will be no map data partitions
       readBufferDispatcher = new ReadBufferDispatcher(this, conf);
-      readBufferTargetChangeListeners = new ArrayList<>();
       readBufferTargetUpdateService.scheduleWithFixedDelay(
           () -> {
             try {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
@@ -96,14 +96,14 @@ public class ChunkStreamManager {
     }
   }
 
-  public void chunkBeingSent(long streamId) {
+  public synchronized void chunkBeingSent(long streamId) {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred++;
     }
   }
 
-  public void chunkSent(long streamId) {
+  public synchronized void chunkSent(long streamId) {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred--;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
@@ -96,17 +96,21 @@ public class ChunkStreamManager {
     }
   }
 
-  public synchronized void chunkBeingSent(long streamId) {
+  public void chunkBeingSent(long streamId) {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
-      streamState.chunksBeingTransferred++;
+      synchronized (streamState) {
+        streamState.chunksBeingTransferred++;
+      }
     }
   }
 
-  public synchronized void chunkSent(long streamId) {
+  public void chunkSent(long streamId) {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
-      streamState.chunksBeingTransferred--;
+      synchronized (streamState) {
+        streamState.chunksBeingTransferred--;
+      }
     }
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java
@@ -253,7 +253,7 @@ public class CreditStreamManager {
     return activeMapPartitions.size();
   }
 
-  protected class StreamState {
+  protected static class StreamState {
     private Channel associatedChannel;
     private String shuffleKey;
     private int bufferSize;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
@@ -332,7 +332,7 @@ public class MapPartitionDataReader implements Comparable<MapPartitionDataReader
     }
   }
 
-  private boolean readBuffer(ByteBuf buffer) throws IOException {
+  private synchronized boolean readBuffer(ByteBuf buffer) throws IOException {
     try {
       dataFileChannel.position(dataConsumingOffset);
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
@@ -248,6 +248,7 @@ public final class MapPartitionDataWriter extends PartitionDataWriter {
     }
   }
 
+  @SuppressWarnings("ByteBufferBackingArray")
   private void flushIndex() throws IOException {
     if (indexBuffer != null) {
       logger.debug("flushIndex start:{}", diskFileInfo.getIndexPath());

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,8 +53,6 @@ public final class MapPartitionDataWriter extends PartitionDataWriter {
   private long regionStartingOffset;
   private FileChannel indexChannel;
   private volatile boolean isRegionFinished = true;
-
-  private FileSystem hadoopFs;
 
   public MapPartitionDataWriter(
       StorageManager storageManager,

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -322,7 +322,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
           int compressedSize = Platform.getInt(batchHeader, Platform.BYTE_ARRAY_OFFSET + 12);
           ShuffleBlockInfo shuffleBlockInfo = new ShuffleBlockInfo();
           shuffleBlockInfo.offset = index;
-          shuffleBlockInfo.length = 16 + compressedSize;
+          shuffleBlockInfo.length = 16L + compressedSize;
           List<ShuffleBlockInfo> singleMapIdShuffleBlockList =
               blocksMap.computeIfAbsent(mapId, v -> new ArrayList<>());
           singleMapIdShuffleBlockList.add(shuffleBlockInfo);

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/SSLRequestTimeoutIntegrationSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/SSLRequestTimeoutIntegrationSuiteJ.java
@@ -29,6 +29,7 @@ import org.apache.celeborn.common.network.ssl.SslSampleConfigs;
 
 public class SSLRequestTimeoutIntegrationSuiteJ extends RequestTimeoutIntegrationSuiteJ {
   @Before
+  @Override
   public void setUp() {
     // set up SSL for TEST_MODULE
     doSetup(
@@ -37,6 +38,7 @@ public class SSLRequestTimeoutIntegrationSuiteJ extends RequestTimeoutIntegratio
   }
 
   @After
+  @Override
   public void tearDown() {
     super.tearDown();
   }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/SSLReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/SSLReducePartitionDataWriterSuiteJ.java
@@ -27,6 +27,7 @@ import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.service.deploy.worker.storage.local.DiskReducePartitionDataWriterSuiteJ;
 
 public class SSLReducePartitionDataWriterSuiteJ extends DiskReducePartitionDataWriterSuiteJ {
+  @Override
   protected TransportConf createModuleTransportConf(String module) {
     CelebornConf conf =
         TestHelper.updateCelebornConfWithMap(


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fix `WARNING` of error prone.
- Disable `EmptyCatch`, `JdkObsolete`, `MutableConstantField` and `UnnecessaryParentheses`. 

### Why are the changes needed?

There are many `WARNING` generated by error prone. We should follow the suggestion of error prone to fix `WARNING`.

```
$ mvn clean install -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslUtils.java:[44,25] [MutableConstantField] Constant field declarations should use the immutable type (such as ImmutableList) instead of the general collection interface type (such as List)
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslUtils.java:[47,18] [MutableConstantField] Constant field declarations should use the immutable type (such as ImmutableList) instead of the general collection interface type (such as List)
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientBootstrap.java:[34,5] [InvalidParam] Parameter name `channel` is unknown.
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java:[96,29] [StaticAssignmentInConstructor] This assignment is to a static field. Mutating static state from a constructor is highly error-prone.
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java:[104,30] [StaticAssignmentInConstructor] This assignment is to a static field. Mutating static state from a constructor is highly error-prone.
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslServerFactory.java:[67,2] [ClassCanBeStatic] Inner class is non-static but does not reference enclosing class
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java:[60,17] [NonAtomicVolatileUpdate] This update of a volatile variable is non-atomic
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java:[54,46] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManager.java:[207,29] [NonAtomicVolatileUpdate] This update of a volatile variable is non-atomic
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManager.java:[216,28] [NonAtomicVolatileUpdate] This update of a volatile variable is non-atomic
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslClientFactory.java:[73,2] [ClassCanBeStatic] Inner class is non-static but does not reference enclosing class
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslClientFactory.java:[93,31] [DefaultCharset] Implicit use of the platform default charset, which can result in differing behaviour between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java:[65,11] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java:[66,11] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java:[164,16] [JavaUtilDate] Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java:[165,14] [JavaUtilDate] Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java:[165,35] [JavaUtilDate] Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/SSLTransportClientFactorySuiteJ.java:[32,14] [MissingOverride] setUp overrides method in TransportClientFactorySuiteJ; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/SSLTransportClientFactorySuiteJ.java:[40,14] [MissingOverride] tearDown overrides method in TransportClientFactorySuiteJ; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/protocol/EncryptedMessageWithHeaderSuiteJ.java:[124,6] [UseCorrectAssertInTests] Java assert is used in test. For testing purposes Assert.* matchers should be used.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/RpcIntegrationSuiteJ.java:[255,15] [UnusedMethod] Private method 'assertErrorAndClosed' is never used.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/RpcIntegrationSuiteJ.java:[154,17] [UnusedNestedClass] This nested class is unused, and can be removed.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/RpcIntegrationSuiteJ.java:[57,15] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManagerSuiteJ.java:[107,10] [AssertThrowsMultipleStatements] The lambda passed to assertThrows should contain exactly one statement
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/ssl/ReloadingX509TrustManagerSuiteJ.java:[134,10] [AssertThrowsMultipleStatements] The lambda passed to assertThrows should contain exactly one statement
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java:[84,31] [StaticAssignmentInConstructor] This assignment is to a static field. Mutating static state from a constructor is highly error-prone.
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[130,6] [ThreadLocalUsage] ThreadLocals should be stored in static fields
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[714,6] [MissingCasesInEnumSwitch] Non-exhaustive switch; either add a default or handle the remaining cases: SUCCESS, PARTIAL_SUCCESS, REQUEST_FAILED, and 43 others
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[1609,10] [MissingCasesInEnumSwitch] Non-exhaustive switch; either add a default or handle the remaining cases: PARTIAL_SUCCESS, REQUEST_FAILED, SHUFFLE_ALREADY_REGISTERED, and 45 others
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[1648,26] [MissingOverride] updateFileGroup implements method in ShuffleClient; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[1654,57] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[1823,32] [MissingOverride] getDataClientFactory implements method in ShuffleClient; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java:[185,6] [UseCorrectAssertInTests] Java assert is used in test. For testing purposes Assert.* matchers should be used.
[WARNING] /Users/nicholas/Github/celeborn/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java:[70,33] [JavaUtilDate] Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.
[WARNING] /Users/nicholas/Github/celeborn/service/src/main/java/org/apache/celeborn/server/common/service/store/db/DbServiceManagerImpl.java:[71,33] [JavaUtilDate] Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.
[WARNING] /Users/nicholas/Github/celeborn/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java:[424,11] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java:[425,11] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java:[496,55] [UnescapedEntity] This looks like a type with type parameters. The < and > characters here will be interpreted as HTML, which can be avoided by wrapping it in a {@code } tag.
[WARNING] /Users/nicholas/Github/celeborn/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java:[166,14] [MissingOverride] handleUpdatePartitionSize implements method in IMetadataHandler; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java:[298,61] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java:[346,37] [NonAtomicVolatileUpdate] This update of a volatile variable is non-atomic
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java:[202,33] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java:[300,31] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java:[497,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java:[503,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java:[513,39] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java:[256,12] [ClassCanBeStatic] Inner class is non-static but does not reference enclosing class
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java:[73,12] [CacheLoaderNull] The result of CacheLoader#load must be non-null.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriter.java:[69,13] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriter.java:[73,13] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriter.java:[103,24] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionDataWriter.java:[104,39] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java:[261,46] [ByteBufferBackingArray] ByteBuffer.array() shouldn't be called unless ByteBuffer.arrayOffset() is used or if the ByteBuffer was initialized using ByteBuffer.wrap() or ByteBuffer.allocate().
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java:[102,40] [NonAtomicVolatileUpdate] This update of a volatile variable is non-atomic
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java:[109,40] [NonAtomicVolatileUpdate] This update of a volatile variable is non-atomic
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java:[318,39] [IntLongMath] Expression of type int may overflow before being assigned to a long
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java:[133,6] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/SSLRequestTimeoutIntegrationSuiteJ.java:[32,14] [MissingOverride] setUp overrides method in RequestTimeoutIntegrationSuiteJ; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/SSLRequestTimeoutIntegrationSuiteJ.java:[40,14] [MissingOverride] tearDown overrides method in RequestTimeoutIntegrationSuiteJ; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/ChunkFetchIntegrationSuiteJ.java:[74,15] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/ChunkFetchIntegrationSuiteJ.java:[186,47] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/SSLReducePartitionDataWriterSuiteJ.java:[30,26] [MissingOverride] createModuleTransportConf overrides method in DiskReducePartitionDataWriterSuiteJ; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java:[234,47] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java:[198,47] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
```
```
$ mvn clean install -Pspark-2.4 -pl client-spark/common,client-spark/spark-2 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java:[109,57] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SendBufferPool.java:[56,14] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SendBufferPool.java:[57,21] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java:[247,14] [UnusedMethod] Private method 'executorCores' is never used.
[WARNING] /Users/nicholas/Github/celeborn/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java:[120,55] [ReferenceEquality] Comparison using reference equality instead of value equality
```
```
$ mvn clean install -Pspark-3.5 -pl client-spark/spark-3 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleDataIO.java:[65,17] [MissingOverride] supportsReliableStorage implements method in ShuffleDriverComponents; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java:[163,55] [ReferenceEquality] Comparison using reference equality instead of value equality
```
```
$ mvn clean install -Pflink-1.14 -pl client-flink/common,client-flink/flink-1.14 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java:[161,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java:[223,27] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfo.java:[46,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[99,66] [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[236,21] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[251,19] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[267,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[354,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[392,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[473,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java:[533,17] [SynchronizeOnNonFinalField] Synchronizing on non-final fields is not safe: if the field is ever updated, different threads may end up locking on different objects.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/TransferBufferPool.java:[182,33] [MixedMutabilityReturnType] This method returns both mutable and immutable collections or maps from different paths. This may be confusing for users of the method.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java:[34,6] [DoubleBraceInitialization] Prefer collection factory methods or builders to the double-brace initialization pattern.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/BufferPackSuiteJ.java:[207,6] [CatchAndPrintStackTrace] Logging or rethrowing exceptions should usually be preferred to catching and calling printStackTrace
[WARNING] /Users/nicholas/Github/celeborn/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java:[140,67] [CanonicalDuration] Duration can be expressed more clearly with different units
```
```
$ mvn clean install -Pflink-1.15 -pl client-flink/flink-1.15 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java:[140,67] [CanonicalDuration] Duration can be expressed more clearly with different units
```
```
$ mvn clean install -Pflink-1.17 -pl client-flink/flink-1.16 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
```
```
$ mvn clean install -Pflink-1.17 -pl client-flink/flink-1.17 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java:[140,67] [CanonicalDuration] Duration can be expressed more clearly with different units
```
```
$ mvn clean install -Pflink-1.18 -pl client-flink/flink-1.18 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java:[140,67] [CanonicalDuration] Duration can be expressed more clearly with different units
```
```
$ mvn clean install -Pflink-1.19 -pl client-flink/flink-1.19 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java:[140,67] [CanonicalDuration] Duration can be expressed more clearly with different units
```
```
$ mvn clean install -Pmr -pl client-mr/mr -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

```
$ mvn clean install -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pspark-2.4 -pl client-spark/common,client-spark/spark-2 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pspark-3.5 -pl client-spark/spark-3 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.14 -pl client-flink/common,client-flink/flink-1.14 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.15 -pl client-flink/flink-1.15 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.16 -pl client-flink/flink-1.15 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.17 -pl client-flink/flink-1.17 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.18 -pl client-flink/flink-1.18 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.19 -pl client-flink/flink-1.19 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pmr -pl client-mr/mr -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
```