### PR TITLE
[CELEBORN-1460][FOLLOWUP] MRAppMasterWithCeleborn support uri of absolute conf path for mapreduce.job.cache.files

### DIFF
--- a/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
+++ b/client-mr/mr/src/main/java/org/apache/celeborn/mapreduce/v2/app/MRAppMasterWithCeleborn.java
@@ -94,7 +94,10 @@ public class MRAppMasterWithCeleborn extends MRAppMaster {
       }
       FileStatus status = fs.getFileStatus(celebornConfPath);
       long currentTs = status.getModificationTime();
-      String uri = fs.getUri() + Path.SEPARATOR + celebornConfPath.toUri();
+      String uri =
+          celebornConfPath.toUri().isAbsolute()
+              ? celebornConfPath.toUri().toString()
+              : fs.getUri() + Path.SEPARATOR + celebornConfPath.toUri();
       String files = conf.get(MRJobConfig.CACHE_FILES);
       conf.set(MRJobConfig.CACHE_FILES, files == null ? uri : uri + "," + files);
       String ts = conf.get(MRJobConfig.CACHE_FILE_TIMESTAMPS);


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MRAppMasterWithCeleborn` supports uri of absolute conf path for `mapreduce.job.cache.files`.

### Why are the changes needed?

`yarn.app.mapreduce.am.staging-dir` could use absolute path of staging directory in production environment. Therefore, the `celebornConfPath` may be absolute conf path with scheme. `MRAppMasterWithCeleborn` should support uri of absolute `celebornConfPath` for `mapreduce.job.cache.files` as follows:

```
<property>
  <name>`yarn.app.mapreduce.am.staging-dir`</name>
  <value>hdfs://bigdata-ns/mrstaging</value>
</property>
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

