### PR TITLE
[CELEBORN-1477] Refine the master/worker RESTful APIs

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/AppDiskUsageMetric.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/AppDiskUsageMetric.scala
@@ -175,6 +175,12 @@ class AppDiskUsageMetric(conf: CelebornConf) extends Logging {
     stringBuilder.toString()
   }
 
+  def topSnapshots(): Seq[AppDiskUsageSnapShot] = {
+    snapShots.take(snapshotCount)
+      .filter(_ != null)
+      .filter(_.topNItems.exists(_ != null))
+  }
+
   def restoreFromSnapshot(array: Array[AppDiskUsageSnapShot]): Unit = {
     // Restored snapshots only contains values not null
     for (i <- 0 until snapshotCount) {

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
@@ -31,8 +31,8 @@ class WorkerPartitionLocationInfo extends Logging {
 
   // key: ShuffleKey, values: (uniqueId -> PartitionLocation))
   type PartitionInfo = ConcurrentHashMap[String, ConcurrentHashMap[String, PartitionLocation]]
-  private val primaryPartitionLocations = new PartitionInfo
-  private val replicaPartitionLocations = new PartitionInfo
+  private[celeborn] val primaryPartitionLocations = new PartitionInfo
+  private[celeborn] val replicaPartitionLocations = new PartitionInfo
 
   def shuffleKeySet: util.HashSet[String] = {
     val shuffleKeySet = new util.HashSet[String]()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -134,7 +134,7 @@ private[celeborn] class Master(
     }
 
   private val rackResolver = new CelebornRackResolver(conf)
-  private val statusSystem =
+  private[celeborn] val statusSystem =
     if (conf.haEnabled) {
       val sys = new HAMasterMetaManager(internalRpcEnvInUse, conf, rackResolver)
       val handler = new MetaHandler(sys)
@@ -1183,33 +1183,31 @@ private[celeborn] class Master(
     statusSystem.workers.asScala.mkString("\n")
   }
 
-  override def handleWorkerEvent(workerEventType: String, workers: String): String = {
-    val sb = new StringBuilder
-    if (workerEventType.isEmpty || workers.isEmpty) {
-      return sb.append(
-        s"handle eventType failed as eventType: $workerEventType or workers: $workers has empty value").toString()
-    }
-
-    sb.append("============================ Handle Worker Event =============================\n")
-    val workerArray = workers.split(",").filter(_.nonEmpty)
+  override def handleWorkerEvent(
+      workerEventType: String,
+      workers: Seq[WorkerInfo]): (Boolean, String) = {
+    val sb = new StringBuilder()
     try {
       val workerEventResponse = self.askSync[PbWorkerEventResponse](WorkerEventRequest(
-        workerArray.map(WorkerInfo.fromUniqueId).toList.asJava,
+        workers.asJava,
         workerEventType,
         MasterClient.genRequestId()))
       if (workerEventResponse.getSuccess) {
-        sb.append(s"handle $workerEventType for ${workerArray.mkString(",")} successfully")
+        sb.append(
+          s"handle $workerEventType for ${workers.map(_.readableAddress).mkString(",")} successfully")
       } else {
-        sb.append(s"handle $workerEventType for ${workerArray.mkString(",")} failed")
+        sb.append(
+          s"handle $workerEventType for ${workers.map(_.readableAddress).mkString(",")} failed")
       }
+      workerEventResponse.getSuccess -> sb.toString()
     } catch {
       case e: Throwable =>
         val message =
-          s"handle $workerEventType for ${workerArray.mkString(",")} failed, message: ${e.getMessage}"
+          s"handle $workerEventType for ${workers.mkString(",")} failed, message: ${e.getMessage}"
         logError(message, e)
         sb.append(message)
+        false -> sb.toString()
     }
-    sb.append("\n").toString()
   }
 
   override def getWorkerInfo: String = {
@@ -1289,30 +1287,30 @@ private[celeborn] class Master(
     sb.toString()
   }
 
-  override def exclude(addWorkers: String, removeWorkers: String): String = {
+  override def exclude(
+      addWorkers: Seq[WorkerInfo],
+      removeWorkers: Seq[WorkerInfo]): (Boolean, String) = {
     val sb = new StringBuilder
-    sb.append("============================ Add/Remove Excluded Workers  Manually =============================\n")
-    val workersToAdd = addWorkers.split(",").filter(_.nonEmpty).map(WorkerInfo.fromUniqueId).toList
-    val workersToRemove =
-      removeWorkers.split(",").filter(_.nonEmpty).map(WorkerInfo.fromUniqueId).toList
     val workerExcludeResponse = self.askSync[PbWorkerExcludeResponse](WorkerExclude(
-      workersToAdd.asJava,
-      workersToRemove.asJava,
+      addWorkers.asJava,
+      removeWorkers.asJava,
       MasterClient.genRequestId()))
     if (workerExcludeResponse.getSuccess) {
       sb.append(
-        s"Excluded workers add ${workersToAdd.mkString(",")} and remove ${workersToRemove.mkString(",")} successfully.\n")
+        s"Excluded workers add ${addWorkers.map(_.readableAddress).mkString(
+          ",")} and remove ${removeWorkers.map(_.readableAddress).mkString(",")} successfully.\n")
     } else {
       sb.append(
-        s"Failed to Exclude workers add ${workersToAdd.mkString(",")} and remove ${workersToRemove.mkString(",")}.\n")
+        s"Failed to Exclude workers add ${addWorkers.map(_.readableAddress).mkString(
+          ",")} and remove ${removeWorkers.map(_.readableAddress).mkString(",")}.\n")
     }
     val unknownExcludedWorkers =
-      (workersToAdd ++ workersToRemove).filter(!statusSystem.workers.contains(_))
+      (addWorkers ++ removeWorkers).filter(!statusSystem.workers.contains(_))
     if (unknownExcludedWorkers.nonEmpty) {
       sb.append(
-        s"Unknown worker ${unknownExcludedWorkers.mkString(",")}. Workers in Master:\n$getWorkers.")
+        s"Unknown workers ${unknownExcludedWorkers.map(_.readableAddress).mkString(",")}. Workers in Master:\n$getWorkers.")
     }
-    sb.toString()
+    workerExcludeResponse.getSuccess -> sb.toString()
   }
 
   private def isMasterActive: Int = {
@@ -1356,7 +1354,6 @@ private[celeborn] class Master(
       } else {
         sb.append(s"leader info: ${leader.getId.toStringUtf8}(${leader.getAddress})\n\n")
       }
-      sb.append(groupInfo.getCommitInfos)
       sb.append("\n")
       sb.toString()
     } else {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResource.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import javax.ws.rs.{GET, Path}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+import org.apache.celeborn.common.util.ThreadStackTrace
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.service.deploy.master.Master
+
+@Path("/api/v1")
+class ApiV1MasterResource extends ApiRequestContext {
+  @Path("shuffles")
+  def shuffles: Class[ShuffleResource] = classOf[ShuffleResource]
+
+  @Path("applications")
+  def applications: Class[ApplicationResource] = classOf[ApplicationResource]
+
+  @Path("masters")
+  def masters: Class[MasterResource] = classOf[MasterResource]
+
+  @Path("workers")
+  def workers: Class[WorkerResource] = classOf[WorkerResource]
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 
-import org.apache.celeborn.common.meta.AppDiskUsageSnapShot
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 import org.apache.celeborn.server.common.http.api.v1.dto.{AppDiskUsageData, AppDiskUsageSnapshotData, ApplicationHeartbeatData}
 import org.apache.celeborn.service.deploy.master.Master

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 
+import org.apache.celeborn.common.meta.AppDiskUsageSnapShot
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 import org.apache.celeborn.server.common.http.api.v1.dto.{AppDiskUsageData, AppDiskUsageSnapshotData, ApplicationHeartbeatData}
 import org.apache.celeborn.service.deploy.master.Master

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import javax.ws.rs.{Consumes, GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+import org.apache.celeborn.common.meta.AppDiskUsageSnapShot
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.dto.{AppDiskUsageData, AppDiskUsageSnapshotData, ApplicationHeartbeatData}
+import org.apache.celeborn.service.deploy.master.Master
+
+@Tag(name = "Application")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class ApplicationResource extends ApiRequestContext {
+  private def statusSystem = httpService.asInstanceOf[Master].statusSystem
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[ApplicationHeartbeatData])))),
+    description = "List all running application's ids of the cluster.")
+  @GET
+  def applications(): Seq[ApplicationHeartbeatData] = {
+    statusSystem.appHeartbeatTime.asScala.map { case (appId, heartbeat) =>
+      new ApplicationHeartbeatData(appId, heartbeat)
+    }.toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[AppDiskUsageSnapshotData])))),
+    description =
+      "List the top disk usage application ids. It will return the top disk usage application ids for the cluster.")
+  @Path("/top_disk_usages")
+  @GET
+  def topDiskUsedApplications(): Seq[AppDiskUsageSnapshotData] = {
+    statusSystem.appDiskUsageMetric.topSnapshots().map { snapshot =>
+      new AppDiskUsageSnapshotData(
+        snapshot.startSnapShotTime,
+        snapshot.endSnapShotTime,
+        snapshot.topNItems.map { usage =>
+          new AppDiskUsageData(usage.appId, usage.estimatedUsage)
+        }.toSeq.asJava)
+    }
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[String])))),
+    description =
+      "List all running application's LifecycleManager's hostnames of the cluster.")
+  @Path("/hostnames")
+  @GET
+  def hostnames(): Seq[String] = {
+    statusSystem.hostnameSet.asScala.toSeq
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/MasterResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/MasterResource.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import javax.ws.rs.{BadRequestException, Consumes, GET, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.dto.{MasterCommitData, MasterGroupData, MasterLeader}
+import org.apache.celeborn.service.deploy.master.Master
+import org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager
+
+@Tag(name = "Master")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class MasterResource extends ApiRequestContext {
+  private def master = httpService.asInstanceOf[Master]
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(
+        implementation = classOf[MasterGroupData]))),
+    description =
+      "List master group information of the service. It will list all master's LEADER, FOLLOWER information.")
+  @GET
+  def masterGroupInfo: MasterGroupData = {
+    if (master.conf.haEnabled) {
+      val groupInfo =
+        master.statusSystem.asInstanceOf[HAMasterMetaManager].getRatisServer.getGroupInfo
+      val leader = Option(groupInfo.getRoleInfoProto).map { roleInfo =>
+        if (roleInfo.getRole == RaftPeerRole.LEADER) {
+          roleInfo.getSelf
+        } else {
+          Option(roleInfo.getFollowerInfo).map(_.getLeaderInfo.getId).orNull
+        }
+      }.orNull
+      val masterLeader = Option(leader).map { _ =>
+        new MasterLeader(leader.getId.toString, leader.getAddress)
+      }.orNull
+      val masterCommitDataList = groupInfo.getCommitInfos.asScala.map { commitInfo =>
+        new MasterCommitData(
+          commitInfo.getCommitIndex,
+          commitInfo.getServer.getId.toString,
+          commitInfo.getServer.getAddress,
+          commitInfo.getServer.getClientAddress,
+          commitInfo.getServer.getStartupRole.toString)
+      }
+      new MasterGroupData(
+        groupInfo.getGroup.getGroupId.getUuid.toString,
+        masterLeader,
+        masterCommitDataList.toSeq.asJava)
+    } else {
+      throw new BadRequestException("HA is not enabled")
+    }
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ShuffleResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ShuffleResource.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import javax.ws.rs.{Consumes, GET, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.service.deploy.master.Master
+
+@Tag(name = "Shuffle")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class ShuffleResource extends ApiRequestContext {
+  private def statusSystem = httpService.asInstanceOf[Master].statusSystem
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[String])))),
+    description =
+      "List all running shuffle keys of the service. It will return all running shuffle's key of the cluster.")
+  @GET
+  def shuffles: Seq[String] = {
+    statusSystem.registeredShuffle.asScala.toSeq
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -64,9 +64,13 @@ class WorkerResource extends ApiRequestContext {
     description = "List all lost workers of the master.")
   @Path("/lost")
   @GET
-  def lostWorkers(): Seq[WorkerTimestampData] = {
-    statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
+  def lostWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerTimestampData] = {
+    var workers = statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
       .map(kv => new WorkerTimestampData(ApiUtils.workerData(kv._1), kv._2))
+    if (StringUtils.isNotEmpty(hostname)) {
+      workers = workers.filter(_.getWorker.getHost == hostname)
+    }
+    workers
   }
 
   @ApiResponse(
@@ -78,9 +82,14 @@ class WorkerResource extends ApiRequestContext {
     description = "List all excluded workers of the master.")
   @Path("/excluded")
   @GET
-  def excludedWorkers(): Seq[WorkerData] = {
-    (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
-      .map(ApiUtils.workerData).toSeq
+  def excludedWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
+    var workers =
+      (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
+        .map(ApiUtils.workerData).toSeq
+    if (StringUtils.isNotEmpty(hostname)) {
+      workers = workers.filter(_.getHost == hostname)
+    }
+    workers
   }
 
   @ApiResponse(
@@ -92,8 +101,12 @@ class WorkerResource extends ApiRequestContext {
     description = "List all shutdown workers of the master.")
   @Path("/shutdown")
   @GET
-  def shutdownWorkers(): Seq[WorkerData] = {
-    statusSystem.shutdownWorkers.asScala.map(ApiUtils.workerData).toSeq
+  def shutdownWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
+    var workers = statusSystem.shutdownWorkers.asScala.map(ApiUtils.workerData).toSeq
+    if (StringUtils.isNotEmpty(hostname)) {
+      workers = workers.filter(_.getHost == hostname)
+    }
+    workers
   }
 
   @ApiResponse(
@@ -105,8 +118,12 @@ class WorkerResource extends ApiRequestContext {
     description = "List all decommissioned workers of the master.")
   @Path("/decommissioned")
   @GET
-  def decommissionWorkers(): Seq[WorkerData] = {
-    statusSystem.decommissionWorkers.asScala.map(ApiUtils.workerData).toSeq
+  def decommissionWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
+    var workers = statusSystem.decommissionWorkers.asScala.map(ApiUtils.workerData).toSeq
+    if (StringUtils.isNotEmpty(hostname)) {
+      workers = workers.filter(_.getHost == hostname)
+    }
+    workers
   }
 
   @ApiResponse(
@@ -134,12 +151,16 @@ class WorkerResource extends ApiRequestContext {
     description = "List all worker event infos of the master.")
   @Path("/events")
   @GET
-  def workerEvents(): Seq[WorkerEventData] = {
-    statusSystem.workerEventInfos.asScala.map { case (worker, event) =>
+  def workerEvents(@QueryParam("hostname") hostname: String = ""): Seq[WorkerEventData] = {
+    var events = statusSystem.workerEventInfos.asScala.map { case (worker, event) =>
       new WorkerEventData(
         ApiUtils.workerData(worker),
         new WorkerEventInfoData(event.getEventType.toString, event.getEventStartTime))
     }.toSeq
+    if (StringUtils.isNotEmpty(hostname)) {
+      events = events.filter(_.getWorker.getHost == hostname)
+    }
+    events
   }
 
   @ApiResponse(

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -64,13 +64,9 @@ class WorkerResource extends ApiRequestContext {
     description = "List all lost workers of the master.")
   @Path("/lost")
   @GET
-  def lostWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerTimestampData] = {
-    var workers = statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
+  def lostWorkers(): Seq[WorkerTimestampData] = {
+    statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
       .map(kv => new WorkerTimestampData(ApiUtils.workerData(kv._1), kv._2))
-    if (StringUtils.isNotEmpty(hostname)) {
-      workers = workers.filter(_.getWorker.getHost == hostname)
-    }
-    workers
   }
 
   @ApiResponse(
@@ -82,14 +78,9 @@ class WorkerResource extends ApiRequestContext {
     description = "List all excluded workers of the master.")
   @Path("/excluded")
   @GET
-  def excludedWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
-    var workers =
-      (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
-        .map(ApiUtils.workerData).toSeq
-    if (StringUtils.isNotEmpty(hostname)) {
-      workers = workers.filter(_.getHost == hostname)
-    }
-    workers
+  def excludedWorkers(): Seq[WorkerData] = {
+    (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
+      .map(ApiUtils.workerData).toSeq
   }
 
   @ApiResponse(
@@ -101,12 +92,8 @@ class WorkerResource extends ApiRequestContext {
     description = "List all shutdown workers of the master.")
   @Path("/shutdown")
   @GET
-  def shutdownWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
-    var workers = statusSystem.shutdownWorkers.asScala.map(ApiUtils.workerData).toSeq
-    if (StringUtils.isNotEmpty(hostname)) {
-      workers = workers.filter(_.getHost == hostname)
-    }
-    workers
+  def shutdownWorkers(): Seq[WorkerData] = {
+    statusSystem.shutdownWorkers.asScala.map(ApiUtils.workerData).toSeq
   }
 
   @ApiResponse(
@@ -118,12 +105,8 @@ class WorkerResource extends ApiRequestContext {
     description = "List all decommissioned workers of the master.")
   @Path("/decommissioned")
   @GET
-  def decommissionWorkers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
-    var workers = statusSystem.decommissionWorkers.asScala.map(ApiUtils.workerData).toSeq
-    if (StringUtils.isNotEmpty(hostname)) {
-      workers = workers.filter(_.getHost == hostname)
-    }
-    workers
+  def decommissionWorkers(): Seq[WorkerData] = {
+    statusSystem.decommissionWorkers.asScala.map(ApiUtils.workerData).toSeq
   }
 
   @ApiResponse(
@@ -151,16 +134,12 @@ class WorkerResource extends ApiRequestContext {
     description = "List all worker event infos of the master.")
   @Path("/events")
   @GET
-  def workerEvents(@QueryParam("hostname") hostname: String = ""): Seq[WorkerEventData] = {
-    var events = statusSystem.workerEventInfos.asScala.map { case (worker, event) =>
+  def workerEvents(): Seq[WorkerEventData] = {
+    statusSystem.workerEventInfos.asScala.map { case (worker, event) =>
       new WorkerEventData(
         ApiUtils.workerData(worker),
         new WorkerEventInfoData(event.getEventType.toString, event.getEventStartTime))
     }.toSeq
-    if (StringUtils.isNotEmpty(hostname)) {
-      events = events.filter(_.getWorker.getHost == hostname)
-    }
-    events
   }
 
   @ApiResponse(

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import javax.ws.rs.{BadRequestException, Consumes, GET, Path, POST, Produces, QueryParam}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.apache.commons.lang3.StringUtils
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.ApiUtils
+import org.apache.celeborn.server.common.http.api.v1.dto.{ExcludeWorkerRequest, HandleResponse, SendWorkerEventRequest, WorkerData, WorkerEventData, WorkerEventInfoData, WorkerTimestampData}
+import org.apache.celeborn.service.deploy.master.Master
+
+@Tag(name = "Worker")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class WorkerResource extends ApiRequestContext {
+  private def statusSystem = httpService.asInstanceOf[Master].statusSystem
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerData])))),
+    description =
+      "List worker information of the service. It will list all registered workers' information.")
+  @GET
+  def workers(@QueryParam("hostname") hostname: String = ""): Seq[WorkerData] = {
+    if (StringUtils.isEmpty(hostname)) {
+      statusSystem.workers.asScala.map(ApiUtils.workerData).toSeq
+    } else {
+      statusSystem.workers.asScala.filter(_.host == hostname).map(ApiUtils.workerData).toSeq
+    }
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerTimestampData])))),
+    description = "List all lost workers of the master.")
+  @Path("/lost")
+  @GET
+  def lostWorkers(): Seq[WorkerTimestampData] = {
+    statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
+      .map(kv => new WorkerTimestampData(ApiUtils.workerData(kv._1), kv._2))
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerData])))),
+    description = "List all excluded workers of the master.")
+  @Path("/excluded")
+  @GET
+  def excludedWorkers(): Seq[WorkerData] = {
+    (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
+      .map(ApiUtils.workerData).toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerData])))),
+    description = "List all shutdown workers of the master.")
+  @Path("/shutdown")
+  @GET
+  def shutdownWorkers(): Seq[WorkerData] = {
+    statusSystem.shutdownWorkers.asScala.map(ApiUtils.workerData).toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerData])))),
+    description = "List all decommissioned workers of the master.")
+  @Path("/decommissioned")
+  @GET
+  def decommissionWorkers(): Seq[WorkerData] = {
+    statusSystem.decommissionWorkers.asScala.map(ApiUtils.workerData).toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))),
+    description =
+      "Excluded workers of the master add or remove the worker manually given worker id. The parameter add or remove specifies the excluded workers to add or remove.")
+  @Path("/exclude")
+  @POST
+  def excludeWorker(request: ExcludeWorkerRequest): HandleResponse = {
+    val (success, msg) = httpService.exclude(
+      request.getAdd.asScala.map(_.toWorkerInfo).toSeq,
+      request.getRemove.asScala.map(_.toWorkerInfo).toSeq)
+    new HandleResponse(success, msg)
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerEventData])))),
+    description = "List all worker event infos of the master.")
+  @Path("/events")
+  @GET
+  def workerEvents(): Seq[WorkerEventData] = {
+    statusSystem.workerEventInfos.asScala.map { case (worker, event) =>
+      new WorkerEventData(
+        ApiUtils.workerData(worker),
+        new WorkerEventInfoData(event.getEventType.toString, event.getEventStartTime))
+    }.toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))),
+    description =
+      "For Master(Leader) can send worker event to manager workers. Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'.")
+  @Path("/events")
+  @POST
+  def sendWorkerEvents(request: SendWorkerEventRequest): HandleResponse = {
+    if (StringUtils.isEmpty(request.getEventType) || request.getWorkers.isEmpty) {
+      throw new BadRequestException(
+        s"eventType(${request.getEventType}) and workers(${request.getWorkers}) are required")
+    }
+    val workers = request.getWorkers.asScala.map(_.toWorkerInfo).toSeq
+    val (filteredWorkers, unknownWorkers) = workers.partition(statusSystem.workers.contains)
+    if (filteredWorkers.isEmpty) {
+      throw new BadRequestException(
+        s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")
+    }
+    val (success, msg) = httpService.handleWorkerEvent(request.getEventType, workers)
+    val finalMsg =
+      if (unknownWorkers.isEmpty) {
+        msg
+      } else {
+        s"${msg}\n(Unknown workers: ${unknownWorkers.map(_.readableAddress).mkString(", ")})"
+      }
+    new HandleResponse(success, finalMsg)
+  }
+}

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import java.util.Collections
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.MediaType
+
+import com.google.common.io.Files
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
+import org.apache.celeborn.server.common.HttpService
+import org.apache.celeborn.server.common.http.api.v1.ApiV1BaseResourceSuite
+import org.apache.celeborn.server.common.http.api.v1.dto.{AppDiskUsageData, ExcludeWorkerRequest, HandleResponse, SendWorkerEventRequest, WorkerData, WorkerEventData, WorkerId}
+import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
+
+class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite {
+  private var master: Master = _
+
+  override protected def httpService: HttpService = master
+
+  def getTmpDir(): String = {
+    val tmpDir = Files.createTempDir()
+    tmpDir.deleteOnExit()
+    tmpDir.getAbsolutePath
+  }
+
+  override def beforeAll(): Unit = {
+    val randomMasterPort = Utils.selectRandomPort(1024, 65535)
+    val randomHttpPort = randomMasterPort + 1
+    celebornConf.set(CelebornConf.HA_ENABLED.key, "false")
+    celebornConf.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR.key, getTmpDir())
+    celebornConf.set(CelebornConf.WORKER_STORAGE_DIRS.key, getTmpDir())
+    celebornConf.set(CelebornConf.MASTER_HTTP_HOST.key, "127.0.0.1")
+    celebornConf.set(CelebornConf.MASTER_HTTP_PORT.key, randomHttpPort.toString)
+
+    val args = Array("-h", "localhost", "-p", randomMasterPort.toString)
+
+    val masterArgs = new MasterArguments(args, celebornConf)
+    master = new Master(celebornConf, masterArgs)
+    new Thread() {
+      override def run(): Unit = {
+        master.initialize()
+      }
+    }.start()
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    master.stop(CelebornExitKind.EXIT_IMMEDIATELY)
+    master.rpcEnv.shutdown()
+  }
+
+  test("shuffle resource") {
+    val response = webTarget.path("shuffles").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[String]]).isEmpty)
+  }
+
+  test("application resource") {
+    var response = webTarget.path("applications").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[String]]).isEmpty)
+
+    response =
+      webTarget.path("applications/top_disk_usages").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[AppDiskUsageData]]).isEmpty)
+
+    response = webTarget.path("applications/hostnames").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[String]]).isEmpty)
+  }
+
+  test("master resource") {
+    val response = webTarget.path("masters").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
+    assert(response.readEntity(classOf[String]).contains("HA is not enabled"))
+  }
+
+  test("worker resource") {
+    var response = webTarget.path("workers").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[WorkerData]]).isEmpty)
+
+    response = webTarget.path("workers/lost").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[WorkerData]]).isEmpty)
+
+    response = webTarget.path("workers/shutdown").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[WorkerData]]).isEmpty)
+
+    response = webTarget.path("workers/decommissioned").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[WorkerData]]).isEmpty)
+
+    val worker = new WorkerId("unknown.celeborn", 0, 0, 0, 0)
+    val excludeWorkerRequest =
+      new ExcludeWorkerRequest(Collections.singletonList(worker), Collections.emptyList[WorkerId]())
+    response = webTarget.path("workers/exclude").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(excludeWorkerRequest, MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[HandleResponse]).getMessage.contains(
+      "Unknown workers Host:unknown.celeborn"))
+
+    response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[WorkerEventData]]).isEmpty)
+
+    val sendWorkerEventRequest = new SendWorkerEventRequest(
+      "Decommission",
+      Collections.singletonList(worker))
+    response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
+    assert(response.readEntity(classOf[String]).contains(
+      "None of the workers are known"))
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/AppDiskUsageData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/AppDiskUsageData.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import org.apache.celeborn.common.util.Utils;
+
+public class AppDiskUsageData {
+  private String appId;
+  private Long estimateUsage;
+
+  public AppDiskUsageData(String appId, Long estimateUsage) {
+    this.appId = appId;
+    this.estimateUsage = estimateUsage;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public void setAppId(String appId) {
+    this.appId = appId;
+  }
+
+  public Long getEstimateUsage() {
+    return estimateUsage;
+  }
+
+  public void setEstimateUsage(Long estimateUsage) {
+    this.estimateUsage = estimateUsage;
+  }
+
+  public String getEstimateUsageStr() {
+    return estimateUsage == null ? null : Utils.bytesToString(estimateUsage);
+  }
+
+  public void setEstimateUsageStr(String estimateUsageStr) {}
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AppDiskUsageData that = (AppDiskUsageData) o;
+    return Objects.equals(getAppId(), that.getAppId())
+        && Objects.equals(getEstimateUsage(), that.getEstimateUsage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getAppId(), getEstimateUsage());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/AppDiskUsageSnapshotData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/AppDiskUsageSnapshotData.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class AppDiskUsageSnapshotData {
+  private Long start;
+  private Long end;
+  private List<AppDiskUsageData> topNItems;
+
+  public AppDiskUsageSnapshotData(Long start, Long end, List<AppDiskUsageData> topNItems) {
+    this.start = start;
+    this.end = end;
+    this.topNItems = topNItems;
+  }
+
+  public Long getStart() {
+    return start;
+  }
+
+  public void setStart(Long start) {
+    this.start = start;
+  }
+
+  public Long getEnd() {
+    return end;
+  }
+
+  public void setEnd(Long end) {
+    this.end = end;
+  }
+
+  public List<AppDiskUsageData> getTopNItems() {
+    if (topNItems == null) {
+      return Collections.EMPTY_LIST;
+    }
+    return topNItems;
+  }
+
+  public void setTopNItems(List<AppDiskUsageData> topNItems) {
+    this.topNItems = topNItems;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AppDiskUsageSnapshotData that = (AppDiskUsageSnapshotData) o;
+    return Objects.equals(getStart(), that.getStart())
+        && Objects.equals(getEnd(), that.getEnd())
+        && Objects.equals(getTopNItems(), that.getTopNItems());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getStart(), getEnd(), getTopNItems());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/ApplicationHeartbeatData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/ApplicationHeartbeatData.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class ApplicationHeartbeatData {
+  private String appId;
+  private Long lastHeartbeat;
+
+  public ApplicationHeartbeatData(String appId, Long lastHeartbeat) {
+    this.appId = appId;
+    this.lastHeartbeat = lastHeartbeat;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public void setAppId(String appId) {
+    this.appId = appId;
+  }
+
+  public Long getLastHeartbeat() {
+    return lastHeartbeat;
+  }
+
+  public void setLastHeartbeat(Long lastHeartbeat) {
+    this.lastHeartbeat = lastHeartbeat;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ApplicationHeartbeatData that = (ApplicationHeartbeatData) o;
+    return Objects.equals(getAppId(), that.getAppId())
+        && Objects.equals(getLastHeartbeat(), that.getLastHeartbeat());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getAppId(), getLastHeartbeat());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/ConfigData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/ConfigData.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class ConfigData {
+  private String name;
+  private String value;
+
+  public ConfigData(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ConfigData that = (ConfigData) o;
+    return Objects.equals(getName(), that.getName()) && Objects.equals(getValue(), that.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getValue());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/DynamicConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/DynamicConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class DynamicConfig {
+  private String level;
+  private String description;
+  private List<ConfigData> configs;
+
+  public DynamicConfig(String level, String description, List<ConfigData> configs) {
+    this.level = level;
+    this.description = description;
+    this.configs = configs;
+  }
+
+  public String getLevel() {
+    return level;
+  }
+
+  public void setLevel(String level) {
+    this.level = level;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public List<ConfigData> getConfigs() {
+    if (configs == null) {
+      return Collections.EMPTY_LIST;
+    }
+    return configs;
+  }
+
+  public void setConfigs(List<ConfigData> configs) {
+    this.configs = configs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DynamicConfig that = (DynamicConfig) o;
+    return Objects.equals(getLevel(), that.getLevel())
+        && Objects.equals(getDescription(), that.getDescription())
+        && Objects.equals(getConfigs(), that.getConfigs());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getLevel(), getDescription(), getConfigs());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/ExcludeWorkerRequest.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/ExcludeWorkerRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class ExcludeWorkerRequest {
+  private List<WorkerId> add;
+  private List<WorkerId> remove;
+
+  public ExcludeWorkerRequest(List<WorkerId> add, List<WorkerId> remove) {
+    this.add = add;
+    this.remove = remove;
+  }
+
+  public List<WorkerId> getAdd() {
+    return add;
+  }
+
+  public void setAdd(List<WorkerId> add) {
+    this.add = add;
+  }
+
+  public List<WorkerId> getRemove() {
+    return remove;
+  }
+
+  public void setRemove(List<WorkerId> remove) {
+    this.remove = remove;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ExcludeWorkerRequest that = (ExcludeWorkerRequest) o;
+    return Objects.equals(getAdd(), that.getAdd()) && Objects.equals(getRemove(), that.getRemove());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getAdd(), getRemove());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/HandleResponse.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/HandleResponse.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class HandleResponse {
+  private Boolean success;
+  private String message;
+
+  public HandleResponse(Boolean success, String message) {
+    this.success = success;
+    this.message = message;
+  }
+
+  public Boolean getSuccess() {
+    return success;
+  }
+
+  public void setSuccess(Boolean success) {
+    this.success = success;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    HandleResponse that = (HandleResponse) o;
+    return Objects.equals(getSuccess(), that.getSuccess())
+        && Objects.equals(getMessage(), that.getMessage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getSuccess(), getMessage());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/MasterCommitData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/MasterCommitData.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class MasterCommitData {
+  private Long commitIndex;
+  private String id;
+  private String address;
+  private String clientAddress;
+  private String startupRole;
+
+  public MasterCommitData(
+      Long commitIndex, String id, String address, String clientAddress, String startupRole) {
+    this.commitIndex = commitIndex;
+    this.id = id;
+    this.address = address;
+    this.clientAddress = clientAddress;
+    this.startupRole = startupRole;
+  }
+
+  public Long getCommitIndex() {
+    return commitIndex;
+  }
+
+  public void setCommitIndex(Long commitIndex) {
+    this.commitIndex = commitIndex;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+
+  public String getClientAddress() {
+    return clientAddress;
+  }
+
+  public void setClientAddress(String clientAddress) {
+    this.clientAddress = clientAddress;
+  }
+
+  public String getStartupRole() {
+    return startupRole;
+  }
+
+  public void setStartupRole(String startupRole) {
+    this.startupRole = startupRole;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MasterCommitData that = (MasterCommitData) o;
+    return Objects.equals(getCommitIndex(), that.getCommitIndex())
+        && Objects.equals(getId(), that.getId())
+        && Objects.equals(getAddress(), that.getAddress())
+        && Objects.equals(getClientAddress(), that.getClientAddress())
+        && Objects.equals(getStartupRole(), that.getStartupRole());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getCommitIndex(), getId(), getAddress(), getClientAddress(), getStartupRole());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/MasterGroupData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/MasterGroupData.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class MasterGroupData {
+  private String groupId;
+  private MasterLeader leader;
+  private List<MasterCommitData> masterCommitInfo;
+
+  public MasterGroupData(
+      String groupId, MasterLeader leader, List<MasterCommitData> masterCommitInfo) {
+    this.groupId = groupId;
+    this.leader = leader;
+    this.masterCommitInfo = masterCommitInfo;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public MasterLeader getLeader() {
+    return leader;
+  }
+
+  public void setLeader(MasterLeader leader) {
+    this.leader = leader;
+  }
+
+  public List<MasterCommitData> getMasterCommitInfo() {
+    if (masterCommitInfo == null) {
+      return Collections.EMPTY_LIST;
+    }
+    return masterCommitInfo;
+  }
+
+  public void setMasterCommitInfo(List<MasterCommitData> masterCommitInfo) {
+    this.masterCommitInfo = masterCommitInfo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MasterGroupData that = (MasterGroupData) o;
+    return Objects.equals(getGroupId(), that.getGroupId())
+        && Objects.equals(getLeader(), that.getLeader())
+        && Objects.equals(getMasterCommitInfo(), that.getMasterCommitInfo());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getGroupId(), getLeader(), getMasterCommitInfo());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/MasterLeader.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/MasterLeader.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class MasterLeader {
+  private String id;
+  private String address;
+
+  public MasterLeader(String id, String address) {
+    this.id = id;
+    this.address = address;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MasterLeader that = (MasterLeader) o;
+    return Objects.equals(getId(), that.getId()) && Objects.equals(getAddress(), that.getAddress());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getAddress());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/PartitionLocationData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/PartitionLocationData.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class PartitionLocationData {
+  private String idEpoch;
+  private String hostAndPorts;
+  private String mode;
+  private String peer;
+  private String storage;
+  private String mapIdBitMap;
+
+  public PartitionLocationData(
+      String idEpoch,
+      String hostAndPorts,
+      String mode,
+      String peer,
+      String storage,
+      String mapIdBitMap) {
+    this.idEpoch = idEpoch;
+    this.hostAndPorts = hostAndPorts;
+    this.mode = mode;
+    this.peer = peer;
+    this.storage = storage;
+    this.mapIdBitMap = mapIdBitMap;
+  }
+
+  public String getIdEpoch() {
+    return idEpoch;
+  }
+
+  public void setIdEpoch(String idEpoch) {
+    this.idEpoch = idEpoch;
+  }
+
+  public String getHostAndPorts() {
+    return hostAndPorts;
+  }
+
+  public void setHostAndPorts(String hostAndPorts) {
+    this.hostAndPorts = hostAndPorts;
+  }
+
+  public String getMode() {
+    return mode;
+  }
+
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
+
+  public String getPeer() {
+    return peer;
+  }
+
+  public void setPeer(String peer) {
+    this.peer = peer;
+  }
+
+  public String getStorage() {
+    return storage;
+  }
+
+  public void setStorage(String storage) {
+    this.storage = storage;
+  }
+
+  public String getMapIdBitMap() {
+    return mapIdBitMap;
+  }
+
+  public void setMapIdBitMap(String mapIdBitMap) {
+    this.mapIdBitMap = mapIdBitMap;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PartitionLocationData that = (PartitionLocationData) o;
+    return Objects.equals(getIdEpoch(), that.getIdEpoch())
+        && Objects.equals(getHostAndPorts(), that.getHostAndPorts())
+        && Objects.equals(getMode(), that.getMode())
+        && Objects.equals(getPeer(), that.getPeer())
+        && Objects.equals(getStorage(), that.getStorage())
+        && Objects.equals(getMapIdBitMap(), that.getMapIdBitMap());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getIdEpoch(), getHostAndPorts(), getMode(), getPeer(), getStorage(), getMapIdBitMap());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/SendWorkerEventRequest.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/SendWorkerEventRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class SendWorkerEventRequest {
+  private String eventType;
+  private List<WorkerId> workers;
+
+  public SendWorkerEventRequest(String eventType, List<WorkerId> workers) {
+    this.eventType = eventType;
+    this.workers = workers;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  public List<WorkerId> getWorkers() {
+    return workers;
+  }
+
+  public void setWorkers(List<WorkerId> workers) {
+    this.workers = workers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SendWorkerEventRequest that = (SendWorkerEventRequest) o;
+    return Objects.equals(getEventType(), that.getEventType())
+        && Objects.equals(getWorkers(), that.getWorkers());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getEventType(), getWorkers());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerData.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class WorkerData {
+  private String host;
+  private int rpcPort;
+  private int pushPort;
+  private int fetchPort;
+  private int replicatePort;
+  private int internalPort;
+  private long slotsUsed;
+  private Long lastHeartbeat;
+  private Long heartbeatElapsedSeconds;
+  private Map<String, String> diskInfos;
+  private Map<String, String> resourceConsumption;
+  private String workerRef;
+  private String workerState;
+  private Long workerStateStartTime;
+  private Boolean isRegistered;
+  private Boolean isShutdown;
+  private Boolean isDecommissioning;
+
+  public WorkerData(
+      String host,
+      int rpcPort,
+      int pushPort,
+      int fetchPort,
+      int replicatePort,
+      int internalPort,
+      long slotsUsed,
+      Long lastHeartbeat,
+      Long heartbeatElapsedSeconds,
+      Map<String, String> diskInfos,
+      Map<String, String> resourceConsumption,
+      String workerRef,
+      String workerState,
+      Long workerStateStartTime) {
+    this.host = host;
+    this.rpcPort = rpcPort;
+    this.pushPort = pushPort;
+    this.fetchPort = fetchPort;
+    this.replicatePort = replicatePort;
+    this.internalPort = internalPort;
+    this.slotsUsed = slotsUsed;
+    this.lastHeartbeat = lastHeartbeat;
+    this.heartbeatElapsedSeconds = heartbeatElapsedSeconds;
+    this.diskInfos = diskInfos;
+    this.resourceConsumption = resourceConsumption;
+    this.workerRef = workerRef;
+    this.workerState = workerState;
+    this.workerStateStartTime = workerStateStartTime;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getRpcPort() {
+    return rpcPort;
+  }
+
+  public void setRpcPort(int rpcPort) {
+    this.rpcPort = rpcPort;
+  }
+
+  public int getPushPort() {
+    return pushPort;
+  }
+
+  public void setPushPort(int pushPort) {
+    this.pushPort = pushPort;
+  }
+
+  public int getFetchPort() {
+    return fetchPort;
+  }
+
+  public void setFetchPort(int fetchPort) {
+    this.fetchPort = fetchPort;
+  }
+
+  public int getReplicatePort() {
+    return replicatePort;
+  }
+
+  public void setReplicatePort(int replicatePort) {
+    this.replicatePort = replicatePort;
+  }
+
+  public int getInternalPort() {
+    return internalPort;
+  }
+
+  public void setInternalPort(int internalPort) {
+    this.internalPort = internalPort;
+  }
+
+  public long getSlotsUsed() {
+    return slotsUsed;
+  }
+
+  public void setSlotsUsed(long slotsUsed) {
+    this.slotsUsed = slotsUsed;
+  }
+
+  public Long getLastHeartbeat() {
+    return lastHeartbeat;
+  }
+
+  public void setLastHeartbeat(Long lastHeartbeat) {
+    this.lastHeartbeat = lastHeartbeat;
+  }
+
+  public Long getHeartbeatElapsedSeconds() {
+    return heartbeatElapsedSeconds;
+  }
+
+  public void setHeartbeatElapsedSeconds(Long heartbeatElapsedSeconds) {
+    this.heartbeatElapsedSeconds = heartbeatElapsedSeconds;
+  }
+
+  public Map<String, String> getDiskInfos() {
+    if (diskInfos == null) {
+      return Collections.EMPTY_MAP;
+    }
+    return diskInfos;
+  }
+
+  public void setDiskInfos(Map<String, String> diskInfos) {
+    this.diskInfos = diskInfos;
+  }
+
+  public Map<String, String> getResourceConsumption() {
+    if (resourceConsumption == null) {
+      return Collections.EMPTY_MAP;
+    }
+    return resourceConsumption;
+  }
+
+  public void setResourceConsumption(Map<String, String> resourceConsumption) {
+    this.resourceConsumption = resourceConsumption;
+  }
+
+  public String getWorkerRef() {
+    return workerRef;
+  }
+
+  public void setWorkerRef(String workerRef) {
+    this.workerRef = workerRef;
+  }
+
+  public String getWorkerState() {
+    return workerState;
+  }
+
+  public void setWorkerState(String workerState) {
+    this.workerState = workerState;
+  }
+
+  public Long getWorkerStateStartTime() {
+    return workerStateStartTime;
+  }
+
+  public void setWorkerStateStartTime(Long workerStateStartTime) {
+    this.workerStateStartTime = workerStateStartTime;
+  }
+
+  public Boolean getRegistered() {
+    return isRegistered;
+  }
+
+  public void setRegistered(Boolean registered) {
+    isRegistered = registered;
+  }
+
+  public Boolean getShutdown() {
+    return isShutdown;
+  }
+
+  public void setShutdown(Boolean shutdown) {
+    isShutdown = shutdown;
+  }
+
+  public Boolean getDecommissioning() {
+    return isDecommissioning;
+  }
+
+  public void setDecommissioning(Boolean decommissioning) {
+    isDecommissioning = decommissioning;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerData that = (WorkerData) o;
+    return getRpcPort() == that.getRpcPort()
+        && getPushPort() == that.getPushPort()
+        && getFetchPort() == that.getFetchPort()
+        && getReplicatePort() == that.getReplicatePort()
+        && getInternalPort() == that.getInternalPort()
+        && getSlotsUsed() == that.getSlotsUsed()
+        && Objects.equals(getHost(), that.getHost())
+        && Objects.equals(getLastHeartbeat(), that.getLastHeartbeat())
+        && Objects.equals(getHeartbeatElapsedSeconds(), that.getHeartbeatElapsedSeconds())
+        && Objects.equals(getDiskInfos(), that.getDiskInfos())
+        && Objects.equals(getResourceConsumption(), that.getResourceConsumption())
+        && Objects.equals(getWorkerRef(), that.getWorkerRef())
+        && Objects.equals(getWorkerState(), that.getWorkerState())
+        && Objects.equals(getWorkerStateStartTime(), that.getWorkerStateStartTime())
+        && Objects.equals(isRegistered, that.isRegistered)
+        && Objects.equals(isShutdown, that.isShutdown)
+        && Objects.equals(isDecommissioning, that.isDecommissioning);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getHost(),
+        getRpcPort(),
+        getPushPort(),
+        getFetchPort(),
+        getReplicatePort(),
+        getInternalPort(),
+        getSlotsUsed(),
+        getLastHeartbeat(),
+        getHeartbeatElapsedSeconds(),
+        getDiskInfos(),
+        getResourceConsumption(),
+        getWorkerRef(),
+        getWorkerState(),
+        getWorkerStateStartTime(),
+        isRegistered,
+        isShutdown,
+        isDecommissioning);
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerEventData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerEventData.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class WorkerEventData {
+  private WorkerData worker;
+  private WorkerEventInfoData event;
+
+  public WorkerEventData(WorkerData worker, WorkerEventInfoData event) {
+    this.worker = worker;
+    this.event = event;
+  }
+
+  public WorkerData getWorker() {
+    return worker;
+  }
+
+  public void setWorker(WorkerData worker) {
+    this.worker = worker;
+  }
+
+  public WorkerEventInfoData getEvent() {
+    return event;
+  }
+
+  public void setEvent(WorkerEventInfoData event) {
+    this.event = event;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerEventData that = (WorkerEventData) o;
+    return Objects.equals(getWorker(), that.getWorker())
+        && Objects.equals(getEvent(), that.getEvent());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getWorker(), getEvent());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerEventInfoData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerEventInfoData.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class WorkerEventInfoData {
+  private String eventType;
+  private Long eventStartTime;
+
+  public WorkerEventInfoData(String eventType, Long eventStartTime) {
+    this.eventType = eventType;
+    this.eventStartTime = eventStartTime;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  public Long getEventStartTime() {
+    return eventStartTime;
+  }
+
+  public void setEventStartTime(Long eventStartTime) {
+    this.eventStartTime = eventStartTime;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerEventInfoData that = (WorkerEventInfoData) o;
+    return Objects.equals(getEventType(), that.getEventType())
+        && Objects.equals(getEventStartTime(), that.getEventStartTime());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getEventType(), getEventStartTime());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerExitRequest.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerExitRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class WorkerExitRequest {
+  private String type;
+
+  public WorkerExitRequest(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerExitRequest that = (WorkerExitRequest) o;
+    return Objects.equals(getType(), that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getType());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerId.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerId.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import org.apache.celeborn.common.meta.WorkerInfo;
+
+public class WorkerId {
+  private String host;
+  private int rpcPort;
+  private int pushPort;
+  private int fetchPort;
+  private int replicatePort;
+
+  public WorkerId(String host, int rpcPort, int pushPort, int fetchPort, int replicatePort) {
+    this.host = host;
+    this.rpcPort = rpcPort;
+    this.pushPort = pushPort;
+    this.fetchPort = fetchPort;
+    this.replicatePort = replicatePort;
+  }
+
+  public WorkerInfo toWorkerInfo() {
+    return new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getRpcPort() {
+    return rpcPort;
+  }
+
+  public void setRpcPort(int rpcPort) {
+    this.rpcPort = rpcPort;
+  }
+
+  public int getPushPort() {
+    return pushPort;
+  }
+
+  public void setPushPort(int pushPort) {
+    this.pushPort = pushPort;
+  }
+
+  public int getFetchPort() {
+    return fetchPort;
+  }
+
+  public void setFetchPort(int fetchPort) {
+    this.fetchPort = fetchPort;
+  }
+
+  public int getReplicatePort() {
+    return replicatePort;
+  }
+
+  public void setReplicatePort(int replicatePort) {
+    this.replicatePort = replicatePort;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerId workerId = (WorkerId) o;
+    return getRpcPort() == workerId.getRpcPort()
+        && getPushPort() == workerId.getPushPort()
+        && getFetchPort() == workerId.getFetchPort()
+        && getReplicatePort() == workerId.getReplicatePort()
+        && Objects.equals(getHost(), workerId.getHost());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getHost(), getRpcPort(), getPushPort(), getFetchPort(), getReplicatePort());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerPartitionLocationData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerPartitionLocationData.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class WorkerPartitionLocationData {
+  private Map<String, Map<String, PartitionLocationData>> primaryPartitions;
+  private Map<String, Map<String, PartitionLocationData>> replicaPartitions;
+
+  public WorkerPartitionLocationData(
+      Map<String, Map<String, PartitionLocationData>> primaryPartitions,
+      Map<String, Map<String, PartitionLocationData>> replicaPartitions) {
+    this.primaryPartitions = primaryPartitions;
+    this.replicaPartitions = replicaPartitions;
+  }
+
+  public Map<String, Map<String, PartitionLocationData>> getPrimaryPartitions() {
+    if (primaryPartitions == null) {
+      return Collections.EMPTY_MAP;
+    }
+    return primaryPartitions;
+  }
+
+  public void setPrimaryPartitions(
+      Map<String, Map<String, PartitionLocationData>> primaryPartitions) {
+    this.primaryPartitions = primaryPartitions;
+  }
+
+  public Map<String, Map<String, PartitionLocationData>> getReplicaPartitions() {
+    if (replicaPartitions == null) {
+      return Collections.EMPTY_MAP;
+    }
+    return replicaPartitions;
+  }
+
+  public void setReplicaPartitions(
+      Map<String, Map<String, PartitionLocationData>> replicaPartitions) {
+    this.replicaPartitions = replicaPartitions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerPartitionLocationData that = (WorkerPartitionLocationData) o;
+    return Objects.equals(getPrimaryPartitions(), that.getPrimaryPartitions())
+        && Objects.equals(getReplicaPartitions(), that.getReplicaPartitions());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getPrimaryPartitions(), getReplicaPartitions());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerTimestampData.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/http/api/v1/dto/WorkerTimestampData.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class WorkerTimestampData {
+  private WorkerData worker;
+  private Long timestamp;
+
+  public WorkerTimestampData(WorkerData worker, Long timestamp) {
+    this.worker = worker;
+    this.timestamp = timestamp;
+  }
+
+  public WorkerData getWorker() {
+    return worker;
+  }
+
+  public void setWorker(WorkerData worker) {
+    this.worker = worker;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WorkerTimestampData that = (WorkerTimestampData) o;
+    return Objects.equals(getWorker(), that.getWorker())
+        && Objects.equals(getTimestamp(), that.getTimestamp());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getWorker(), getTimestamp());
+  }
+
+  @Override
+  public String toString() {
+    return ReflectionToStringBuilder.toString(this, ToStringStyle.JSON_STYLE);
+  }
+}

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -26,6 +26,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.meta.WorkerInfo
 import org.apache.celeborn.common.util.Utils
 import org.apache.celeborn.server.common.http.HttpServer
 import org.apache.celeborn.server.common.http.api.ApiRootResource
@@ -169,7 +170,7 @@ abstract class HttpService extends Service with Logging {
 
   def getHostnameList: String = throw new UnsupportedOperationException()
 
-  def exclude(addWorkers: String, removeWorkers: String): String =
+  def exclude(addWorkers: Seq[WorkerInfo], removeWorkers: Seq[WorkerInfo]): (Boolean, String) =
     throw new UnsupportedOperationException()
 
   def listPartitionLocationInfo: String = throw new UnsupportedOperationException()
@@ -184,7 +185,7 @@ abstract class HttpService extends Service with Logging {
 
   def exit(exitType: String): String = throw new UnsupportedOperationException()
 
-  def handleWorkerEvent(workerEventType: String, workers: String): String =
+  def handleWorkerEvent(workerEventType: String, workers: Seq[WorkerInfo]): (Boolean, String) =
     throw new UnsupportedOperationException()
 
   def getWorkerEventInfo(): String = throw new UnsupportedOperationException()

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/ApiBaseResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/ApiBaseResource.scala
@@ -22,7 +22,9 @@ import javax.ws.rs.core.MediaType
 
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 
+@Tag(name = "Deprecated")
 @Path("/")
 private[api] class ApiBaseResource extends ApiRequestContext {
   def service: String = httpService.serviceName

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/ApiRootResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/ApiRootResource.scala
@@ -25,7 +25,7 @@ import org.apache.celeborn.server.common.HttpService
 
 private[celeborn] object ApiRootResource {
   def getServletHandler(rs: HttpService): ServletContextHandler = {
-    val openapiConf: ResourceConfig = new OpenAPIConfig
+    val openapiConf: ResourceConfig = new OpenAPIConfig(rs.serviceName)
     val holder = new ServletHolder(new ServletContainer(openapiConf))
     val handler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
     handler.setContextPath("/")

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
@@ -53,7 +53,7 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
     val ctx: OpenApiContext = new CelebornJaxrsOpenApiContextBuilder()
       .servletConfig(config)
       .application(app)
-      .resourcePackages(OpenAPIConfig.packages.toSet.asJava)
+      .resourcePackages(OpenAPIConfig.packages(httpService.serviceName).toSet.asJava)
       .configLocation(configLocation)
       .openApiConfiguration(openApiConfiguration)
       .ctxId(ctxId)

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/OpenAPIConfig.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/OpenAPIConfig.scala
@@ -19,16 +19,21 @@ package org.apache.celeborn.server.common.http.api
 
 import org.glassfish.jersey.server.ResourceConfig
 
-class OpenAPIConfig extends ResourceConfig {
-  packages(OpenAPIConfig.packages: _*)
+import org.apache.celeborn.server.common.Service
+
+class OpenAPIConfig(serviceName: String) extends ResourceConfig {
+  packages(OpenAPIConfig.packages(serviceName): _*)
   register(classOf[CelebornOpenApiResource])
   register(classOf[CelebornScalaObjectMapper])
   register(classOf[RestExceptionMapper])
 }
 
 object OpenAPIConfig {
-  val packages = Seq(
-    "org.apache.celeborn.server.common.http.api",
-    "org.apache.celeborn.service.deploy.master.http.api",
-    "org.apache.celeborn.service.deploy.worker.http.api")
+  val packages = Map(
+    Service.MASTER -> Seq(
+      "org.apache.celeborn.server.common.http.api",
+      "org.apache.celeborn.service.deploy.master.http.api"),
+    Service.WORKER -> Seq(
+      "org.apache.celeborn.server.common.http.api",
+      "org.apache.celeborn.service.deploy.worker.http.api"))
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1
+
+import java.util.concurrent.TimeUnit
+
+import scala.collection.JavaConverters._
+
+import org.apache.celeborn.common.meta.{WorkerInfo, WorkerStatus}
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.PbWorkerStatus.State
+import org.apache.celeborn.server.common.http.api.v1.dto.{PartitionLocationData, WorkerData}
+
+object ApiUtils {
+  def workerData(workerInfo: WorkerInfo): WorkerData = {
+    val (diskInfos, slots) =
+      if (workerInfo.diskInfos == null) {
+        Map.empty[String, String] -> 0L
+      } else {
+        workerInfo.diskInfos.asScala.map { case (disk, diskInfo) =>
+          disk -> diskInfo.toString()
+        }.toMap -> workerInfo.usedSlots()
+      }
+    val userResourceConsumption =
+      if (workerInfo.userResourceConsumption == null) {
+        Map.empty[String, String]
+      } else {
+        workerInfo.userResourceConsumption.asScala.map { case (user, resourceConsumption) =>
+          user.toString -> resourceConsumption.toString()
+        }.toMap
+      }
+
+    new WorkerData(
+      workerInfo.host,
+      workerInfo.rpcPort,
+      workerInfo.pushPort,
+      workerInfo.fetchPort,
+      workerInfo.replicatePort,
+      workerInfo.internalPort,
+      slots,
+      workerInfo.lastHeartbeat,
+      TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - workerInfo.lastHeartbeat),
+      diskInfos.asJava,
+      userResourceConsumption.asJava,
+      Option(workerInfo.endpoint).map(_.toString).orNull,
+      workerInfo.workerStatus.getState.toString,
+      workerInfo.workerStatus.getStateStartTime)
+  }
+
+  def workerData(
+      workerInfo: WorkerInfo,
+      currentStatus: WorkerStatus,
+      isShutdown: Boolean,
+      isRegistered: Boolean): WorkerData = {
+    val data = workerData(workerInfo)
+
+    data.setWorkerState(currentStatus.getState.toString)
+    data.setWorkerStateStartTime(currentStatus.getStateStartTime)
+
+    data.setShutdown(isShutdown)
+    data.setRegistered(isRegistered)
+    data.setDecommissioning(
+      isShutdown && (currentStatus.getState == State.InDecommission || currentStatus.getState == State.InDecommissionThenIdle))
+
+    data
+  }
+
+  def partitionLocationData(partitionLocation: PartitionLocation): PartitionLocationData = {
+    new PartitionLocationData(
+      partitionLocation.getId + "-" + partitionLocation.getEpoch,
+      partitionLocation.hostAndPorts(),
+      partitionLocation.getMode.toString,
+      Option(partitionLocation.getPeer).map(_.hostAndPorts()).orNull,
+      partitionLocation.getStorageInfo.toString,
+      partitionLocation.getMapIdBitMap.toString)
+  }
+}

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiV1BaseResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiV1BaseResource.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1
+
+import javax.ws.rs.{GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+import org.apache.celeborn.common.util.{ThreadStackTrace, Utils}
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+
+@Path("/api/v1")
+private[v1] class ApiV1BaseResource extends ApiRequestContext {
+  @GET
+  @Path("ping")
+  @Produces(Array(MediaType.TEXT_PLAIN))
+  def ping(): String = "pong"
+
+  @Path("conf")
+  def conf: Class[ConfResource] = classOf[ConfResource]
+
+  @Path("/thread_dump")
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[ThreadStackTrace])))),
+    description = "List the current thread dump.")
+  @GET
+  def threadDump(): Seq[ThreadStackTrace] = {
+    Utils.getThreadDump()
+  }
+}

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ConfResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ConfResource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.server.common.http.api.v1
 
-import javax.ws.rs.{BadRequestException, Consumes, GET, Path, Produces, QueryParam}
+import javax.ws.rs.{Consumes, GET, Path, Produces, QueryParam, ServiceUnavailableException}
 import javax.ws.rs.core.MediaType
 
 import scala.collection.JavaConverters._
@@ -71,7 +71,7 @@ private[api] class ConfResource extends ApiRequestContext {
       @QueryParam("tenant") tenant: String,
       @QueryParam("name") name: String): Seq[DynamicConfig] = {
     if (configService == null) {
-      throw new BadRequestException(
+      throw new ServiceUnavailableException(
         s"Dynamic configuration is disabled. Please check whether to config" +
           s" `${CelebornConf.DYNAMIC_CONFIG_STORE_BACKEND.key}`.")
     } else {

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ConfResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ConfResource.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1
+
+import javax.ws.rs.{BadRequestException, Consumes, GET, Path, Produces, QueryParam}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.apache.commons.lang3.StringUtils
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.dto.{ConfigData, DynamicConfig}
+import org.apache.celeborn.server.common.service.config.ConfigLevel
+
+@Tag(name = "Conf")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+private[api] class ConfResource extends ApiRequestContext {
+  private def configService = httpService.configService
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[ConfigData])))),
+    description = "List the conf setting")
+  @GET
+  def conf: Seq[ConfigData] = {
+    Utils.redact(httpService.conf, httpService.conf.getAll).sortBy(_._1).map { case (n, v) =>
+      new ConfigData(n, v)
+    }
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[DynamicConfig])))),
+    description = "List the dynamic configs. " +
+      "The parameter level specifies the config level of dynamic configs. " +
+      "The parameter tenant specifies the tenant id of TENANT or TENANT_USER level. " +
+      "The parameter name specifies the user name of TENANT_USER level. " +
+      "Meanwhile, either none or all of the parameter tenant and name are specified for TENANT_USER level.")
+  @Path("/dynamic")
+  @GET
+  def dynamicConf(
+      @QueryParam("level") level: String,
+      @QueryParam("tenant") tenant: String,
+      @QueryParam("name") name: String): Seq[DynamicConfig] = {
+    if (configService == null) {
+      throw new BadRequestException(
+        s"Dynamic configuration is disabled. Please check whether to config" +
+          s" `${CelebornConf.DYNAMIC_CONFIG_STORE_BACKEND.key}`.")
+    } else {
+      if (StringUtils.isEmpty(level)) {
+        ConfigLevel.values().flatMap { configLevel =>
+          getDynamicConfig(configLevel.name(), tenant, name)
+        }
+      } else {
+        getDynamicConfig(level, tenant, name)
+      }
+    }
+  }
+
+  private def getDynamicConfig(level: String, tenant: String, name: String): Seq[DynamicConfig] = {
+    if (ConfigLevel.SYSTEM.name().equalsIgnoreCase(level)) {
+      val config = configService.getSystemConfigFromCache.getConfigs.asScala
+      Seq(new DynamicConfig(
+        ConfigLevel.SYSTEM.toString,
+        "",
+        config.toSeq.sortBy(_._1).map { case (n, v) =>
+          new ConfigData(n, v)
+        }.asJava))
+    } else if (ConfigLevel.TENANT.name().equalsIgnoreCase(level)) {
+      val tenantConfigs =
+        if (StringUtils.isEmpty(tenant)) {
+          configService.listRawTenantConfigsFromCache().asScala
+        } else {
+          List(configService.getRawTenantConfigFromCache(tenant))
+        }
+      tenantConfigs.sortBy(_.getTenantId).map { tenantConfig =>
+        new DynamicConfig(
+          ConfigLevel.TENANT.toString,
+          s"Tenant: ${tenantConfig.getTenantId}",
+          tenantConfig.getConfigs.asScala.toSeq.sortBy(_._1).map { case (n, v) =>
+            new ConfigData(n, v)
+          }.asJava)
+      }.toSeq
+    } else if (ConfigLevel.TENANT_USER.name().equalsIgnoreCase(level)) {
+      val tenantUserConfigs =
+        if (StringUtils.isEmpty(tenant) && StringUtils.isEmpty(name)) {
+          configService.listRawTenantUserConfigsFromCache().asScala
+        } else if (tenant.nonEmpty && name.nonEmpty) {
+          List(configService.getRawTenantUserConfigFromCache(tenant, name))
+        } else {
+          List()
+        }
+      tenantUserConfigs.sortBy(_.getTenantId).map { tenantUserConfig =>
+        new DynamicConfig(
+          ConfigLevel.TENANT_USER.toString,
+          s"Tenant: ${tenantUserConfig.getTenantId}, User: ${tenantUserConfig.getName}",
+          tenantUserConfig.getConfigs.asScala.toSeq.sortBy(_._1).map { case (n, v) =>
+            new ConfigData(n, v)
+          }.asJava)
+      }.toSeq
+    } else {
+      Seq.empty[DynamicConfig]
+    }
+  }
+}

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/api/v1/ApiV1BaseResourceSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/api/v1/ApiV1BaseResourceSuite.scala
@@ -41,7 +41,7 @@ abstract class ApiV1BaseResourceSuite extends HttpTestHelper {
     assert(response.readEntity(classOf[Seq[ConfigData]]).nonEmpty)
 
     response = webTarget.path("conf/dynamic").request(MediaType.APPLICATION_JSON).get()
-    assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
+    assert(HttpServletResponse.SC_SERVICE_UNAVAILABLE == response.getStatus)
     assert(response.readEntity(classOf[String]).contains("Dynamic configuration is disabled."))
   }
 

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/api/v1/ApiV1BaseResourceSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/api/v1/ApiV1BaseResourceSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.api.v1
+
+import java.net.URI
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.{MediaType, UriBuilder}
+
+import org.apache.celeborn.common.util.ThreadStackTrace
+import org.apache.celeborn.server.common.http.HttpTestHelper
+import org.apache.celeborn.server.common.http.api.v1.dto.ConfigData
+
+abstract class ApiV1BaseResourceSuite extends HttpTestHelper {
+  override protected lazy val baseUri: URI =
+    UriBuilder.fromUri(s"http://${httpService.connectionUrl}/api/v1").build()
+
+  test("ping") {
+    val response = webTarget.path("ping").request(MediaType.TEXT_PLAIN).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[String]) == "pong")
+  }
+
+  test("conf resource") {
+    var response = webTarget.path("conf").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[ConfigData]]).nonEmpty)
+
+    response = webTarget.path("conf/dynamic").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
+    assert(response.readEntity(classOf[String]).contains("Dynamic configuration is disabled."))
+  }
+
+  test("thread_dump") {
+    val response = webTarget.path("thread_dump").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[ThreadStackTrace]]).nonEmpty)
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/ApiWorkerResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/ApiWorkerResource.scala
@@ -22,9 +22,11 @@ import javax.ws.rs.core.MediaType
 
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 
+@Tag(name = "Deprecated")
 @Path("/")
 class ApiWorkerResource extends ApiRequestContext {
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResource.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.http.api.v1
+
+import javax.ws.rs.{Path, POST}
+import javax.ws.rs.core.MediaType
+
+import io.swagger.v3.oas.annotations.media.{Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.dto.{HandleResponse, WorkerExitRequest}
+
+@Path("/api/v1")
+class ApiV1WorkerResource extends ApiRequestContext {
+  @Path("shuffles")
+  def shuffles: Class[ShuffleResource] = classOf[ShuffleResource]
+
+  @Path("applications")
+  def applications: Class[ApplicationResource] = classOf[ApplicationResource]
+
+  @Path("workers")
+  def workers: Class[WorkerResource] = classOf[WorkerResource]
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(
+        implementation = classOf[HandleResponse]))),
+    description =
+      "Trigger this worker to exit. Legal exit types are 'Decommission', 'Graceful' and 'Immediately'.")
+  @POST
+  @Path("exit")
+  def exit(request: WorkerExitRequest): HandleResponse = {
+    new HandleResponse(true, httpService.exit(normalizeParam(request.getType)))
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApplicationResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApplicationResource.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.http.api.v1
+
+import javax.ws.rs.{Consumes, GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.dto.AppDiskUsageData
+import org.apache.celeborn.service.deploy.worker.Worker
+
+@Tag(name = "Application")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class ApplicationResource extends ApiRequestContext {
+  private def worker = httpService.asInstanceOf[Worker]
+  private def storageManager = worker.storageManager
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[String])))),
+    description =
+      "List all running application's ids of the worker. It only return application ids running in that worker.")
+  @GET
+  def applications(): Seq[String] = {
+    worker.workerInfo.getApplicationIdSet.asScala.toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[AppDiskUsageData])))),
+    description =
+      "List the top disk usage application ids. It will return the top disk usage application ids for the cluster.")
+  @Path("/top_disk_usages")
+  @GET
+  def topDiskUsedApplications(): Seq[AppDiskUsageData] = {
+    storageManager.topAppDiskUsage.asScala.map { case (appId, diskUsage) =>
+      new AppDiskUsageData(appId, diskUsage)
+    }.toSeq
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ShuffleResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ShuffleResource.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.http.api.v1
+
+import javax.ws.rs.{Consumes, GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.ApiUtils
+import org.apache.celeborn.server.common.http.api.v1.dto.WorkerPartitionLocationData
+import org.apache.celeborn.service.deploy.worker.Worker
+
+@Tag(name = "Shuffle")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class ShuffleResource extends ApiRequestContext {
+  private def worker = httpService.asInstanceOf[Worker]
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[String])))),
+    description =
+      "List all the running shuffle keys of the worker. It only return keys of shuffles running in that worker.")
+  @GET
+  def shuffles(): Seq[String] = {
+    worker.storageManager.shuffleKeySet().asScala.toSeq
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(
+        implementation = classOf[WorkerPartitionLocationData]))),
+    description = "List all the living shuffle PartitionLocation information in the worker.")
+  @Path("/partitions")
+  @GET
+  def partitions(): WorkerPartitionLocationData = {
+    new WorkerPartitionLocationData(
+      worker.partitionLocationInfo.primaryPartitionLocations.asScala.map { case (k, v) =>
+        k -> v.asScala.map { case (id, location) =>
+          id -> ApiUtils.partitionLocationData(location)
+        }.asJava
+      }.asJava,
+      worker.partitionLocationInfo.replicaPartitionLocations.asScala.map { case (k, v) =>
+        k -> v.asScala.map { case (id, location) =>
+          id -> ApiUtils.partitionLocationData(location)
+        }.asJava
+      }.asJava)
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/WorkerResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/WorkerResource.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.http.api.v1
+
+import javax.ws.rs.{Consumes, GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.server.common.http.api.v1.ApiUtils
+import org.apache.celeborn.server.common.http.api.v1.dto.{WorkerData, WorkerTimestampData}
+import org.apache.celeborn.service.deploy.worker.Worker
+
+@Tag(name = "Worker")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class WorkerResource extends ApiRequestContext {
+  private def worker = httpService.asInstanceOf[Worker]
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(
+        implementation = classOf[WorkerData]))),
+    description = "List the worker information.")
+  @GET
+  def workers(): WorkerData = {
+    ApiUtils.workerData(
+      worker.workerInfo,
+      worker.workerStatusManager.currentWorkerStatus,
+      worker.shutdown.get(),
+      worker.registered.get())
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      array = new ArraySchema(schema = new Schema(
+        implementation = classOf[WorkerTimestampData])))),
+    description =
+      "List the unavailable peers of the worker, this always means the worker connect to the peer failed.")
+  @Path("/unavailable_peers")
+  @GET
+  def unavailablePeerWorkers(): Seq[WorkerTimestampData] = {
+    worker.unavailablePeers.asScala.map { case (worker, lastTimeout) =>
+      new WorkerTimestampData(ApiUtils.workerData(worker), lastTimeout)
+    }.toSeq
+  }
+}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResourceSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResourceSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.http.api.v1
+
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.MediaType
+
+import org.apache.celeborn.server.common.HttpService
+import org.apache.celeborn.server.common.http.api.v1.ApiV1BaseResourceSuite
+import org.apache.celeborn.server.common.http.api.v1.dto.{AppDiskUsageData, WorkerData, WorkerPartitionLocationData, WorkerTimestampData}
+import org.apache.celeborn.service.deploy.MiniClusterFeature
+import org.apache.celeborn.service.deploy.worker.Worker
+
+class ApiV1WorkerResourceSuite extends ApiV1BaseResourceSuite with MiniClusterFeature {
+  private var worker: Worker = _
+  override protected def httpService: HttpService = worker
+
+  override def beforeAll(): Unit = {
+    logInfo("test initialized, setup celeborn mini cluster")
+    val (m, w) =
+      setupMiniClusterWithRandomPorts(workerConf = celebornConf.getAll.toMap, workerNum = 1)
+    worker = w.head
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    logInfo("all test complete, stop celeborn mini cluster")
+    shutdownMiniCluster()
+  }
+
+  test("shuffle resource") {
+    var response = webTarget.path("shuffles").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[String]]).isEmpty)
+
+    response = webTarget.path("shuffles/partitions").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    val partitions = response.readEntity(classOf[WorkerPartitionLocationData])
+    assert(partitions.getPrimaryPartitions.isEmpty)
+    assert(partitions.getReplicaPartitions.isEmpty)
+  }
+
+  test("application resource") {
+    var response = webTarget.path("applications").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[String]]).isEmpty)
+
+    response =
+      webTarget.path("applications/top_disk_usages").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[AppDiskUsageData]]).isEmpty)
+  }
+
+  test("worker resource") {
+    var response = webTarget.path("workers").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    val workerData = response.readEntity(classOf[WorkerData])
+    assert(workerData.getRegistered)
+    assert(!workerData.getShutdown)
+    assert(!workerData.getDecommissioning)
+
+    response = webTarget.path("workers/unavailable_peers").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[Seq[WorkerTimestampData]]).isEmpty)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

