### PR TITLE
[CELEBORN-1519] Do not update estimated partition size if it is unchanged

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -468,6 +468,12 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     } else {
       estimatedPartitionSize = initialEstimatedPartitionSize;
     }
+
+    // Do not trigger update is estimated partition size value is unchanged
+    if (estimatedPartitionSize == oldEstimatedPartitionSize) {
+      return;
+    }
+
     LOG.warn(
         "Celeborn cluster estimated partition size changed from {} to {}",
         Utils.bytesToString(oldEstimatedPartitionSize),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

We will not update the estimated partition size if it is unchanged.

### Why are the changes needed?

Celeborn currently triggers an workerinfo update even-though the estimated partition size is not changed. This leads to unnecessary logging and redundant worker info update operations.

Example log -

```
[master-partition-size-updater] WARN org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager - Celeborn cluster estimated partition size changed from 64.0 MiB to 64.0 MiB 
```

### Does this PR introduce _any_ user-facing change?

NO


### How was this patch tested?
Existing UT's
