### PR TITLE
[CELEBORN-1510] Partial task unable to switch to the replica

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -344,6 +344,11 @@ public abstract class CelebornInputStream extends InputStream {
           if (isExcluded(location)) {
             throw new CelebornIOException("Fetch data from excluded worker! " + location);
           }
+          // should switch the location at a high level
+          if (fetchChunkRetryCnt == 0 && attemptNumber % 2 == 1 && location.hasPeer()) {
+            location = location.getPeer();
+            logger.info("Read peer {} for attempt {}.", location, attemptNumber);
+          }
           return createReader(location, pbStreamHandler, fetchChunkRetryCnt, fetchChunkMaxRetry);
         } catch (Exception e) {
           lastException = e;
@@ -432,13 +437,7 @@ public abstract class CelebornInputStream extends InputStream {
         int fetchChunkRetryCnt,
         int fetchChunkMaxRetry)
         throws IOException, InterruptedException {
-      if (!location.hasPeer()) {
-        logger.debug("Partition {} has only one partition replica.", location);
-      } else if (pbStreamHandler == null && attemptNumber % 2 == 1) {
-        location = location.getPeer();
-        logger.debug("Read peer {} for attempt {}.", location, attemptNumber);
-      }
-      logger.debug("Create reader for location {}", location);
+      logger.info("Create reader for location {}", location);
 
       StorageInfo storageInfo = location.getStorageInfo();
       switch (storageInfo.getType()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Attempt%2 = 1 unable to switch to the replica

### Why are the changes needed?

When Attempt equals 1, createReader will access location.peer. Special circumstances can lead to unexpected behaviors. For example, an exception occurs during the process of obtaining data and the peer needs to be used. However, this logic will switch to the abnormal node again.

<img width="1626" alt="image" src="https://github.com/user-attachments/assets/21c50953-db0f-4717-9b91-e3aeae16ece2">
<img width="1652" alt="image" src="https://github.com/user-attachments/assets/7430786c-26a4-4b3b-be68-f8bdf780c58c">

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Internal test.