In this pr, I refine the existing master/worker APIs.
#### **Master API**



------



- **/${version}/conf**
  - mapping: /conf
  - method: GET
  - params: none
  - return config key value map
- **/${version}/conf/dynamic**
  - mapping: /listDynamicConfigs
  - method: GET
  - params: level, tenant, name
  - return 
- **/${version}/thread_dump**
  - mapping: /threadDump
- **/${version}/applications**
  - mapping: /applications
- **/${version}/applications/top_disk_usages**
  - mapping: /listTopDiskUsedApps
  - method: GET
- **/${version}/applications/hostnames**
  - mapping: /hostnames
  - method: GET
  - description: List all running application's LifecycleManager's hostnames of the cluster
- **/${version}/shuffles**
  - mapping: /shuffle
- **/${version}/masters**
  - mapping: /masterGroupInfo
  - method: GET
- **/${version}/workers**
  - mapping: /workerInfo
  - method: GET
  - params: 
    - hostname(optional), if no worker hostname, return all
  - return: workers
- **/${version}/workers/lost**
  - mapping: /lostWorkers
  - method: GET
- **/${version}/workers/excluded**
  - mapping: /excludedWorkers
  - method: GET
- **/${version}/workers/shutdown**
  - mapping: /shutdownWorkers
  - method: GET
