### PR TITLE
[CELEBORN-1512] Bump Flink from 1.19.0 to 1.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1671,7 +1671,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>1.19.0</flink.version>
+        <flink.version>1.19.1</flink.version>
         <flink.binary.version>1.19</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.19_${scala.binary.version}</celeborn.flink.plugin.artifact>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -954,7 +954,7 @@ object Flink118 extends FlinkClientProjects {
 }
 
 object Flink119 extends FlinkClientProjects {
-  val flinkVersion = "1.19.0"
+  val flinkVersion = "1.19.1"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-1.19"
@@ -984,7 +984,7 @@ trait FlinkClientProjects {
     .aggregate(flinkCommon, flinkClient, flinkIt)
 
   // get flink major version. e.g:
-  //   1.19.0 -> 1.19
+  //   1.19.1 -> 1.19
   //   1.18.1 -> 1.18
   //   1.17.2 -> 1.17
   //   1.15.4 -> 1.15


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Flink from 1.19.0 to 1.19.1.

### Why are the changes needed?

Flink 1.19.1 has been announced to release: [Apache Flink 1.19.1 Release Announcement](https://nightlies.apache.org/flink/flink-docs-release-1.19/release-notes/flink-1.19). The profile flink-1.19 could bump Flink from 1.19.0 to 1.19.1.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.