```
************************************************************/
2024-06-18 16:10:53,884 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: session.id is deprecated. Instead, use dfs.metrics.session-id
2024-06-18 16:10:54,198 INFO [main] org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter: File Output Committer Algorithm version is 2
2024-06-18 16:10:54,198 INFO [main] org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter: FileOutputCommitter skip cleanup _temporary folders under output directory:false, ignore cleanup failures: false
2024-06-18 16:10:54,206 INFO [main] org.apache.hadoop.mapred.Task:  Using ResourceCalculatorProcessTree : [ ]
2024-06-18 16:10:54,212 INFO [org.apache.hadoop.mapreduce.TaskPauseMonitor$Monitor@1992eaf4] org.apache.hadoop.mapreduce.TaskPauseMonitor: Starting JVM pause monitor
2024-06-18 16:10:54,814 INFO [main] com.hadoop.compression.lzo.GPLNativeCodeLoader: Loaded native gpl library from the embedded binaries
2024-06-18 16:10:54,815 INFO [main] com.hadoop.compression.lzo.LzoCodec: Successfully loaded & initialized native-lzo library [hadoop-lzo rev Unknown build revisionscripts/get_build_revision.sh: 21: scripts/get_build_revision.sh: [[: not found
]
2024-06-18 16:10:54,822 INFO [main] org.apache.hadoop.mapred.MapTask: numReduceTasks: 2000
2024-06-18 16:10:55,145 INFO [main] org.apache.hadoop.mapred.CelebornMapOutputCollector: Mapper initialized with celeborn 127.0.0.1 37683 appattempt_1650016801129_32855067_000001 256
2024-06-18 16:10:55,201 INFO [main] org.apache.celeborn.common.rpc.netty.Dispatcher: Dispatcher numThreads: 16
2024-06-18 16:10:55,223 INFO [main] org.apache.celeborn.common.network.TransportContext: SSL not enabled for module = rpc_app_client
2024-06-18 16:10:55,237 INFO [main] org.apache.celeborn.common.network.client.TransportClientFactory: mode NIO threads 1
2024-06-18 16:10:55,317 INFO [main] org.apache.celeborn.common.rpc.netty.NettyRpcEnvFactory: Starting RPC Server [ShuffleClient] on 127.0.0.1:0 with advisor endpoint 127.0.0.1:0
2024-06-18 16:10:55,383 INFO [main] org.apache.celeborn.common.util.Utils: Successfully started service 'ShuffleClient' on port 31315.
2024-06-18 16:10:55,384 INFO [main] org.apache.celeborn.common.network.TransportContext: SSL not enabled for module = data
2024-06-18 16:10:55,384 INFO [main] org.apache.celeborn.client.ShuffleClientImpl: Initializing data client factory for appattempt_1650016801129_32855067_000001.
2024-06-18 16:10:55,384 INFO [main] org.apache.celeborn.common.network.client.TransportClientFactory: mode NIO threads 8
2024-06-18 16:10:55,387 INFO [main] org.apache.celeborn.client.ShuffleClientImpl: Created ShuffleClientImpl, appUniqueId: appattempt_1650016801129_32855067_000001
2024-06-18 16:10:55,553 INFO [main] org.apache.hadoop.mapred.CelebornSortBasedPusher: Sort based push initialized with numMappers:500 numReducers:2000 mapId:0 attemptId:0 maxIOBufferSize:268435456 spillIOBufferSize:214748368
2024-06-18 16:10:55,553 INFO [main] org.apache.hadoop.mapred.MapTask: Map output collector class = org.apache.hadoop.mapred.CelebornMapOutputCollector
2024-06-18 16:10:55,563 INFO [main] org.apache.hadoop.streaming.PipeMapRed: PipeMapRed exec [/usr/bin/python, cf_out.py, map]
2024-06-18 16:10:55,569 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.work.output.dir is deprecated. Instead, use mapreduce.task.output.dir
2024-06-18 16:10:55,569 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: map.input.start is deprecated. Instead, use mapreduce.map.input.start
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: job.local.dir is deprecated. Instead, use mapreduce.job.local.dir
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.task.is.map is deprecated. Instead, use mapreduce.task.ismap
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.task.id is deprecated. Instead, use mapreduce.task.attempt.id
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.tip.id is deprecated. Instead, use mapreduce.task.id
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.local.dir is deprecated. Instead, use mapreduce.cluster.local.dir
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: map.input.file is deprecated. Instead, use mapreduce.map.input.file
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.skip.on is deprecated. Instead, use mapreduce.job.skiprecords
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: map.input.length is deprecated. Instead, use mapreduce.map.input.length
2024-06-18 16:10:55,570 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.cache.localFiles is deprecated. Instead, use mapreduce.job.cache.local.files
2024-06-18 16:10:55,571 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.job.id is deprecated. Instead, use mapreduce.job.id
2024-06-18 16:10:55,571 INFO [main] org.apache.hadoop.conf.Configuration.deprecation: mapred.task.partition is deprecated. Instead, use mapreduce.task.partition
2024-06-18 16:10:55,628 INFO [main] org.apache.hadoop.streaming.PipeMapRed: R/W/S=1/0/0 in:NA [rec/s] out:NA [rec/s]
2024-06-18 16:10:55,628 INFO [main] org.apache.hadoop.streaming.PipeMapRed: R/W/S=10/0/0 in:NA [rec/s] out:NA [rec/s]
2024-06-18 16:10:55,629 INFO [main] org.apache.hadoop.streaming.PipeMapRed: R/W/S=100/0/0 in:NA [rec/s] out:NA [rec/s]
2024-06-18 16:10:55,633 INFO [main] org.apache.hadoop.streaming.PipeMapRed: R/W/S=1000/0/0 in:NA [rec/s] out:NA [rec/s]
2024-06-18 16:10:55,640 INFO [Thread-16] org.apache.hadoop.streaming.PipeMapRed: Records R/W=4198/1
2024-06-18 16:10:55,655 INFO [main] org.apache.hadoop.streaming.PipeMapRed: R/W/S=10000/5454/0 in:NA [rec/s] out:NA [rec/s]
2024-06-18 16:10:55,824 INFO [Thread-17] org.apache.hadoop.streaming.PipeMapRed: MRErrorThread done
2024-06-18 16:10:55,825 INFO [main] org.apache.hadoop.streaming.PipeMapRed: mapRedFinished
2024-06-18 16:10:55,829 INFO [main] org.apache.hadoop.mapred.CelebornMapOutputCollector: Mapper collector flush
2024-06-18 16:10:55,830 INFO [main] org.apache.hadoop.mapred.CelebornSortBasedPusher: Sort based pusher called flush
2024-06-18 16:10:56,488 INFO [main] org.apache.hadoop.mapred.CelebornMapOutputCollector: Mapper collector close
2024-06-18 16:10:56,488 INFO [main] org.apache.hadoop.mapred.CelebornSortBasedPusher: Sort based pusher called flush
2024-06-18 16:10:56,488 INFO [main] org.apache.hadoop.mapred.CelebornSortBasedPusher: Call mapper end shuffleId:0 mapId:0 attemptId:0 numMappers:500
2024-06-18 16:10:56,798 INFO [main] org.apache.hadoop.mapred.Task: Task:attempt_1650016801129_32855067_m_000000_0 is done. And is in the process of committing
```