### PR TITLE
[CELEBORN-1528][HELM] Use volumeClaimTemplates to support various storage backend

### DIFF
--- a/charts/celeborn/Chart.yaml
+++ b/charts/celeborn/Chart.yaml
@@ -22,7 +22,7 @@ description: >
   Intermediate data typically include shuffle and spilled data.
 type: application
 version: 0.1.0
-appVersion: 0.4.0
+appVersion: 0.5.1
 keywords:
   - Apache Celeborn
   - Big Data

--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -15,122 +15,106 @@
 # limitations under the License.
 #
 
-# Default values for celeborn.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-# Specifies the Celeborn image to use
 image:
-  # -- Image repository
-  repository: apache/celeborn
-  # -- Image tag
   tag: latest
-  # -- Image pull policy
-  pullPolicy: IfNotPresent
 
-# -- Specifies the number of Celeborn master replicas to deploy
-masterReplicas: 1
-# -- Specifies the number of Celeborn worker replicas to deploy
-workerReplicas: 1
+master:
+  replicas: 1
 
-service:
-  # -- Specifies service type
-  type: ClusterIP
-  # -- Specifies service port
-  port: 9097
+  volumeClaimTemplates:
+  - metadata:
+      name: volume-ratis
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+        limits:
+          storage: 1Gi
+      storageClassName: standard
 
-cluster:
-  # -- Specifies Kubernetes cluster name
-  name: cluster
+  dnsPolicy: ClusterFirstWithHostNet
 
-# Specifies Celeborn volumes.
-# Currently supported volume types are `emptyDir` and `hostPath`.
-# Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
-# Celeborn Master will pick first volumes for store raft log.
-# `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
-volumes:
-  # -- Specifies volumes for Celeborn master pods
-  master:
-    - mountPath: /mnt/celeborn_ratis
-      type: emptyDir
-      size: 1Gi
-  # -- Specifies volumes for Celeborn worker pods
-  worker:
-    - mountPath: /mnt/disk1
-      type: emptyDir
-      size: 1Gi
-    - mountPath: /mnt/disk2
-      type: emptyDir
-      size: 1Gi
+  hostNetwork: true
 
-# celeborn configurations
-celeborn:
-  celeborn.master.ha.enabled: false
-  celeborn.metrics.enabled: false
-  celeborn.master.http.port: 9098
-  celeborn.worker.http.port: 9096
-  celeborn.worker.monitor.disk.enabled: false
-  celeborn.shuffle.chunk.size: 8m
-  celeborn.rpc.io.serverThreads: 64
-  celeborn.rpc.io.numConnectionsPerPeer: 2
-  celeborn.rpc.io.clientThreads: 64
-  celeborn.rpc.dispatcher.numThreads: 4
-  celeborn.worker.flusher.buffer.size: 256K
-  celeborn.worker.fetch.io.threads: 32
-  celeborn.worker.push.io.threads: 32
-  celeborn.push.stageEnd.timeout: 120s
-  celeborn.application.heartbeat.timeout: 120s
-  celeborn.worker.heartbeat.timeout: 120s
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 100m
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
 
-# -- Celeborn configurations
-environments:
-  CELEBORN_MASTER_MEMORY: 100m
-  CELEBORN_WORKER_MEMORY: 100m
-  CELEBORN_WORKER_OFFHEAP_MEMORY: 100m
-  CELEBORN_NO_DAEMONIZE: 1
-  TZ: "Asia/Shanghai"
+  volumeMounts:
+  - name: volume-ratis
+    mountPath: /mnt/celeborn_ratis
 
-# -- Specifies the DNS policy for Celeborn pods to use
-dnsPolicy: ClusterFirstWithHostNet
-
-# -- Specifies whether to use the host's network namespace
-hostNetwork: true
-
-resources:
-  # -- Pod resources for Celeborn master pods
-  master:
-    limits:
-      cpu: 100m
-      memory: 800Mi
+  resources:
     requests:
       cpu: 100m
       memory: 800Mi
-  # -- Pod resources for Celeborn worker pods
-  worker:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 800Mi
+
+worker:
+  replicas: 1
+
+  volumeClaimTemplates:
+  - metadata:
+      name: volume-1
+      annotations:
+        celeborn.apache.org/worker-storage-dir: "true"
+        celeborn.apache.org/disk-capacity: 1Gi
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+        limits:
+          storage: 1Gi
+      storageClassName: standard
+  - metadata:
+      name: volume-2
+      annotations:
+        celeborn.apache.org/worker-storage-dir: "true"
+        celeborn.apache.org/disk-capacity: 1Gi
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+        limits:
+          storage: 1Gi
+      storageClassName: standard
+
+  dnsPolicy: ClusterFirstWithHostNet
+
+  hostNetwork: true
+
+  env:
+  - name: CELEBORN_WORKER_MEMORY
+    value: 2g
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 12g
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
+
+  volumeMounts:
+  - name: volume-1
+    mountPath: /mnt/disk1
+  - name: volume-2
+    mountPath: /mnt/disk2
+
+  resources:
     requests:
       cpu: 100m
       memory: 1Gi
-
-# -- Container security context
-securityContext:
-  # Specifies the user ID to run the entrypoint of the container process
-  runAsUser: 10006
-  # Specifies the group ID to run the entrypoint of the container process
-  runAsGroup: 10006
-  # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
-  fsGroup: 10006
-
-podMonitor:
-  # -- Specifies whether to enable creating pod monitors for Celeborn pods
-  enable: false
-  # -- Specifies pod metrics endpoint
-  podMetricsEndpoint:
-    # Specifies scheme
-    scheme: http
-    # Specifies scrape interval
-    interval: 5s
-    # Specifies port name
-    portName: metrics
+    limits:
+      cpu: 100m
+      memory: 1Gi

--- a/charts/celeborn/files/conf/log4j2.xml
+++ b/charts/celeborn/files/conf/log4j2.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    ~ Licensed to the Apache Software Foundation (ASF) under one or more
+    ~ contributor license agreements.  See the NOTICE file distributed with
+    ~ this work for additional information regarding copyright ownership.
+    ~ The ASF licenses this file to You under the Apache License, Version 2.0
+    ~ (the "License"); you may not use this file except in compliance with
+    ~ the License.  You may obtain a copy of the License at
+    ~
+    ~     http://www.apache.org/licenses/LICENSE-2.0
+    ~
+    ~ Unless required by applicable law or agreed to in writing, software
+    ~ distributed under the License is distributed on an "AS IS" BASIS,
+    ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    ~ See the License for the specific language governing permissions and
+    ~ limitations under the License.
+    -->
+<!--
+    ~ Extra logging related to initialization of Log4j.
+    ~ Set to debug or trace if log4j initialization is failing.
+    -->
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <!--
+                  ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
+                  ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
+                  ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
+                  ~ class packaging information. That extra information can sometimes add a substantial
+                  ~ performance overhead, so we disable it in our default logging config.
+                  -->
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex" />
+        </Console>
+        <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log"
+            filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex" />
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}" maxDepth="1">
+                    <IfFileName glob="celeborn.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB" />
+                            <IfAccumulatedFileCount exceeds="10" />
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+    </Appenders>
+
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="stdout" />
+            <AppenderRef ref="file" />
+        </Root>
+        <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
+            <Appender-ref ref="stdout" level="WARN" />
+            <Appender-ref ref="file" level="WARN" />
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/charts/celeborn/files/conf/metrics.properties
+++ b/charts/celeborn/files/conf/metrics.properties
@@ -1,0 +1,1 @@
+*.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet

