### PR TITLE
[CELEBORN-1182][FOLLOWUP] Worker should remove application active connection via clean thread pool

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -708,6 +708,7 @@ private[celeborn] class Worker(
   @VisibleForTesting
   def cleanup(expiredShuffleKeys: JHashSet[String], threadPool: ThreadPoolExecutor): Unit =
     synchronized {
+      val expiredApplicationIds = new JHashSet[String]()
       expiredShuffleKeys.asScala.foreach { shuffleKey =>
         partitionLocationInfo.removeShuffle(shuffleKey)
         shufflePartitionType.remove(shuffleKey)
@@ -717,10 +718,7 @@ private[celeborn] class Worker(
         workerInfo.releaseSlots(shuffleKey)
         val applicationId = Utils.splitShuffleKey(shuffleKey)._1
         if (!workerInfo.getApplicationIdSet.contains(applicationId)) {
-          // When the running applications does not contain the application corresponding to expired shuffle key,
-          // resource consumption source should remove lose application gauges.
-          removeAppResourceConsumption(applicationId)
-          removeAppActiveConnection(applicationId)
+          expiredApplicationIds.add(applicationId)
           secretRegistry.unregister(applicationId)
         }
         logInfo(s"Cleaned up expired shuffle $shuffleKey")
@@ -728,36 +726,15 @@ private[celeborn] class Worker(
       partitionsSorter.cleanup(expiredShuffleKeys)
       fetchHandler.cleanupExpiredShuffleKey(expiredShuffleKeys)
       threadPool.execute(new Runnable {
-        override def run(): Unit = storageManager.cleanupExpiredShuffleKey(expiredShuffleKeys)
+        override def run(): Unit = {
+          removeAppActiveConnection(expiredApplicationIds)
+          storageManager.cleanupExpiredShuffleKey(expiredShuffleKeys)
+        }
       })
     }
 
-  private def removeAppResourceConsumption(applicationId: String): Unit = {
-    removeResourceConsumptionGauge(
-      ResourceConsumptionSource.DISK_FILE_COUNT,
-      applicationId)
-    removeResourceConsumptionGauge(
-      ResourceConsumptionSource.DISK_BYTES_WRITTEN,
-      applicationId)
-    removeResourceConsumptionGauge(
-      ResourceConsumptionSource.HDFS_FILE_COUNT,
-      applicationId)
-    removeResourceConsumptionGauge(
-      ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
-      applicationId)
-  }
-
-  private def removeResourceConsumptionGauge(
-      resourceConsumptionName: String,
-      applicationId: String): Unit = {
-    resourceConsumptionSource.removeGauge(
-      resourceConsumptionName,
-      resourceConsumptionSource.applicationLabel,
-      applicationId)
-  }
-
-  private def removeAppActiveConnection(applicationId: String): Unit = {
-    workerSource.removeAppActiveConnection(applicationId)
+  private def removeAppActiveConnection(applicationIds: JHashSet[String]): Unit = {
+    workerSource.removeAppActiveConnection(applicationIds)
   }
 
   override def getWorkerInfo: String = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -107,13 +107,11 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
     }
   }
 
-  def removeAppActiveConnection(applicationId: String): Unit = {
-    removeCounter(ACTIVE_CONNECTION_COUNT, Map(applicationLabel -> applicationId))
-    appActiveConnections.asScala.foreach { case (_, applicationIds) =>
-      if (applicationIds.contains(applicationId)) {
-        applicationIds.remove(applicationId)
-      }
-    }
+  def removeAppActiveConnection(applicationIds: util.Set[String]): Unit = {
+    applicationIds.asScala.foreach(applicationId =>
+      removeCounter(ACTIVE_CONNECTION_COUNT, Map(applicationLabel -> applicationId)))
+    appActiveConnections.values().asScala.foreach(connectionAppIds =>
+      applicationIds.asScala.foreach(applicationId => connectionAppIds.remove(applicationId)))
   }
 
   // start cleaner thread


### PR DESCRIPTION
### What changes were proposed in this pull request?

Worker removes application active connection via clean thread pool to improve performance of `cleanup`.

### Why are the changes needed?

`cleanTaskQueue` has the situation that there is large backlog which causes delay in cleaning up expired shuffle keys and high CPU usage as follows:

```
top - 16:09:14 up 52 days, 19:34,  0 users,  load average: 5.42, 8.37, 7.54
Threads: 941 total,   2 running, 939 sleeping,   0 stopped,   0 zombie
%Cpu(s):  3.8 us,  1.6 sy,  0.0 ni, 93.6 id,  0.7 wa,  0.0 hi,  0.3 si,  0.0 st
KiB Mem : 39410694+total,  7602132 free, 18303019+used, 20347460+buff/cache
KiB Swap:        0 total,        0 free,        0 used. 19179446+avail Mem

  PID USER      PR  NI    VIRT    RES    SHR S %CPU %MEM     TIME+ COMMAND
  647 celeborn  20   0  0.245t 0.164t      0 R 95.7 44.7   1352:09 java
```
```
"worker-expired-shuffle-cleaner" #263 daemon prio=5 os_prio=0 tid=0x00007f06e9f6e000 nid=0x287 runnable [0x00007eecf15ef000]
   java.lang.Thread.State: RUNNABLE
        at scala.collection.convert.Wrappers$JMapWrapperLike$$anon$5.next(Wrappers.scala:288)
        at scala.collection.convert.Wrappers$JMapWrapperLike$$anon$5.next(Wrappers.scala:285)
        at scala.collection.Iterator.foreach(Iterator.scala:941)
        at scala.collection.Iterator.foreach$(Iterator.scala:941)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
        at scala.collection.IterableLike.foreach(IterableLike.scala:74)
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
        at org.apache.celeborn.service.deploy.worker.WorkerSource.removeAppActiveConnection(WorkerSource.scala:112)
```

Worker should remove application active connection via clean thread pool when cleaning expired shuffle keys. Otherwise, it may cause high disk usage for worker.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Cluster test.