### PR TITLE
[CELEBORN-775][FOLLOWUP] Fix executorCores calculation in SparkShuffleManager for Spark2 local mode

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -69,7 +69,7 @@ public class SparkShuffleManager implements ShuffleManager {
     this.conf = conf;
     this.isDriver = isDriver;
     this.celebornConf = SparkUtils.fromSparkConf(conf);
-    this.cores = conf.getInt(SparkLauncher.EXECUTOR_CORES, 1);
+    this.cores = executorCores(conf);
     this.fallbackPolicyRunner = new CelebornShuffleFallbackPolicyRunner(celebornConf);
     this.sendBufferPoolCheckInterval = celebornConf.clientPushSendBufferPoolExpireCheckInterval();
     this.sendBufferPoolExpireTimeout = celebornConf.clientPushSendBufferPoolExpireTimeout();


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
CELEBORN-775 The `executorCores` method was introduced in Spark2, but it was not used.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
