### PR TITLE
[CELEBORN-1477][FOLLOWUP] Fix shaded celeborn-openapi-client dependency lack issue

### DIFF
--- a/openapi/openapi-client/pom.xml
+++ b/openapi/openapi-client/pom.xml
@@ -57,8 +57,28 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2.external</groupId>
+      <artifactId>jakarta.inject</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-entity-filtering</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -67,6 +87,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -79,6 +103,10 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.mimepull</groupId>
+      <artifactId>mimepull</artifactId>
     </dependency>
   </dependencies>
 
@@ -190,6 +218,26 @@
               </sources>
             </configuration>
           </execution>
+          <!--
+          This is to ensure references to shaded classes can be resolved in IDEs such as Intellij.
+          For reference: https://youtrack.jetbrains.com/issue/IDEA-126596
+          -->
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${basedir}/target/${project.artifactId}-${project.version}.jar</file>
+                  <type>jar</type>
+                  <classifier>optional</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -226,8 +274,36 @@
               <shadedPattern>${shading.prefix}.jakarta.validation</shadedPattern>
             </relocation>
             <relocation>
+              <pattern>javax.inject</pattern>
+              <shadedPattern>${shading.prefix}.javax.inject</shadedPattern>
+            </relocation>
+            <relocation>
               <pattern>javax.validation</pattern>
               <shadedPattern>${shading.prefix}.javax.validation</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>javax.ws.rs</pattern>
+              <shadedPattern>${shading.prefix}.javax.ws.rs</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.jvnet.mimepull</pattern>
+              <shadedPattern>${shading.prefix}.org.jvnet.mimepull</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>META-INF/versions/11/com/fasterxml/jackson</pattern>
+              <shadedPattern>META-INF/versions/11/org/apache/celeborn/shaded/com/fasterxml/jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>META-INF/versions/17/com/fasterxml/jackson</pattern>
+              <shadedPattern>META-INF/versions/17/org/apache/celeborn/shaded/com/fasterxml/jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>META-INF/versions/19/com/fasterxml/jackson</pattern>
+              <shadedPattern>META-INF/versions/19/org/apache/celeborn/shaded/com/fasterxml/jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>META-INF/versions/11/org/glassfish/jersey</pattern>
+              <shadedPattern>META-INF/versions/11/org/apache/celeborn/shaded/org/glassfish/jersey</shadedPattern>
             </relocation>
           </relocations>
           <artifactSet>
@@ -237,11 +313,18 @@
               <include>org.openapitools:jackson-databind-nullable</include>
               <include>com.google.code.findbugs:jsr305</include>
               <include>org.glassfish.jersey.core:jersey-client</include>
+              <include>org.glassfish.jersey.core:jersey-common</include>
+              <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
               <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
               <include>com.fasterxml.jackson.core:jackson-annotations</include>
+              <include>com.fasterxml.jackson.core:jackson-core</include>
               <include>com.fasterxml.jackson.core:jackson-databind</include>
               <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+              <include>jakarta.annotation:jakarta.annotation-api</include>
+              <include>jakarta.ws.rs:jakarta.ws.rs-api</include>
+              <include>org.glassfish.hk2.external:jakarta.inject</include>
               <include>org.glassfish.jersey.media:jersey-media-multipart</include>
+              <include>org.jvnet.mimepull:mimepull</include>
             </includes>
           </artifactSet>
           <filters>
@@ -252,8 +335,12 @@
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
                 <exclude>**/log4j.properties</exclude>
-                <exclude>META-INF/LICENSE.txt</exclude>
-                <exclude>META-INF/NOTICE.txt</exclude>
+                <exclude>META-INF/DEPENDENCIES</exclude>
+                <exclude>META-INF/*LICENSE*</exclude>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+                <exclude>META-INF/native-image/**</exclude>
+                <exclude>META-INF/*NOTICE*</exclude>
+                <exclude>META-INF/**/module-info.class</exclude>
                 <exclude>LICENSE.txt</exclude>
                 <exclude>NOTICE.txt</exclude>
               </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,11 @@
     <swagger-ui.version>4.9.1</swagger-ui.version>
     <jersey.version>2.39.1</jersey.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
+    <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+    <jakarta.inject.version>2.6.1</jakarta.inject.version>
     <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
