### PR TITLE
[CELEBORN-1478] Fix wrong use partitionId as shuffleId when readPartition

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1679,7 +1679,7 @@ public class ShuffleClientImpl extends ShuffleClient {
       int[] mapAttempts,
       MetricsCallback metricsCallback)
       throws IOException {
-    if (partitionId == Utils$.MODULE$.UNKNOWN_APP_SHUFFLE_ID()) {
+    if (shuffleId == Utils$.MODULE$.UNKNOWN_APP_SHUFFLE_ID()) {
       logger.warn("Shuffle data is empty for shuffle {}: UNKNOWN_APP_SHUFFLE_ID.", shuffleId);
       return CelebornInputStream.empty();
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Change partitionId to shuffleId


### Why are the changes needed?
As title, Although the partitionId is used as the shuffleId when reading a partition, it has no effect on the final result


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
PASS GA
