### PR TITLE
[CELEBORN-1524] Support IPv6 hostnames for Apache Ratis

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -174,7 +174,7 @@ public class HARaftServer {
         TimeUnit.MILLISECONDS);
   }
 
-  // copy of org.apache.ratis.util.NetUtils.address2String https://github.com/apache/ratis/pull/1125
+  // copy of org.apache.ratis.util.NetUtils.address2String
   private static String address2String(InetSocketAddress address) {
     if (address == null) {
       return null;
@@ -200,6 +200,8 @@ public class HARaftServer {
     RaftPeer localRaftPeer =
         RaftPeer.newBuilder()
             .setId(localRaftPeerId)
+            // TODO(CELEBORN-1525): Once Ratis 3.2.0 is released and we move to it, we
+            // should remove address2String and change this to .setAddress(ratisAddr)
             .setAddress(address2String(ratisAddr))
             .setClientAddress(localNode.rpcEndpoint())
             // We use admin address to host the internal rpc address

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.service.deploy.master.clustermeta.ha;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +35,7 @@ import javax.net.ssl.TrustManager;
 import scala.Tuple2;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.InetAddresses;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.RaftClientConfigKeys;
@@ -172,6 +174,22 @@ public class HARaftServer {
         TimeUnit.MILLISECONDS);
   }
 
+  // copy of org.apache.ratis.util.NetUtils.address2String https://github.com/apache/ratis/pull/1125
+  private static String address2String(InetSocketAddress address) {
+    if (address == null) {
+      return null;
+    }
+    String hostName = address.getHostName();
+    final StringBuilder b = new StringBuilder(hostName);
+    // Surround with '[', ']' only if it is a IPv6 ip - not for a IPv6 host
+    if (address.getAddress() instanceof Inet6Address
+        && InetAddresses.isInetAddress(hostName)
+        && InetAddresses.forString(hostName).getAddress().length == 16) {
+      b.insert(0, '[').append(']');
+    }
+    return b.append(':').append(address.getPort()).toString();
+  }
+
   public static HARaftServer newMasterRatisServer(
       MetaHandler metaHandler, CelebornConf conf, MasterNode localNode, List<MasterNode> peerNodes)
       throws IOException {
@@ -182,7 +200,7 @@ public class HARaftServer {
     RaftPeer localRaftPeer =
         RaftPeer.newBuilder()
             .setId(localRaftPeerId)
-            .setAddress(ratisAddr)
+            .setAddress(address2String(ratisAddr))
             .setClientAddress(localNode.rpcEndpoint())
             // We use admin address to host the internal rpc address
             .setAdminAddress(localNode.internalRpcEndpoint())
@@ -209,7 +227,7 @@ public class HARaftServer {
             raftPeer =
                 RaftPeer.newBuilder()
                     .setId(raftPeerId)
-                    .setAddress(peerRatisAddr)
+                    .setAddress(address2String(peerRatisAddr))
                     .setClientAddress(peer.rpcEndpoint())
                     // We use admin address to host the internal rpc address
                     .setAdminAddress(peer.internalRpcEndpoint())

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -41,15 +41,9 @@ case class MasterNode(
 
   def rpcEndpoint: String = rpcHost + ":" + rpcPort
 
-  def rpcIpEndpoint: String = rpcAddr.getAddress.getHostAddress + ":" + rpcPort
-
   def internalRpcEndpoint: String = rpcHost + ":" + internalRpcPort
 
-  def internalRpcIpEndpoint: String = rpcAddr.getAddress.getHostAddress + ":" + rpcPort
-
   lazy val ratisAddr = MasterNode.createSocketAddr(ratisHost, ratisPort)
-
-  lazy val rpcAddr = MasterNode.createSocketAddr(rpcHost, rpcPort)
 }
 
 object MasterNode extends Logging {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Workaround a Apache Ratis bug in Celeborn until a new Ratis release with the fix is released which we can use.


### Why are the changes needed?

[RATIS-2131](https://issues.apache.org/jira/browse/RATIS-2131) has been fixed, and will be available in 3.2.0 - until it is released, this will work around the issue.


### Does this PR introduce _any_ user-facing change?

Fixes a bug


### How was this patch tested?

Manual testing in IPv6 env with hostnames for ratis config.