### PR TITLE
[CELEBORN-1522] Fix applicationId extraction from shuffle key

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -327,7 +327,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
 
       registeredShuffle.forEach(
           shuffleKey -> {
-            String appId = shuffleKey.split("-")[0];
+            String appId = Utils.splitShuffleKey(shuffleKey)._1;
             if (!appHeartbeatTime.containsKey(appId)) {
               appHeartbeatTime.put(appId, System.currentTimeMillis());
             }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -531,7 +531,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         keyedWriters._1 -> keyedWriters._2.values().asScala.map(_.getFileLength).sum
       }
     }.toList.map { case (shuffleKey, usage) =>
-      shuffleKey.split("-")(0) -> usage
+      Utils.splitShuffleKey(shuffleKey)._1 -> usage
     }.groupBy(_._1).map { case (key, values) =>
       key -> values.map(_._2).sum
     }.toSeq.sortBy(_._2).reverse.take(conf.metricsAppTopDiskUsageCount * 2).toMap.asJava


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix applicationId extraction from shuffle key.

### Why are the changes needed?

For spark on k8s, the applicationId might be `spark-da4571bd2cbf491c892cbd4de40fc918`.

Due the application extraction is not correct, the result of API `/api/v1/applications/top_disk_usages` is not correct.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not needed, just leverage existing method.