### PR TITLE
[CELEBORN-1440] Support baseline implementation of Celeborn Dashboard Server

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/protocol/RpcNameConstants.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/RpcNameConstants.java
@@ -33,6 +33,12 @@ public class RpcNameConstants {
   public static String WORKER_EP = "WorkerEndpoint";
   public static String WORKER_INTERNAL_EP = "WorkerInternalEndpoint";
 
+  // For Web
+  public static String WEB_SYS = "Web";
+
+  // Web Endpoint Name
+  public static String WEB_EP = "WebEndpoint";
+
   // For LifecycleManager
   public static String LIFECYCLE_MANAGER_SYS = "LifecycleManager";
   public static String LIFECYCLE_MANAGER_MASTER_SYS = "LifecycleManagerMasterSys";

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -103,6 +103,8 @@ enum MessageType {
   BATCH_OPEN_STREAM = 80;
   BATCH_OPEN_STREAM_RESPONSE = 81;
   REPORT_WORKER_DECOMMISSION = 82;
+  MASTER_GROUP_REQUEST = 83;
+  MASTER_GROUP_RESPONSE = 84;
 }
 
 enum StreamType {
@@ -796,4 +798,13 @@ message PbPackedWorkerResource {
 message PbReportWorkerDecommission {
   repeated PbWorkerInfo workers = 1;
   string requestId = 2;
+}
+
+message PbMasterGroupRequest {
+}
+
+message PbMasterGroupResponse {
+  string groupId = 1;
+  string masterLeader = 2;
+  repeated string commits = 3;
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -848,6 +848,22 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerJvmQuakeExitCode: Int = get(WORKER_JVM_QUAKE_EXIT_CODE)
 
   // //////////////////////////////////////////////////////
+  //                      Web                            //
+  // //////////////////////////////////////////////////////
+
+  def webHost: String = get(WEB_HOST).replace("<localhost>", Utils.localHostName(this))
+  def webHttpHost: String =
+    get(WEB_HTTP_HOST).replace("<localhost>", Utils.localHostName(this))
+  def webPort: Int = get(WEB_PORT)
+  def webHttpPort: Int = get(WEB_HTTP_PORT)
+
+  def webHttpMaxWorkerThreads: Int = get(WEB_HTTP_MAX_WORKER_THREADS)
+
+  def webHttpStopTimeout: Long = get(WEB_HTTP_STOP_TIMEOUT)
+
+  def webHttpIdleTimeout: Long = get(WEB_HTTP_IDLE_TIMEOUT)
+
+  // //////////////////////////////////////////////////////
   //                 Metrics System                      //
   // //////////////////////////////////////////////////////
   def metricsConf: Option[String] = get(METRICS_CONF)
@@ -5363,10 +5379,68 @@ object CelebornConf extends Logging {
 
   val LOG_CELEBORN_CONF_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.logConf.enabled")
-      .categories("master", "worker")
+      .categories("master", "worker", "web")
       .version("0.5.0")
       .doc("When `true`, log the CelebornConf for debugging purposes.")
       .booleanConf
       .createWithDefault(false)
 
+  val WEB_HOST: ConfigEntry[String] =
+    buildConf("celeborn.web.host")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Hostname for web to bind.")
+      .stringConf
+      .createWithDefaultString("<localhost>")
+
+  val WEB_HTTP_HOST: ConfigEntry[String] =
+    buildConf("celeborn.web.http.host")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Web's http host.")
+      .stringConf
+      .createWithDefaultString("<localhost>")
+
+  val WEB_PORT: ConfigEntry[Int] =
+    buildConf("celeborn.web.port")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Port for web to bind.")
+      .intConf
+      .checkValue(p => p >= 1024 && p < 65535, "Invalid port")
+      .createWithDefault(9090)
+
+  val WEB_HTTP_PORT: ConfigEntry[Int] =
+    buildConf("celeborn.web.http.port")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Web's http port.")
+      .intConf
+      .checkValue(p => p >= 1024 && p < 65535, "Invalid port")
+      .createWithDefault(9091)
+
+  val WEB_HTTP_MAX_WORKER_THREADS: ConfigEntry[Int] =
+    buildConf("celeborn.web.http.maxWorkerThreads")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Maximum number of threads in the web http worker thread pool.")
+      .intConf
+      .checkValue(_ > 0, "Must be positive.")
+      .createWithDefault(200)
+
+  val WEB_HTTP_STOP_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.web.http.stopTimeout")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Web http server stop timeout.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("5s")
+
+  val WEB_HTTP_IDLE_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.web.http.idleTimeout")
+      .categories("web")
+      .version("0.6.0")
+      .doc("Web http server idle timeout.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
 }

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -426,6 +426,25 @@ object ControlMessages extends Logging {
         .build()
   }
 
+  object MasterGroupRequest {
+    def apply(): PbMasterGroupRequest = {
+      PbMasterGroupRequest.newBuilder().build()
+    }
+  }
+
+  object MasterGroupResponse {
+    def apply(
+        groupId: String = null,
+        masterLeader: String = null,
+        commits: util.List[String] = null): PbMasterGroupResponse = {
+      val masterGroupResponse = PbMasterGroupResponse.newBuilder()
+      if (groupId != null) {
+        masterGroupResponse.setGroupId(groupId).setMasterLeader(masterLeader).addAllCommits(commits)
+      }
+      masterGroupResponse.build()
+    }
+  }
+
   /**
    * ==========================================
    *         handled by worker
@@ -917,6 +936,12 @@ object ControlMessages extends Logging {
 
     case pb: PbApplicationMetaRequest =>
       new TransportMessage(MessageType.APPLICATION_META_REQUEST, pb.toByteArray)
+
+    case pb: PbMasterGroupRequest =>
+      new TransportMessage(MessageType.MASTER_GROUP_REQUEST, pb.toByteArray)
+
+    case pb: PbMasterGroupResponse =>
+      new TransportMessage(MessageType.MASTER_GROUP_RESPONSE, pb.toByteArray)
   }
 
   // TODO change return type to GeneratedMessageV3
@@ -1294,6 +1319,12 @@ object ControlMessages extends Logging {
 
       case APPLICATION_META_REQUEST_VALUE =>
         PbApplicationMetaRequest.parseFrom(message.getPayload)
+
+      case MASTER_GROUP_REQUEST_VALUE =>
+        PbMasterGroupRequest.parseFrom(message.getPayload)
+
+      case MASTER_GROUP_RESPONSE_VALUE =>
+        PbMasterGroupResponse.parseFrom(message.getPayload)
     }
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -406,7 +406,7 @@ object Utils extends Logging {
     }
   }
 
-  private var customHostname: Option[String] = sys.env.get("CELEBORN_LOCAL_HOSTNAME")
+  var customHostname: Option[String] = sys.env.get("CELEBORN_LOCAL_HOSTNAME")
 
   // for testing
   def setCustomHostname(hostname: String) {

--- a/common/src/test/scala/org/apache/celeborn/ConfigurationSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/ConfigurationSuite.scala
@@ -70,6 +70,10 @@ class ConfigurationSuite extends AnyFunSuite {
     generateConfigurationMarkdown("worker")
   }
 
+  test("docs - configuration/web.md") {
+    generateConfigurationMarkdown("web")
+  }
+
   test("docs - configuration/quota.md") {
     generateConfigurationMarkdown("quota")
   }

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -75,6 +75,13 @@ start="<!--begin-include-->"
 end="<!--end-include-->"
 !}
 
+### Web
+
+{!
+include-markdown "./web.md"
+start="<!--begin-include-->"
+end="<!--end-include-->"
+!}
 
 ### Client
 

--- a/docs/configuration/web.md
+++ b/docs/configuration/web.md
@@ -1,0 +1,30 @@
+---
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+<!--begin-include-->
+| Key | Default | isDynamic | Description | Since | Deprecated |
+| --- | ------- | --------- | ----------- | ----- | ---------- |
+| celeborn.logConf.enabled | false | false | When `true`, log the CelebornConf for debugging purposes. | 0.5.0 |  | 
+| celeborn.web.host | &lt;localhost&gt; | false | Hostname for web to bind. | 0.6.0 |  | 
+| celeborn.web.http.host | &lt;localhost&gt; | false | Web's http host. | 0.6.0 |  | 
+| celeborn.web.http.idleTimeout | 30s | false | Web http server idle timeout. | 0.6.0 |  | 
+| celeborn.web.http.maxWorkerThreads | 200 | false | Maximum number of threads in the web http worker thread pool. | 0.6.0 |  | 
+| celeborn.web.http.port | 9091 | false | Web's http port. | 0.6.0 |  | 
+| celeborn.web.http.stopTimeout | 5s | false | Web http server stop timeout. | 0.6.0 |  | 
+| celeborn.web.port | 9090 | false | Port for web to bind. | 0.6.0 |  | 
+<!--end-include-->

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -331,7 +331,8 @@ object CelebornBuild extends sbt.internal.BuildDef {
       CelebornClient.client,
       CelebornService.service,
       CelebornWorker.worker,
-      CelebornMaster.master) ++ maybeSparkClientModules ++ maybeFlinkClientModules ++ maybeMRClientModules
+      CelebornMaster.master,
+      CelebornWeb.web) ++ maybeSparkClientModules ++ maybeFlinkClientModules ++ maybeMRClientModules
   }
 
   // ThisBuild / parallelExecution := false
@@ -581,6 +582,22 @@ object CelebornWorker {
         Dependencies.scalatestMockito % "test",
         Dependencies.jerseyTestFrameworkCore % "test",
         Dependencies.jerseyTestFrameworkProviderJetty % "test"
+      ) ++ commonUnitTestDependencies
+    )
+}
+
+object CelebornWeb {
+  lazy val web = Project("celeborn-web", file("web"))
+    .dependsOn(CelebornService.service)
+    .dependsOn(CelebornCommon.common % "test->test;compile->compile")
+    .dependsOn(CelebornService.service % "test->test;compile->compile")
+    .dependsOn(CelebornMaster.master % "test->compile")
+    .settings(
+      commonSettings,
+      libraryDependencies ++= Seq(
+        Dependencies.ioNetty,
+        Dependencies.log4j12Api,
+        Dependencies.log4jSlf4jImpl,
       ) ++ commonUnitTestDependencies
     )
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/OpenAPIConfig.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/OpenAPIConfig.scala
@@ -29,5 +29,6 @@ object OpenAPIConfig {
   val packages = Seq(
     "org.apache.celeborn.server.common.http.api",
     "org.apache.celeborn.service.deploy.master.http.api",
-    "org.apache.celeborn.service.deploy.worker.http.api")
+    "org.apache.celeborn.service.deploy.worker.http.api",
+    "org.apache.celeborn.service.deploy.web.http.api")
 }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>celeborn-web_${scala.binary.version}</artifactId>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <name>Celeborn Web</name>
 
   <properties>
@@ -33,8 +33,73 @@
     <build.pnpm.version>8.14.3</build.pnpm.version>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-service_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-service_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-master_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework</groupId>
+      <artifactId>jersey-test-framework-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>

--- a/web/src/main/java/org/apache/celeborn/service/deploy/web/http/api/dto/ClusterSummary.java
+++ b/web/src/main/java/org/apache/celeborn/service/deploy/web/http/api/dto/ClusterSummary.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.web.http.api.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class ClusterSummary {
+
+  private String endpoint;
+  private String leader;
+
+  public ClusterSummary() {}
+
+  public ClusterSummary(String endpoint, String leader) {
+    this.endpoint = endpoint;
+    this.leader = leader;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getLeader() {
+    return leader;
+  }
+
+  public void setLeader(String leader) {
+    this.leader = leader;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) return true;
+    if (!(object instanceof ClusterSummary)) return false;
+    ClusterSummary that = (ClusterSummary) object;
+    return Objects.equals(getEndpoint(), that.getEndpoint())
+        && Objects.equals(getLeader(), that.getLeader());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getEndpoint(), getLeader());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/web/src/main/scala/org/apache/celeborn/service/deploy/web/Web.scala
+++ b/web/src/main/scala/org/apache/celeborn/service/deploy/web/Web.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.web
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.CelebornConf.MASTER_ENDPOINTS
+import org.apache.celeborn.common.client.MasterClient
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.metrics.MetricsSystem
+import org.apache.celeborn.common.protocol.{PbMasterGroupResponse, RpcNameConstants, TransportModuleConstants}
+import org.apache.celeborn.common.protocol.message.ControlMessages.MasterGroupRequest
+import org.apache.celeborn.common.rpc._
+import org.apache.celeborn.common.util.SignalUtils
+import org.apache.celeborn.server.common.{HttpService, Service}
+import org.apache.celeborn.service.deploy.web.http.api.dto.ClusterSummary
+
+private[celeborn] class Web(
+    override val conf: CelebornConf,
+    val webArgs: WebArguments)
+  extends HttpService with RpcEndpoint with Logging {
+
+  @volatile private var stopped = false
+
+  override def serviceName: String = Service.WEB
+
+  override val metricsSystem: MetricsSystem =
+    MetricsSystem.createMetricsSystem(serviceName, conf)
+
+  if (conf.logCelebornConfEnabled) {
+    logInfo(getConf)
+  }
+
+  override val rpcEnv: RpcEnv = {
+    RpcEnv.create(
+      RpcNameConstants.WEB_SYS,
+      TransportModuleConstants.RPC_SERVICE_MODULE,
+      webArgs.host,
+      webArgs.host,
+      webArgs.port,
+      conf,
+      Math.max(64, Runtime.getRuntime.availableProcessors()))
+  }
+
+  rpcEnv.setupEndpoint(RpcNameConstants.WEB_EP, this)
+
+  override def initialize(): Unit = {
+    super.initialize()
+    logInfo("Web started.")
+    rpcEnv.awaitTermination()
+  }
+
+  override def stop(exitKind: Int): Unit = synchronized {
+    if (!stopped) {
+      logInfo("Stopping Web.")
+      rpcEnv.stop(self)
+      super.stop(exitKind)
+      logInfo("Web is stopped.")
+      stopped = true
+    }
+  }
+
+  private val masterClient = new MasterClient(rpcEnv, conf, false)
+
+  def clusterOverview: ClusterSummary = {
+    val response =
+      masterClient.askSync[PbMasterGroupResponse](
+        MasterGroupRequest(),
+        classOf[PbMasterGroupResponse])
+    new ClusterSummary(conf.masterEndpoints.mkString(","), response.getMasterLeader)
+  }
+}
+
+private[deploy] object Web extends Logging {
+
+  def main(args: Array[String]): Unit = {
+    SignalUtils.registerLogger(log)
+    val conf = new CelebornConf()
+    val webArgs = new WebArguments(args, conf)
+    // There are many entries for setting the master address, and we should unify the entries as
+    // much as possible. Therefore, if the user manually specifies the address of the Master when
+    // starting the Web, we should set it in the parameters and automatically calculate what the
+    // address of the Master should be used in the end.
+    webArgs.master.foreach { master =>
+      conf.set(MASTER_ENDPOINTS.key, RpcAddress.fromCelebornURL(master).hostPort)
+    }
+    try {
+      new Web(conf, webArgs).initialize()
+    } catch {
+      case e: Throwable =>
+        logError("Initialize web failed.", e)
+        System.exit(-1)
+    }
+  }
+}

--- a/web/src/main/scala/org/apache/celeborn/service/deploy/web/http/api/ApiWebResource.scala
+++ b/web/src/main/scala/org/apache/celeborn/service/deploy/web/http/api/ApiWebResource.scala
@@ -15,34 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.server.common
+package org.apache.celeborn.service.deploy.web.http.api
 
-import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.server.common.service.config.{ConfigService, DynamicConfigServiceFactory}
+import javax.ws.rs.Path
 
-abstract class Service extends Logging {
-  def serviceName: String
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
 
-  def conf: CelebornConf
+@Path("/")
+class ApiWebResource extends ApiRequestContext {
 
-  def metricsSystem: MetricsSystem
-
-  def configService: ConfigService = DynamicConfigServiceFactory.getConfigService(conf)
-
-  def initialize(): Unit = {
-    if (conf.metricsSystemEnable) {
-      logInfo(s"Metrics system enabled.")
-      metricsSystem.start()
-    }
-  }
-
-  def stop(exitKind: Int): Unit = {}
-}
-
-object Service {
-  val MASTER = "master"
-  val WORKER = "worker"
-  val WEB = "web"
+  @Path("cluster")
+  def cluster: Class[ClusterResource] = classOf[ClusterResource]
 }

--- a/web/src/main/scala/org/apache/celeborn/service/deploy/web/http/api/ClusterResource.scala
+++ b/web/src/main/scala/org/apache/celeborn/service/deploy/web/http/api/ClusterResource.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.web.http.api
+
+import javax.ws.rs._
+import javax.ws.rs.core.MediaType
+
+import scala.language.implicitConversions
+
+import io.swagger.v3.oas.annotations.media.{Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.service.deploy.web.Web
+import org.apache.celeborn.service.deploy.web.http.api.dto.ClusterSummary
+
+@Tag(name = "Cluster")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class ClusterResource extends ApiRequestContext with Logging {
+
+  def service: Web = httpService.asInstanceOf[Web]
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[ClusterSummary]))),
+    description = "Returns the overview summary of cluster.")
+  @GET
+  @Path("overview")
+  def overview(): ClusterSummary = {
+    service.clusterOverview
+  }
+}

--- a/web/src/test/resources/log4j2-test.xml
+++ b/web/src/test/resources/log4j2-test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+            <Filters>
+                <ThresholdFilter level="ERROR"/>
+            </Filters>
+        </Console>
+        <File name="file" fileName="target/unit-tests.log">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="file"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/web/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/web/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy
+
+import java.io.IOException
+import java.net.BindException
+import java.nio.file.Files
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.mutable
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
+import org.apache.celeborn.common.util.Utils.selectRandomPort
+import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
+
+trait MiniClusterFeature extends Logging {
+
+  var masterInfos = new mutable.HashMap[Master, Thread]()
+
+  class RunnerWrap[T](code: => T) extends Thread {
+
+    override def run(): Unit = {
+      Utils.tryLogNonFatalError(code)
+    }
+  }
+
+  def setupMiniClusterWithRandomPorts(
+      masterConf: Map[String, String] = Map()): collection.Set[Master] = {
+    var retryCount = 0
+    var created = false
+    var masters: collection.Set[Master] = null
+    while (!created) {
+      try {
+        val randomPort = selectRandomPort(1024, 65535)
+        val finalMasterConf = Map(
+          s"${CelebornConf.HA_ENABLED.key}" -> "true",
+          s"celeborn.master.ha.node.1.port" -> s"$randomPort",
+          s"celeborn.master.ha.node.1.ratis.port" -> s"${randomPort + 1}",
+          s"celeborn.master.ha.node.2.port" -> s"${randomPort + 2}",
+          s"celeborn.master.ha.node.2.ratis.port" -> s"${randomPort + 3}",
+          s"celeborn.master.ha.node.3.port" -> s"${randomPort + 4}",
+          s"celeborn.master.ha.node.3.ratis.port" -> s"${randomPort + 5}",
+          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort,localhost:${randomPort + 2},localhost:${randomPort + 4}",
+          s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
+          s"${CelebornConf.PORT_MAX_RETRY.key}" -> "0") ++
+          masterConf
+
+        logInfo(s"Generated configuration $finalMasterConf.")
+        val m = setUpMiniCluster(finalMasterConf)
+        masters = m
+        created = true
+      } catch {
+        case e: IOException
+            if e.isInstanceOf[BindException] || Option(e.getCause).exists(
+              _.isInstanceOf[BindException]) =>
+          logError(s"Failed to setup mini cluster, retrying (retry count: $retryCount)", e)
+          retryCount += 1
+          if (retryCount == 3) {
+            logError("Failed to setup mini cluster, reached the max retry count", e)
+            throw e
+          }
+      }
+    }
+    masters
+  }
+
+  def createTmpDir(): String = {
+    val tmpDir = Files.createTempDirectory("celeborn-")
+    logInfo(s"Created temp dir: $tmpDir.")
+    tmpDir.toFile.deleteOnExit()
+    tmpDir.toAbsolutePath.toString
+  }
+
+  def createMaster(nodeId: Int, map: Map[String, String] = null): Master = {
+    createMaster(nodeId, map, createTmpDir())
+  }
+
+  def createMaster(
+      nodeId: Int,
+      map: Map[String, String],
+      storageDir: String): Master = {
+    logInfo("Start create master for mini cluster.")
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.HA_MASTER_NODE_ID, s"$nodeId")
+    conf.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR, storageDir)
+    conf.set(CelebornConf.METRICS_ENABLED.key, "false")
+    conf.set(CelebornConf.MASTER_HTTP_PORT.key, s"${selectRandomPort(1024, 65535)}")
+    if (map != null) {
+      map.foreach(m => conf.set(m._1, m._2))
+    }
+    logInfo("Celeborn master conf created.")
+
+    val masterArguments = new MasterArguments(Array(), conf)
+    logInfo("Master argument created.")
+    try {
+      val master = new Master(conf, masterArguments)
+      logInfo("Master created for mini cluster.")
+      master
+    } catch {
+      case e: Exception =>
+        logError("Create master failed, detail:", e)
+        System.exit(-1)
+        null
+    }
+  }
+
+  private def setUpMiniCluster(
+      masterConf: Map[String, String] = null): collection.Set[Master] = {
+    val timeout = 30000
+    val masters = new Array[Master](3)
+    val flagUpdateLock = new ReentrantLock()
+    val threads = (1 to 3).map { nodeId =>
+      val masterThread = new RunnerWrap({
+        var masterStartRetry = 0
+        var masterStarted = false
+        while (!masterStarted) {
+          try {
+            val master = createMaster(nodeId, masterConf)
+            flagUpdateLock.lock()
+            masters(nodeId - 1) = master
+            flagUpdateLock.unlock()
+            masterStarted = true
+            master.initialize()
+          } catch {
+            case e: Exception =>
+              if (masters(nodeId - 1) != null) {
+                masters(nodeId - 1).stop(CelebornExitKind.EXIT_IMMEDIATELY)
+              }
+              masterStarted = false
+              masterStartRetry += 1
+              logError(s"Cannot start master $nodeId, retrying: ", e)
+              if (masterStartRetry == 3) {
+                logError(s"Cannot start master $nodeId, reached to max retrying", e)
+                throw e
+              } else {
+                Thread.sleep(math.pow(2000, masterStartRetry).toInt)
+              }
+          }
+        }
+      })
+      masterThread.setName(s"master-$nodeId-starter")
+      masterThread
+    }
+    threads.foreach(_.start())
+    Thread.sleep(5000)
+    var allMastersStarted = false
+    var mastersWaitingTime = 0
+    while (!allMastersStarted) {
+      try {
+        (0 until 3).foreach { i =>
+          {
+            if (masters(i) == null) {
+              throw new IllegalStateException(s"Master $i hasn't been initialized")
+            } else {
+              masterInfos.put(masters(i), threads(i))
+            }
+          }
+        }
+        allMastersStarted = true
+      } catch {
+        case e: Exception =>
+          logError("All masters haven't been started retrying", e)
+          Thread.sleep(5000)
+          mastersWaitingTime += 5000
+          if (mastersWaitingTime >= timeout) {
+            logError(s"Cannot start all masters after $timeout ms", e)
+            throw e
+          }
+      }
+    }
+    masterInfos.keySet
+  }
+
+  def shutdownMiniCluster(): Unit = {
+    // shutdown masters
+    masterInfos.foreach {
+      case (master, _) =>
+        master.stop(CelebornExitKind.EXIT_IMMEDIATELY)
+        master.rpcEnv.shutdown()
+    }
+
+    // interrupt threads
+    Thread.sleep(5000)
+    masterInfos.foreach {
+      case (_, thread) =>
+        thread.interrupt()
+    }
+    masterInfos.clear()
+  }
+}

--- a/web/src/test/scala/org/apache/celeborn/service/deploy/web/WebArgumentsSuite.scala
+++ b/web/src/test/scala/org/apache/celeborn/service/deploy/web/WebArgumentsSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.web
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.Utils
+
+class WebArgumentsSuite extends AnyFunSuite with Logging {
+
+  test("[CELEBORN-98] Test build webArguments in different case") {
+    val args1 = Array.empty[String]
+    val conf1 = new CelebornConf()
+
+    val arguments1 = new WebArguments(args1, conf1)
+    assert(arguments1.host === sys.env.getOrElse(
+      "CELEBORN_LOCAL_HOSTNAME",
+      Utils.localHostName(conf1)))
+    assert(arguments1.port === 9090)
+
+    // should use celeborn conf
+    val conf2 =
+      new CelebornConf().set(CelebornConf.WEB_HOST, "test-host-1").set(CelebornConf.WEB_PORT, 19090)
+
+    val arguments2 = new WebArguments(args1, conf2)
+    assert(arguments2.host === sys.env.getOrElse("CELEBORN_LOCAL_HOSTNAME", "test-host-1"))
+    assert(arguments2.port === 19090)
+
+    // should use cli args
+    val arguments3 = new WebArguments(Array("-h", "test-host-1", "-p", "19090"), conf2)
+    assert(arguments3.host.equals("test-host-1"))
+    assert(arguments3.port == 19090)
+  }
+}

--- a/web/src/test/scala/org/apache/celeborn/service/deploy/web/http/api/ApiWebResourceSuite.scala
+++ b/web/src/test/scala/org/apache/celeborn/service/deploy/web/http/api/ApiWebResourceSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.web.http.api
+
+import javax.ws.rs.core.MediaType
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
+import org.apache.celeborn.server.common.HttpService
+import org.apache.celeborn.server.common.http.HttpTestHelper
+import org.apache.celeborn.service.deploy.MiniClusterFeature
+import org.apache.celeborn.service.deploy.web.{Web, WebArguments}
+import org.apache.celeborn.service.deploy.web.http.api.dto.ClusterSummary
+
+class ApiWebResourceSuite extends HttpTestHelper with MiniClusterFeature {
+
+  private var masterEndpoint: collection.Set[String] = _
+  private var web: Web = _
+
+  override protected def httpService: HttpService = web
+
+  override def beforeAll(): Unit = {
+    val masters = setupMiniClusterWithRandomPorts()
+    masterEndpoint = masters.map(master => s"${master.masterArgs.host}:${master.masterArgs.port}")
+    val port = Utils.selectRandomPort(1024, 65535)
+    celebornConf.set(CelebornConf.WEB_HTTP_HOST, "127.0.0.1")
+      .set(CelebornConf.WEB_HTTP_PORT, port + 1)
+      .set(CelebornConf.MASTER_ENDPOINTS, masterEndpoint.toSeq)
+    web = new Web(
+      celebornConf,
+      new WebArguments(Array("-h", "localhost", "-p", port.toString), celebornConf))
+    new Thread() {
+      override def run(): Unit = {
+        web.initialize()
+      }
+    }.start()
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    web.stop(CelebornExitKind.EXIT_IMMEDIATELY)
+    web.rpcEnv.shutdown()
+    shutdownMiniCluster()
+  }
+
+  test("cluster/overview") {
+    val response = webTarget.path("cluster/overview").request(MediaType.APPLICATION_JSON).get()
+    assert(200 == response.getStatus)
+    val clusterSummary = response.readEntity(classOf[ClusterSummary])
+    assert(masterEndpoint.mkString(",") == clusterSummary.getEndpoint)
+    assert(clusterSummary.getLeader != null)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support baseline implementation of Celeborn Dashboard Server including:

- Introduce `Web` server to support Web Rest API of Celeborn Dashboard.
- Introduce `/cluster/overview` to support Cluster Rest API of Celeborn Dashboard.

### Why are the changes needed?

Celeborn Dashboard has already supported frontend, which needs server to provide Celeborn backend. Celeborn Dashboard should support implementation of Celeborn Dashboard Server.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `WebArgumentsSuite`
- `ApiWebResourceSuite`