### PR TITLE
[CELEBORN-1471] CelebornScalaObjectMapper supports configuring FAIL_ON_UNKNOWN_PROPERTIES to false

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornScalaObjectMapper.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornScalaObjectMapper.scala
@@ -19,11 +19,13 @@ package org.apache.celeborn.server.common.http.api
 
 import javax.ws.rs.ext.ContextResolver
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 class CelebornScalaObjectMapper extends ContextResolver[ObjectMapper] {
-  private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  private val mapper = new ObjectMapper()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .registerModule(DefaultScalaModule)
 
   override def getContext(aClass: Class[_]): ObjectMapper = mapper
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CelebornScalaObjectMapper` supports configuring `FAIL_ON_UNKNOWN_PROPERTIES` to false.

### Why are the changes needed?

`CelebornScalaObjectMapper` would fail on unknown properties in Celeborn server side. Therefore, `CelebornScalaObjectMapper` could support configuring `FAIL_ON_UNKNOWN_PROPERTIES` to false which does not fail on unknown properties for Celeborn Master/Worker.

Backport: https://github.com/apache/kyuubi/pull/4691.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.