### PR TITLE
[CELEBORN-1495] CelebornColumnDictionary supports dictionary of float and double column type

### DIFF
--- a/client-spark/spark-3-columnar-shuffle/src/main/java/org/apache/spark/sql/execution/columnar/CelebornColumnDictionary.java
+++ b/client-spark/spark-3-columnar-shuffle/src/main/java/org/apache/spark/sql/execution/columnar/CelebornColumnDictionary.java
@@ -24,6 +24,8 @@ import org.apache.spark.sql.execution.vectorized.Dictionary;
 public class CelebornColumnDictionary implements Dictionary {
   private int[] intDictionary;
   private long[] longDictionary;
+  private float[] floatDictionary;
+  private double[] doubleDictionary;
   private String[] stringDictionary;
 
   public CelebornColumnDictionary(int[] dictionary) {
@@ -32,6 +34,14 @@ public class CelebornColumnDictionary implements Dictionary {
 
   public CelebornColumnDictionary(long[] dictionary) {
     this.longDictionary = dictionary;
+  }
+
+  public CelebornColumnDictionary(float[] dictionary) {
+    this.floatDictionary = dictionary;
+  }
+
+  public CelebornColumnDictionary(double[] dictionary) {
+    this.doubleDictionary = dictionary;
   }
 
   public CelebornColumnDictionary(String[] dictionary) {
@@ -50,12 +60,12 @@ public class CelebornColumnDictionary implements Dictionary {
 
   @Override
   public float decodeToFloat(int id) {
-    throw new UnsupportedOperationException("Dictionary encoding does not support float");
+    return floatDictionary[id];
   }
 
   @Override
   public double decodeToDouble(int id) {
-    throw new UnsupportedOperationException("Dictionary encoding does not support double");
+    return doubleDictionary[id];
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CelebornColumnDictionary` supports dictionary of float and double column type.

### Why are the changes needed?

`CelebornColumnDictionary` only supports dictionary of int, long and string column type at present. It's recommended to support dictionary of float and double column type for columnar shuffle.

Backport https://github.com/apache/spark/pull/42850.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.