### PR TITLE
[CELEBORN-1457][0.4] Avoid NPE during shuffle data cleanup

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -217,8 +217,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       reloadAndCleanFileInfos(this.db)
     } catch {
       case e: Exception =>
-        logError("Init level DB failed:", e)
-        this.db = null
+        throw new IllegalStateException(
+          "Failed to initialize db for recovery during graceful worker shutdown.",
+          e)
     }
     saveCommittedFileInfosExecutor =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor(


### PR DESCRIPTION
### What changes were proposed in this pull request?

backport https://github.com/apache/celeborn/pull/2553 to `branch-0.4`

Avoid NPE during shuffle data cleanup by checking for null LevelDB.

### Why are the changes needed?
If the LevelDB in StorageManager fails to initialize, the db will be null. This will cause a java.lang.NullPointerException when storageManager.cleanupExpiredShuffleKey(expiredShuffleKeys) is called, and the shuffle data in expiredShuffleKeys will not be cleaned up. The worker's disk may be filled up as a result.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
Manual Testing

