### PR TITLE
[CELEBORN-1318][FOLLOWUP] Upload the celeborn-common to nexus staging for http authentication extensions 

### DIFF
--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -127,6 +127,9 @@ upload_nexus_staging() {
 
   echo "Deploying celeborn-openapi-client_2.12"
   ${PROJECT_DIR}/build/sbt "clean;celeborn-openapi-client/publishSigned"
+
+  echo "Deploying celeborn-common_2.12"
+  ${PROJECT_DIR}/build/sbt "clean;celeborn-common/publishSigned"
 }
 
 finalize_svn() {

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -446,6 +446,7 @@ object CelebornCommon {
     .settings (
       commonSettings,
       protoSettings,
+      releaseSettings,
       libraryDependencies ++= Seq(
         Dependencies.protobufJava,
         Dependencies.findbugsJsr305,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Since https://github.com/apache/celeborn/pull/2440, http authentication is supported.

In this pr, we deploy the `celeborn-common` so that users can leverage the SDK for http authentication extensions. 

### Why are the changes needed?

For http authentication extensions in users end.

### Does this PR introduce _any_ user-facing change?

No, just deploy the `celeborn-common` dependency.

### How was this patch tested?
Run the command locally.
