### PR TITLE
[CELEBORN-1402][FOLLOWUP] Correct document of setting spark.executor.userClassPathFirst to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ spark.dynamicAllocation.shuffleTracking.enabled false
 
 # Support ShuffleManager when defined in user jars
 # Required Spark version < 4.0.0 or without SPARK-45762, highly recommended to false for ShuffleManager in user-defined jar specified by --jars or spark.jars
-spark.executor.userClassPathFirst=false
+spark.executor.userClassPathFirst false
 ```
 
 ### Deploy Flink client

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -201,7 +201,7 @@ spark.dynamicAllocation.shuffleTracking.enabled false
 
 # Support ShuffleManager when defined in user jars
 # Required Spark version < 4.0.0 or without SPARK-45762, highly recommended to false for ShuffleManager in user-defined jar specified by --jars or spark.jars
-spark.executor.userClassPathFirst=false
+spark.executor.userClassPathFirst false
 ```
 
 ## Deploy Flink client


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct document of setting `spark.executor.userClassPathFirst` to false.

### Why are the changes needed?

Document sets `spark.executor.userClassPathFirst` to false via `spark.executor.userClassPathFirst=false`, which is wrong setting.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.