### PR TITLE
[CELEBORN-1190][FOLLOWUP] Update WARNING checks of error prone to ERROR for CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1136,6 +1136,27 @@
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne \
                 -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                -Xep:AssertThrowsMultipleStatements:ERROR \
+                -Xep:ByteBufferBackingArray:ERROR \
+                -Xep:CacheLoaderNull:ERROR \
+                -Xep:CanonicalDuration:ERROR \
+                -Xep:ClassCanBeStatic:ERROR \
+                -Xep:DefaultCharset:ERROR \
+                -Xep:InconsistentCapitalization:ERROR \
+                -Xep:IntLongMath:ERROR \
+                -Xep:InvalidParam:ERROR \
+                -Xep:JavaUtilDateChecker:ERROR \
+                -Xep:MissingCasesInEnumSwitch:ERROR \
+                -Xep:MissingOverride:ERROR \
+                -Xep:NonAtomicVolatileUpdate:ERROR \
+                -Xep:StaticAssignmentInConstructor:ERROR \
+                -Xep:SynchronizeOnNonFinalField:ERROR \
+                -Xep:ThreadLocalUsage:ERROR \
+                -Xep:UnescapedEntity:ERROR \
+                -Xep:UnnecessaryAssignment:ERROR \
+                -Xep:UnusedMethod:ERROR \
+                -Xep:UnusedNestedClass:ERROR \
+                -Xep:UseCorrectAssertInTests:ERROR \
                 -Xep:BadImport:OFF \
                 -Xep:EmptyBlockTag:OFF \
                 -Xep:EmptyCatch:OFF \
@@ -1498,6 +1519,27 @@
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
                   -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                  -Xep:AssertThrowsMultipleStatements:ERROR \
+                  -Xep:ByteBufferBackingArray:ERROR \
+                  -Xep:CacheLoaderNull:ERROR \
+                  -Xep:CanonicalDuration:ERROR \
+                  -Xep:ClassCanBeStatic:ERROR \
+                  -Xep:DefaultCharset:ERROR \
+                  -Xep:InconsistentCapitalization:ERROR \
+                  -Xep:IntLongMath:ERROR \
+                  -Xep:InvalidParam:ERROR \
+                  -Xep:JavaUtilDateChecker:ERROR \
+                  -Xep:MissingCasesInEnumSwitch:ERROR \
+                  -Xep:MissingOverride:ERROR \
+                  -Xep:NonAtomicVolatileUpdate:ERROR \
+                  -Xep:StaticAssignmentInConstructor:ERROR \
+                  -Xep:SynchronizeOnNonFinalField:ERROR \
+                  -Xep:ThreadLocalUsage:ERROR \
+                  -Xep:UnescapedEntity:ERROR \
+                  -Xep:UnnecessaryAssignment:ERROR \
+                  -Xep:UnusedMethod:ERROR \
+                  -Xep:UnusedNestedClass:ERROR \
+                  -Xep:UseCorrectAssertInTests:ERROR \
                   -Xep:BadImport:OFF \
                   -Xep:EmptyBlockTag:OFF \
                   -Xep:EmptyCatch:OFF \
@@ -1558,6 +1600,27 @@
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
                   -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                  -Xep:AssertThrowsMultipleStatements:ERROR \
+                  -Xep:ByteBufferBackingArray:ERROR \
+                  -Xep:CacheLoaderNull:ERROR \
+                  -Xep:CanonicalDuration:ERROR \
+                  -Xep:ClassCanBeStatic:ERROR \
+                  -Xep:DefaultCharset:ERROR \
+                  -Xep:InconsistentCapitalization:ERROR \
+                  -Xep:IntLongMath:ERROR \
+                  -Xep:InvalidParam:ERROR \
+                  -Xep:JavaUtilDateChecker:ERROR \
+                  -Xep:MissingCasesInEnumSwitch:ERROR \
+                  -Xep:MissingOverride:ERROR \
+                  -Xep:NonAtomicVolatileUpdate:ERROR \
+                  -Xep:StaticAssignmentInConstructor:ERROR \
+                  -Xep:SynchronizeOnNonFinalField:ERROR \
+                  -Xep:ThreadLocalUsage:ERROR \
+                  -Xep:UnescapedEntity:ERROR \
+                  -Xep:UnnecessaryAssignment:ERROR \
+                  -Xep:UnusedMethod:ERROR \
+                  -Xep:UnusedNestedClass:ERROR \
+                  -Xep:UseCorrectAssertInTests:ERROR \
                   -Xep:BadImport:OFF \
                   -Xep:EmptyBlockTag:OFF \
                   -Xep:EmptyCatch:OFF \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `WARNING` checks of error prone to `ERROR` for CI.

 Follow up #2177, #2180, #2555.

### Why are the changes needed?

Error prone generates some WARNING in complication, which has been fixed in #2177, #2180, #2555. Therefore, the following WARNING checks should be updated to ERROR for CI, which rules are supported in error prone [2.10.0](https://github.com/google/error-prone/blob/v2.10.0/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java#L750) and [2.25.0](https://github.com/google/error-prone/blob/v2.25.0/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java#L831):

- AssertThrowsMultipleStatements
- ByteBufferBackingArray
- CacheLoaderNull
- CanonicalDuration
- ClassCanBeStatic
- DefaultCharset
- InconsistentCapitalization
- IntLongMath
- InvalidParam
- JavaUtilDateChecker
- MissingCasesInEnumSwitch
- MissingOverride
- NonAtomicVolatileUpdate
- StaticAssignmentInConstructor
- SynchronizeOnNonFinalField
- ThreadLocalUsage
- UnescapedEntity
- UnnecessaryAssignment
- UnusedMethod
- UnusedNestedClass
- UseCorrectAssertInTests

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.