### PR TITLE
[CELEBORN-1432][0.4] ShuffleClientImpl should invoke loadFileGroupInternal only once when using the reduce partition mode

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -174,7 +174,9 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   protected ReduceFileGroups updateFileGroup(int shuffleId, int partitionId)
       throws CelebornIOException {
     ReduceFileGroups reduceFileGroups =
-        reduceFileGroupsMap.computeIfAbsent(shuffleId, (id) -> new ReduceFileGroups());
+        reduceFileGroupsMap.computeIfAbsent(
+                shuffleId, (id) -> Tuple2.apply(new ReduceFileGroups(), null))
+            ._1;
     if (reduceFileGroups.partitionIds != null
         && reduceFileGroups.partitionIds.contains(partitionId)) {
       logger.debug(


### PR DESCRIPTION


### What changes were proposed in this pull request?

backport https://github.com/apache/celeborn/pull/2531 to `branch-0.4`

`ShuffleClientImpl` invokes `loadFileGroupInternal` only once when using the reduce partition mode.

### Why are the changes needed?

`ShuffleClientImpl` may call `loadFileGroupInternal` multiple times when using reduce partition mode, which is not as expected. This bug was introduced in #2219.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.
