### PR TITLE
[MINOR][0.4] Bump minikube and kubernetes version of integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,8 +27,8 @@ on:
       - main
       - branch-*
 env:
-  MINIKUBE_VERSION: v1.29.0
-  KUBERNETES_VERSION: v1.26.1
+  MINIKUBE_VERSION: v1.33.1
+  KUBERNETES_VERSION: v1.30.0
 
 jobs:
   celeborn_integration_test:


### PR DESCRIPTION
### What changes were proposed in this pull request?

backport https://github.com/apache/celeborn/pull/2560 to `branch-0.4`

Bump minikube and kubernetes version of integration test to fix failure of integration test in CI.

- minikube: v1.29.0->v1.33.1
- kubernetes: v1.26.1->v1.30.0

### Why are the changes needed?

Docker version 25 loads images into various distributions of Kubernetes has been impossible due to what appears to be mismatching hashes of manifests/images as follows:

```
X Exiting due to GUEST_IMAGE_LOAD: save to dir: caching images: caching image "/home/runner/.minikube/cache/images/amd64/apache/celeborn_latest": write: unable to calculate manifest: blob sha256:5bbc241b2d6dcc55b5a63c080556ad458ba1395e93af3204d12e72c9a192eb06 not found
```

Minikube and kubernetes version should be bumped to fix failure of integration test which refers to https://github.com/moby/moby/issues/47207.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Integration test.
