### PR TITLE
[CELEBORN-1458][FOLLOWUP] Fix REST API endpoint of decommissioning in decommissioning.md

### DIFF
--- a/docs/decommissioning.md
+++ b/docs/decommissioning.md
@@ -61,12 +61,12 @@ Administrators perform decommissioning operation in two approaches:
 
 1. Via Celeborn Worker REST API endpoint:
   ```shell
-  curl --request POST --url 'ip:port/exit' --data '{"type":"Decommission"}'
+  curl -X POST -d "type=Decommission" http://ip:port/exit
   ```
 2. Via Celeborn Master(Leader) REST API endpoint:
   ```shell
-  curl --request POST --url 'ip:port/sendWorkerEvent' --data '{"type":"Decommission", "workers":"ip_1,ip_2"}'
-  curl --request POST --url 'ip:port/sendWorkerEvent' --data '{"type":"DecommissionThenIdle", "workers":"ip_1,ip_2"}'
+  curl -X POST -d "type=Decommission&workers=ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort" http://ip:port/sendWorkerEvent
+  curl -X POST -d "type=DecommissionThenIdle&workers=ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort" http://ip:port/sendWorkerEvent
   ```
 
 Details of decommissioning interface can refer to [REST API](../monitoring/#rest-api)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix REST API endpoint of decommissioning in `decommissioning.md` including `/exit` and `/sendWorkerEvent`.

### Why are the changes needed?

The parameters of REST API endpoint `/exit` and `/sendWorkerEvent` use form data. Therefore, `decommissioning.md` should not regard the parameters of `/exit` and `/sendWorkerEvent` as json.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.