### PR TITLE
[CELEBORN-1527] Error prone plugin should exclude target/generated-sources/java of module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1135,7 +1135,7 @@
             <compilerArgs>
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne \
-                -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                -XepExcludedPaths:.*/target/generated-sources/.* \
                 -Xep:BadImport:OFF \
                 -Xep:EmptyBlockTag:OFF \
                 -Xep:EmptyCatch:OFF \
@@ -1497,7 +1497,7 @@
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
-                  -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                  -XepExcludedPaths:.*/target/generated-sources/.* \
                   -Xep:BadImport:OFF \
                   -Xep:EmptyBlockTag:OFF \
                   -Xep:EmptyCatch:OFF \
@@ -1557,7 +1557,7 @@
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
-                  -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                  -XepExcludedPaths:.*/target/generated-sources/.* \
                   -Xep:BadImport:OFF \
                   -Xep:EmptyBlockTag:OFF \
                   -Xep:EmptyCatch:OFF \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Error prone plugin excludes `target/generated-sources/java` of module.

### Why are the changes needed?

Error prone plugin only excludes `target/generated-sources/protobuf` of module, which should also exclude `target/generated-sources/java` for `openapi` module.

```
$ mvn clean install -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[59,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[75,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[95,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[110,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[130,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[145,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[166,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java:[182,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ApiClient.java:[1107,28] [InlineMeSuggester] This deprecated API looks inlineable. If you'd like the body of the API to be inlined to its callers, please annotate it with @InlineMe.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/model/SendWorkerEventRequest.java:[59,19] [ImmutableEnumChecker] enums should be immutable: 'EventTypeEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ApplicationApi.java:[55,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ApplicationApi.java:[70,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ApplicationApi.java:[90,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ApplicationApi.java:[105,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ApiClient.java:[1107,28] [InlineMeSuggester] This deprecated API looks inlineable. If you'd like the body of the API to be inlined to its callers, please annotate it with @InlineMe.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/model/DynamicConfig.java:[54,19] [ImmutableEnumChecker] enums should be immutable: 'LevelEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ShuffleApi.java:[55,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ShuffleApi.java:[70,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ShuffleApi.java:[90,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ShuffleApi.java:[105,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/model/PartitionLocationData.java:[58,19] [ImmutableEnumChecker] enums should be immutable: 'ModeEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/model/PartitionLocationData.java:[107,19] [ImmutableEnumChecker] enums should be immutable: 'StorageEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/DefaultApi.java:[54,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/DefaultApi.java:[69,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/model/DynamicConfig.java:[54,19] [ImmutableEnumChecker] enums should be immutable: 'LevelEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java:[56,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java:[71,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java:[91,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java:[106,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java:[126,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java:[141,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/MasterApi.java:[54,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/MasterApi.java:[70,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ConfApi.java:[55,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ConfApi.java:[70,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ConfApi.java:[93,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/ConfApi.java:[112,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/DefaultApi.java:[54,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/DefaultApi.java:[69,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ShuffleApi.java:[54,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ShuffleApi.java:[69,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java:[57,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java:[72,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java:[92,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java:[107,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java:[128,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java:[144,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/worker/model/WorkerExitRequest.java:[51,19] [ImmutableEnumChecker] enums should be immutable: 'TypeEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ConfApi.java:[55,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ConfApi.java:[70,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ConfApi.java:[93,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-client/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/master/ConfApi.java:[112,5] [InvalidBlockTag] Tag name `http.response.details` is unknown. If this is a commonly-used custom tag, please click 'not useful' and file a bug.
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-model/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java:[51,19] [ImmutableEnumChecker] enums should be immutable: 'TypeEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-model/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java:[59,19] [ImmutableEnumChecker] enums should be immutable: 'EventTypeEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-model/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfig.java:[54,19] [ImmutableEnumChecker] enums should be immutable: 'LevelEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-model/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/model/PartitionLocationData.java:[58,19] [ImmutableEnumChecker] enums should be immutable: 'ModeEnum' has non-final field 'value'
[WARNING] /Users/nicholas/Github/celeborn/openapi/openapi-model/target/generated-sources/java/src/main/java/org/apache/celeborn/rest/v1/model/PartitionLocationData.java:[107,19] [ImmutableEnumChecker] enums should be immutable: 'StorageEnum' has non-final field 'value'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local test.

```
$ mvn clean install -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
```