### PR TITLE
[CELEBORN-1489] Update Flink support with authentication support - backport to 0.5

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -232,7 +232,10 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
   public void close() throws Exception {
     try {
       jobShuffleIds.clear();
-      lifecycleManager.stop();
+      LifecycleManager manager = lifecycleManager;
+      if (null != manager) {
+        manager.stop();
+      }
     } catch (Exception e) {
       LOG.warn("Encounter exception when shutdown: {}", e.getMessage(), e);
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
@@ -18,7 +18,7 @@
 package org.apache.celeborn.plugin.flink.network;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -29,8 +29,10 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.network.TransportContext;
 import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.client.TransportClientBootstrap;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.util.JavaUtils;
+import org.apache.celeborn.plugin.flink.utils.Utils;
 
 public class FlinkTransportClientFactory extends TransportClientFactory {
 
@@ -39,8 +41,9 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
   private ConcurrentHashMap<Long, Supplier<ByteBuf>> bufferSuppliers;
   private final int fetchMaxRetries;
 
-  public FlinkTransportClientFactory(TransportContext context, int fetchMaxRetries) {
-    super(context, Collections.emptyList());
+  public FlinkTransportClientFactory(
+      TransportContext context, int fetchMaxRetries, List<TransportClientBootstrap> bootstraps) {
+    super(context, bootstraps);
     bufferSuppliers = JavaUtils.newConcurrentHashMap();
     this.fetchMaxRetries = fetchMaxRetries;
     this.pooledAllocator = new UnpooledByteBufAllocator(true);
@@ -53,7 +56,7 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
     while (retryCount > 0) {
       try {
         return createClient(remoteHost, remotePort);
-      } catch (IOException e) {
+      } catch (Exception e) {
         retryCount--;
         logger.warn(
             "Retrying ({}/{}) times create client to {}:{}",
@@ -63,7 +66,11 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
             remotePort,
             e);
         if (retryCount == 0) {
-          throw e;
+          if (e instanceof InterruptedException || e instanceof IOException) {
+            throw e;
+          } else {
+            Utils.rethrowAsRuntimeException(e);
+          }
         }
       }
     }

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -65,6 +65,7 @@ public class MasterClient {
     this.isWorker = isWorker;
     this.masterEndpoints = resolveMasterEndpoints();
     Collections.shuffle(this.masterEndpoints);
+    LOG.info("masterEndpoints = {}", masterEndpoints);
     this.maxRetries = Math.max(masterEndpoints.size(), conf.masterClientMaxRetries());
     this.rpcTimeout = conf.masterClientRpcAskTimeout();
     this.rpcEndpointRef = new AtomicReference<>();

--- a/common/src/test/java/org/apache/celeborn/common/network/TestHelper.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TestHelper.java
@@ -17,9 +17,15 @@
 
 package org.apache.celeborn.common.network;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
+
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.ssl.SslSampleConfigs;
 
 /** A few helper utilities to reduce duplication within test code. */
 public class TestHelper {
@@ -29,5 +35,20 @@ public class TestHelper {
       conf.set(entry.getKey(), entry.getValue());
     }
     return conf;
+  }
+
+  public static String getResourceAsAbsolutePath(String path) {
+    try {
+      File tempFile = File.createTempFile(new File(path).getName(), null);
+      tempFile.deleteOnExit();
+      URL url = SslSampleConfigs.class.getResource(path);
+      if (null == url) {
+        throw new IllegalArgumentException("Unable to find " + path);
+      }
+      FileUtils.copyInputStreamToFile(url.openStream(), tempFile);
+      return tempFile.getCanonicalPath();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to resolve path " + path, e);
+    }
   }
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/ssl/SslSampleConfigs.java
@@ -17,11 +17,12 @@
 
 package org.apache.celeborn.common.network.ssl;
 
+import static org.apache.celeborn.common.network.TestHelper.getResourceAsAbsolutePath;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.*;
@@ -30,7 +31,6 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.FileUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.Extension;
@@ -274,21 +274,6 @@ public class SslSampleConfigs {
           StandardCopyOption.ATOMIC_MOVE);
     } finally {
       out.close();
-    }
-  }
-
-  public static String getResourceAsAbsolutePath(String path) {
-    try {
-      File tempFile = File.createTempFile(new File(path).getName(), null);
-      tempFile.deleteOnExit();
-      URL url = SslSampleConfigs.class.getResource(path);
-      if (null == url) {
-        throw new IllegalArgumentException("Unable to find " + path);
-      }
-      FileUtils.copyInputStreamToFile(url.openStream(), tempFile);
-      return tempFile.getCanonicalPath();
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to resolve path " + path, e);
     }
   }
 }

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -502,7 +502,7 @@ object CelebornClient {
 
 object CelebornService {
   lazy val service = Project("celeborn-service", file("service"))
-    .dependsOn(CelebornCommon.common)
+    .dependsOn(CelebornCommon.common % "test->test;compile->compile")
     .settings (
       commonSettings,
       libraryDependencies ++= Seq(

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -66,6 +66,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/ApiBaseResourceSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/ApiBaseResourceSuite.scala
@@ -20,12 +20,13 @@ package org.apache.celeborn.server.common.http
 import javax.ws.rs.core.MediaType
 
 import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.network.TestHelper
 
 abstract class ApiBaseResourceSuite extends HttpTestHelper {
   celebornConf.set(CelebornConf.METRICS_ENABLED.key, "true")
     .set(
       CelebornConf.METRICS_CONF.key,
-      Thread.currentThread().getContextClassLoader.getResource("metrics-api.properties").getFile)
+      TestHelper.getResourceAsAbsolutePath("/metrics-api.properties"))
 
   test("ping") {
     val response = webTarget.path("ping").request(MediaType.TEXT_PLAIN).get()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -95,8 +95,10 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
   def connectionInactive(client: TransportClient): Unit = {
     val applicationIds = appActiveConnections.remove(client.getChannel.id().asLongText())
     incCounter(ACTIVE_CONNECTION_COUNT, -1)
-    applicationIds.asScala.foreach(applicationId =>
-      incCounter(ACTIVE_CONNECTION_COUNT, -1, Map(applicationLabel -> applicationId)))
+    if (null != applicationIds) {
+      applicationIds.asScala.foreach(applicationId =>
+        incCounter(ACTIVE_CONNECTION_COUNT, -1, Map(applicationLabel -> applicationId)))
+    }
   }
 
   def recordAppActiveConnection(client: TransportClient, shuffleKey: String): Unit = {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -55,16 +55,21 @@ trait MiniClusterFeature extends Logging {
     while (!created) {
       try {
         val randomPort = selectRandomPort(1024, 65535)
+        val randomInternalPort = selectRandomPort(1024, 65535)
         val finalMasterConf = Map(
           s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
           s"${CelebornConf.PORT_MAX_RETRY.key}" -> "0",
           s"${CelebornConf.MASTER_PORT.key}" -> s"$randomPort",
-          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
+          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort",
+          s"${CelebornConf.MASTER_INTERNAL_PORT.key}" -> s"$randomInternalPort",
+          s"${CelebornConf.MASTER_INTERNAL_ENDPOINTS.key}" -> s"localhost:$randomInternalPort") ++
           masterConf
         val finalWorkerConf = Map(
-          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
+          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort",
+          s"${CelebornConf.MASTER_INTERNAL_ENDPOINTS.key}" -> s"localhost:$randomInternalPort") ++
           workerConf
-        logInfo(s"generated configuration $finalMasterConf")
+        logInfo(
+          s"generated configuration. Master conf = $finalMasterConf, worker conf = $finalWorkerConf")
         val (m, w) =
           setUpMiniCluster(masterConf = finalMasterConf, workerConf = finalWorkerConf, workerNum)
         master = m


### PR DESCRIPTION
Backport of #2596 to branch-0.5
Conflicts were in:
* ApiBaseResourceAuthenticationSuite.scala
* ApiBaseResourceSuite.scala

Description from #2596:

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix authentication support for Apache Flink.


### Why are the changes needed?
Without these changes, Apache Flink applications fail when Celeborn cluster has authentication enabled.


### Does this PR introduce _any_ user-facing change?

Fixes authentication support for Apache Flink integration


### How was this patch tested?

This is forward port + adaptation of changes we did internally (against 0.4) when testing Apache Flink applications against Celeborn cluster with authentication (and TLS) enabled.
Integration test has been updated to additionally test for Flink applications with authentication enabled in Celeborn cluster.