- **/${version}/workers/decommissioned**
  - mapping: /decommissionWorkers
  - method: GET
- **/${version}/applications/hostnames**
  - mapping: /hostnames
  - method: GET
  - description: List all running application's LifecycleManager's hostnames of the cluster
- **/${version}/workers/events**
  - mapping: /workerEventInfo
  - method: GET
  - description: List all worker event info of the master
- **/${version}/workers/exclude**
  - mapping: /exclude
  - method: POST
  - description: Excluded workers of the master add or remove the worker manually given worker id. The parameter add or remove specifies the excluded workers to add or remove, which value is separated by commas.
- **/${version}/workers/events**
  - mapping: /sendWorkerEvent
  - method: POST
  - description: For Master(Leader) can send worker events to manager workers. Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission', and the parameter workers are separated by commas.

#### **Worker API**



------



- **/${version}/conf**
  - mapping: /conf
  - method: GET
  - params: none
  - return config key value map
- **/${version}/conf/dynamic**
  - mapping: /listDynamicConfigs
  - method: GET
  - params: level, tenant, name
  - return 
- **/${version}/thread_dump**
  - mapping: /threadDump
- **/${version}/shuffles**
- **/${version}/shuffles/partitions**
  - mapping: /listPartitionLocationInfo
  - method: GET
- **/${version}/applications**
  - mapping: /applications
- **/${version}/applications/top_disk_usages**
  - mapping: /listTopDiskUsedApps
  - method: GET
- **/${version}/workers/unavailable_peers**
  - mapping: /unavailablePeers
  - method: GET
- **/${version}/workers**
  - mapping:
    - /workerInfo
    -  /isShutdown
    -  /isDecomissioning
    - /isRegistered
- **/${version}/exit**
  - mapping: /exit


Master:
<img width="731" alt="image" src="https://github.com/apache/celeborn/assets/6757692/929ca29c-b710-4406-9714-8b039845620d">
<img width="1009" alt="image" src="https://github.com/apache/celeborn/assets/6757692/d18f9af2-1135-414e-8bb0-a845d6ec1fb0">
Worker:
<img width="809" alt="image" src="https://github.com/apache/celeborn/assets/6757692/4bdbc663-e4a3-4a71-8b5b-6350dba54498">


### Why are the changes needed?

Before, the api request/response are not normalized. 

### Does this PR introduce _any_ user-facing change?

No, just introduce new `/api/v1` APIs and keep current APIs unchanged.

### How was this patch tested?
UT.
