### PR TITLE
[CELEBORN-1466] Add local command in celeborn_ratis_shell.md

### DIFF
--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -61,6 +61,7 @@ Usage: celeborn-ratis sh [generic options]
          [group [info] [list]]
          [peer [add] [remove] [setPriority]]
          [snapshot [create]]
+         [local [raftMetaConf]]
 ```
 
 ## generic options
@@ -155,4 +156,15 @@ It has the following subcommands:
 Trigger the specified server take snapshot.
 ```
 $ celeborn-ratis sh snapshot create -peers <P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT> -peerId <peerId0> [-groupid <RAFT_GROUP_ID>]
+```
+
+## local
+The `local` command is used to process local operation, which no need to connect to ratis server.
+It has the following subcommands:
+`raftMetaConf`
+
+### local raftMetaConf
+Generate a new raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
+```
+$ celeborn-ratis sh local raftMetaConf -peers <P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `local` command in `celeborn_ratis_shell.md` to sync document [cli.md](https://github.com/apache/ratis/blob/ratis-3.0.1/ratis-docs/src/site/markdown/cli.md).

### Why are the changes needed?

Celeborn has already bumped Ratis version from 2.5.1 to 3.0.1. Ratis v3.0.1 supports `local` command to process local operation, which no need to connect to ratis server. `celeborn_ratis_shell.md` should add local command to guide users to process local operation.

Backport: https://github.com/apache/ratis/pull/901

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.