### PR TITLE
[CELEBORN-1470] CelebornInputStream should retry to get next chunk starting from returned chunk for no replication

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -418,7 +418,11 @@ public abstract class CelebornInputStream extends InputStream {
                   currentReader.getLocation(),
                   e);
               Uninterruptibles.sleepUninterruptibly(retryWaitMs, TimeUnit.MILLISECONDS);
+              int currentChunk = currentReader.getCurrentChunk();
               currentReader = createReaderWithRetry(currentReader.getLocation(), null);
+              // Current reader reads next chunk starting from returned chunk instead of starting
+              // from the beginning.
+              currentReader.setCurrentChunk(currentChunk);
             }
           }
         }

--- a/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
@@ -290,4 +290,15 @@ public class DfsPartitionReader implements PartitionReader {
   public PartitionLocation getLocation() {
     return location;
   }
+
+  @Override
+  public int getCurrentChunk() {
+    return returnedChunks;
+  }
+
+  @Override
+  public void setCurrentChunk(int currentChunk) {
+    currentChunkIndex = currentChunk;
+    returnedChunks = currentChunk;
+  }
 }

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -260,4 +260,15 @@ public class LocalPartitionReader implements PartitionReader {
   public PartitionLocation getLocation() {
     return location;
   }
+
+  @Override
+  public int getCurrentChunk() {
+    return returnedChunks;
+  }
+
+  @Override
+  public void setCurrentChunk(int currentChunk) {
+    chunkIndex = currentChunk;
+    returnedChunks = currentChunk;
+  }
 }

--- a/client/src/main/java/org/apache/celeborn/client/read/PartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/PartitionReader.java
@@ -31,4 +31,8 @@ public interface PartitionReader {
   void close();
 
   PartitionLocation getLocation();
+
+  int getCurrentChunk();
+
+  void setCurrentChunk(int currentChunk);
 }

--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -201,6 +201,17 @@ public class WorkerPartitionReader implements PartitionReader {
     return location;
   }
 
+  @Override
+  public int getCurrentChunk() {
+    return returnedChunks;
+  }
+
+  @Override
+  public void setCurrentChunk(int currentChunk) {
+    chunkIndex = currentChunk;
+    returnedChunks = currentChunk;
+  }
+
   private void fetchChunks() throws IOException, InterruptedException {
     final int inFlight = chunkIndex - returnedChunks;
     if (inFlight < fetchMaxReqsInFlight) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CelebornInputStream` retries to get next chunk starting from returned chunk for no replication.

### Why are the changes needed?

`CelebornInputStream` retries to get next chunk starting from the beginning for retry for no replication at present. `CelebornInputStream` could retry to get next chunk starting from returned chunk instead of starting from the beginning to improve performance of fetching chunk without replication.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.