### PR TITLE
[CELEBORN-1463] Create network memory allocator with celeborn.network.memory.allocator.numArenas

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -150,7 +150,8 @@ public class NettyUtils {
           allowCache && conf.getCelebornConf().networkMemoryAllocatorAllowCache());
     }
     PooledByteBufAllocator allocator =
-        createPooledByteBufAllocator(conf.preferDirectBufs(), allowCache, conf.clientThreads());
+        createPooledByteBufAllocator(
+            conf.preferDirectBufs(), allowCache, conf.getCelebornConf().networkAllocatorArenas());
     if (source != null) {
       String poolName = "default-netty-pool";
       Map<String, String> labels = new HashMap<>();


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Create netty pooled network memory allocator with `celeborn.network.memory.allocator.numArenas`.


### Why are the changes needed?
Before this, when user call to build non shared pooled memory allocator will use the number of module client threads as the 
core number.

Intuitively we should respect to build memory allocator with user define `celeborn.network.memory.allocator.numArenas`.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
None
