### PR TITLE
[CELEBORN-1498] Decide whether to reuse the shuffle id based on the appShuffle's numAvailableOutputs

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/ExecutorShuffleIdTracker.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/ExecutorShuffleIdTracker.java
@@ -20,6 +20,8 @@ package org.apache.spark.shuffle.celeborn;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.util.JavaUtils;
 
@@ -43,5 +45,10 @@ public class ExecutorShuffleIdTracker {
         shuffleIds.forEach(shuffleClient::cleanupShuffle);
       }
     }
+  }
+
+  @VisibleForTesting
+  public HashSet<Integer> getShuffleIdSet(int appShuffleId) {
+    return shuffleIdMap.get(appShuffleId);
   }
 }

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/TestCelebornShuffleManager.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/TestCelebornShuffleManager.java
@@ -17,6 +17,9 @@
 
 package org.apache.spark.shuffle.celeborn;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
 import org.apache.spark.shuffle.ShuffleHandle;
@@ -32,6 +35,24 @@ public class TestCelebornShuffleManager extends SparkShuffleManager {
 
   public static void registerReaderGetHook(ShuffleManagerHook hook) {
     shuffleReaderGetHook = hook;
+  }
+
+  private static ExecutorShuffleIdTracker executorShuffleIdTracker = null;
+  private static AtomicBoolean initShuffleIdTracker = new AtomicBoolean(false);
+
+  public static void staticRegisterExecutorShuffleIdTracker(ExecutorShuffleIdTracker tracker) {
+    executorShuffleIdTracker = tracker;
+    initShuffleIdTracker.set(false);
+  }
+
+  @Override
+  public <K, V, C> ShuffleHandle registerShuffle(
+      int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency) {
+    if (executorShuffleIdTracker != null && !initShuffleIdTracker.get()) {
+      super.registerExecutorShuffleIdTracker(executorShuffleIdTracker);
+      initShuffleIdTracker.set(true);
+    }
+    return super.registerShuffle(shuffleId, numMaps, dependency);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Decide whether to reuse the shuffle id based on the appShuffle's numAvailableOutputs instead of deterministic level 


### Why are the changes needed?
In Spark, the DAGScheduler determines whether to reuse task output based on multiple factors, deterministic level is one of them, but not all. I constructed a case in the test, where a shuffleId should be regenerated instead of reused. IMO, celeborn should decide whether to reuse the shuffle id based on whether the map output is empty, which means to delegating the decision of reusing previous attempt results to the DAGScheduler.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add a test:  org.apache.celeborn.tests.spark.CelebornFetchFailureSuite#test("celeborn spark integration test - resubmit a barrier stage and do not reuse the shuffle id")