### PR TITLE
[CELEBORN-1318][FOLLOWUP] Transfer extraInfo for http authentication providers

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/authentication/AnonymousAuthenticationProviderImpl.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/AnonymousAuthenticationProviderImpl.scala
@@ -21,9 +21,9 @@ import java.security.Principal
 
 class AnonymousAuthenticationProviderImpl extends PasswdAuthenticationProvider
   with TokenAuthenticationProvider {
-  override def authenticate(user: String, password: String): Principal = {
+  override def authenticate(credential: PasswordCredential): Principal = {
     // no-op authentication
-    new BasicPrincipal(user)
+    new BasicPrincipal(credential.username)
   }
 
   override def authenticate(credential: TokenCredential): Principal = {

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/AnonymousAuthenticationProviderImpl.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/AnonymousAuthenticationProviderImpl.scala
@@ -26,7 +26,7 @@ class AnonymousAuthenticationProviderImpl extends PasswdAuthenticationProvider
     new BasicPrincipal(user)
   }
 
-  override def authenticate(credential: Credential): Principal = {
+  override def authenticate(credential: TokenCredential): Principal = {
     // no-op authentication
     new BasicPrincipal("anonymous")
   }

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
@@ -38,5 +38,5 @@ case class DefaultTokenCredential(
     override val extraInfo: Map[String, String] = Map.empty) extends TokenCredential
 
 object Credential {
-  val CLIENT_IP_PROPERTY = "clientIp"
+  val CLIENT_IP_KEY = "clientIp"
 }

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
@@ -36,3 +36,7 @@ trait TokenCredential {
 case class DefaultTokenCredential(
     token: String,
     override val extraInfo: Map[String, String] = Map.empty) extends TokenCredential
+
+object CredentialUtils {
+  val CLIENT_IP_PROPERTY = "clientIp"
+}

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
@@ -28,10 +28,11 @@ case class DefaultPasswordCredential(
     password: String,
     override val extraInfo: Map[String, String] = Map.empty) extends PasswordCredential
 
-/**
- * The credential object that is passed to the token authentication provider.
- *
- * @param token The token that is used for authentication
- * @param extraInfo The extraInfo that associated with the token
- */
-case class TokenCredential(token: String, extraInfo: Map[String, String] = Map.empty)
+trait TokenCredential {
+  def token: String
+  def extraInfo: Map[String, String] = Map.empty
+}
+
+case class DefaultTokenCredential(
+    token: String,
+    override val extraInfo: Map[String, String] = Map.empty) extends TokenCredential

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
@@ -37,6 +37,6 @@ case class DefaultTokenCredential(
     token: String,
     override val extraInfo: Map[String, String] = Map.empty) extends TokenCredential
 
-object CredentialUtils {
+object Credential {
   val CLIENT_IP_PROPERTY = "clientIp"
 }

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
@@ -17,17 +17,10 @@
 
 package org.apache.celeborn.common.authentication
 
-import java.security.Principal
-
-class AnonymousAuthenticationProviderImpl extends PasswdAuthenticationProvider
-  with TokenAuthenticationProvider {
-  override def authenticate(user: String, password: String): Principal = {
-    // no-op authentication
-    new BasicPrincipal(user)
-  }
-
-  override def authenticate(credential: Credential): Principal = {
-    // no-op authentication
-    new BasicPrincipal("anonymous")
-  }
-}
+/**
+ * The credential object that is passed to the token authentication provider.
+ *
+ * @param token The token that is used for authentication
+ * @param props The properties that associated with the token
+ */
+case class Credential(token: String, props: Map[String, String] = Map.empty)

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/Credential.scala
@@ -17,6 +17,17 @@
 
 package org.apache.celeborn.common.authentication
 
+trait PasswordCredential {
+  def username: String
+  def password: String
+  def extraInfo: Map[String, String] = Map.empty
+}
+
+case class DefaultPasswordCredential(
+    username: String,
+    password: String,
+    override val extraInfo: Map[String, String] = Map.empty) extends PasswordCredential
+
 /**
  * The credential object that is passed to the token authentication provider.
  *

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/PasswdAuthenticationProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/PasswdAuthenticationProvider.scala
@@ -23,15 +23,14 @@ trait PasswdAuthenticationProvider {
 
   /**
    * The authenticate method is called by the celeborn authentication layer
-   * to authenticate user & password for their requests.
-   * If a user is to be granted, return nothing/throw nothing.
-   * When a user is to be disallowed, throw an appropriate [[SecurityException]].
+   * to authenticate password credential for their requests.
+   * If a credential is to be granted, return nothing/throw nothing.
+   * When a credential is to be disallowed, throw an appropriate [[SecurityException]].
    *
-   * @param user     The username received over the connection request
-   * @param password The password received over the connection request
+   * @param credential The credential received over the connection request
    *
    * @throws SecurityException When a user is found to be invalid by the implementation
    */
   @throws[SecurityException]
-  def authenticate(user: String, password: String): Principal
+  def authenticate(credential: PasswordCredential): Principal
 }

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/TokenAuthenticationProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/TokenAuthenticationProvider.scala
@@ -35,7 +35,3 @@ trait TokenAuthenticationProvider {
   @throws[SecurityException]
   def authenticate(credential: TokenCredential): Principal
 }
-
-object TokenAuthenticationProvider {
-  val CLIENT_IP_PROPERTY = "CLIENT_IP"
-}

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/TokenAuthenticationProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/TokenAuthenticationProvider.scala
@@ -27,11 +27,15 @@ trait TokenAuthenticationProvider {
    * If the token is to be granted, return nothing/throw nothing.
    * When the token is to be disallowed, throw an appropriate [[SecurityException]].
    *
-   * @param token The token received over the connection request.
+   * @param credential The credential received over the connection request
    * @return The identifier associated with the token
    *
    * @throws SecurityException When the token is found to be invalid by the implementation
    */
   @throws[SecurityException]
-  def authenticate(token: String): Principal
+  def authenticate(credential: Credential): Principal
+}
+
+object TokenAuthenticationProvider {
+  val CLIENT_IP_PROPERTY = "CLIENT_IP"
 }

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/TokenAuthenticationProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/TokenAuthenticationProvider.scala
@@ -23,17 +23,17 @@ trait TokenAuthenticationProvider {
 
   /**
    * The authenticate method is called by the celeborn authentication layer
-   * to authenticate token for their requests.
-   * If the token is to be granted, return nothing/throw nothing.
-   * When the token is to be disallowed, throw an appropriate [[SecurityException]].
+   * to authenticate credential for their requests.
+   * If the credential is to be granted, return nothing/throw nothing.
+   * When the credential is to be disallowed, throw an appropriate [[SecurityException]].
    *
    * @param credential The credential received over the connection request
    * @return The identifier associated with the token
    *
-   * @throws SecurityException When the token is found to be invalid by the implementation
+   * @throws SecurityException When the credential is found to be invalid by the implementation
    */
   @throws[SecurityException]
-  def authenticate(credential: Credential): Principal
+  def authenticate(credential: TokenCredential): Principal
 }
 
 object TokenAuthenticationProvider {

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/TokenCredential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/TokenCredential.scala
@@ -21,6 +21,6 @@ package org.apache.celeborn.common.authentication
  * The credential object that is passed to the token authentication provider.
  *
  * @param token The token that is used for authentication
- * @param props The properties that associated with the token
+ * @param extraInfo The extraInfo that associated with the token
  */
-case class TokenCredential(token: String, props: Map[String, String] = Map.empty)
+case class TokenCredential(token: String, extraInfo: Map[String, String] = Map.empty)

--- a/common/src/main/scala/org/apache/celeborn/common/authentication/TokenCredential.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/authentication/TokenCredential.scala
@@ -23,4 +23,4 @@ package org.apache.celeborn.common.authentication
  * @param token The token that is used for authentication
  * @param props The properties that associated with the token
  */
-case class Credential(token: String, props: Map[String, String] = Map.empty)
+case class TokenCredential(token: String, props: Map[String, String] = Map.empty)

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
@@ -17,9 +17,19 @@
 
 package org.apache.celeborn.server.common.http
 
+import org.apache.celeborn.common.authentication.CredentialUtils
+import org.apache.celeborn.server.common.http.authentication.AuthenticationFilter
+
 object HttpAuthUtils {
   // HTTP header used by the server endpoint during an authentication sequence.
   val WWW_AUTHENTICATE_HEADER = "WWW-Authenticate"
   // HTTP header used by the client endpoint during an authentication sequence.
   val AUTHORIZATION_HEADER = "Authorization"
+
+  def getAuthenticationExtraInfo: Map[String, String] = {
+    Map(CredentialUtils.CLIENT_IP_PROPERTY ->
+      Option(
+        AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(
+        AuthenticationFilter.HTTP_CLIENT_IP_ADDRESS.get()))
+  }
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.server.common.http
 
-import org.apache.celeborn.common.authentication.CredentialUtils
+import org.apache.celeborn.common.authentication.Credential
 import org.apache.celeborn.server.common.http.authentication.AuthenticationFilter
 
 object HttpAuthUtils {
@@ -27,7 +27,7 @@ object HttpAuthUtils {
   val AUTHORIZATION_HEADER = "Authorization"
 
   def getAuthenticationExtraInfo: Map[String, String] = {
-    Map(CredentialUtils.CLIENT_IP_PROPERTY ->
+    Map(Credential.CLIENT_IP_PROPERTY ->
       Option(
         AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(
         AuthenticationFilter.HTTP_CLIENT_IP_ADDRESS.get()))

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
@@ -27,7 +27,7 @@ object HttpAuthUtils {
   val AUTHORIZATION_HEADER = "Authorization"
 
   def getCredentialExtraInfo: Map[String, String] = {
-    Map(Credential.CLIENT_IP_PROPERTY ->
+    Map(Credential.CLIENT_IP_KEY ->
       Option(
         AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(
         AuthenticationFilter.HTTP_CLIENT_IP_ADDRESS.get()))

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpAuthUtils.scala
@@ -26,7 +26,7 @@ object HttpAuthUtils {
   // HTTP header used by the client endpoint during an authentication sequence.
   val AUTHORIZATION_HEADER = "Authorization"
 
-  def getAuthenticationExtraInfo: Map[String, String] = {
+  def getCredentialExtraInfo: Map[String, String] = {
     Map(Credential.CLIENT_IP_PROPERTY ->
       Option(
         AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
@@ -91,7 +91,7 @@ class BasicAuthenticationHandler(providerClass: String) extends AuthenticationHa
           DefaultPasswordCredential(
             user,
             password,
-            HttpAuthUtils.getAuthenticationExtraInfo)).getName
+            HttpAuthUtils.getCredentialExtraInfo)).getName
         response.setStatus(HttpServletResponse.SC_OK)
       }
     }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
@@ -25,6 +25,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, DefaultPasswordCredential, PasswdAuthenticationProvider}
 import org.apache.celeborn.common.authentication.HttpAuthSchemes._
 import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.server.common.http.HttpAuthUtils
 import org.apache.celeborn.server.common.http.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
 
 class BasicAuthenticationHandler(providerClass: String) extends AuthenticationHandler with Logging {
@@ -89,7 +90,8 @@ class BasicAuthenticationHandler(providerClass: String) extends AuthenticationHa
         authUser = passwdAuthenticationProvider.authenticate(
           DefaultPasswordCredential(
             user,
-            password)).getName
+            password,
+            HttpAuthUtils.getAuthenticationExtraInfo)).getName
         response.setStatus(HttpServletResponse.SC_OK)
       }
     }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
@@ -22,7 +22,7 @@ import java.util.Base64
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, PasswdAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, DefaultPasswordCredential, PasswdAuthenticationProvider}
 import org.apache.celeborn.common.authentication.HttpAuthSchemes._
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
@@ -86,7 +86,10 @@ class BasicAuthenticationHandler(providerClass: String) extends AuthenticationHa
         val Seq(user, password) = creds.toSeq.take(2)
         val passwdAuthenticationProvider = HttpAuthenticationFactory
           .getPasswordAuthenticationProvider(providerClass, conf)
-        authUser = passwdAuthenticationProvider.authenticate(user, password).getName
+        authUser = passwdAuthenticationProvider.authenticate(
+          DefaultPasswordCredential(
+            user,
+            password)).getName
         response.setStatus(HttpServletResponse.SC_OK)
       }
     }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
@@ -22,9 +22,10 @@ import java.util.Base64
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, DefaultTokenCredential, TokenAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, CredentialUtils, DefaultTokenCredential, TokenAuthenticationProvider}
 import org.apache.celeborn.common.authentication.HttpAuthSchemes._
 import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.server.common.http.HttpAuthUtils
 import org.apache.celeborn.server.common.http.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
 
 class BearerAuthenticationHandler(providerClass: String)
@@ -79,9 +80,7 @@ class BearerAuthenticationHandler(providerClass: String)
     } else {
       val credential = DefaultTokenCredential(
         new String(inputToken, StandardCharsets.UTF_8),
-        Map(TokenAuthenticationProvider.CLIENT_IP_PROPERTY -> Option(
-          AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(
-          AuthenticationFilter.HTTP_CLIENT_IP_ADDRESS.get())))
+        HttpAuthUtils.getAuthenticationExtraInfo)
       principal = HttpAuthenticationFactory
         .getTokenAuthenticationProvider(providerClass, conf)
         .authenticate(credential).getName

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
@@ -22,7 +22,7 @@ import java.util.Base64
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, TokenAuthenticationProvider, TokenCredential}
+import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, DefaultTokenCredential, TokenAuthenticationProvider}
 import org.apache.celeborn.common.authentication.HttpAuthSchemes._
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
@@ -77,7 +77,7 @@ class BearerAuthenticationHandler(providerClass: String)
       response.setHeader(WWW_AUTHENTICATE_HEADER, authScheme.toString)
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
     } else {
-      val credential = TokenCredential(
+      val credential = DefaultTokenCredential(
         new String(inputToken, StandardCharsets.UTF_8),
         Map(TokenAuthenticationProvider.CLIENT_IP_PROPERTY -> Option(
           AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
@@ -22,7 +22,7 @@ import java.util.Base64
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, Credential, TokenAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, TokenAuthenticationProvider, TokenCredential}
 import org.apache.celeborn.common.authentication.HttpAuthSchemes._
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
@@ -77,7 +77,7 @@ class BearerAuthenticationHandler(providerClass: String)
       response.setHeader(WWW_AUTHENTICATE_HEADER, authScheme.toString)
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
     } else {
-      val credential = Credential(
+      val credential = TokenCredential(
         new String(inputToken, StandardCharsets.UTF_8),
         Map(TokenAuthenticationProvider.CLIENT_IP_PROPERTY -> Option(
           AuthenticationFilter.HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS.get()).getOrElse(

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
@@ -80,7 +80,7 @@ class BearerAuthenticationHandler(providerClass: String)
     } else {
       val credential = DefaultTokenCredential(
         new String(inputToken, StandardCharsets.UTF_8),
-        HttpAuthUtils.getAuthenticationExtraInfo)
+        HttpAuthUtils.getCredentialExtraInfo)
       principal = HttpAuthenticationFactory
         .getTokenAuthenticationProvider(providerClass, conf)
         .authenticate(credential).getName

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
@@ -22,7 +22,7 @@ import java.util.Base64
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, CredentialUtils, DefaultTokenCredential, TokenAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{AnonymousAuthenticationProviderImpl, Credential, DefaultTokenCredential, TokenAuthenticationProvider}
 import org.apache.celeborn.common.authentication.HttpAuthSchemes._
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.HttpAuthUtils

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, CredentialUtils, PasswdAuthenticationProvider, PasswordCredential}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, Credential, PasswdAuthenticationProvider, PasswordCredential}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefinePasswordAuthenticationProviderImpl.VALID_PASSWORD
 
@@ -28,7 +28,7 @@ class UserDefinePasswordAuthenticationProviderImpl
   extends PasswdAuthenticationProvider with Logging {
   override def authenticate(credential: PasswordCredential): Principal = {
     val clientIp =
-      credential.extraInfo.getOrElse(CredentialUtils.CLIENT_IP_PROPERTY, null)
+      credential.extraInfo.getOrElse(Credential.CLIENT_IP_PROPERTY, null)
     if (credential.password == VALID_PASSWORD) {
       logInfo(s"Success log in of user: ${credential.username} with clientIp: $clientIp")
       new BasicPrincipal(credential.username)

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
@@ -28,7 +28,7 @@ class UserDefinePasswordAuthenticationProviderImpl
   extends PasswdAuthenticationProvider with Logging {
   override def authenticate(credential: PasswordCredential): Principal = {
     val clientIp =
-      credential.extraInfo.getOrElse(Credential.CLIENT_IP_PROPERTY, null)
+      credential.extraInfo.getOrElse(Credential.CLIENT_IP_KEY, null)
     if (credential.password == VALID_PASSWORD) {
       logInfo(s"Success log in of user: ${credential.username} with clientIp: $clientIp")
       new BasicPrincipal(credential.username)

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
@@ -20,15 +20,17 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, PasswdAuthenticationProvider, PasswordCredential}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, CredentialUtils, PasswdAuthenticationProvider, PasswordCredential}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefinePasswordAuthenticationProviderImpl.VALID_PASSWORD
 
 class UserDefinePasswordAuthenticationProviderImpl
   extends PasswdAuthenticationProvider with Logging {
   override def authenticate(credential: PasswordCredential): Principal = {
+    val clientIp =
+      credential.extraInfo.getOrElse(CredentialUtils.CLIENT_IP_PROPERTY, null)
     if (credential.password == VALID_PASSWORD) {
-      logInfo(s"Success log in of user: ${credential.username}")
+      logInfo(s"Success log in of user: ${credential.username} with clientIp: $clientIp")
       new BasicPrincipal(credential.username)
     } else {
       throw new AuthenticationException("Username or password is not valid!")

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefinePasswordAuthenticationProviderImpl.scala
@@ -20,16 +20,16 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, PasswdAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, PasswdAuthenticationProvider, PasswordCredential}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefinePasswordAuthenticationProviderImpl.VALID_PASSWORD
 
 class UserDefinePasswordAuthenticationProviderImpl
   extends PasswdAuthenticationProvider with Logging {
-  override def authenticate(user: String, password: String): Principal = {
-    if (password == VALID_PASSWORD) {
-      logInfo(s"Success log in of user: $user")
-      new BasicPrincipal(user)
+  override def authenticate(credential: PasswordCredential): Principal = {
+    if (credential.password == VALID_PASSWORD) {
+      logInfo(s"Success log in of user: ${credential.username}")
+      new BasicPrincipal(credential.username)
     } else {
       throw new AuthenticationException("Username or password is not valid!")
     }

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
@@ -20,14 +20,14 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, TokenAuthenticationProvider, TokenCredential}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, CredentialUtils, TokenAuthenticationProvider, TokenCredential}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefineTokenAuthenticationProviderImpl.VALID_TOKEN
 
 class UserDefineTokenAuthenticationProviderImpl extends TokenAuthenticationProvider with Logging {
   override def authenticate(credential: TokenCredential): Principal = {
     val clientIp =
-      credential.extraInfo.getOrElse(TokenAuthenticationProvider.CLIENT_IP_PROPERTY, null)
+      credential.extraInfo.getOrElse(CredentialUtils.CLIENT_IP_PROPERTY, null)
     if (credential.token == VALID_TOKEN) {
       logInfo(s"Success log in of token: ${credential.token} with clientIp: $clientIp")
       new BasicPrincipal("user")

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
@@ -20,14 +20,15 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, TokenAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, Credential, TokenAuthenticationProvider}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefineTokenAuthenticationProviderImpl.VALID_TOKEN
 
 class UserDefineTokenAuthenticationProviderImpl extends TokenAuthenticationProvider with Logging {
-  override def authenticate(token: String): Principal = {
-    if (token == VALID_TOKEN) {
-      logInfo(s"Success log in of token: $token")
+  override def authenticate(credential: Credential): Principal = {
+    val clientIp = credential.props.getOrElse(TokenAuthenticationProvider.CLIENT_IP_PROPERTY, null)
+    if (credential.token == VALID_TOKEN) {
+      logInfo(s"Success log in of token: ${credential.token} with clientIp: $clientIp")
       new BasicPrincipal("user")
     } else {
       throw new AuthenticationException("Token is not valid!")

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
@@ -20,14 +20,14 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, CredentialUtils, TokenAuthenticationProvider, TokenCredential}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, Credential, TokenAuthenticationProvider, TokenCredential}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefineTokenAuthenticationProviderImpl.VALID_TOKEN
 
 class UserDefineTokenAuthenticationProviderImpl extends TokenAuthenticationProvider with Logging {
   override def authenticate(credential: TokenCredential): Principal = {
     val clientIp =
-      credential.extraInfo.getOrElse(CredentialUtils.CLIENT_IP_PROPERTY, null)
+      credential.extraInfo.getOrElse(Credential.CLIENT_IP_PROPERTY, null)
     if (credential.token == VALID_TOKEN) {
       logInfo(s"Success log in of token: ${credential.token} with clientIp: $clientIp")
       new BasicPrincipal("user")

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
@@ -20,12 +20,12 @@ package org.apache.celeborn.server.common.http.authentication
 import java.security.Principal
 import javax.security.sasl.AuthenticationException
 
-import org.apache.celeborn.common.authentication.{BasicPrincipal, Credential, TokenAuthenticationProvider}
+import org.apache.celeborn.common.authentication.{BasicPrincipal, TokenAuthenticationProvider, TokenCredential}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.UserDefineTokenAuthenticationProviderImpl.VALID_TOKEN
 
 class UserDefineTokenAuthenticationProviderImpl extends TokenAuthenticationProvider with Logging {
-  override def authenticate(credential: Credential): Principal = {
+  override def authenticate(credential: TokenCredential): Principal = {
     val clientIp = credential.props.getOrElse(TokenAuthenticationProvider.CLIENT_IP_PROPERTY, null)
     if (credential.token == VALID_TOKEN) {
       logInfo(s"Success log in of token: ${credential.token} with clientIp: $clientIp")

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
@@ -26,7 +26,8 @@ import org.apache.celeborn.server.common.http.authentication.UserDefineTokenAuth
 
 class UserDefineTokenAuthenticationProviderImpl extends TokenAuthenticationProvider with Logging {
   override def authenticate(credential: TokenCredential): Principal = {
-    val clientIp = credential.props.getOrElse(TokenAuthenticationProvider.CLIENT_IP_PROPERTY, null)
+    val clientIp =
+      credential.extraInfo.getOrElse(TokenAuthenticationProvider.CLIENT_IP_PROPERTY, null)
     if (credential.token == VALID_TOKEN) {
       logInfo(s"Success log in of token: ${credential.token} with clientIp: $clientIp")
       new BasicPrincipal("user")

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/UserDefineTokenAuthenticationProviderImpl.scala
@@ -27,7 +27,7 @@ import org.apache.celeborn.server.common.http.authentication.UserDefineTokenAuth
 class UserDefineTokenAuthenticationProviderImpl extends TokenAuthenticationProvider with Logging {
   override def authenticate(credential: TokenCredential): Principal = {
     val clientIp =
-      credential.extraInfo.getOrElse(Credential.CLIENT_IP_PROPERTY, null)
+      credential.extraInfo.getOrElse(Credential.CLIENT_IP_KEY, null)
     if (credential.token == VALID_TOKEN) {
       logInfo(s"Success log in of token: ${credential.token} with clientIp: $clientIp")
       new BasicPrincipal("user")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
I am implementing the plugin for Bearer token authentication, and I found that, in ebay, the tokens are bound to client IP.

So, I also need to transfer the clientIp for token validation, I wonder that it is a general case.

This pr is a followup for Http password/token authentication and extend the current interface api.

### Why are the changes needed?
To extend the token authentication use case in case that we need more properties associate with the token.


### Does this PR introduce _any_ user-facing change?

No, this interface `TokenAuthenticationProvider` has not been released.

### How was this patch tested?

Not needed.
