### PR TITLE
[CELEBORN-1453][0.4] Fix the thread safety bug in getMetrics

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -384,26 +384,26 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
   }
 
   override def getMetrics(): String = {
-    counters().foreach(c => recordCounter(c))
-    gauges().foreach(g => recordGauge(g))
-    histograms().foreach(h => {
-      recordHistogram(h)
-      h.asInstanceOf[CelebornHistogram].reservoir
-        .asInstanceOf[ResettableSlidingWindowReservoir].reset()
-    })
-    timers().foreach(t => {
-      recordTimer(t)
-      t.timer.asInstanceOf[CelebornTimer].reservoir
-        .asInstanceOf[ResettableSlidingWindowReservoir].reset()
-    })
-    val sb = new mutable.StringBuilder
     innerMetrics.synchronized {
+      counters().foreach(c => recordCounter(c))
+      gauges().foreach(g => recordGauge(g))
+      histograms().foreach(h => {
+        recordHistogram(h)
+        h.asInstanceOf[CelebornHistogram].reservoir
+          .asInstanceOf[ResettableSlidingWindowReservoir].reset()
+      })
+      timers().foreach(t => {
+        recordTimer(t)
+        t.timer.asInstanceOf[CelebornTimer].reservoir
+          .asInstanceOf[ResettableSlidingWindowReservoir].reset()
+      })
+      val sb = new mutable.StringBuilder
       while (!innerMetrics.isEmpty) {
         sb.append(innerMetrics.poll())
       }
       innerMetrics.clear()
+      sb.toString()
     }
-    sb.toString()
   }
 
   override def destroy(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

backport https://github.com/apache/celeborn/pull/2548 to branch-0.4

Fix the thread safety bug in getMetrics of AbstractSource by changing the lock scope

### Why are the changes needed?
When two threads access the getMetrics method in AbstractSource at the same time, one of the threads may get fewer metrics than the actual value, because the actual execution order may be like this: Thread A gets the lock, adds the metrics of the worker source to the innerMetrics queue and releases the lock, Thread B gets the lock, adds the metrics of the worker source to the innerMetrics queue and releases the lock, Thread A gets the lock, adds the metrics of other sources to the innerMetrics queue, assembles the values of innerMetrics, clears innerMetrics and releases the lock, Thread B gets the lock, adds the metrics of other sources to the innerMetrics queue, assembles the values of innerMetrics, clears innerMetrics and releases the lock. The result of this is that Thread A gets two sets of metrics data from the worker source, while Thread B doesn't get any.

### Does this PR introduce _any_ user-facing change? No

### How was this patch tested?
manual test
