### PR TITLE
[CELEBORN-1436][FOLLOWUP] Fix REST API endpoint of decommissioning in decommissioning.md

### DIFF
--- a/docs/decommissioning.md
+++ b/docs/decommissioning.md
@@ -61,15 +61,15 @@ Administrators perform decommissioning operation in two approaches:
 
 1. Via Celeborn Worker REST API endpoint:
   ```shell
-  curl -X POST -d "type=Decommission" http://ip:port/exit
+  curl -X POST -H "Content-Type: application/json" -d '{"type":"Decommission"}' http://ip:port/api/v1/workers/exit
   ```
 2. Via Celeborn Master(Leader) REST API endpoint:
   ```shell
-  curl -X POST -d "type=Decommission&workers=ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort" http://ip:port/sendWorkerEvent
-  curl -X POST -d "type=DecommissionThenIdle&workers=ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort" http://ip:port/sendWorkerEvent
+  curl -X POST -H "Content-Type: application/json" -d '{"eventType":"Decommission","workers":"ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort"}' http://ip:port/api/v1/workers/events
+  curl -X POST -H "Content-Type: application/json" -d '{"eventType":"DecommissionThenIdle","workers":"ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort"}' http://ip:port/api/v1/workers/events
   ```
 
-Details of decommissioning interface can refer to [REST API](../monitoring/#rest-api)
+Details of decommissioning interface can refer to [REST API](../webapi/#rest-api)
 
 ## Decommission Monitoring
 

--- a/docs/decommissioning.md
+++ b/docs/decommissioning.md
@@ -65,8 +65,8 @@ Administrators perform decommissioning operation in two approaches:
   ```
 2. Via Celeborn Master(Leader) REST API endpoint:
   ```shell
-  curl -X POST -H "Content-Type: application/json" -d '{"eventType":"Decommission","workers":"ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort"}' http://ip:port/api/v1/workers/events
-  curl -X POST -H "Content-Type: application/json" -d '{"eventType":"DecommissionThenIdle","workers":"ip_1:rpcPort:pushPort:fetchPort:replicatePort,ip_2:rpcPort:pushPort:fetchPort:replicatePort"}' http://ip:port/api/v1/workers/events
+  curl -X POST -H "Content-Type: application/json" -d '{"eventType":"Decommission","workers":[{"host":"192.168.15.140","rpcPort":"37359","pushPort":"38303","fetchPort":"37569","replicatePort":"37093"},{"host":"192.168.15.141","rpcPort":"37359","pushPort":"38303","fetchPort":"37569","replicatePort":"37093"}]}' http://ip:port/api/v1/workers/events
+  curl -X POST -H "Content-Type: application/json" -d '{"eventType":"DecommissionThenIdle","workers":[{"host":"192.168.15.140","rpcPort":"37359","pushPort":"38303","fetchPort":"37569","replicatePort":"37093"},{"host":"192.168.15.141","rpcPort":"37359","pushPort":"38303","fetchPort":"37569","replicatePort":"37093"}]}' http://ip:port/api/v1/workers/events
   ```
 
 Details of decommissioning interface can refer to [REST API](../webapi/#rest-api)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix REST API endpoint of decommissioning in `decommissioning.md`.

### Why are the changes needed?

`/sendWorkerEvent` and `/exit` have already migrated to `/api/v1/workers/events` and `/api/v1/workers/exit`. Meanwhile, the `monitoring.md` has migrated to `webapi.md`. Therefore, the REST API endpoint of decommissioning in `decommissioning.md` should also be migrated.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.