### PR TITLE
[CELEBORN-1479] Report register shuffle failed reason in exception

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -262,7 +262,7 @@ public abstract class ShuffleClient {
       int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) throws IOException;
 
   public abstract ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
-      int shuffleId, int numMappers, int numPartitions);
+      int shuffleId, int numMappers, int numPartitions) throws CelebornIOException;
 
   public abstract PushState getPushState(String mapKey);
 

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -505,7 +505,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   private ConcurrentHashMap<Integer, PartitionLocation> registerShuffle(
-      int shuffleId, int numMappers, int numPartitions) {
+      int shuffleId, int numMappers, int numPartitions) throws CelebornIOException {
     return registerShuffleInternal(
         shuffleId,
         numMappers,
@@ -539,18 +539,29 @@ public class ShuffleClientImpl extends ShuffleClient {
                     conf.clientRpcRegisterShuffleAskTimeout(),
                     ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)));
 
-    if (partitionLocationMap == null) {
-      throw new CelebornIOException("Register shuffle failed for shuffle " + shuffleId);
-    }
-
     return partitionLocationMap.get(partitionId);
   }
 
   @Override
   public ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
-      int shuffleId, int numMappers, int numPartitions) {
-    return reducePartitionMap.computeIfAbsent(
-        shuffleId, (id) -> registerShuffle(shuffleId, numMappers, numPartitions));
+      int shuffleId, int numMappers, int numPartitions) throws CelebornIOException {
+    try {
+      return reducePartitionMap.computeIfAbsent(
+          shuffleId,
+          (id) -> {
+            try {
+              return registerShuffle(shuffleId, numMappers, numPartitions);
+            } catch (CelebornIOException e) {
+              throw new RuntimeException(e);
+            }
+          });
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof CelebornIOException) {
+        throw (CelebornIOException) e.getCause();
+      } else {
+        throw e;
+      }
+    }
   }
 
   @Override
@@ -597,8 +608,10 @@ public class ShuffleClientImpl extends ShuffleClient {
       int shuffleId,
       int numMappers,
       int numPartitions,
-      Callable<PbRegisterShuffleResponse> callable) {
+      Callable<PbRegisterShuffleResponse> callable)
+      throws CelebornIOException {
     int numRetries = registerShuffleMaxRetries;
+    StatusCode lastFailedStatusCode = null;
     while (numRetries > 0) {
       try {
         PbRegisterShuffleResponse response = callable.call();
@@ -617,16 +630,19 @@ public class ShuffleClientImpl extends ShuffleClient {
           }
           return result;
         } else if (StatusCode.SLOT_NOT_AVAILABLE.equals(respStatus)) {
+          lastFailedStatusCode = respStatus;
           logger.error(
               "LifecycleManager request slots return {}, retry again, remain retry times {}.",
               StatusCode.SLOT_NOT_AVAILABLE,
               numRetries - 1);
         } else if (StatusCode.RESERVE_SLOTS_FAILED.equals(respStatus)) {
+          lastFailedStatusCode = respStatus;
           logger.error(
               "LifecycleManager request slots return {}, retry again, remain retry times {}.",
               StatusCode.RESERVE_SLOTS_FAILED,
               numRetries - 1);
         } else {
+          lastFailedStatusCode = respStatus;
           logger.error(
               "LifecycleManager request slots return {}, retry again, remain retry times {}.",
               StatusCode.REQUEST_FAILED,
@@ -639,7 +655,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             numMappers,
             numPartitions,
             e);
-        break;
+        throw new CelebornIOException("Register shuffle failed for shuffle " + shuffleId + ".", e);
       }
 
       try {
@@ -649,8 +665,8 @@ public class ShuffleClientImpl extends ShuffleClient {
       }
       numRetries--;
     }
-
-    return null;
+    throw new CelebornIOException(
+        "Register shuffle failed for shuffle " + shuffleId + ", reason: " + lastFailedStatusCode);
   }
 
   protected void limitMaxInFlight(String mapKey, PushState pushState, String hostAndPushPort)
@@ -869,10 +885,6 @@ public class ShuffleClientImpl extends ShuffleClient {
     // register shuffle if not registered
     final ConcurrentHashMap<Integer, PartitionLocation> map =
         getPartitionLocation(shuffleId, numMappers, numPartitions);
-
-    if (map == null) {
-      throw new CelebornIOException("Register shuffle failed for shuffle " + shuffleId + ".");
-    }
 
     // get location
     // If rerun or speculation task running after LifecycleManager call stageEnd,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add `ConcurrentHashMap<Integer, Exception> registerShuffleExceptions` in ShuffleClientImpl to record register shuffle failed reason.


### Why are the changes needed?
There could be various reasons for a Register Shuffle failure, such as SLOT_NOT_AVAILABLE, RESERVE_SLOTS_FAILED, and so on. However, the current exceptions only indicate that a shuffle registration has failed without providing details on the cause of the failure. We are unable to determine the exact reason for the failure unless we check the LifecycleManager logs.
In this PR, the actual reason for a register shuffle failure is included in the thrown exception.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
unit test: org.apache.celeborn.client.ShuffleClientSuiteJ#testRegisterShuffleFailed
