### PR TITLE
[CELEBORN-1507] Prevent invalid Filegroups from being used

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1669,7 +1669,9 @@ public class ShuffleClientImpl extends ShuffleClient {
   public ReduceFileGroups updateFileGroup(int shuffleId, int partitionId)
       throws CelebornIOException {
     Tuple2<ReduceFileGroups, String> fileGroupTuple =
-            reduceFileGroupsMap.compute(shuffleId, (id, existsTuple) -> {
+        reduceFileGroupsMap.compute(
+            shuffleId,
+            (id, existsTuple) -> {
               if (existsTuple == null || existsTuple._1 == null) {
                 return loadFileGroupInternal(shuffleId);
               } else {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1669,6 +1669,13 @@ public class ShuffleClientImpl extends ShuffleClient {
   public ReduceFileGroups updateFileGroup(int shuffleId, int partitionId)
       throws CelebornIOException {
     Tuple2<ReduceFileGroups, String> fileGroupTuple =
+            reduceFileGroupsMap.compute(shuffleId, (id, existsTuple) -> {
+              if (existsTuple == null || existsTuple._1 == null) {
+                return loadFileGroupInternal(shuffleId);
+              } else {
+                return existsTuple;
+              }
+            });
         reduceFileGroupsMap.computeIfAbsent(shuffleId, (id) -> loadFileGroupInternal(shuffleId));
     // when the cache is invalid, it should be fetched by oneself.
     if (fileGroupTuple._2 != null) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1670,6 +1670,11 @@ public class ShuffleClientImpl extends ShuffleClient {
       throws CelebornIOException {
     Tuple2<ReduceFileGroups, String> fileGroupTuple =
         reduceFileGroupsMap.computeIfAbsent(shuffleId, (id) -> loadFileGroupInternal(shuffleId));
+    // when the cache is invalid, it should be fetched by oneself.
+    if (fileGroupTuple._2 != null) {
+      reduceFileGroupsMap.remove(shuffleId);
+      fileGroupTuple = loadFileGroupInternal(shuffleId);
+    }
     if (fileGroupTuple._1 == null) {
       throw new CelebornIOException(
           loadFileGroupException(shuffleId, partitionId, (fileGroupTuple._2)));

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1676,12 +1676,6 @@ public class ShuffleClientImpl extends ShuffleClient {
                 return existsTuple;
               }
             });
-        reduceFileGroupsMap.computeIfAbsent(shuffleId, (id) -> loadFileGroupInternal(shuffleId));
-    // when the cache is invalid, it should be fetched by oneself.
-    if (fileGroupTuple._2 != null) {
-      reduceFileGroupsMap.remove(shuffleId);
-      fileGroupTuple = loadFileGroupInternal(shuffleId);
-    }
     if (fileGroupTuple._1 == null) {
       throw new CelebornIOException(
           loadFileGroupException(shuffleId, partitionId, (fileGroupTuple._2)));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Prevent invalid Filegroups from being used.


### Why are the changes needed?

#2531 introduced a new feature regarding Filegroups. For multiple tasks belonging to the same shuffleKey, only one of them will actively fetch, and the others will use the cached results in memory. If the Task that actively fetches the Filegroups is killed for some reason (such as another attempt succeeded), it will cause other tasks to obtain invalid Filegroups, eventually leading to stage retry.

![image](https://github.com/user-attachments/assets/7bb258bc-3c9b-457d-a583-2c60888af0e2)

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Internal test.
