### PR TITLE
[CELEBORN-1462] Fix layout of DeviceCelebornTotalBytes, DeviceCelebornFreeBytes, RunningApplicationCount and DecommissionWorkerCount in celeborn-dashboard.json

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -115,7 +115,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -130,7 +131,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 1
           },
           "id": 2,
           "options": {
@@ -205,7 +206,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -220,7 +222,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 1
           },
           "id": 94,
           "options": {
@@ -579,7 +581,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -595,7 +598,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 2
           },
           "id": 121,
           "options": {
@@ -672,7 +675,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -688,7 +692,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 2
           },
           "id": 120,
           "options": {
@@ -765,7 +769,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -781,7 +786,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 10
           },
           "id": 122,
           "options": {
@@ -858,7 +863,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -873,7 +879,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 10
           },
           "id": 124,
           "options": {
@@ -949,7 +955,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -965,7 +972,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 18
           },
           "id": 100,
           "options": {
@@ -1039,7 +1046,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1055,7 +1063,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 18
           },
           "id": 102,
           "options": {
@@ -1130,7 +1138,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1145,7 +1154,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 26
           },
           "id": 36,
           "options": {
@@ -1221,7 +1230,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1236,7 +1246,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 26
           },
           "id": 117,
           "options": {
@@ -1313,7 +1323,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1328,7 +1339,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 34
           },
           "id": 36,
           "options": {
@@ -1458,7 +1469,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 42
       },
       "id": 28,
       "panels": [
@@ -2536,7 +2547,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 43
       },
       "id": 134,
       "panels": [
@@ -3729,7 +3740,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 44
       },
       "id": 12,
       "panels": [
@@ -4558,7 +4569,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 45
       },
       "id": 10,
       "panels": [
@@ -5112,7 +5123,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 46
       },
       "id": 8,
       "panels": [
@@ -6511,7 +6522,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 47
       },
       "id": 50,
       "panels": [
@@ -7067,7 +7078,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 48
       },
       "id": 157,
       "panels": [
@@ -7360,7 +7371,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 49
       },
       "id": 137,
       "panels": [
@@ -8751,7 +8762,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 50
       },
       "id": 110,
       "panels": [
@@ -8947,7 +8958,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 51
       },
       "id": 123,
       "panels": [
@@ -9425,7 +9436,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 52
       },
       "id": 172,
       "panels": [


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix layout of `DeviceCelebornTotalBytes`, `DeviceCelebornFreeBytes`, `RunningApplicationCount` and `DecommissionWorkerCount` in `celeborn-dashboard.json`.

### Why are the changes needed?

The layout of `DeviceCelebornTotalBytes`, `DeviceCelebornFreeBytes`, `RunningApplicationCount` and `DecommissionWorkerCount` in `celeborn-dashboard.json` have wrong position as follows:

![celeborn-dashboard](https://github.com/apache/celeborn/assets/10048174/adf82c15-ce31-4755-8c81-ffde9ceef822)
 
We should fix the correct position to provide layout of `DeviceCelebornTotalBytes`, `DeviceCelebornFreeBytes`, `RunningApplicationCount` and `DecommissionWorkerCount`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test: [Celeborn Grafana Dashboard](https://stenicholas.grafana.net/public-dashboards/822b08768a324dfe9fc526254bae5ae5).