--- a/charts/celeborn/files/conf/metrics.properties
+++ b/charts/celeborn/files/conf/metrics.properties
@@ -1,1 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 *.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
+*.sink.jsonServlet.class=org.apache.celeborn.common.metrics.sink.JsonServlet

--- a/charts/celeborn/templates/_helpers.tpl
+++ b/charts/celeborn/templates/_helpers.tpl
@@ -86,72 +86,8 @@ Create the name of configmap to use
 {{- end -}}
 
 {{/*
-Create the name of the master service to use
-*/}}
-{{- define "celeborn.masterServiceName" -}}
-{{ include "celeborn.fullname" . }}-master-svc
-{{- end }}
-
-{{/*
-Create the name of the worker service to use
-*/}}
-{{- define "celeborn.workerServiceName" -}}
-{{ include "celeborn.fullname" . }}-worker-svc
-{{- end }}
-
-{{/*
-Create the name of the master priority class to use
-*/}}
-{{- define "celeborn.masterPriorityClassName" -}}
-{{- if .Values.priorityClass.master.name -}}
-{{ .Values.priorityClass.master.name }}
-{{- else -}}
-{{ include "celeborn.fullname" . }}-master-priority-class
-{{- end }}
-{{- end }}
-
-{{/*
-Create the name of the worker priority class to use
-*/}}
-{{- define "celeborn.workerPriorityClassName" -}}
-{{- if .Values.priorityClass.worker.name -}}
-{{ .Values.priorityClass.worker.name }}
-{{- else -}}
-{{ include "celeborn.fullname" . }}-worker-priority-class
-{{- end }}
-{{- end }}
-
-{{/*
 Create the name of the celeborn image to use
 */}}
 {{- define "celeborn.image" -}}
-{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-{{- end }}
-
-{{/*
-Create the name of the master statefulset to use
-*/}}
-{{- define "celeborn.masterStatefulSetName" -}}
-{{ include "celeborn.fullname" . }}-master
-{{- end }}
-
-{{/*
-Create the name of the worker statefulset to use
-*/}}
-{{- define "celeborn.workerStatefulSetName" -}}
-{{ include "celeborn.fullname" . }}-worker
-{{- end }}
-
-{{/*
-Create the name of the master podmonitor to use
-*/}}
-{{- define "celeborn.masterPodMonitorName" -}}
-{{ include "celeborn.fullname" . }}-master-podmonitor
-{{- end }}
-
-{{/*
-Create the name of the worker podmonitor to use
-*/}}
-{{- define "celeborn.workerPodMonitorName" -}}
-{{ include "celeborn.fullname" . }}-worker-podmonitor
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
 {{- end }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -23,96 +23,44 @@ metadata:
     {{- include "celeborn.labels" . | nindent 4 }}
 data:
   celeborn-defaults.conf: |-
-    {{- $namespace := .Release.Namespace }}
-    celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}{{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
-    {{- range until (.Values.masterReplicas |int) }}
-    celeborn.master.ha.node.{{ . }}.host={{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
+    {{- if not (get .Values.celeborn "celeborn.master.endpoints") }}
+    {{- $list := list }}
+    {{- range until (.Values.master.replicas | int) }}
+    {{- $endpoint := (printf "%s-%d.%s.%s.svc.%s.local" (include "celeborn.master.statefulSetName" $) . (include "celeborn.master.serviceName" $) $.Release.Namespace $.Values.cluster.name) }}
+    {{- $list = append $list $endpoint }}
     {{- end }}
-    {{- $dirs := .Values.volumes.master }}
-    celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
-    {{- $path := "" }}
-    {{- range $worker := .Values.volumes.worker }}
-    {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "diskType" | default "HDD") ":capacity=" (get $worker "capacity" | default "1PB") | nospace) }}
-    {{- if eq $path "" }}
-    {{- $path = $info }}
-    {{- else }}
-    {{- $path = ( list $path $info | join ",") }}
+    celeborn.master.endpoints={{ $list | join "," }}
+    {{- end }}
+
+    {{- range until (.Values.master.replicas | int) }}
+    celeborn.master.ha.node.{{ . }}.host={{ printf "%s-%d.%s.%s.svc.%s.local" (include "celeborn.master.statefulSetName" $) . (include "celeborn.master.serviceName" $) $.Release.Namespace $.Values.cluster.name }}
+    {{- end }}
+
+    {{- if not (get .Values.celeborn "celeborn.master.ha.ratis.raft.server.storage.dir") }}
+    {{- $first := .Values.master.volumeMounts | mustFirst }}
+    celeborn.master.ha.ratis.raft.server.storage.dir={{ $first.mountPath }}
+    {{- end }}
+
+    {{- $list := list }}
+    {{- range $volumeClaimTemplate := .Values.worker.volumeClaimTemplates }}
+    {{- $mountPath := "" }}
+    {{- range $volumeMount := $.Values.worker.volumeMounts }}
+    {{- if $volumeMount.name | eq $volumeClaimTemplate.metadata.name }}
+    {{- $mountPath = $volumeMount.mountPath }}
     {{- end }}
     {{- end }}
-    celeborn.worker.storage.dirs={{ $path }}
+    {{- $diskType := get $volumeClaimTemplate.metadata.annotations "celeborn.apache.org/disk-type" | default "HDD" }}
+    {{- $diskCapacity := get $volumeClaimTemplate.metadata.annotations "celeborn.apache.org/disk-capacity" | default "1PB" }}
+    {{- $list = append $list (printf "%s:disktype=%s:capacity=%s" $mountPath $diskType $diskCapacity) }}
+    {{- end }}
+    celeborn.worker.storage.dirs={{ $list | join "," }}
+
     {{- range $key, $val := .Values.celeborn }}
     {{ $key }}={{ $val }}
     {{- end }}
 
-  celeborn-env.sh: |
-    {{- range $key, $val := .Values.environments }}
-    {{ $key }}="{{ $val }}"
-    {{- end}} 
-
   log4j2.xml: |-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!--
-    ~ Licensed to the Apache Software Foundation (ASF) under one or more
-    ~ contributor license agreements.  See the NOTICE file distributed with
-    ~ this work for additional information regarding copyright ownership.
-    ~ The ASF licenses this file to You under the Apache License, Version 2.0
-    ~ (the "License"); you may not use this file except in compliance with
-    ~ the License.  You may obtain a copy of the License at
-    ~
-    ~     http://www.apache.org/licenses/LICENSE-2.0
-    ~
-    ~ Unless required by applicable law or agreed to in writing, software
-    ~ distributed under the License is distributed on an "AS IS" BASIS,
-    ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    ~ See the License for the specific language governing permissions and
-    ~ limitations under the License.
-    -->
-    <!--
-    ~ Extra logging related to initialization of Log4j.
-    ~ Set to debug or trace if log4j initialization is failing.
-    -->
-    <Configuration status="INFO">
-        <Appenders>
-            <Console name="stdout" target="SYSTEM_OUT">
-                <!--
-                  ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
-                  ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
-                  ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
-                  ~ class packaging information. That extra information can sometimes add a substantial
-                  ~ performance overhead, so we disable it in our default logging config.
-                  -->
-                <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
-            </Console>
-            <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log"
-                                     filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d-%i">
-                <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
-                <Policies>
-                    <SizeBasedTriggeringPolicy size="200 MB"/>
-                </Policies>
-                <DefaultRolloverStrategy max="7">
-                    <Delete basePath="${env:CELEBORN_LOG_DIR}" maxDepth="1">
-                        <IfFileName glob="celeborn.log*">
-                            <IfAny>
-                                <IfAccumulatedFileSize exceeds="1 GB" />
-                                <IfAccumulatedFileCount exceeds="10" />
-                            </IfAny>
-                        </IfFileName>
-                    </Delete>
-                </DefaultRolloverStrategy>
-            </RollingRandomAccessFile>
-        </Appenders>
+    {{- .Files.Get "files/conf/log4j2.xml" | nindent 4 }}
 
-        <Loggers>
-            <Root level="INFO">
-                <AppenderRef ref="stdout"/>
-                <AppenderRef ref="file"/>
-            </Root>
-            <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
-                <Appender-ref ref="stdout" level="WARN" />
-                <Appender-ref ref="file" level="WARN"/>
-            </Logger>
-        </Loggers>
-    </Configuration>
-
-  metrics.properties: >-
-    *.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
+  metrics.properties: |-
+    {{- .Files.Get "files/conf/metrics.properties" | nindent 4 }}

--- a/charts/celeborn/templates/master/_helpers.tpl
+++ b/charts/celeborn/templates/master/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Common labels for Celeborn master resoruces
+*/}}
+{{- define "celeborn.master.labels" -}}
+{{ include "celeborn.labels" . }}
+app.kubernetes.io/role: master
+{{- end }}
+
+{{/*
+Selector labels for Celeborn master pods
+*/}}
+{{- define "celeborn.master.selectorLabels" -}}
+{{ include "celeborn.selectorLabels" . }}
+app.kubernetes.io/role: master
+{{- end }}
+
+{{/*
+Create the name of the master service to use
+*/}}
+{{- define "celeborn.master.serviceName" -}}
+{{ include "celeborn.fullname" . }}-master-svc
+{{- end }}
+
+
+{{/*
+Create the name of the master priority class to use
+*/}}
+{{- define "celeborn.master.priorityClassName" -}}
+{{- with .Values.master.priorityClass.name -}}
+{{ . }}
+{{- else -}}
+{{ include "celeborn.fullname" . }}-master-priority-class
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the master statefulset to use
+*/}}
+{{- define "celeborn.master.statefulSetName" -}}
+{{ include "celeborn.fullname" . }}-master
+{{- end }}
+
+{{/*
+Create the name of the master podmonitor to use
+*/}}
+{{- define "celeborn.master.podMonitorName" -}}
+{{ include "celeborn.fullname" . }}-master-podmonitor
+{{- end }}

