### PR TITLE
[CELEBORN-1515] SparkShuffleManager should set lifecycleManager to null after stopping lifecycleManager in Spark 2

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -168,6 +168,7 @@ public class SparkShuffleManager implements ShuffleManager {
     }
     if (lifecycleManager != null) {
       lifecycleManager.stop();
+      lifecycleManager = null;
     }
     if (_sortShuffleManager != null) {
       _sortShuffleManager.stop();


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkShuffleManager` set `lifecycleManager` to null after stopping `lifecycleManager` in Spark 2.

### Why are the changes needed?

`SparkShuffleManager` should set `lifecycleManager` to null after stopping `lifecycleManager` for `stop` to avoid using stopped `lifecycleManager` in Spark 2.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.