+    <jakarta.ws.rs.version>2.1.6</jakarta.ws.rs.version>
+    <mimepull.version>1.9.15</mimepull.version>
     <!-- openapi-generator dependencies -->
     <openapitools.jackson-databind-nullable.version>0.2.6</openapitools.jackson-databind-nullable.version>
     <openapitools.swagger.version>1.6.11</openapitools.swagger.version>
@@ -492,6 +496,24 @@
       </dependency>
 
       <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>${jakarta.annotation-api.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakarta.ws.rs.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jvnet.mimepull</groupId>
+        <artifactId>mimepull</artifactId>
+        <version>${mimepull.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.openapitools</groupId>
         <artifactId>jackson-databind-nullable</artifactId>
         <version>${openapitools.jackson-databind-nullable.version}</version>
@@ -516,6 +538,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.glassfish.hk2.external</groupId>
+        <artifactId>jakarta.inject</artifactId>
+        <version>${jakarta.inject.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-server</artifactId>
         <version>${jersey.version}</version>
@@ -528,8 +556,26 @@
       </dependency>
 
       <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-common</artifactId>
+        <version>${jersey.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-servlet-core</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish.jersey.ext</groupId>
+        <artifactId>jersey-entity-filtering</artifactId>
         <version>${jersey.version}</version>
       </dependency>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

I am working on the integration with our devOps tool integration, and found issues due to dependency lack in the shaded jar:
Likes:
```
java.lang.NoClassDefFoundError: org/apache/celeborn/shaded/com/fasterxml/jackson/core/Versioned
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at org.apache.celeborn.rest.v1.master.invoker.ApiClient.<init>(ApiClient.java:122)
	at org.apache.celeborn.rest.v1.master.invoker.ApiClient.<init>(ApiClient.java:113)



java.lang.NoClassDefFoundError: org/apache/celeborn/shaded/org/glassfish/jersey/ExtendedConfig
	at org.apache.celeborn.rest.v1.master.invoker.ApiClient.getDefaultClientConfig(ApiClient.java:1132)
	at org.apache.celeborn.rest.v1.master.invoker.ApiClient.buildHttpClient(ApiClient.java:1118)
	at org.apache.celeborn.rest.v1.master.invoker.ApiClient.<init>(ApiClient.java:123)
	at org.apache.celeborn.rest.v1.master.invoker.ApiClient.<init>(ApiClient.java:113)
```

In this PR, I include all the necessary dependencies.

### Why are the changes needed?
Fix above issues.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Testing with sample maven project.

pom.xml:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>org.example</groupId>
    <artifactId>test_openapi</artifactId>
    <version>1.0-SNAPSHOT</version>

    <properties>
        <maven.compiler.source>8</maven.compiler.source>
        <maven.compiler.target>8</maven.compiler.target>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>

    <dependencies>
        <dependency>
            <groupId>org.apache.celeborn</groupId>
            <artifactId>celeborn-openapi-client_2.12</artifactId>
            <version>0.6.0-SNAPSHOT</version>
        </dependency>
    </dependencies>
</project>
```

Testing code:
```
package org.example;

import org.apache.celeborn.rest.v1.master.MasterApi;
import org.apache.celeborn.rest.v1.master.WorkerApi;
import org.apache.celeborn.rest.v1.master.invoker.ApiClient;

public class Main {
    public static void main(String[] args) throws Exception {

        String cmUrl = "http://***:9098";
        MasterApi masterApi  = new MasterApi(new ApiClient().setBasePath(cmUrl));
        System.out.println(masterApi.getMasterGroupInfo().getLeader().getAddress().split(":")[0]);
        WorkerApi workerApi = new WorkerApi(new ApiClient().setBasePath(cmUrl));
        System.out.println(workerApi.getWorkers());
        System.out.println(workerApi.getWorkerEvents());
    }
}
```

```
java -Dfile.encoding=UTF-8 -classpath /Users/fwang12/todo/test_openapi/target/classes:/Users/fwang12/todo/celeborn/openapi/openapi-client/target/celeborn-openapi-client_2.12-0.6.0-SNAPSHOT.jar org.example.Main
```

<img width="1688" alt="image" src="https://github.com/user-attachments/assets/84f4fc8c-b9a8-44d6-ac4d-aba99bf31fd2">