--- a/charts/celeborn/templates/master/podmonitor.yaml
+++ b/charts/celeborn/templates/master/podmonitor.yaml
@@ -20,9 +20,9 @@ limitations under the License.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "celeborn.masterPodMonitorName" . }}
+  name: {{ include "celeborn.master.podMonitorName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
@@ -35,7 +35,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: master
+      {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/celeborn/templates/master/priorityclass.yaml
+++ b/charts/celeborn/templates/master/priorityclass.yaml
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.priorityClass.master.create }}
+{{- if .Values.master.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: {{ include "celeborn.masterPriorityClassName" . }}
+  name: {{ include "celeborn.master.priorityClassName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
-value: {{ .Values.priorityClass.master.value }}
+    {{- include "celeborn.master.labels" . | nindent 4 }}
+value: {{ .Values.master.priorityClass.value }}
 {{- end }}

--- a/charts/celeborn/templates/master/service.yaml
+++ b/charts/celeborn/templates/master/service.yaml
@@ -18,13 +18,12 @@ limitations under the License.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "celeborn.masterServiceName" . }}
+  name: {{ include "celeborn.master.serviceName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "celeborn.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/role: master
+    {{- include "celeborn.master.selectorLabels" . | nindent 4 }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.service.port }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -18,43 +18,45 @@ limitations under the License.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "celeborn.masterStatefulSetName" . }}
+  name: {{ include "celeborn.master.statefulSetName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
-    app.kubernetes.io/role: master
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "celeborn.masterServiceName" . }}
+  serviceName: {{ include "celeborn.master.serviceName" . }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: master
+      {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "celeborn.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/role: master
+        {{- include "celeborn.master.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.master.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.master.volumeMounts }}
       initContainers:
-      {{- $dirs := .Values.volumes.master }}
-      {{- if eq "hostPath" (index $dirs 0).type }}
-      - name: chown-{{ $.Release.Name }}-master-volume
-        image: alpine:3.18
+      - name: chown-celeborn-master-volume
+        image: {{ include "celeborn.image" . }}
         {{- with .Values.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
         command:
         - chown
-        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
-        - {{ (index $dirs 0).mountPath }}
+        - {{ .Values.master.securityContext.runAsUser | default 10006 }}:{{ .Values.master.securityContext.runAsGroup | default 10006 }}
+        {{- range $volumeMount := .Values.master.volumeMounts }}
+        - {{ $volumeMount.mountPath }}
+        {{- end}}
+        {{- with .Values.master.volumeMounts }}
         volumeMounts:
-        - name: {{ $.Release.Name }}-master-vol-0
-          mountPath: {{ (index $dirs 0).mountPath }}
-        {{- with .Values.resources.master }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.master.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -62,7 +64,7 @@ spec:
           runAsUser: 0
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: celeborn-master
         image: {{ include "celeborn.image" . }}
         {{- with .Values.image.pullPolicy }}
         imagePullPolicy: {{ . }}
@@ -74,38 +76,42 @@ spec:
         - -c
         {{- $namespace := .Release.Namespace }}
         - >
-          until {{ range until (.Values.masterReplicas | int) }}
-          nslookup {{ include "celeborn.masterStatefulSetName" $ }}-{{ . }}.{{ include "celeborn.masterServiceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
+          until {{ range until (.Values.master.replicas | int) }}
+          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
           {{- end }}
           true; do
             echo "waiting for master"; 
             sleep 2;
           done && exec /opt/celeborn/sbin/start-master.sh
-        resources:
-          {{- toYaml .Values.resources.master | nindent 10 }}
         ports:
         - containerPort: {{ .Values.service.port }}
         - containerPort: {{ get .Values.celeborn "celeborn.master.http.port" | default 9098 }}
           name: metrics
           protocol: TCP
+        {{- with .Values.master.env }}
         env:
-        {{- range $key, $val := .Values.environments }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.master.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: {{ include "celeborn.fullname" . }}-volume
           mountPath: /opt/celeborn/conf
           readOnly: true
-        {{- range $index, $volume := .Values.volumes.master }}
-        - name: {{ $.Release.Name }}-master-vol-{{ $index }}
-          mountPath: {{ .mountPath }}
+        {{- with .Values.master.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.resources.master }}
+        {{- with .Values.master.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- with .Values.imagePullSecrets }}
+        {{- with .Values.master.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -113,43 +119,39 @@ spec:
       - name: {{ include "celeborn.fullname" . }}-volume
         configMap:
           name: {{ include "celeborn.configMapName" . }}
-      {{- range $index, $volume := .Values.volumes.master }}
-      - name: {{ $.Release.Name }}-master-vol-{{ $index }}
-      {{- if eq "emptyDir" $volume.type }}
-        emptyDir:
-          sizeLimit: {{ $volume.capacity }}
-      {{- else if eq "hostPath" $volume.type }}
-        hostPath:
-          path: {{ $volume.hostPath | default $volume.mountPath }}/master
-          type: DirectoryOrCreate
-      {{- else }}
-      {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}
-      {{- end }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.master.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity.master }}
+      {{- with .Values.master.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.priorityClass.master.name .Values.priorityClass.master.create }}
-      priorityClassName: {{ include "celeborn.masterPriorityClassName" . }}
+      {{- with .Values.master.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
+      {{- if or .Values.master.priorityClass.name .Values.master.priorityClass.create }}
+      priorityClassName: {{ include "celeborn.master.priorityClassName" . }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.master.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
+      {{- with .Values.master.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.master.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 30
-  replicas: {{ .Values.masterReplicas }}
+  {{- with .Values.master.replicas }}
+  replicas: {{ . }}
+  {{- end }}
+  {{- with .Values.master.volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain

--- a/charts/celeborn/templates/worker/_helpers.tpl
+++ b/charts/celeborn/templates/worker/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Common labels for Celeborn master resoruces
+*/}}
+{{- define "celeborn.worker.labels" -}}
+{{ include "celeborn.labels" . }}
+app.kubernetes.io/role: worker
+{{- end }}
+
+{{/*
+Selector labels for Celeborn master pods
+*/}}
+{{- define "celeborn.worker.selectorLabels" -}}
+{{ include "celeborn.selectorLabels" . }}
+app.kubernetes.io/role: worker
+{{- end }}
+
+{{/*
+Create the name of the worker service to use
+*/}}
+{{- define "celeborn.worker.serviceName" -}}
+{{ include "celeborn.fullname" . }}-worker-svc
+{{- end }}
+
+
+{{/*
+Create the name of the worker priority class to use
+*/}}
+{{- define "celeborn.worker.priorityClassName" -}}
+{{- with .Values.worker.priorityClass.name -}}
+{{ . }}
+{{- else -}}
+{{ include "celeborn.fullname" . }}-worker-priority-class
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the worker statefulset to use
+*/}}
+{{- define "celeborn.worker.statefulSetName" -}}
+{{ include "celeborn.fullname" . }}-worker
+{{- end }}
+
+
+{{/*
+Create the name of the worker podmonitor to use
+*/}}
+{{- define "celeborn.worker.podMonitorName" -}}
+{{ include "celeborn.fullname" . }}-worker-podmonitor
+{{- end }}

--- a/charts/celeborn/templates/worker/podmonitor.yaml
+++ b/charts/celeborn/templates/worker/podmonitor.yaml
@@ -20,9 +20,9 @@ limitations under the License.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "celeborn.workerPodMonitorName" . }}
+  name: {{ include "celeborn.worker.podMonitorName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
@@ -35,7 +35,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: worker
+      {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/celeborn/templates/worker/priorityclass.yaml
+++ b/charts/celeborn/templates/worker/priorityclass.yaml
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.priorityClass.worker.create }}
+{{- if .Values.worker.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: {{ include "celeborn.workerPriorityClassName" . }}
+  name: {{ include "celeborn.worker.priorityClassName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
-value: {{ .Values.priorityClass.worker.value }}
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
+value: {{ .Values.worker.priorityClass.value }}
 {{- end }}

--- a/charts/celeborn/templates/worker/service.yaml
+++ b/charts/celeborn/templates/worker/service.yaml
@@ -18,12 +18,11 @@ limitations under the License.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "celeborn.workerServiceName" . }}
+  name: {{ include "celeborn.worker.serviceName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "celeborn.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/role: worker
+    {{- include "celeborn.worker.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
   clusterIP: None

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -18,47 +18,45 @@ limitations under the License.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "celeborn.workerStatefulSetName" . }}
+  name: {{ include "celeborn.worker.statefulSetName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
-    app.kubernetes.io/role: worker
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "celeborn.workerServiceName" . }}
+  serviceName: {{ include "celeborn.worker.serviceName" . }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: worker
+      {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "celeborn.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/role: worker
+        {{- include "celeborn.worker.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.worker.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.worker.volumeMounts }}
       initContainers:
-      {{- $dirs := .Values.volumes.worker }}
-      {{- if eq "hostPath" (index $dirs 0).type }}
-      - name: chown-{{ $.Release.Name }}-worker-volume
-        image: alpine:3.18
+      - name: chown-celeborn-worker-volume
+        image: {{ include "celeborn.image" . }}
         {{- with .Values.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
         command:
         - chown
-        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
-        {{- range $dir := $dirs }}
-        - {{ $dir.mountPath }}
+        - {{ .Values.worker.securityContext.runAsUser | default 10006 }}:{{ .Values.worker.securityContext.runAsGroup | default 10006 }}
+        {{- range $volumeMount := .Values.worker.volumeMounts }}
+        - {{ $volumeMount.mountPath }}
         {{- end}}
+        {{- with .Values.worker.volumeMounts }}
         volumeMounts:
-        {{- range $index, $dir := $dirs }}
-        - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
-          mountPath: {{ $dir.mountPath }}
-        {{- end}}
-        {{- with .Values.resources.worker }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -66,7 +64,7 @@ spec:
           runAsUser: 0
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: celeborn-worker
         image: {{ include "celeborn.image" . }}
         {{- with .Values.image.pullPolicy }}
         imagePullPolicy: {{ . }}
@@ -78,37 +76,41 @@ spec:
         - -c
         {{- $namespace := .Release.Namespace }}
         - >
-          until {{ range until (.Values.masterReplicas | int) }}
-          nslookup {{ include "celeborn.masterStatefulSetName" $ }}-{{ . }}.{{ include "celeborn.masterServiceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
+          until {{ range until (.Values.master.replicas | int) }}
+          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
           {{- end }}
           true; do
             echo "waiting for master";
             sleep 2;
           done && exec /opt/celeborn/sbin/start-worker.sh
-        resources:
-          {{- toYaml .Values.resources.worker | nindent 10 }}
         ports:
         - containerPort: {{ get .Values.celeborn "celeborn.worker.http.port" | default 9096 }}
           name: metrics
           protocol: TCP
+        {{- with .Values.worker.env }}
         env:
-        {{- range $key, $val := .Values.environments }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /opt/celeborn/conf
           name: {{ include "celeborn.fullname" . }}-volume
           readOnly: true
-        {{- range $index, $volume := .Values.volumes.worker }}
-        - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
-          mountPath: {{ .mountPath }}
+        {{- with .Values.worker.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.resources.worker }}
+        {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- with .Values.imagePullSecrets }}
+        {{- with .Values.worker.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -116,43 +118,39 @@ spec:
       - name: {{ include "celeborn.fullname" . }}-volume
         configMap:
           name: {{ include "celeborn.configMapName" . }}
-      {{- range $index, $volume := .Values.volumes.worker }}
-      - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
-      {{- if eq "emptyDir" $volume.type }}
-        emptyDir:
-          sizeLimit: {{ $volume.capacity }}
-      {{- else if eq "hostPath" $volume.type }}
-        hostPath:
-          path: {{ $volume.hostPath | default $volume.mountPath }}/worker
-          type: DirectoryOrCreate
-      {{- else }}
-      {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}
-      {{- end }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity.worker }}
+      {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.priorityClass.worker.name .Values.priorityClass.worker.create }}
-      priorityClassName: {{ include "celeborn.workerPriorityClassName" . }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
+      {{- if or .Values.worker.priorityClass.name .Values.worker.priorityClass.create }}
+      priorityClassName: {{ include "celeborn.worker.priorityClassName" . }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.worker.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
+      {{- with .Values.worker.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.worker.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 30
-  replicas: {{ .Values.workerReplicas }}
+  {{- with .Values.worker.replicas }}
+  replicas: {{ . }}
+  {{- end }}
+  {{- with .Values.worker.volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain

--- a/charts/celeborn/tests/configmap_test.yaml
+++ b/charts/celeborn/tests/configmap_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should create configmap
@@ -35,7 +36,5 @@ tests:
     asserts:
       - exists:
           path: data["celeborn-defaults.conf"]
-      - exists:
-          path: data["celeborn-env.sh"]
       - exists:
           path: data["log4j2.xml"]

--- a/charts/celeborn/tests/master/podmonitor_test.yaml
+++ b/charts/celeborn/tests/master/podmonitor_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create master pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true

--- a/charts/celeborn/tests/master/priorityclass_test.yaml
+++ b/charts/celeborn/tests/master/priorityclass_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create master priority as default
@@ -29,10 +30,10 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: Should create master priority class if `priorityClass.master.create` is true
+  - it: Should create master priority class if `master.priorityClass.create` is true
     set:
-      priorityClass:
-        master:
+      master:
+        priorityClass:
           create: true
     asserts:
       - containsDocument:
@@ -42,8 +43,8 @@ tests:
 
   - it: Should use the specified priority class value
     set:
-      priorityClass:
-        master:
+      master:
+        priorityClass:
           create: true
           value: 1000
     asserts:

--- a/charts/celeborn/tests/master/service_test.yaml
+++ b/charts/celeborn/tests/master/service_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should create master service

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -22,30 +22,19 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
-  - it: Should add extra pod annotations if `podAnnotations` is specified
-    set:
-      podAnnotations:
-        key1: value1
-        key2: value2
-    asserts:
-      - equal:
-          path: spec.template.metadata.annotations.key1
-          value: value1
-      - equal:
-          path: spec.template.metadata.annotations.key2
-          value: value2
-
-  - it: Should use the specified image if `image.repository` and `image.tag` is set
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` are set
     set:
       image:
+        registry: test-registry
         repository: test-repository
         tag: test-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: test-repository:test-tag
+          value: test-registry/test-repository:test-tag
 
   - it: Should use the specified image pull policy if `image.pullPolicy` is set
     set:
@@ -56,11 +45,12 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
-  - it: Should add secrets if `imagePullSecrets` is set
+  - it: Should add image pull secrets if `image.pullSecrets` is set
     set:
-      imagePullSecrets:
-        - name: test-secret1
-        - name: test-secret2
+      image:
+        pullSecrets:
+          - name: test-secret1
+          - name: test-secret2
     asserts:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
@@ -69,11 +59,101 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should use the specified replicas if `master.replicas` is set
     set:
-      nodeSelector:
-        key1: value1
-        key2: value2
+      master:
+        replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+
+  - it: Should add volume claim templates if `master.volumeClaimTemplates` is set
+    set:
+      master:
+        volumeClaimTemplates:
+          - metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+          - metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+
+  - it: Should add extra pod labels if `master.labels` is set
+    set:
+      master:
+        labels:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.labels.key2
+          value: value2
+
+  - it: Should add extra pod annotations if `master.annotations` is set
+    set:
+      master:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add node selector if `master.nodeSelector` is set
+    set:
+      master:
+        nodeSelector:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector.key1
@@ -82,32 +162,10 @@ tests:
           path: spec.template.spec.nodeSelector.key2
           value: value2
 
-  - it: Should add tolerations if `tolerations` is set
+  - it: Should use the specified affinity if `master.affinity` is set
     set:
-      tolerations:
-        - key: key1
-          operator: Equal
-          value: value1
-          effect: NoSchedule
-        - key: key2
-          operator: Exists
-          effect: NoSchedule
-    asserts:
-      - equal:
-          path: spec.template.spec.tolerations
-          value:
-            - key: key1
-              operator: Equal
-              value: value1
-              effect: NoSchedule
-            - key: key2
-              operator: Exists
-              effect: NoSchedule
-
-  - it: Should use the specified affinity if `affinity.master` is set
-    set:
-      affinity:
-        master:
+      master:
+        affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
@@ -146,53 +204,190 @@ tests:
                       values:
                         - another-node-label-value
 
-  - it: Should use the specified priority class name if `priorityClass.master.name` is set
+  - it: Should add tolerations if `master.tolerations` is set
     set:
-      priorityClass:
-        master:
+      master:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified priority class name if `master.priorityClass.name` is set
+    set:
+      master:
+        priorityClass:
           name: test-priority-class
     asserts:
       - equal:
           path: spec.template.spec.priorityClassName
           value: test-priority-class
 
-  - it: Should use the specified dns policy if `dnsPolicy` is set
+  - it: Should use the specified dns policy if `master.dnsPolicy` is set
     set:
-      dnsPolicy: ClusterFirstWithHostNet
+      master:
+        dnsPolicy: ClusterFirstWithHostNet
     asserts:
       - equal:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
-  - it: Should enable host network if `hostNetwork` is set to true
+  - it: Should enable host network if `master.hostNetwork` is set to true
     set:
-      hostNetwork: true
+      master:
+        hostNetwork: true
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
 
-  - it: Should use the specified security context if `podSecurityContext` is set
+  - it: Should use the specified pod security context if `master.podSecurityContext` is set
     set:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      master:
+        podSecurityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
     asserts:
       - equal:
-          path: spec.template.spec.securityContext.runAsUser
-          value: 1000
-      - equal:
-          path: spec.template.spec.securityContext.runAsGroup
-          value: 2000
-      - equal:
-          path: spec.template.spec.securityContext.fsGroup
-          value: 3000
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003
 
-  - it: Should use the specified replicas if `masterReplicas` is set
+  - it: Should add environment variables if `master.env` is set
     set:
-      masterReplicas: 10
+      master:
+        env:
+          - name: test-env-name-1
+            value: test-env-value-1
+          - name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+          - name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-1
+            value: test-env-value-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+
+  - it: Should add environment variables if `master.envFrom` is set
+    set:
+      master:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+              optional: false
+          - secretRef:
+              name: test-secret
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+              optional: false
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret
+              optional: false
+
+  - it: Should add volume mounts if `master.volumeMounts` is set
+    set:
+      master:
+        volumeMounts:
+          - name: test-volume-1
+            mountPath: /mnt/disk1
+          - name: test-volume-2
+            mountPath: /mnt/disk2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-volume-1
+            mountPath: /mnt/disk1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-volume-2
+            mountPath: /mnt/disk2
+
+  - it: Should add resources if `master.resources` if set
+    set:
+      master:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
     asserts:
       - equal:
-          path: spec.replicas
-          value: 10
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+  - it: Should add container security context if `master.securityContext` is set
+    set:
+      master:
+        securityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003

--- a/charts/celeborn/tests/worker/podmonitor_test.yaml
+++ b/charts/celeborn/tests/worker/podmonitor_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create worker pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true

--- a/charts/celeborn/tests/worker/priorityclass_test.yaml
+++ b/charts/celeborn/tests/worker/priorityclass_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create worker priority as default
@@ -29,10 +30,10 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: Should create worker priority class if `priorityClass.worker.create` is true
+  - it: Should create worker priority class if `worker.priorityClass.create` is true
     set:
-      priorityClass:
-        worker:
+      worker:
+        priorityClass:
           create: true
     asserts:
       - containsDocument:
@@ -42,8 +43,8 @@ tests:
 
   - it: Should use the specified priority class value
     set:
-      priorityClass:
-        worker:
+      worker:
+        priorityClass:
           create: true
           value: 1000
     asserts:

--- a/charts/celeborn/tests/worker/service_test.yaml
+++ b/charts/celeborn/tests/worker/service_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should create worker service

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -22,30 +22,19 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
-  - it: Should add extra pod annotations if `podAnnotations` is specified
-    set:
-      podAnnotations:
-        key1: value1
-        key2: value2
-    asserts:
-      - equal:
-          path: spec.template.metadata.annotations.key1
-          value: value1
-      - equal:
-          path: spec.template.metadata.annotations.key2
-          value: value2
-
-  - it: Should use the specified image if `image.repository` and `image.tag` is set
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` are set
     set:
       image:
+        registry: test-registry
         repository: test-repository
         tag: test-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: test-repository:test-tag
+          value: test-registry/test-repository:test-tag
 
   - it: Should use the specified image pull policy if `image.pullPolicy` is set
     set:
@@ -56,11 +45,12 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
-  - it: Should add secrets if `imagePullSecrets` is set
+  - it: Should add image pull secrets if `image.pullSecrets` is set
     set:
-      imagePullSecrets:
-        - name: test-secret1
-        - name: test-secret2
+      image:
+        pullSecrets:
+          - name: test-secret1
+          - name: test-secret2
     asserts:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
@@ -69,11 +59,101 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should use the specified replicas if `worker.replicas` is set
     set:
-      nodeSelector:
-        key1: value1
-        key2: value2
+      worker:
+        replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+
+  - it: Should add volume claim templates if `worker.volumeClaimTemplates` is set
+    set:
+      worker:
+        volumeClaimTemplates:
+          - metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+          - metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+
+  - it: Should add extra pod labels if `worker.labels` is set
+    set:
+      worker:
+        labels:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.labels.key2
+          value: value2
+
+  - it: Should add extra pod annotations if `worker.annotations` is set
+    set:
+      worker:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add node selector if `worker.nodeSelector` is set
+    set:
+      worker:
+        nodeSelector:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector.key1
@@ -82,32 +162,10 @@ tests:
           path: spec.template.spec.nodeSelector.key2
           value: value2
 
-  - it: Should add tolerations if `tolerations` is set
+  - it: Should use the specified affinity if `worker.affinity` is specified
     set:
-      tolerations:
-        - key: key1
-          operator: Equal
-          value: value1
-          effect: NoSchedule
-        - key: key2
-          operator: Exists
-          effect: NoSchedule
-    asserts:
-      - equal:
-          path: spec.template.spec.tolerations
-          value:
-            - key: key1
-              operator: Equal
-              value: value1
-              effect: NoSchedule
-            - key: key2
-              operator: Exists
-              effect: NoSchedule
-
-  - it: Should use the specified affinity if `affinity.worker` is specified
-    set:
-      affinity:
-        worker:
+      worker:
+        affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
@@ -146,53 +204,190 @@ tests:
                       values:
                         - another-node-label-value
 
-  - it: Should use the specified priority class name if `priorityClass.worker.name` is set
+  - it: Should add tolerations if `worker.tolerations` is set
     set:
-      priorityClass:
-        worker:
+      worker:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified priority class name if `worker.priorityClass.name` is set
+    set:
+      worker:
+        priorityClass:
           name: test-priority-class
     asserts:
       - equal:
           path: spec.template.spec.priorityClassName
           value: test-priority-class
 
-  - it: Should use the specified dns policy if `dnsPolicy` is set
+  - it: Should use the specified dns policy if `worker.dnsPolicy` is set
     set:
-      dnsPolicy: ClusterFirstWithHostNet
+      worker:
+        dnsPolicy: ClusterFirstWithHostNet
     asserts:
       - equal:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
-  - it: Should enable host network if `hostNetwork` is set to true
+  - it: Should enable host network if `worker.hostNetwork` is set to true
     set:
-      hostNetwork: true
+      worker:
+        hostNetwork: true
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
 
-  - it: Should use the specified security context if `podSecurityContext` is set
+  - it: Should use the specified security context if `worker.podSecurityContext` is set
     set:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      worker:
+        podSecurityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
     asserts:
       - equal:
-          path: spec.template.spec.securityContext.runAsUser
-          value: 1000
-      - equal:
-          path: spec.template.spec.securityContext.runAsGroup
-          value: 2000
-      - equal:
-          path: spec.template.spec.securityContext.fsGroup
-          value: 3000
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003
 
-  - it: Should use the specified replicas if `workerReplicas` is set
+  - it: Should add environment variables if `worker.env` is set
     set:
-      workerReplicas: 10
+      worker:
+        env:
+          - name: test-env-name-1
+            value: test-env-value-1
+          - name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+          - name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-1
+            value: test-env-value-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+
+  - it: Should add environment variables if `worker.envFrom` is set
+    set:
+      worker:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+              optional: false
+          - secretRef:
+              name: test-secret
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+              optional: false
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret
+              optional: false
+
+  - it: Should add volume mounts if `worker.volumeMounts` is set
+    set:
+      worker:
+        volumeMounts:
+          - name: test-volume-1
+            mountPath: /mnt/disk1
+          - name: test-volume-2
+            mountPath: /mnt/disk2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-volume-1
+            mountPath: /mnt/disk1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-volume-2
+            mountPath: /mnt/disk2
+
+  - it: Should add resources if `worker.resources` if set
+    set:
+      worker:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
     asserts:
       - equal:
-          path: spec.replicas
-          value: 10
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+  - it: Should add container security context if `worker.securityContext` is set
+    set:
+      worker:
+        securityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -84,7 +84,7 @@ celeborn:
 
   # ============================================================================
   # Network
-  # ============================================================================ 
+  # ============================================================================
   celeborn.rpc.io.serverThreads: 64
   celeborn.rpc.io.numConnectionsPerPeer: 2
   celeborn.rpc.io.clientThreads: 64
@@ -92,7 +92,7 @@ celeborn:
 
   # ============================================================================
   # Metrics
-  # ============================================================================ 
+  # ============================================================================
   celeborn.metrics.enabled: true
   celeborn.metrics.prometheus.path: /metrics/prometheus
 
@@ -200,7 +200,7 @@ master:
   - name: CELEBORN_WORKER_OFFHEAP_MEMORY
     value: 12g
   - name: CELEBORN_WORKER_JAVA_OPTS
-    value: |- 
+    value: |-
       -XX:-PrintGC
       -XX:+PrintGCDetails
       -XX:+PrintGCTimeStamps
@@ -246,7 +246,7 @@ master:
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
-  
+
   # -- Labels for Celeborn worker pods
   labels: {}
     # key1: value1
@@ -256,7 +256,7 @@ worker:
   annotations: {}
     # key1: value1
     # key2: value2
-  
+
   # -- Specifies volume claim templates for Celeborn worker pods
   volumeClaimTemplates:
   - metadata:
@@ -389,7 +389,7 @@ worker:
   - name: CELEBORN_WORKER_OFFHEAP_MEMORY
     value: 12g
   - name: CELEBORN_WORKER_JAVA_OPTS
-    value: |- 
+    value: |-
       -XX:-PrintGC
       -XX:+PrintGCDetails
       -XX:+PrintGCTimeStamps

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -19,28 +19,423 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- String to override the default generated name
+# -- String to partially override the default generated name
 nameOverride: ""
 
-# -- String to override the default generated fullname
+# -- String to fully override the default generated name
 fullnameOverride: ""
 
-# Specifies the Celeborn image to use
 image:
+  # -- Image registry
+  registry: docker.io
   # -- Image repository
-  repository: aliyunemr/remote-shuffle-service
-  # -- Image tag
-  tag: 0.1.1-6badd20
+  repository: apache/celeborn
+  # -- Image tag, default is chart `appVersion`
+  tag: ""
   # -- Image pull policy
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
+  # -- Image pull secrets for private image registry
+  pullSecrets: []
+  # - name: secret-name
 
-# -- Image pull secrets for private image registry
-imagePullSecrets: []
+# -- Celeborn configurations.
+# Ref: [Configuration - Apache Celeborn](https://celeborn.apache.org/docs/latest/configuration)
+celeborn:
+  # ============================================================================
+  # Mater
+  # ============================================================================
+  celeborn.master.http.port: 9098
+  celeborn.master.heartbeat.application.timeout: 300s
+  celeborn.master.heartbeat.worker.timeout: 120s
 
-# -- Specifies the number of Celeborn master replicas to deploy, master replicas should not less than 3
-masterReplicas: 3
-# -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
-workerReplicas: 5
+  # ============================================================================
+  # Mater HA
+  # ============================================================================
+  celeborn.master.ha.enabled: true
+
+  # If not specified, and `celeborn.master.ha.enabled` is set to `true`,
+  # then it will be configured automatically as `master.volumeMounts[0].mountPath`.
+  # celeborn.master.ha.ratis.raft.server.storage.dir: /tmp/ratis
+
+  # Note that, `celeborn.master.ha.node.<id>.host` should be configured automatically by Helm.
+  # celeborn.master.ha.node.<id>.host: ""
+
+  # ============================================================================
+  # Worker
+  # ============================================================================
+
+  # Note that, `celeborn.master.endpoints` should be configured automatically by Helm.
+  # celeborn.master.endpoints: <localhost>:9097
+
+  celeborn.shuffle.chunk.size: 8m
+  celeborn.worker.flusher.buffer.size: 256K
+  celeborn.worker.http.port: 9096
+  celeborn.worker.fetch.io.threads: 32
+  celeborn.worker.monitor.disk.enabled: false
+  celeborn.worker.push.io.threads: 32
+
+  # If not specified, `celeborn.worker.storage.dirs` will be configured automatically by Helm according to `master.worker.volumeMounts`.
+  # celeborn.worker.storage.dirs: ""
+
+  # ============================================================================
+  # Client
+  # ============================================================================
+  celeborn.client.push.stageEnd.timeout: 120s
+
+  # ============================================================================
+  # Network
+  # ============================================================================ 
+  celeborn.rpc.io.serverThreads: 64
+  celeborn.rpc.io.numConnectionsPerPeer: 2
+  celeborn.rpc.io.clientThreads: 64
+  celeborn.rpc.dispatcher.numThreads: 4
+
+  # ============================================================================
+  # Metrics
+  # ============================================================================ 
+  celeborn.metrics.enabled: true
+  celeborn.metrics.prometheus.path: /metrics/prometheus
+
+master:
+  # -- Number of Celeborn master replicas to deploy.
+  # master replicas should not less than 3
+  replicas: 3
+
+  # -- Volume claim templates for Celeborn master statefulset
+  volumeClaimTemplates:
+  - metadata:
+      name: volume-ratis
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+        limits:
+          storage: 100Gi
+
+  # -- Labels for Celeborn master pods
+  labels: {}
+    # key1: value1
+    # key2: value2
+
+  # -- Annotations for Celeborn master pods
+  annotations: {}
+    # key1: value1
+    # key2: value2
+
+  # -- Volumes for Celeborn master pods
+  volumes: []
+
+  # -- Node selector for Celeborn master pods
+  nodeSelector: {}
+    # key1: value1
+    # key2: value2
+
+  # -- Affinity for Celeborn master pods
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - celeborn
+          - key: app.kubernetes.io/role
+            operator: In
+            values:
+            - master
+        topologyKey: kubernetes.io/hostname
+
+  # -- Node selector for Celeborn master pods
+  tolerations: []
+  # - key: key1
+  #   operator: Equal
+  #   value: value1
+  #   effect: NoSchedule
+  # - key: key2
+  #   operator: Exists
+  #   effect: NoSchedule
+
+  # Priority class for Celeborn master pods
+  priorityClass:
+    # -- Specifies whether to create a new priority class for Celeborn master pods
+    create: false
+    # -- Specifies the name of priority class for Celeborn master pods to be used (created if `create: true`).
+    # Empty means `${Release.Name}-master-priority-class`.
+    name: ""
+    # -- Specifies the integer value of this priority class, default is half of system-cluster-critical
+    value: 1000000000
+
+  # -- DNS policy for Celeborn pods
+  dnsPolicy: ClusterFirst
+
+  # -- Specifies whether to use the host's network namespace
+  hostNetwork: false
+
+  # -- Specifies security context for Celeborn master pods
+  podSecurityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+    # Specifies the GID to use when modifying ownership and permissions of the mounted volumes
+    fsGroup: 10006
+
+  # -- Specifies environment variables for Celeborn master containers
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 2g
+  - name: CELEBORN_MASTER_JAVA_OPTS
+    value: |-
+      -XX:-PrintGC
+      -XX:+PrintGCDetails
+      -XX:+PrintGCTimeStamps
+      -XX:+PrintGCDateStamps
+      -Xloggc:gc-master.out
+      -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_WORKER_MEMORY
+    value: 2g
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 12g
+  - name: CELEBORN_WORKER_JAVA_OPTS
+    value: |- 
+      -XX:-PrintGC
+      -XX:+PrintGCDetails
+      -XX:+PrintGCTimeStamps
+      -XX:+PrintGCDateStamps
+      -Xloggc:gc-worker.out
+      -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
+
+  # -- Specifies environment variable sources for Celeborn master containers
+  envFrom: []
+  # - configMapRef:
+  #     name: celeborn-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: celeborn-secret
+  #     optional: false
+
+  # -- Specifies volume mounts for Celeborn master containers.
+  # Note that, Celeborn master pods will pick first volume mount for Raft log storage.
+  volumeMounts:
+  - name: celeborn_ratis
+    mountPath: /mnt/celeborn_ratis
+
+  # -- Resources for Celeborn master containers
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # -- Security context for Celeborn master containers
+  securityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+
+worker:
+  # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
+  replicas: 5
+  
+  # -- Labels for Celeborn worker pods
+  labels: {}
+    # key1: value1
+    # key2: value2
+
+  # -- Annotations for Celeborn worker pods
+  annotations: {}
+    # key1: value1
+    # key2: value2
+  
+  # -- Specifies volume claim templates for Celeborn worker pods
+  volumeClaimTemplates:
+  - metadata:
+      name: volume-1
+      annotations:
+        celeborn.apache.org/worker-storage-dir: "true"
+        celeborn.apache.org/disk-type: SSD
+        celeborn.apache.org/disk-capacity: 100Gi
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+        limits:
+          storage: 100Gi
+  - metadata:
+      name: volume-2
+      annotations:
+        celeborn.apache.org/worker-storage-dir: "true"
+        celeborn.apache.org/disk-type: SSD
+        celeborn.apache.org/disk-capacity: 100Gi
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+        limits:
+          storage: 100Gi
+  - metadata:
+      name: volume-3
+      annotations:
+        celeborn.apache.org/worker-storage-dir: "true"
+        celeborn.apache.org/disk-type: SSD
+        celeborn.apache.org/disk-capacity: 100Gi
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+        limits:
+          storage: 100Gi
+  - metadata:
+      name: volume-4
+      annotations:
+        celeborn.apache.org/worker-storage-dir: "true"
+        celeborn.apache.org/disk-type: SSD
+        celeborn.apache.org/disk-capacity: 100Gi
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+        limits:
+          storage: 100Gi
+
+  # -- Node selector for Celeborn worker pods
+  nodeSelector: {}
+    # key1: value1
+    # key2: value2
+
+  # -- Affinity for Celeborn worker pods
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - celeborn
+          - key: app.kubernetes.io/role
+            operator: In
+            values:
+            - worker
+        topologyKey: kubernetes.io/hostname
+
+  # -- Node selector for Celeborn worker pods
+  tolerations: []
+  # - key: key1
+  #   operator: Equal
+  #   value: value1
+  #   effect: NoSchedule
+  # - key: key2
+  #   operator: Exists
+  #   effect: NoSchedule
+
+  # Priority class for Celeborn worker pods
+  priorityClass:
+    # -- Specifies whether to create a new priority class for Celeborn worker pods
+    create: false
+    # -- Specifies the name of priority class for Celeborn worker pods to be used (created if `create: true`)
+    # Empty means `${Release.Name}-worker-priority-class`.
+    name: ""
+    # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
+    value: 999999000
+
+  # -- Specifies the DNS policy for Celeborn worker pods
+  dnsPolicy: ClusterFirst
+
+  # -- Specifies whether to use the host's network namespace
+  hostNetwork: false
+
+  # -- Specifies security context for Celeborn worker pods
+  podSecurityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+    # Specifies the GID to use when modifying ownership and permissions of the mounted volumes
+    fsGroup: 10006
+
+  # -- Specifies environment variables for Celeborn worker containers
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 2g
+  - name: CELEBORN_MASTER_JAVA_OPTS
+    value: |-
+      -XX:-PrintGC
+      -XX:+PrintGCDetails
+      -XX:+PrintGCTimeStamps
+      -XX:+PrintGCDateStamps
+      -Xloggc:gc-master.out
+      -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_WORKER_MEMORY
+    value: 2g
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 12g
+  - name: CELEBORN_WORKER_JAVA_OPTS
+    value: |- 
+      -XX:-PrintGC
+      -XX:+PrintGCDetails
+      -XX:+PrintGCTimeStamps
+      -XX:+PrintGCDateStamps
+      -Xloggc:gc-worker.out
+      -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
+
+  # -- Specifies environment variable sources for Celeborn worker containers
+  envFrom: []
+  # - configMapRef:
+  #     name: celeborn-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: celeborn-secret
+  #     optional: false
+
+  # -- Specifies volume mounts for Celeborn worker pods
+  volumeMounts:
+  - name: volume-1
+    mountPath: /mnt/disk1
+  - name: volume-2
+    mountPath: /mnt/disk2
+  - name: volume-3
+    mountPath: /mnt/disk3
+  - name: volume-4
+    mountPath: /mnt/disk4
+
+  # -- Resources for Celeborn worker pods
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # -- Security context for Celeborn worker containers
+  securityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
 
 service:
   # -- Specifies service type
@@ -51,176 +446,6 @@ service:
 cluster:
   # -- Specifies Kubernetes cluster name
   name: cluster
-
-# Specifies Celeborn volumes.
-# Currently supported volume types are `emptyDir` and `hostPath`.
-# Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
-# Celeborn Master will pick first volumes for store raft log.
-# `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
-volumes:
-  # -- Specifies volumes for Celeborn master pods
-  master:
-    - mountPath: /mnt/celeborn_ratis
-      hostPath: /mnt/celeborn_ratis
-      type: hostPath
-      capacity: 100Gi
-  # -- Specifies volumes for Celeborn worker pods
-  worker:
-    - mountPath: /mnt/disk1
-      hostPath: /mnt/disk1
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-    - mountPath: /mnt/disk2
-      hostPath: /mnt/disk2
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-    - mountPath: /mnt/disk3
-      hostPath: /mnt/disk3
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-    - mountPath: /mnt/disk4
-      hostPath: /mnt/disk4
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-
-# -- Celeborn configurations
-celeborn:
-  celeborn.master.ha.enabled: true
-  celeborn.metrics.enabled: true
-  celeborn.metrics.prometheus.path: /metrics/prometheus
-  celeborn.master.http.port: 9098
-  celeborn.worker.http.port: 9096
-  celeborn.worker.monitor.disk.enabled: false
-  celeborn.shuffle.chunk.size: 8m
-  celeborn.rpc.io.serverThreads: 64
-  celeborn.rpc.io.numConnectionsPerPeer: 2
-  celeborn.rpc.io.clientThreads: 64
-  celeborn.rpc.dispatcher.numThreads: 4
-  celeborn.worker.flusher.buffer.size: 256K
-  celeborn.worker.fetch.io.threads: 32
-  celeborn.worker.push.io.threads: 32
-  celeborn.push.stageEnd.timeout: 120s
-  celeborn.application.heartbeat.timeout: 120s
-  celeborn.worker.heartbeat.timeout: 120s
-
-# -- Celeborn environment variables
-environments:
-  CELEBORN_MASTER_MEMORY: 2g
-  CELEBORN_MASTER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-master.out -Dio.netty.leakDetectionLevel=advanced"
-  CELEBORN_WORKER_MEMORY: 2g
-  CELEBORN_WORKER_OFFHEAP_MEMORY: 12g
-  CELEBORN_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
-  CELEBORN_NO_DAEMONIZE: 1
-  TZ: "Asia/Shanghai"
-
-# -- Specifies the DNS policy for Celeborn pods to use
-dnsPolicy: ClusterFirst
-
-# -- Specifies whether to use the host's network namespace
-hostNetwork: false
-
-resources:
-  # -- Pod resources for Celeborn master pods
-  master: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  # -- Pod resources for Celeborn worker pods
-  worker: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-# -- Container security context
-securityContext:
-  # Specifies the user ID to run the entrypoint of the container process
-  runAsUser: 10006
-  # Specifies the group ID to run the entrypoint of the container process
-  runAsGroup: 10006
-  # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
-  fsGroup: 10006
-
-priorityClass:
-  # Priority class for Celeborn master pods
-  master:
-    # -- Specifies whether a new priority class for Celeborn master pods should be created
-    create: false
-    # -- Specifies the name of priority class for Celeborn master pods to be used (created if `create: true`), empty means `${Release.Name}-master-priority-class`
-    name: ""
-    # -- Specifies the integer value of this priority class, default is half of system-cluster-critical
-    value: 1000000000
-
-  # Priority class for Celeborn worker pods
-  worker:
-    # -- Specifies whether a new priority class for Celeborn worker pods should be created
-    create: false
-    # -- Specifies the name of priority class for Celeborn worker pods to be used (created if `create: true`), empty means `${Release.Name}-worker-priority-class`
-    name: ""
-    # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
-    value: 999999000
-
-# -- Pod annotations
-podAnnotations: {}
-# key1: value1
-# key2: value2
-
-# -- Pod node selector
-nodeSelector: {}
-# key1: value1
-# key2: value2
-
-# -- Pod tolerations
-tolerations: []
-# - key: key1
-#   operator: Equal
-#   value: value1
-#   effect: NoSchedule
-# - key: key2
-#   operator: Exists
-#   effect: NoSchedule
-
-affinity:
-  # -- Pod affinity for Celeborn master pods
-  master:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - celeborn
-              - key: app.kubernetes.io/role
-                operator: In
-                values:
-                  - master
-          topologyKey: kubernetes.io/hostname
-  # -- Pod affinity for Celeborn worker pods
-  worker:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - celeborn
-              - key: app.kubernetes.io/role
-                operator: In
-                values:
-                  - worker
-          topologyKey: "kubernetes.io/hostname"
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Make helm chart more customizable:
- All master related configurations are prefixed with `master`, e.g. `master.replicas`, `master.volumeClaimTemplates`, `master.volumeMounts`.
- All worker related configurations are prefixed with `worker`, e.g. `worker.replicas`, `worker.nodeSelector`, `worker.affinity`.
- Add support for `labels`, `env`, `envFrom` and `volumeClaimTemplates`.

- Bump chart `appVersion` to `0.5.1`.

### Why are the changes needed?

By using volumeClaimTemplates in StatefulSet, we can support various types of storage backend.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Test locally.
