### PR TITLE
[CELEBORN-1461] Fix Celeborn ipv6 local hostname resolution

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -414,27 +414,17 @@ object Utils extends Logging {
     customHostname = Some(hostname)
   }
 
-  val ipv6AddressPattern = """^\[.*:.*\]$""".r
-
   def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
     if (conf.bindPreferIP) {
       localIpAddress match {
-        case ipv6Address: Inet6Address => addBracketsIfNeeded(ipv6Address.getHostAddress)
+        case ipv6Address: Inet6Address =>
+          val ip = ipv6Address.getHostAddress
+          assert(!ip.startsWith("[") && !ip.endsWith("]"))
+          s"[$ip]"
         case other => other.getHostAddress
       }
     } else {
       localIpAddress.getCanonicalHostName
-    }
-  }
-
-  private[util] def addBracketsIfNeeded(addr: String): String = {
-    addr match {
-      // Already is in ipv6 pattern and enclosed []
-      case ipv6AddressPattern(_*) => addr
-      // It is a ipv6 address not enclosed in []
-      case ip if ip.contains(":") => s"[$ip]"
-      // It is a ipv4 address
-      case ip => ip
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -415,7 +415,8 @@ object Utils extends Logging {
   }
 
   def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
-    if (conf.bindPreferIP) addBracketsIfNeeded(localIpAddress.getHostAddress) else localIpAddress.getCanonicalHostName
+    if (conf.bindPreferIP) addBracketsIfNeeded(localIpAddress.getHostAddress)
+    else localIpAddress.getCanonicalHostName
   }
 
   private[util] def addBracketsIfNeeded(addr: String): String = {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -416,8 +416,14 @@ object Utils extends Logging {
 
   def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
     if (conf.bindPreferIP) {
+      val ipv6AddressPattern = """^\[.*]$""".r
       localIpAddress match {
-        case v6: Inet6Address => s"[${v6.getHostAddress}]"
+        case v6: Inet6Address =>
+          if (ipv6AddressPattern.pattern.pattern().matches(v6.getHostAddress)) {
+            s"[${v6.getHostAddress}]"
+          } else {
+            v6.getHostAddress
+          }
         case other => other.getHostAddress
       }
     } else {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -414,7 +414,7 @@ object Utils extends Logging {
     customHostname = Some(hostname)
   }
 
-  val ipv6AddressPattern = """^\[.*]$""".r
+  val ipv6AddressPattern = """^\[.*:.*\]$""".r
 
   def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
     if (conf.bindPreferIP) {
@@ -429,8 +429,12 @@ object Utils extends Logging {
 
   private[util] def addBracketsIfNeeded(addr: String): String = {
     addr match {
-      case ipv6AddressPattern(host) => host
-      case ip: String => s"[$ip]"
+      // Already is in ipv6 pattern and enclosed []
+      case ipv6AddressPattern(_*) => addr
+      // It is a ipv6 address not enclosed in []
+      case ip if ip.contains(":") => s"[$ip]"
+      // It is a ipv4 address
+      case ip => ip
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -420,9 +420,9 @@ object Utils extends Logging {
       localIpAddress match {
         case v6: Inet6Address =>
           if (ipv6AddressPattern.pattern.pattern().matches(v6.getHostAddress)) {
-            s"[${v6.getHostAddress}]"
-          } else {
             v6.getHostAddress
+          } else {
+            s"[${v6.getHostAddress}]"
           }
         case other => other.getHostAddress
       }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -419,7 +419,9 @@ object Utils extends Logging {
       localIpAddress match {
         case ipv6Address: Inet6Address =>
           val ip = ipv6Address.getHostAddress
-          assert(!ip.startsWith("[") && !ip.endsWith("]"))
+          assert(
+            !ip.startsWith("[") && !ip.endsWith("]"),
+            s"Resolved IPv6 address should not be enclosed in [] but got $ip")
           s"[$ip]"
         case other => other.getHostAddress
       }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -415,19 +415,14 @@ object Utils extends Logging {
   }
 
   def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
-    if (conf.bindPreferIP) {
-      val ipv6AddressPattern = """^\[.*]$""".r
-      localIpAddress match {
-        case ipv6: Inet6Address =>
-          if (ipv6AddressPattern.pattern.pattern().matches(ipv6.getHostAddress)) {
-            ipv6.getHostAddress
-          } else {
-            s"[${ipv6.getHostAddress}]"
-          }
-        case other => other.getHostAddress
-      }
+    if (conf.bindPreferIP) addBracketsIfNeeded(localIpAddress.getHostAddress) else localIpAddress.getCanonicalHostName
+  }
+
+  private[util] def addBracketsIfNeeded(addr: String): String = {
+    if (addr.contains(":") && !addr.contains("[")) {
+      s"[$addr]"
     } else {
-      localIpAddress.getCanonicalHostName
+      addr
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -418,11 +418,11 @@ object Utils extends Logging {
     if (conf.bindPreferIP) {
       val ipv6AddressPattern = """^\[.*]$""".r
       localIpAddress match {
-        case v6: Inet6Address =>
-          if (ipv6AddressPattern.pattern.pattern().matches(v6.getHostAddress)) {
-            v6.getHostAddress
+        case ipv6: Inet6Address =>
+          if (ipv6AddressPattern.pattern.pattern().matches(ipv6.getHostAddress)) {
+            ipv6.getHostAddress
           } else {
-            s"[${v6.getHostAddress}]"
+            s"[${ipv6.getHostAddress}]"
           }
         case other => other.getHostAddress
       }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -415,7 +415,14 @@ object Utils extends Logging {
   }
 
   def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
-    if (conf.bindPreferIP) localIpAddress.getHostAddress else localIpAddress.getCanonicalHostName
+    if (conf.bindPreferIP) {
+      localIpAddress match {
+        case v6: Inet6Address => s"[${v6.getHostAddress}]"
+        case other => other.getHostAddress
+      }
+    } else {
+      localIpAddress.getCanonicalHostName
+    }
   }
 
   /**

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -191,14 +191,6 @@ class UtilsSuite extends CelebornFunSuite {
       Array[Object](ipV6Host, "1", "2", "3", "4")))
   }
 
-  test("test addBracketsIfNeeded") {
-    val ipV4Host = "192.168.0.1"
-    val ipV6Host = "2600:1f13:9f:2d00:4a70:cc69:737d:7cb0"
-    assert(Utils.addBracketsIfNeeded(ipV4Host) == ipV4Host)
-    assert(Utils.addBracketsIfNeeded(ipV6Host) == s"[$ipV6Host]")
-    assert(Utils.addBracketsIfNeeded(s"[$ipV6Host]") == s"[$ipV6Host]")
-  }
-
   def partitionLocation(partitionId: Int): util.HashSet[PartitionLocation] = {
     val partitionSet = new util.HashSet[PartitionLocation]
     for (i <- 0 until 3) {

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -191,6 +191,14 @@ class UtilsSuite extends CelebornFunSuite {
       Array[Object](ipV6Host, "1", "2", "3", "4")))
   }
 
+  test("test addBracketsIfNeeded") {
+    val ipV4Host = "192.168.0.1"
+    val ipV6Host = "2600:1f13:9f:2d00:4a70:cc69:737d:7cb0"
+    assert(Utils.addBracketsIfNeeded(ipV4Host) == ipV4Host)
+    assert(Utils.addBracketsIfNeeded(ipV6Host) == s"[$ipV6Host]")
+    assert(Utils.addBracketsIfNeeded(s"[$ipV6Host]") == s"[$ipV6Host]")
+  }
+
   def partitionLocation(partitionId: Int): util.HashSet[PartitionLocation] = {
     val partitionSet = new util.HashSet[PartitionLocation]
     for (i <- 0 until 3) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix ipv6 hostname resolution to have `[]` around the ipv6 address. 


### Why are the changes needed?
Previously was getting error: 
```
java.lang.AssertionError: assertion failed: Expected hostname or IPv6 IP enclosed in [] but got <ipv6 address>
  	at scala.Predef$.assert(Predef.scala:223)
  	at org.apache.celeborn.common.util.Utils$.checkHost(Utils.scala:429)
  	at org.apache.celeborn.service.deploy.worker.Worker.<init>(Worker.scala:136)
  	at org.apache.celeborn.service.deploy.worker.Worker$.main(Worker.scala:953)
  	at org.apache.celeborn.service.deploy.worker.Worker.main(Worker.scala)
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
started the worker and the service starts up now and binds to ipv6 address
