### PR TITLE
[CELEBORN-1532][HELM] Make helm charts more customizable

### DIFF
--- a/charts/celeborn/Chart.yaml
+++ b/charts/celeborn/Chart.yaml
@@ -22,7 +22,7 @@ description: >
   Intermediate data typically include shuffle and spilled data.
 type: application
 version: 0.1.0
-appVersion: 0.4.0
+appVersion: 0.5.1
 keywords:
   - Apache Celeborn
   - Big Data

--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -15,122 +15,66 @@
 # limitations under the License.
 #
 
-# Default values for celeborn.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-# Specifies the Celeborn image to use
 image:
-  # -- Image repository
-  repository: apache/celeborn
-  # -- Image tag
   tag: latest
-  # -- Image pull policy
-  pullPolicy: IfNotPresent
 
-# -- Specifies the number of Celeborn master replicas to deploy
-masterReplicas: 1
-# -- Specifies the number of Celeborn worker replicas to deploy
-workerReplicas: 1
+master:
+  replicas: 1
 
-service:
-  # -- Specifies service type
-  type: ClusterIP
-  # -- Specifies service port
-  port: 9097
+  volumes:
+  - mountPath: /mnt/celeborn_ratis
+    type: emptyDir
+    size: 1Gi
 
-cluster:
-  # -- Specifies Kubernetes cluster name
-  name: cluster
+  dnsPolicy: ClusterFirstWithHostNet
 
-# Specifies Celeborn volumes.
-# Currently supported volume types are `emptyDir` and `hostPath`.
-# Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
-# Celeborn Master will pick first volumes for store raft log.
-# `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
-volumes:
-  # -- Specifies volumes for Celeborn master pods
-  master:
-    - mountPath: /mnt/celeborn_ratis
-      type: emptyDir
-      size: 1Gi
-  # -- Specifies volumes for Celeborn worker pods
-  worker:
-    - mountPath: /mnt/disk1
-      type: emptyDir
-      size: 1Gi
-    - mountPath: /mnt/disk2
-      type: emptyDir
-      size: 1Gi
+  hostNetwork: true
 
-# celeborn configurations
-celeborn:
-  celeborn.master.ha.enabled: false
-  celeborn.metrics.enabled: false
-  celeborn.master.http.port: 9098
-  celeborn.worker.http.port: 9096
-  celeborn.worker.monitor.disk.enabled: false
-  celeborn.shuffle.chunk.size: 8m
-  celeborn.rpc.io.serverThreads: 64
-  celeborn.rpc.io.numConnectionsPerPeer: 2
-  celeborn.rpc.io.clientThreads: 64
-  celeborn.rpc.dispatcher.numThreads: 4
-  celeborn.worker.flusher.buffer.size: 256K
-  celeborn.worker.fetch.io.threads: 32
-  celeborn.worker.push.io.threads: 32
-  celeborn.push.stageEnd.timeout: 120s
-  celeborn.application.heartbeat.timeout: 120s
-  celeborn.worker.heartbeat.timeout: 120s
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 100m
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
 
-# -- Celeborn configurations
-environments:
-  CELEBORN_MASTER_MEMORY: 100m
-  CELEBORN_WORKER_MEMORY: 100m
-  CELEBORN_WORKER_OFFHEAP_MEMORY: 100m
-  CELEBORN_NO_DAEMONIZE: 1
-  TZ: "Asia/Shanghai"
-
-# -- Specifies the DNS policy for Celeborn pods to use
-dnsPolicy: ClusterFirstWithHostNet
-
-# -- Specifies whether to use the host's network namespace
-hostNetwork: true
-
-resources:
-  # -- Pod resources for Celeborn master pods
-  master:
-    limits:
-      cpu: 100m
-      memory: 800Mi
+  resources:
     requests:
       cpu: 100m
       memory: 800Mi
-  # -- Pod resources for Celeborn worker pods
-  worker:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 800Mi
+
+worker:
+  replicas: 1
+
+  volumes:
+  - mountPath: /mnt/disk1
+    type: emptyDir
+    size: 1Gi
+  - mountPath: /mnt/disk2
+    type: emptyDir
+    size: 1Gi
+
+  dnsPolicy: ClusterFirstWithHostNet
+
+  hostNetwork: true
+
+  env:
+  - name: CELEBORN_WORKER_MEMORY
+    value: 2g
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 12g
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
+
+  resources:
     requests:
       cpu: 100m
       memory: 1Gi
-
-# -- Container security context
-securityContext:
-  # Specifies the user ID to run the entrypoint of the container process
-  runAsUser: 10006
-  # Specifies the group ID to run the entrypoint of the container process
-  runAsGroup: 10006
-  # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
-  fsGroup: 10006
-
-podMonitor:
-  # -- Specifies whether to enable creating pod monitors for Celeborn pods
-  enable: false
-  # -- Specifies pod metrics endpoint
-  podMetricsEndpoint:
-    # Specifies scheme
-    scheme: http
-    # Specifies scrape interval
-    interval: 5s
-    # Specifies port name
-    portName: metrics
+    limits:
+      cpu: 100m
+      memory: 1Gi

--- a/charts/celeborn/files/conf/log4j2.xml
+++ b/charts/celeborn/files/conf/log4j2.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    ~ Licensed to the Apache Software Foundation (ASF) under one or more
+    ~ contributor license agreements.  See the NOTICE file distributed with
+    ~ this work for additional information regarding copyright ownership.
+    ~ The ASF licenses this file to You under the Apache License, Version 2.0
+    ~ (the "License"); you may not use this file except in compliance with
+    ~ the License.  You may obtain a copy of the License at
+    ~
+    ~     http://www.apache.org/licenses/LICENSE-2.0
+    ~
+    ~ Unless required by applicable law or agreed to in writing, software
+    ~ distributed under the License is distributed on an "AS IS" BASIS,
+    ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    ~ See the License for the specific language governing permissions and
+    ~ limitations under the License.
+    -->
+<!--
+    ~ Extra logging related to initialization of Log4j.
+    ~ Set to debug or trace if log4j initialization is failing.
+    -->
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <!--
+                  ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
+                  ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
+                  ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
+                  ~ class packaging information. That extra information can sometimes add a substantial
+                  ~ performance overhead, so we disable it in our default logging config.
+                  -->
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex" />
+        </Console>
+        <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log"
+            filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex" />
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}" maxDepth="1">
+                    <IfFileName glob="celeborn.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB" />
+                            <IfAccumulatedFileCount exceeds="10" />
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+    </Appenders>
+
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="stdout" />
+            <AppenderRef ref="file" />
+        </Root>
+        <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
+            <Appender-ref ref="stdout" level="WARN" />
+            <Appender-ref ref="file" level="WARN" />
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/charts/celeborn/files/conf/metrics.properties
+++ b/charts/celeborn/files/conf/metrics.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+*.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
+*.sink.jsonServlet.class=org.apache.celeborn.common.metrics.sink.JsonServlet

--- a/charts/celeborn/templates/_helpers.tpl
+++ b/charts/celeborn/templates/_helpers.tpl
@@ -89,5 +89,5 @@ Create the name of configmap to use
 Create the name of the celeborn image to use
 */}}
 {{- define "celeborn.image" -}}
-{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
 {{- end }}

--- a/charts/celeborn/templates/_helpers.tpl
+++ b/charts/celeborn/templates/_helpers.tpl
@@ -86,72 +86,8 @@ Create the name of configmap to use
 {{- end -}}
 
 {{/*
-Create the name of the master service to use
-*/}}
-{{- define "celeborn.masterServiceName" -}}
-{{ include "celeborn.fullname" . }}-master-svc
-{{- end }}
-
-{{/*
-Create the name of the worker service to use
-*/}}
-{{- define "celeborn.workerServiceName" -}}
-{{ include "celeborn.fullname" . }}-worker-svc
-{{- end }}
-
-{{/*
-Create the name of the master priority class to use
-*/}}
-{{- define "celeborn.masterPriorityClassName" -}}
-{{- if .Values.priorityClass.master.name -}}
-{{ .Values.priorityClass.master.name }}
-{{- else -}}
-{{ include "celeborn.fullname" . }}-master-priority-class
-{{- end }}
-{{- end }}
-
-{{/*
-Create the name of the worker priority class to use
-*/}}
-{{- define "celeborn.workerPriorityClassName" -}}
-{{- if .Values.priorityClass.worker.name -}}
-{{ .Values.priorityClass.worker.name }}
-{{- else -}}
-{{ include "celeborn.fullname" . }}-worker-priority-class
-{{- end }}
-{{- end }}
-
-{{/*
 Create the name of the celeborn image to use
 */}}
 {{- define "celeborn.image" -}}
 {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-{{- end }}
-
-{{/*
-Create the name of the master statefulset to use
-*/}}
-{{- define "celeborn.masterStatefulSetName" -}}
-{{ include "celeborn.fullname" . }}-master
-{{- end }}
-
-{{/*
-Create the name of the worker statefulset to use
-*/}}
-{{- define "celeborn.workerStatefulSetName" -}}
-{{ include "celeborn.fullname" . }}-worker
-{{- end }}
-
-{{/*
-Create the name of the master podmonitor to use
-*/}}
-{{- define "celeborn.masterPodMonitorName" -}}
-{{ include "celeborn.fullname" . }}-master-podmonitor
-{{- end }}
-
-{{/*
-Create the name of the worker podmonitor to use
-*/}}
-{{- define "celeborn.workerPodMonitorName" -}}
-{{ include "celeborn.fullname" . }}-worker-podmonitor
 {{- end }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -24,8 +24,8 @@ metadata:
 data:
   celeborn-defaults.conf: |-
     {{- $namespace := .Release.Namespace }}
-    celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}{{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
-    {{- range until (.Values.masterReplicas |int) }}
+    celeborn.master.endpoints={{ range until (.Values.master.replicas |int) }}{{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
+    {{- range until (.Values.master.replicas |int) }}
     celeborn.master.ha.node.{{ . }}.host={{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
     {{- end }}
     {{- $dirs := .Values.volumes.master }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -24,12 +24,21 @@ metadata:
 data:
   celeborn-defaults.conf: |-
     {{- $namespace := .Release.Namespace }}
-    celeborn.master.endpoints={{ range until (.Values.master.replicas |int) }}{{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
-    {{- range until (.Values.master.replicas |int) }}
-    celeborn.master.ha.node.{{ . }}.host={{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
+
+    {{- $endpoints := list }}
+    {{- range until (.Values.master.replicas | int) }}
+    {{- $endpoint := (printf "%s-%d.%s.%s.svc.%s" (include "celeborn.master.statefulSetName" $) . (include "celeborn.master.serviceName" $) $.Release.Namespace $.Values.cluster.domain) }}
+    {{- $endpoints = append $endpoints $endpoint }}
     {{- end }}
+    celeborn.master.endpoints={{ $endpoints | join "," }}
+
+    {{- range until (.Values.master.replicas | int) }}
+    celeborn.master.ha.node.{{ . }}.host={{ printf "%s-%d.%s.%s.svc.%s" (include "celeborn.master.statefulSetName" $) . (include "celeborn.master.serviceName" $) $.Release.Namespace $.Values.cluster.domain }}
+    {{- end }}
+
     {{- $dirs := .Values.master.volumes }}
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
+  
     {{- $path := "" }}
     {{- range $worker := .Values.worker.volumes }}
     {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "diskType" | default "HDD") ":capacity=" (get $worker "capacity" | default "1PB") | nospace) }}
@@ -40,6 +49,7 @@ data:
     {{- end }}
     {{- end }}
     celeborn.worker.storage.dirs={{ $path }}
+
     {{- range $key, $val := .Values.celeborn }}
     {{ $key }}={{ $val }}
     {{- end }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -44,75 +44,8 @@ data:
     {{ $key }}={{ $val }}
     {{- end }}
 
-  celeborn-env.sh: |
-    {{- range $key, $val := .Values.environments }}
-    {{ $key }}="{{ $val }}"
-    {{- end}} 
-
   log4j2.xml: |-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!--
-    ~ Licensed to the Apache Software Foundation (ASF) under one or more
-    ~ contributor license agreements.  See the NOTICE file distributed with
-    ~ this work for additional information regarding copyright ownership.
-    ~ The ASF licenses this file to You under the Apache License, Version 2.0
-    ~ (the "License"); you may not use this file except in compliance with
-    ~ the License.  You may obtain a copy of the License at
-    ~
-    ~     http://www.apache.org/licenses/LICENSE-2.0
-    ~
-    ~ Unless required by applicable law or agreed to in writing, software
-    ~ distributed under the License is distributed on an "AS IS" BASIS,
-    ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    ~ See the License for the specific language governing permissions and
-    ~ limitations under the License.
-    -->
-    <!--
-    ~ Extra logging related to initialization of Log4j.
-    ~ Set to debug or trace if log4j initialization is failing.
-    -->
-    <Configuration status="INFO">
-        <Appenders>
-            <Console name="stdout" target="SYSTEM_OUT">
-                <!--
-                  ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
-                  ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
-                  ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
-                  ~ class packaging information. That extra information can sometimes add a substantial
-                  ~ performance overhead, so we disable it in our default logging config.
-                  -->
-                <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
-            </Console>
-            <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log"
-                                     filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d-%i">
-                <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
-                <Policies>
-                    <SizeBasedTriggeringPolicy size="200 MB"/>
-                </Policies>
-                <DefaultRolloverStrategy max="7">
-                    <Delete basePath="${env:CELEBORN_LOG_DIR}" maxDepth="1">
-                        <IfFileName glob="celeborn.log*">
-                            <IfAny>
-                                <IfAccumulatedFileSize exceeds="1 GB" />
-                                <IfAccumulatedFileCount exceeds="10" />
-                            </IfAny>
-                        </IfFileName>
-                    </Delete>
-                </DefaultRolloverStrategy>
-            </RollingRandomAccessFile>
-        </Appenders>
+    {{- .Files.Get "files/conf/log4j2.xml" | nindent 4 }}
 
-        <Loggers>
-            <Root level="INFO">
-                <AppenderRef ref="stdout"/>
-                <AppenderRef ref="file"/>
-            </Root>
-            <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
-                <Appender-ref ref="stdout" level="WARN" />
-                <Appender-ref ref="file" level="WARN"/>
-            </Logger>
-        </Loggers>
-    </Configuration>
-
-  metrics.properties: >-
-    *.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
+  metrics.properties: |-
+    {{- .Files.Get "files/conf/metrics.properties" | nindent 4 }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -28,10 +28,10 @@ data:
     {{- range until (.Values.master.replicas |int) }}
     celeborn.master.ha.node.{{ . }}.host={{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
     {{- end }}
-    {{- $dirs := .Values.volumes.master }}
+    {{- $dirs := .Values.master.volumes }}
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
     {{- $path := "" }}
-    {{- range $worker := .Values.volumes.worker }}
+    {{- range $worker := .Values.worker.volumes }}
     {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "diskType" | default "HDD") ":capacity=" (get $worker "capacity" | default "1PB") | nospace) }}
     {{- if eq $path "" }}
     {{- $path = $info }}

--- a/charts/celeborn/templates/master/_helpers.tpl
+++ b/charts/celeborn/templates/master/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Common labels for Celeborn master resoruces
+*/}}
+{{- define "celeborn.master.labels" -}}
+{{ include "celeborn.labels" . }}
+app.kubernetes.io/role: master
+{{- end }}
+
+{{/*
+Selector labels for Celeborn master pods
+*/}}
+{{- define "celeborn.master.selectorLabels" -}}
+{{ include "celeborn.selectorLabels" . }}
+app.kubernetes.io/role: master
+{{- end }}
+
+{{/*
+Create the name of the master service to use
+*/}}
+{{- define "celeborn.master.serviceName" -}}
+{{ include "celeborn.fullname" . }}-master-svc
+{{- end }}
+
+
+{{/*
+Create the name of the master priority class to use
+*/}}
+{{- define "celeborn.master.priorityClassName" -}}
+{{- with .Values.master.priorityClass.name -}}
+{{ . }}
+{{- else -}}
+{{ include "celeborn.fullname" . }}-master-priority-class
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the master statefulset to use
+*/}}
+{{- define "celeborn.master.statefulSetName" -}}
+{{ include "celeborn.fullname" . }}-master
+{{- end }}
+
+{{/*
+Create the name of the master podmonitor to use
+*/}}
+{{- define "celeborn.master.podMonitorName" -}}
+{{ include "celeborn.fullname" . }}-master-podmonitor
+{{- end }}

--- a/charts/celeborn/templates/master/podmonitor.yaml
+++ b/charts/celeborn/templates/master/podmonitor.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.podMonitor.enable }}
+{{- if .Values.worker.podMonitor.enable }}
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -25,9 +25,9 @@ metadata:
     {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
-  - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
-    port: {{ .Values.podMonitor.podMetricsEndpoint.portName | quote }}
-    scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
+  - interval: {{ .Values.master.podMonitor.podMetricsEndpoint.interval }}
+    port: {{ .Values.master.podMonitor.podMetricsEndpoint.portName | quote }}
+    scheme: {{ .Values.master.podMonitor.podMetricsEndpoint.scheme }}
     path: {{ get .Values.celeborn "celeborn.metrics.prometheus.path" | default "/metrics/prometheus" }}
   jobLabel: celeborn-master-podmonitor
   namespaceSelector:

--- a/charts/celeborn/templates/master/podmonitor.yaml
+++ b/charts/celeborn/templates/master/podmonitor.yaml
@@ -20,9 +20,9 @@ limitations under the License.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "celeborn.masterPodMonitorName" . }}
+  name: {{ include "celeborn.master.podMonitorName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
@@ -35,7 +35,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: master
+      {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/celeborn/templates/master/priorityclass.yaml
+++ b/charts/celeborn/templates/master/priorityclass.yaml
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.priorityClass.master.create }}
+{{- if .Values.master.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "celeborn.master.priorityClassName" . }}
   labels:
     {{- include "celeborn.master.labels" . | nindent 4 }}
-value: {{ .Values.priorityClass.master.value }}
+value: {{ .Values.master.priorityClass.value }}
 {{- end }}

--- a/charts/celeborn/templates/master/priorityclass.yaml
+++ b/charts/celeborn/templates/master/priorityclass.yaml
@@ -19,8 +19,8 @@ limitations under the License.
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: {{ include "celeborn.masterPriorityClassName" . }}
+  name: {{ include "celeborn.master.priorityClassName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 value: {{ .Values.priorityClass.master.value }}
 {{- end }}

--- a/charts/celeborn/templates/master/service.yaml
+++ b/charts/celeborn/templates/master/service.yaml
@@ -25,9 +25,9 @@ spec:
   selector:
     {{- include "celeborn.master.selectorLabels" . | nindent 4 }}
   ports:
-  - port: {{ .Values.service.port }}
-    targetPort: {{ .Values.service.port }}
+  - port: {{ .Values.master.service.port }}
+    targetPort: {{ .Values.master.service.port }}
     protocol: TCP
     name: celeborn-master
-  type: {{ .Values.service.type }}
+  type: {{ .Values.master.service.type }}
   clusterIP: None

--- a/charts/celeborn/templates/master/service.yaml
+++ b/charts/celeborn/templates/master/service.yaml
@@ -18,13 +18,12 @@ limitations under the License.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "celeborn.masterServiceName" . }}
+  name: {{ include "celeborn.master.serviceName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "celeborn.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/role: master
+    {{- include "celeborn.master.selectorLabels" . | nindent 4 }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.service.port }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -133,7 +133,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.priorityClass.master.name .Values.priorityClass.master.create }}
+      {{- if or .Values.master.priorityClass.name .Values.master.priorityClass.create }}
       priorityClassName: {{ include "celeborn.master.priorityClassName" . }}
       {{- end }}
       {{- with .Values.dnsPolicy }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -83,11 +83,10 @@ spec:
         - containerPort: {{ get .Values.celeborn "celeborn.master.http.port" | default 9098 }}
           name: metrics
           protocol: TCP
+        {{- with .Values.master.env }}
         env:
-        {{- range $key, $val := .Values.environments }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: {{ include "celeborn.fullname" . }}-volume
           mountPath: /opt/celeborn/conf

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
         volumeMounts:
         - name: {{ $.Release.Name }}-master-vol-0
           mountPath: {{ (index $dirs 0).mountPath }}
-        {{- with .Values.resources.master }}
+        {{- with .Values.master.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -78,8 +78,6 @@ spec:
             echo "waiting for master"; 
             sleep 2;
           done && exec /opt/celeborn/sbin/start-master.sh
-        resources:
-          {{- toYaml .Values.resources.master | nindent 10 }}
         ports:
         - containerPort: {{ .Values.service.port }}
         - containerPort: {{ get .Values.celeborn "celeborn.master.http.port" | default 9098 }}
@@ -98,7 +96,7 @@ spec:
         - name: {{ $.Release.Name }}-master-vol-{{ $index }}
           mountPath: {{ .mountPath }}
         {{- end }}
-        {{- with .Values.resources.master }}
+        {{- with .Values.master.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -18,21 +18,18 @@ limitations under the License.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "celeborn.masterStatefulSetName" . }}
+  name: {{ include "celeborn.master.statefulSetName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
-    app.kubernetes.io/role: master
+    {{- include "celeborn.master.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "celeborn.masterServiceName" . }}
+  serviceName: {{ include "celeborn.master.serviceName" . }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: master
+      {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "celeborn.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/role: master
+        {{- include "celeborn.master.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
       {{- with .Values.podAnnotations }}
       annotations:
@@ -75,7 +72,7 @@ spec:
         {{- $namespace := .Release.Namespace }}
         - >
           until {{ range until (.Values.masterReplicas | int) }}
-          nslookup {{ include "celeborn.masterStatefulSetName" $ }}-{{ . }}.{{ include "celeborn.masterServiceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
+          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
           {{- end }}
           true; do
             echo "waiting for master"; 
@@ -139,7 +136,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if or .Values.priorityClass.master.name .Values.priorityClass.master.create }}
-      priorityClassName: {{ include "celeborn.masterPriorityClassName" . }}
+      priorityClassName: {{ include "celeborn.master.priorityClassName" . }}
       {{- end }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -106,6 +106,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.master.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         {{- include "celeborn.master.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.master.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
         - -c
         {{- $namespace := .Release.Namespace }}
         - >
-          until {{ range until (.Values.masterReplicas | int) }}
+          until {{ range until (.Values.master.replicas | int) }}
           nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
           {{- end }}
           true; do
@@ -149,4 +149,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 30
-  replicas: {{ .Values.masterReplicas }}
+  {{- with .Values.master.replicas }}
+  replicas: {{ . }}
+  {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
     spec:
       initContainers:
-      {{- $dirs := .Values.volumes.master }}
+      {{- $dirs := .Values.master.volumes }}
       {{- if eq "hostPath" (index $dirs 0).type }}
       - name: chown-{{ $.Release.Name }}-master-volume
         image: alpine:3.18
@@ -92,7 +92,7 @@ spec:
         - name: {{ include "celeborn.fullname" . }}-volume
           mountPath: /opt/celeborn/conf
           readOnly: true
-        {{- range $index, $volume := .Values.volumes.master }}
+        {{- range $index, $volume := .Values.master.volumes}}
         - name: {{ $.Release.Name }}-master-vol-{{ $index }}
           mountPath: {{ .mountPath }}
         {{- end }}
@@ -108,7 +108,7 @@ spec:
       - name: {{ include "celeborn.fullname" . }}-volume
         configMap:
           name: {{ include "celeborn.configMapName" . }}
-      {{- range $index, $volume := .Values.volumes.master }}
+      {{- range $index, $volume := .Values.master.volumes }}
       - name: {{ $.Release.Name }}-master-vol-{{ $index }}
       {{- if eq "emptyDir" $volume.type }}
         emptyDir:

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
             sleep 2;
           done && exec /opt/celeborn/sbin/start-master.sh
         ports:
-        - containerPort: {{ .Values.service.port }}
+        - containerPort: {{ .Values.master.service.port }}
         - containerPort: {{ get .Values.celeborn "celeborn.master.http.port" | default 9098 }}
           name: metrics
           protocol: TCP

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -136,7 +136,7 @@ spec:
       {{- if or .Values.master.priorityClass.name .Values.master.priorityClass.create }}
       priorityClassName: {{ include "celeborn.master.priorityClassName" . }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
+      {{- with .Values.master.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.hostNetwork }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -125,12 +125,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
+      {{- with .Values.master.affinity }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity.master }}
-      affinity:
+      {{- with .Values.tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if or .Values.master.priorityClass.name .Values.master.priorityClass.create }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -72,7 +72,7 @@ spec:
         {{- $namespace := .Release.Namespace }}
         - >
           until {{ range until (.Values.master.replicas | int) }}
-          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
+          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.domain }} &&
           {{- end }}
           true; do
             echo "waiting for master"; 

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
       labels:
         {{- include "celeborn.master.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
+      {{- with .Values.master.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.master.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
       {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.master.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
         command:
         - chown
-        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
+        - {{ .Values.master.podSecurityContext.runAsUser | default 10006 }}:{{ .Values.worker.podSecurityContext.runAsGroup | default 10006 }}
         - {{ (index $dirs 0).mountPath }}
         volumeMounts:
         - name: {{ $.Release.Name }}-master-vol-0
@@ -142,7 +142,7 @@ spec:
       {{- with .Values.master.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.master.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -87,6 +87,10 @@ spec:
         env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.master.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: {{ include "celeborn.fullname" . }}-volume
           mountPath: /opt/celeborn/conf

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -129,7 +129,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.master.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -139,7 +139,7 @@ spec:
       {{- with .Values.master.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
+      {{- with .Values.master.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
       {{- with .Values.securityContext }}

--- a/charts/celeborn/templates/worker/_helpers.tpl
+++ b/charts/celeborn/templates/worker/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Common labels for Celeborn master resoruces
+*/}}
+{{- define "celeborn.worker.labels" -}}
+{{ include "celeborn.labels" . }}
+app.kubernetes.io/role: worker
+{{- end }}
+
+{{/*
+Selector labels for Celeborn master pods
+*/}}
+{{- define "celeborn.worker.selectorLabels" -}}
+{{ include "celeborn.selectorLabels" . }}
+app.kubernetes.io/role: worker
+{{- end }}
+
+{{/*
+Create the name of the worker service to use
+*/}}
+{{- define "celeborn.worker.serviceName" -}}
+{{ include "celeborn.fullname" . }}-worker-svc
+{{- end }}
+
+
+{{/*
+Create the name of the worker priority class to use
+*/}}
+{{- define "celeborn.worker.priorityClassName" -}}
+{{- with .Values.worker.priorityClass.name -}}
+{{ . }}
+{{- else -}}
+{{ include "celeborn.fullname" . }}-worker-priority-class
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the worker statefulset to use
+*/}}
+{{- define "celeborn.worker.statefulSetName" -}}
+{{ include "celeborn.fullname" . }}-worker
+{{- end }}
+
+
+{{/*
+Create the name of the worker podmonitor to use
+*/}}
+{{- define "celeborn.worker.podMonitorName" -}}
+{{ include "celeborn.fullname" . }}-worker-podmonitor
+{{- end }}

--- a/charts/celeborn/templates/worker/podmonitor.yaml
+++ b/charts/celeborn/templates/worker/podmonitor.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.podMonitor.enable }}
+{{- if .Values.worker.podMonitor.enable }}
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -25,9 +25,9 @@ metadata:
     {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
-  - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
-    port: {{ .Values.podMonitor.podMetricsEndpoint.portName | quote }}
-    scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
+  - interval: {{ .Values.worker.podMonitor.podMetricsEndpoint.interval }}
+    port: {{ .Values.worker.podMonitor.podMetricsEndpoint.portName | quote }}
+    scheme: {{ .Values.worker.podMonitor.podMetricsEndpoint.scheme }}
     path: {{ get .Values.celeborn "celeborn.metrics.prometheus.path" | default "/metrics/prometheus" }}
   jobLabel: celeborn-worker-podmonitor
   namespaceSelector:

--- a/charts/celeborn/templates/worker/podmonitor.yaml
+++ b/charts/celeborn/templates/worker/podmonitor.yaml
@@ -20,9 +20,9 @@ limitations under the License.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "celeborn.workerPodMonitorName" . }}
+  name: {{ include "celeborn.worker.podMonitorName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
@@ -35,7 +35,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: worker
+      {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/celeborn/templates/worker/priorityclass.yaml
+++ b/charts/celeborn/templates/worker/priorityclass.yaml
@@ -19,8 +19,8 @@ limitations under the License.
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: {{ include "celeborn.workerPriorityClassName" . }}
+  name: {{ include "celeborn.worker.priorityClassName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 value: {{ .Values.priorityClass.worker.value }}
 {{- end }}

--- a/charts/celeborn/templates/worker/priorityclass.yaml
+++ b/charts/celeborn/templates/worker/priorityclass.yaml
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.priorityClass.worker.create }}
+{{- if .Values.worker.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "celeborn.worker.priorityClassName" . }}
   labels:
     {{- include "celeborn.worker.labels" . | nindent 4 }}
-value: {{ .Values.priorityClass.worker.value }}
+value: {{ .Values.worker.priorityClass.value }}
 {{- end }}

--- a/charts/celeborn/templates/worker/service.yaml
+++ b/charts/celeborn/templates/worker/service.yaml
@@ -18,12 +18,11 @@ limitations under the License.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "celeborn.workerServiceName" . }}
+  name: {{ include "celeborn.worker.serviceName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "celeborn.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/role: worker
+    {{- include "celeborn.worker.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
   clusterIP: None

--- a/charts/celeborn/templates/worker/service.yaml
+++ b/charts/celeborn/templates/worker/service.yaml
@@ -24,5 +24,5 @@ metadata:
 spec:
   selector:
     {{- include "celeborn.worker.selectorLabels" . | nindent 4 }}
-  type: {{ .Values.service.type }}
+  type: {{ .Values.worker.service.type }}
   clusterIP: None

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
       labels:
         {{- include "celeborn.worker.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
+      {{- with .Values.worker.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.worker.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
           mountPath: {{ $dir.mountPath }}
         {{- end}}
-        {{- with .Values.resources.worker }}
+        {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -82,8 +82,6 @@ spec:
             echo "waiting for master";
             sleep 2;
           done && exec /opt/celeborn/sbin/start-worker.sh
-        resources:
-          {{- toYaml .Values.resources.worker | nindent 10 }}
         ports:
         - containerPort: {{ get .Values.celeborn "celeborn.worker.http.port" | default 9096 }}
           name: metrics
@@ -101,7 +99,7 @@ spec:
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
           mountPath: {{ .mountPath }}
         {{- end }}
-        {{- with .Values.resources.worker }}
+        {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
         {{- $namespace := .Release.Namespace }}
         - >
           until {{ range until (.Values.master.replicas | int) }}
-          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
+          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.domain }} && 
           {{- end }}
           true; do
             echo "waiting for master";

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -128,12 +128,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
+      {{- with .Values.worker.affinity }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity.worker }}
-      affinity:
+      {{- with .Values.tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if or .Values.worker.priorityClass.name .Values.worker.priorityClass.create }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -132,7 +132,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -136,7 +136,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.priorityClass.worker.name .Values.priorityClass.worker.create }}
+      {{- if or .Values.worker.priorityClass.name .Values.worker.priorityClass.create }}
       priorityClassName: {{ include "celeborn.worker.priorityClassName" . }}
       {{- end }}
       {{- with .Values.dnsPolicy }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -105,7 +105,7 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         {{- include "celeborn.worker.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.worker.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
     spec:
       initContainers:
-      {{- $dirs := .Values.volumes.worker }}
+      {{- $dirs := .Values.worker.volumes }}
       {{- if eq "hostPath" (index $dirs 0).type }}
       - name: chown-{{ $.Release.Name }}-worker-volume
         image: alpine:3.18
@@ -95,7 +95,7 @@ spec:
         - mountPath: /opt/celeborn/conf
           name: {{ include "celeborn.fullname" . }}-volume
           readOnly: true
-        {{- range $index, $volume := .Values.volumes.worker }}
+        {{- range $index, $volume := .Values.worker.volumes }}
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
           mountPath: {{ .mountPath }}
         {{- end }}
@@ -111,7 +111,7 @@ spec:
       - name: {{ include "celeborn.fullname" . }}-volume
         configMap:
           name: {{ include "celeborn.configMapName" . }}
-      {{- range $index, $volume := .Values.volumes.worker }}
+      {{- range $index, $volume := .Values.worker.volumes }}
       - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
       {{- if eq "emptyDir" $volume.type }}
         emptyDir:

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -109,6 +109,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.worker.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -18,21 +18,18 @@ limitations under the License.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "celeborn.workerStatefulSetName" . }}
+  name: {{ include "celeborn.worker.statefulSetName" . }}
   labels:
-    {{- include "celeborn.labels" . | nindent 4 }}
-    app.kubernetes.io/role: worker
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "celeborn.workerServiceName" . }}
+  serviceName: {{ include "celeborn.worker.serviceName" . }}
   selector:
     matchLabels:
-      {{- include "celeborn.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/role: worker
+      {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "celeborn.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/role: worker
+        {{- include "celeborn.worker.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
       {{- with .Values.podAnnotations }}
       annotations:
@@ -79,7 +76,7 @@ spec:
         {{- $namespace := .Release.Namespace }}
         - >
           until {{ range until (.Values.masterReplicas | int) }}
-          nslookup {{ include "celeborn.masterStatefulSetName" $ }}-{{ . }}.{{ include "celeborn.masterServiceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
+          nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
           {{- end }}
           true; do
             echo "waiting for master";
@@ -142,7 +139,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if or .Values.priorityClass.worker.name .Values.priorityClass.worker.create }}
-      priorityClassName: {{ include "celeborn.workerPriorityClassName" . }}
+      priorityClassName: {{ include "celeborn.worker.priorityClassName" . }}
       {{- end }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -86,11 +86,10 @@ spec:
         - containerPort: {{ get .Values.celeborn "celeborn.worker.http.port" | default 9096 }}
           name: metrics
           protocol: TCP
+        {{- with .Values.worker.env }}
         env:
-        {{- range $key, $val := .Values.environments }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /opt/celeborn/conf
           name: {{ include "celeborn.fullname" . }}-volume

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -139,7 +139,7 @@ spec:
       {{- if or .Values.worker.priorityClass.name .Values.worker.priorityClass.create }}
       priorityClassName: {{ include "celeborn.worker.priorityClassName" . }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
+      {{- with .Values.worker.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.hostNetwork }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
         command:
         - chown
-        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
+        - {{ .Values.worker.podSecurityContext.runAsUser | default 10006 }}:{{ .Values.worker.podSecurityContext.runAsGroup | default 10006 }}
         {{- range $dir := $dirs }}
         - {{ $dir.mountPath }}
         {{- end}}
@@ -145,7 +145,7 @@ spec:
       {{- with .Values.worker.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.worker.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
         - -c
         {{- $namespace := .Release.Namespace }}
         - >
-          until {{ range until (.Values.masterReplicas | int) }}
+          until {{ range until (.Values.master.replicas | int) }}
           nslookup {{ include "celeborn.master.statefulSetName" $ }}-{{ . }}.{{ include "celeborn.master.serviceName" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
           {{- end }}
           true; do
@@ -152,4 +152,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 30
-  replicas: {{ .Values.workerReplicas }}
+  {{- with .Values.worker.replicas }}
+  replicas: {{ . }}
+  {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -124,7 +124,7 @@ spec:
       {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -142,7 +142,7 @@ spec:
       {{- with .Values.worker.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
+      {{- with .Values.worker.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
       {{- with .Values.securityContext }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -90,6 +90,10 @@ spec:
         env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.worker.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /opt/celeborn/conf
           name: {{ include "celeborn.fullname" . }}-volume

--- a/charts/celeborn/tests/configmap_test.yaml
+++ b/charts/celeborn/tests/configmap_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should create configmap
@@ -35,7 +36,5 @@ tests:
     asserts:
       - exists:
           path: data["celeborn-defaults.conf"]
-      - exists:
-          path: data["celeborn-env.sh"]
       - exists:
           path: data["log4j2.xml"]

--- a/charts/celeborn/tests/master/podmonitor_test.yaml
+++ b/charts/celeborn/tests/master/podmonitor_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create master pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true
@@ -50,12 +51,13 @@ tests:
       apiVersions:
         - monitoring.coreos.com/v1/PodMonitor
     set:
-      podMonitor:
-        enable: true
-        podMetricsEndpoint:
-          scheme: http
-          interval: 3s
-          portName: test-port
+      master:
+        podMonitor:
+          enable: true
+          podMetricsEndpoint:
+            scheme: http
+            interval: 3s
+            portName: test-port
     asserts:
       - contains:
           path: spec.podMetricsEndpoints
@@ -73,8 +75,9 @@ tests:
     set:
       celeborn:
         celeborn.metrics.prometheus.path: custom-metrics-path
-      podMonitor:
-        enable: true
+      master:
+        podMonitor:
+          enable: true
     asserts:
       - contains:
           path: spec.podMetricsEndpoints

--- a/charts/celeborn/tests/master/priorityclass_test.yaml
+++ b/charts/celeborn/tests/master/priorityclass_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create master priority as default
@@ -29,10 +30,10 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: Should create master priority class if `priorityClass.master.create` is true
+  - it: Should create master priority class if `master.priorityClass.create` is true
     set:
-      priorityClass:
-        master:
+      master:
+        priorityClass:
           create: true
     asserts:
       - containsDocument:
@@ -42,8 +43,8 @@ tests:
 
   - it: Should use the specified priority class value
     set:
-      priorityClass:
-        master:
+      master:
+        priorityClass:
           create: true
           value: 1000
     asserts:

--- a/charts/celeborn/tests/master/service_test.yaml
+++ b/charts/celeborn/tests/master/service_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should create master service
@@ -39,9 +40,10 @@ tests:
 
   - it: Should create master service with the specified service type and port
     set:
-      service:
-        type: NodePort
-        port: 9097
+      master:
+        service:
+          type: NodePort
+          port: 9097
     asserts:
       - equal:
           path: spec.type

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -22,30 +22,19 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
-  - it: Should add extra pod annotations if `podAnnotations` is specified
-    set:
-      podAnnotations:
-        key1: value1
-        key2: value2
-    asserts:
-      - equal:
-          path: spec.template.metadata.annotations.key1
-          value: value1
-      - equal:
-          path: spec.template.metadata.annotations.key2
-          value: value2
-
-  - it: Should use the specified image if `image.repository` and `image.tag` is set
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` are set
     set:
       image:
+        registry: test-registry
         repository: test-repository
         tag: test-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: test-repository:test-tag
+          value: test-registry/test-repository:test-tag
 
   - it: Should use the specified image pull policy if `image.pullPolicy` is set
     set:
@@ -56,11 +45,12 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
-  - it: Should add secrets if `imagePullSecrets` is set
+  - it: Should add image pull secrets if `image.pullSecrets` is set
     set:
-      imagePullSecrets:
-        - name: test-secret1
-        - name: test-secret2
+      image:
+        pullSecrets:
+          - name: test-secret1
+          - name: test-secret2
     asserts:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
@@ -69,11 +59,49 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should use the specified replicas if `master.replicas` is set
     set:
-      nodeSelector:
-        key1: value1
-        key2: value2
+      master:
+        replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+
+  - it: Should add extra pod labels if `master.labels` is set
+    set:
+      master:
+        labels:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.labels.key2
+          value: value2
+
+  - it: Should add extra pod annotations if `master.annotations` is set
+    set:
+      master:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add node selector if `master.nodeSelector` is set
+    set:
+      master:
+        nodeSelector:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector.key1
@@ -82,32 +110,10 @@ tests:
           path: spec.template.spec.nodeSelector.key2
           value: value2
 
-  - it: Should add tolerations if `tolerations` is set
+  - it: Should use the specified affinity if `master.affinity` is set
     set:
-      tolerations:
-        - key: key1
-          operator: Equal
-          value: value1
-          effect: NoSchedule
-        - key: key2
-          operator: Exists
-          effect: NoSchedule
-    asserts:
-      - equal:
-          path: spec.template.spec.tolerations
-          value:
-            - key: key1
-              operator: Equal
-              value: value1
-              effect: NoSchedule
-            - key: key2
-              operator: Exists
-              effect: NoSchedule
-
-  - it: Should use the specified affinity if `affinity.master` is set
-    set:
-      affinity:
-        master:
+      master:
+        affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
@@ -146,53 +152,170 @@ tests:
                       values:
                         - another-node-label-value
 
-  - it: Should use the specified priority class name if `priorityClass.master.name` is set
+  - it: Should add tolerations if `master.tolerations` is set
     set:
-      priorityClass:
-        master:
+      master:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified priority class name if `master.priorityClass.name` is set
+    set:
+      master:
+        priorityClass:
           name: test-priority-class
     asserts:
       - equal:
           path: spec.template.spec.priorityClassName
           value: test-priority-class
 
-  - it: Should use the specified dns policy if `dnsPolicy` is set
+  - it: Should use the specified dns policy if `master.dnsPolicy` is set
     set:
-      dnsPolicy: ClusterFirstWithHostNet
+      master:
+        dnsPolicy: ClusterFirstWithHostNet
     asserts:
       - equal:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
-  - it: Should enable host network if `hostNetwork` is set to true
+  - it: Should enable host network if `master.hostNetwork` is set to true
     set:
-      hostNetwork: true
+      master:
+        hostNetwork: true
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
 
-  - it: Should use the specified security context if `podSecurityContext` is set
+  - it: Should use the specified pod security context if `master.podSecurityContext` is set
     set:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      master:
+        podSecurityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
     asserts:
       - equal:
-          path: spec.template.spec.securityContext.runAsUser
-          value: 1000
-      - equal:
-          path: spec.template.spec.securityContext.runAsGroup
-          value: 2000
-      - equal:
-          path: spec.template.spec.securityContext.fsGroup
-          value: 3000
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003
 
-  - it: Should use the specified replicas if `masterReplicas` is set
+  - it: Should add environment variables if `master.env` is set
     set:
-      masterReplicas: 10
+      master:
+        env:
+          - name: test-env-name-1
+            value: test-env-value-1
+          - name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+          - name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-1
+            value: test-env-value-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+
+  - it: Should add environment variables if `master.envFrom` is set
+    set:
+      master:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+              optional: false
+          - secretRef:
+              name: test-secret
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+              optional: false
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret
+              optional: false
+
+  - it: Should add resources if `master.resources` if set
+    set:
+      master:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
     asserts:
       - equal:
-          path: spec.replicas
-          value: 10
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+  - it: Should add container security context if `master.securityContext` is set
+    set:
+      master:
+        securityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003

--- a/charts/celeborn/tests/worker/podmonitor_test.yaml
+++ b/charts/celeborn/tests/worker/podmonitor_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create worker pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true
@@ -50,12 +51,13 @@ tests:
       apiVersions:
         - monitoring.coreos.com/v1/PodMonitor
     set:
-      podMonitor:
-        enable: true
-        podMetricsEndpoint:
-          scheme: http
-          interval: 3s
-          portName: test-port
+      worker:
+        podMonitor:
+          enable: true
+          podMetricsEndpoint:
+            scheme: http
+            interval: 3s
+            portName: test-port
     asserts:
       - contains:
           path: spec.podMetricsEndpoints
@@ -73,8 +75,9 @@ tests:
     set:
       celeborn:
         celeborn.metrics.prometheus.path: custom-metrics-path
-      podMonitor:
-        enable: true
+      worker:
+        podMonitor:
+          enable: true
     asserts:
       - contains:
           path: spec.podMetricsEndpoints

--- a/charts/celeborn/tests/worker/priorityclass_test.yaml
+++ b/charts/celeborn/tests/worker/priorityclass_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should not create worker priority as default
@@ -29,10 +30,10 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: Should create worker priority class if `priorityClass.worker.create` is true
+  - it: Should create worker priority class if `worker.priorityClass.create` is true
     set:
-      priorityClass:
-        worker:
+      worker:
+        priorityClass:
           create: true
     asserts:
       - containsDocument:
@@ -42,8 +43,8 @@ tests:
 
   - it: Should use the specified priority class value
     set:
-      priorityClass:
-        worker:
+      worker:
+        priorityClass:
           create: true
           value: 1000
     asserts:

--- a/charts/celeborn/tests/worker/service_test.yaml
+++ b/charts/celeborn/tests/worker/service_test.yaml
@@ -22,6 +22,7 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
   - it: Should create worker service
@@ -39,8 +40,9 @@ tests:
 
   - it: Should create worker service with the specified service type
     set:
-      service:
-        type: NodePort
+      worker:
+        service:
+          type: NodePort
     asserts:
       - equal:
           path: spec.type

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -22,30 +22,19 @@ templates:
 
 release:
   name: celeborn
+  namespace: celeborn
 
 tests:
-  - it: Should add extra pod annotations if `podAnnotations` is specified
-    set:
-      podAnnotations:
-        key1: value1
-        key2: value2
-    asserts:
-      - equal:
-          path: spec.template.metadata.annotations.key1
-          value: value1
-      - equal:
-          path: spec.template.metadata.annotations.key2
-          value: value2
-
-  - it: Should use the specified image if `image.repository` and `image.tag` is set
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` are set
     set:
       image:
+        registry: test-registry
         repository: test-repository
         tag: test-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: test-repository:test-tag
+          value: test-registry/test-repository:test-tag
 
   - it: Should use the specified image pull policy if `image.pullPolicy` is set
     set:
@@ -56,11 +45,12 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
-  - it: Should add secrets if `imagePullSecrets` is set
+  - it: Should add image pull secrets if `image.pullSecrets` is set
     set:
-      imagePullSecrets:
-        - name: test-secret1
-        - name: test-secret2
+      image:
+        pullSecrets:
+          - name: test-secret1
+          - name: test-secret2
     asserts:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
@@ -69,11 +59,49 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should use the specified replicas if `worker.replicas` is set
     set:
-      nodeSelector:
-        key1: value1
-        key2: value2
+      worker:
+        replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+
+  - it: Should add extra pod labels if `worker.labels` is set
+    set:
+      worker:
+        labels:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.labels.key2
+          value: value2
+
+  - it: Should add extra pod annotations if `worker.annotations` is set
+    set:
+      worker:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add node selector if `worker.nodeSelector` is set
+    set:
+      worker:
+        nodeSelector:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector.key1
@@ -82,32 +110,10 @@ tests:
           path: spec.template.spec.nodeSelector.key2
           value: value2
 
-  - it: Should add tolerations if `tolerations` is set
+  - it: Should use the specified affinity if `worker.affinity` is specified
     set:
-      tolerations:
-        - key: key1
-          operator: Equal
-          value: value1
-          effect: NoSchedule
-        - key: key2
-          operator: Exists
-          effect: NoSchedule
-    asserts:
-      - equal:
-          path: spec.template.spec.tolerations
-          value:
-            - key: key1
-              operator: Equal
-              value: value1
-              effect: NoSchedule
-            - key: key2
-              operator: Exists
-              effect: NoSchedule
-
-  - it: Should use the specified affinity if `affinity.worker` is specified
-    set:
-      affinity:
-        worker:
+      worker:
+        affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
@@ -146,53 +152,170 @@ tests:
                       values:
                         - another-node-label-value
 
-  - it: Should use the specified priority class name if `priorityClass.worker.name` is set
+  - it: Should add tolerations if `worker.tolerations` is set
     set:
-      priorityClass:
-        worker:
+      worker:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified priority class name if `worker.priorityClass.name` is set
+    set:
+      worker:
+        priorityClass:
           name: test-priority-class
     asserts:
       - equal:
           path: spec.template.spec.priorityClassName
           value: test-priority-class
 
-  - it: Should use the specified dns policy if `dnsPolicy` is set
+  - it: Should use the specified dns policy if `worker.dnsPolicy` is set
     set:
-      dnsPolicy: ClusterFirstWithHostNet
+      worker:
+        dnsPolicy: ClusterFirstWithHostNet
     asserts:
       - equal:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
-  - it: Should enable host network if `hostNetwork` is set to true
+  - it: Should enable host network if `worker.hostNetwork` is set to true
     set:
-      hostNetwork: true
+      worker:
+        hostNetwork: true
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
 
-  - it: Should use the specified security context if `podSecurityContext` is set
+  - it: Should use the specified security context if `worker.podSecurityContext` is set
     set:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      worker:
+        podSecurityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
     asserts:
       - equal:
-          path: spec.template.spec.securityContext.runAsUser
-          value: 1000
-      - equal:
-          path: spec.template.spec.securityContext.runAsGroup
-          value: 2000
-      - equal:
-          path: spec.template.spec.securityContext.fsGroup
-          value: 3000
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003
 
-  - it: Should use the specified replicas if `workerReplicas` is set
+  - it: Should add environment variables if `worker.env` is set
     set:
-      workerReplicas: 10
+      worker:
+        env:
+          - name: test-env-name-1
+            value: test-env-value-1
+          - name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+          - name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-1
+            value: test-env-value-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+
+  - it: Should add environment variables if `worker.envFrom` is set
+    set:
+      worker:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+              optional: false
+          - secretRef:
+              name: test-secret
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+              optional: false
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret
+              optional: false
+
+  - it: Should add resources if `worker.resources` if set
+    set:
+      worker:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
     asserts:
       - equal:
-          path: spec.replicas
-          value: 10
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+  - it: Should add container security context if `worker.securityContext` is set
+    set:
+      worker:
+        securityContext:
+          runAsUser: 10001
+          runAsGroup: 10002
+          fsGroup: 10003
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 10001
+            runAsGroup: 10002
+            fsGroup: 10003

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -106,6 +106,15 @@ master:
   # -- Specifies whether to use the host's network namespace for Celeborn master pods
   hostNetwork: false
 
+  # -- Specifies security context for Celeborn master pods
+  podSecurityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+    # Specifies the GID to use when modifying ownership and permissions of the mounted volumes
+    fsGroup: 10006
+    
   # -- Resources for Celeborn master pods
   resources: {}
     # requests:
@@ -197,6 +206,15 @@ worker:
   # -- Specifies whether to use the host's network namespace for Celeborn worker pods
   hostNetwork: false
 
+  # -- Specifies security context for Celeborn worker pods
+  podSecurityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+    # Specifies the GID to use when modifying ownership and permissions of the mounted volumes
+    fsGroup: 10006
+
   # -- Resources for Celeborn worker pods
   resources: {}
     # requests:
@@ -245,15 +263,6 @@ environments:
   CELEBORN_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
   CELEBORN_NO_DAEMONIZE: 1
   TZ: "Asia/Shanghai"
-
-# -- Container security context
-securityContext:
-  # Specifies the user ID to run the entrypoint of the container process
-  runAsUser: 10006
-  # Specifies the group ID to run the entrypoint of the container process
-  runAsGroup: 10006
-  # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
-  fsGroup: 10006
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -43,6 +43,17 @@ master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3
   replicas: 3
 
+  # Currently supported volume types are `emptyDir` and `hostPath`.
+  # Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
+  # Celeborn Master will pick first volumes for store raft log.
+  # `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
+  # -- Specifies volumes for Celeborn master pods
+  volumes:
+  - mountPath: /mnt/celeborn_ratis
+    hostPath: /mnt/celeborn_ratis
+    type: hostPath
+    capacity: 100Gi
+
   # Priority class for Celeborn master pods
   priorityClass:
     # -- Specifies whether to create a new priority class for Celeborn master pods
@@ -65,6 +76,32 @@ master:
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
+
+  # Currently supported volume types are `emptyDir` and `hostPath`.
+  # Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
+  # `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
+  # -- Specifies volumes for Celeborn worker pods
+  volumes:
+  - mountPath: /mnt/disk1
+    hostPath: /mnt/disk1
+    type: hostPath
+    diskType: SSD
+    capacity: 100Gi
+  - mountPath: /mnt/disk2
+    hostPath: /mnt/disk2
+    type: hostPath
+    diskType: SSD
+    capacity: 100Gi
+  - mountPath: /mnt/disk3
+    hostPath: /mnt/disk3
+    type: hostPath
+    diskType: SSD
+    capacity: 100Gi
+  - mountPath: /mnt/disk4
+    hostPath: /mnt/disk4
+    type: hostPath
+    diskType: SSD
+    capacity: 100Gi
 
   # Priority class for Celeborn worker pods
   priorityClass:
@@ -94,41 +131,6 @@ service:
 cluster:
   # -- Specifies Kubernetes cluster name
   name: cluster
-
-# Specifies Celeborn volumes.
-# Currently supported volume types are `emptyDir` and `hostPath`.
-# Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
-# Celeborn Master will pick first volumes for store raft log.
-# `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
-volumes:
-  # -- Specifies volumes for Celeborn master pods
-  master:
-    - mountPath: /mnt/celeborn_ratis
-      hostPath: /mnt/celeborn_ratis
-      type: hostPath
-      capacity: 100Gi
-  # -- Specifies volumes for Celeborn worker pods
-  worker:
-    - mountPath: /mnt/disk1
-      hostPath: /mnt/disk1
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-    - mountPath: /mnt/disk2
-      hostPath: /mnt/disk2
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-    - mountPath: /mnt/disk3
-      hostPath: /mnt/disk3
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
-    - mountPath: /mnt/disk4
-      hostPath: /mnt/disk4
-      type: hostPath
-      diskType: SSD
-      capacity: 100Gi
 
 # -- Celeborn configurations
 celeborn:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -100,6 +100,9 @@ master:
     # -- Specifies the integer value of this priority class, default is half of system-cluster-critical
     value: 1000000000
 
+  # -- Specifies the DNS policy for Celeborn master pods
+  dnsPolicy: ClusterFirst
+
   # -- Resources for Celeborn master pods
   resources: {}
     # requests:
@@ -185,6 +188,9 @@ worker:
     # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
     value: 999999000
 
+  # -- Specifies the DNS policy for Celeborn worker pods
+  dnsPolicy: ClusterFirst
+
   # -- Resources for Celeborn worker pods
   resources: {}
     # requests:
@@ -233,9 +239,6 @@ environments:
   CELEBORN_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
   CELEBORN_NO_DAEMONIZE: 1
   TZ: "Asia/Shanghai"
-
-# -- Specifies the DNS policy for Celeborn pods to use
-dnsPolicy: ClusterFirst
 
 # -- Specifies whether to use the host's network namespace
 hostNetwork: false

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -59,6 +59,11 @@ master:
     type: hostPath
     capacity: 100Gi
 
+  # -- Node selector for Celeborn master pods
+  nodeSelector: {}
+    # key1: value1
+    # key2: value2
+
   # Priority class for Celeborn master pods
   priorityClass:
     # -- Specifies whether to create a new priority class for Celeborn master pods
@@ -112,6 +117,11 @@ worker:
     type: hostPath
     diskType: SSD
     capacity: 100Gi
+
+  # -- Node selector for Celeborn worker pods
+  nodeSelector: {}
+    # key1: value1
+    # key2: value2
 
   # Priority class for Celeborn worker pods
   priorityClass:
@@ -186,11 +196,6 @@ securityContext:
   runAsGroup: 10006
   # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
   fsGroup: 10006
-
-# -- Pod node selector
-nodeSelector: {}
-# key1: value1
-# key2: value2
 
 # -- Pod tolerations
 tolerations: []

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -80,6 +80,16 @@ master:
             - master
         topologyKey: kubernetes.io/hostname
 
+  # -- Node selector for Celeborn master pods
+  tolerations: []
+  # - key: key1
+  #   operator: Equal
+  #   value: value1
+  #   effect: NoSchedule
+  # - key: key2
+  #   operator: Exists
+  #   effect: NoSchedule
+
   # Priority class for Celeborn master pods
   priorityClass:
     # -- Specifies whether to create a new priority class for Celeborn master pods
@@ -155,6 +165,16 @@ worker:
             - worker
         topologyKey: kubernetes.io/hostname
 
+  # -- Node selector for Celeborn worker pods
+  tolerations: []
+  # - key: key1
+  #   operator: Equal
+  #   value: value1
+  #   effect: NoSchedule
+  # - key: key2
+  #   operator: Exists
+  #   effect: NoSchedule
+
   # Priority class for Celeborn worker pods
   priorityClass:
     # -- Specifies whether to create a new priority class for Celeborn worker pods
@@ -228,16 +248,6 @@ securityContext:
   runAsGroup: 10006
   # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
   fsGroup: 10006
-
-# -- Pod tolerations
-tolerations: []
-# - key: key1
-#   operator: Equal
-#   value: value1
-#   effect: NoSchedule
-# - key: key2
-#   operator: Exists
-#   effect: NoSchedule
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -213,6 +213,13 @@ master:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # -- Security context for Celeborn master containers
+  securityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+
   service:
     # -- Specifies service type for Celeborn master service
     type: ClusterIP
@@ -363,7 +370,14 @@ worker:
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
-  
+
+  # -- Security context for Celeborn worker containers
+  securityContext:
+    # Specifies the UID to run the entrypoint of the container process
+    runAsUser: 10006
+    # Specifies the GID to run the entrypoint of the container process
+    runAsGroup: 10006
+
   service:
     # -- Specifies service type for Celeborn worker service
     type: ClusterIP

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -114,7 +114,24 @@ master:
     runAsGroup: 10006
     # Specifies the GID to use when modifying ownership and permissions of the mounted volumes
     fsGroup: 10006
-    
+
+  # -- Specifies environment variables for Celeborn master containers
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 2g
+  - name: CELEBORN_MASTER_JAVA_OPTS
+    value: >
+      -XX:-PrintGC
+      -XX:+PrintGCDetails
+      -XX:+PrintGCTimeStamps
+      -XX:+PrintGCDateStamps
+      -Xloggc:gc-master.out
+      -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
+
   # -- Resources for Celeborn master pods
   resources: {}
     # requests:
@@ -215,6 +232,25 @@ worker:
     # Specifies the GID to use when modifying ownership and permissions of the mounted volumes
     fsGroup: 10006
 
+  # -- Specifies environment variables for Celeborn worker containers
+  env:
+  - name: CELEBORN_WORKER_MEMORY
+    value: 2g
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 12g
+  - name: CELEBORN_WORKER_JAVA_OPTS
+    value: >
+      -XX:-PrintGC
+      -XX:+PrintGCDetails
+      -XX:+PrintGCTimeStamps
+      -XX:+PrintGCDateStamps
+      -Xloggc:gc-worker.out
+      -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "1"
+  - name: TZ
+    value: Asia/Shanghai
+
   # -- Resources for Celeborn worker pods
   resources: {}
     # requests:
@@ -253,16 +289,6 @@ celeborn:
   celeborn.push.stageEnd.timeout: 120s
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
-
-# -- Celeborn environment variables
-environments:
-  CELEBORN_MASTER_MEMORY: 2g
-  CELEBORN_MASTER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-master.out -Dio.netty.leakDetectionLevel=advanced"
-  CELEBORN_WORKER_MEMORY: 2g
-  CELEBORN_WORKER_OFFHEAP_MEMORY: 12g
-  CELEBORN_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
-  CELEBORN_NO_DAEMONIZE: 1
-  TZ: "Asia/Shanghai"
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -64,6 +64,22 @@ master:
     # key1: value1
     # key2: value2
 
+  # -- Affinity for Celeborn master pods
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - celeborn
+          - key: app.kubernetes.io/role
+            operator: In
+            values:
+            - master
+        topologyKey: kubernetes.io/hostname
+
   # Priority class for Celeborn master pods
   priorityClass:
     # -- Specifies whether to create a new priority class for Celeborn master pods
@@ -122,6 +138,22 @@ worker:
   nodeSelector: {}
     # key1: value1
     # key2: value2
+
+  # -- Affinity for Celeborn worker pods
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - celeborn
+          - key: app.kubernetes.io/role
+            operator: In
+            values:
+            - worker
+        topologyKey: kubernetes.io/hostname
 
   # Priority class for Celeborn worker pods
   priorityClass:
@@ -206,38 +238,6 @@ tolerations: []
 # - key: key2
 #   operator: Exists
 #   effect: NoSchedule
-
-affinity:
-  # -- Pod affinity for Celeborn master pods
-  master:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - celeborn
-              - key: app.kubernetes.io/role
-                operator: In
-                values:
-                  - master
-          topologyKey: kubernetes.io/hostname
-  # -- Pod affinity for Celeborn worker pods
-  worker:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - celeborn
-              - key: app.kubernetes.io/role
-                operator: In
-                values:
-                  - worker
-          topologyKey: "kubernetes.io/hostname"
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -43,6 +43,11 @@ master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3
   replicas: 3
 
+  # -- Annotations for Celeborn master pods
+  annotations: {}
+    # key1: value1
+    # key2: value2
+
   # Currently supported volume types are `emptyDir` and `hostPath`.
   # Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
   # Celeborn Master will pick first volumes for store raft log.
@@ -76,6 +81,11 @@ master:
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
+
+  # -- Annotations for Celeborn worker pods
+  annotations: {}
+    # key1: value1
+    # key2: value2
 
   # Currently supported volume types are `emptyDir` and `hostPath`.
   # Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
@@ -176,11 +186,6 @@ securityContext:
   runAsGroup: 10006
   # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
   fsGroup: 10006
-
-# -- Pod annotations
-podAnnotations: {}
-# key1: value1
-# key2: value2
 
 # -- Pod node selector
 nodeSelector: {}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -43,6 +43,16 @@ master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3
   replicas: 3
 
+  # Priority class for Celeborn master pods
+  priorityClass:
+    # -- Specifies whether to create a new priority class for Celeborn master pods
+    create: false
+    # -- Specifies the name of priority class for Celeborn master pods to be used (created if `create: true`).
+    # Empty means `${Release.Name}-master-priority-class`.
+    name: ""
+    # -- Specifies the integer value of this priority class, default is half of system-cluster-critical
+    value: 1000000000
+
   # -- Resources for Celeborn master pods
   resources: {}
     # requests:
@@ -55,6 +65,16 @@ master:
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
+
+  # Priority class for Celeborn worker pods
+  priorityClass:
+    # -- Specifies whether to create a new priority class for Celeborn worker pods
+    create: false
+    # -- Specifies the name of priority class for Celeborn worker pods to be used (created if `create: true`)
+    # Empty means `${Release.Name}-worker-priority-class`.
+    name: ""
+    # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
+    value: 999999000
 
   # -- Resources for Celeborn worker pods
   resources: {}
@@ -154,25 +174,6 @@ securityContext:
   runAsGroup: 10006
   # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
   fsGroup: 10006
-
-priorityClass:
-  # Priority class for Celeborn master pods
-  master:
-    # -- Specifies whether a new priority class for Celeborn master pods should be created
-    create: false
-    # -- Specifies the name of priority class for Celeborn master pods to be used (created if `create: true`), empty means `${Release.Name}-master-priority-class`
-    name: ""
-    # -- Specifies the integer value of this priority class, default is half of system-cluster-critical
-    value: 1000000000
-
-  # Priority class for Celeborn worker pods
-  worker:
-    # -- Specifies whether a new priority class for Celeborn worker pods should be created
-    create: false
-    # -- Specifies the name of priority class for Celeborn worker pods to be used (created if `create: true`), empty means `${Release.Name}-worker-priority-class`
-    name: ""
-    # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
-    value: 999999000
 
 # -- Pod annotations
 podAnnotations: {}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -156,6 +156,18 @@ master:
     # -- Specifies service port for Celeborn master service
     port: 9097
 
+  podMonitor:
+    # -- Specifies whether to create pod monitor for Celeborn master pods
+    enable: true
+    # -- Specifies pod metrics endpoint for Celeborn master pods
+    podMetricsEndpoint:
+      # Specifies scheme
+      scheme: http
+      # Specifies scrape interval
+      interval: 5s
+      # Specifies port name
+      portName: metrics
+
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
@@ -288,6 +300,18 @@ worker:
     # -- Specifies service type for Celeborn worker service
     type: ClusterIP
 
+  podMonitor:
+    # -- Specifies whether to create pod monitor for Celeborn worker pods
+    enable: true
+    # -- Specifies pod metrics endpoint for Celeborn worker pods
+    podMetricsEndpoint:
+      # Specifies scheme
+      scheme: http
+      # Specifies scrape interval
+      interval: 5s
+      # Specifies port name
+      portName: metrics
+
 cluster:
   # -- Specifies Kubernetes cluster name
   name: cluster
@@ -311,15 +335,3 @@ celeborn:
   celeborn.push.stageEnd.timeout: 120s
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
-
-podMonitor:
-  # -- Specifies whether to enable creating pod monitors for Celeborn pods
-  enable: true
-  # -- Specifies pod metrics endpoint
-  podMetricsEndpoint:
-    # Specifies scheme
-    scheme: http
-    # Specifies scrape interval
-    interval: 5s
-    # Specifies port name
-    portName: metrics

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -27,15 +27,17 @@ fullnameOverride: ""
 
 # Specifies the Celeborn image to use
 image:
+  # -- Image registry
+  registry: docker.io
   # -- Image repository
-  repository: aliyunemr/remote-shuffle-service
-  # -- Image tag
-  tag: 0.1.1-6badd20
+  repository: apache/celeborn
+  # -- Image tag, default is chart `appVersion`
+  tag: ""
   # -- Image pull policy
-  pullPolicy: Always
-
-# -- Image pull secrets for private image registry
-imagePullSecrets: []
+  pullPolicy: IfNotPresent
+  # -- Image pull secrets for private image registry
+  pullSecrets: []
+  # - name: secret-name
 
 # -- Specifies the number of Celeborn master replicas to deploy, master replicas should not less than 3
 masterReplicas: 3

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -150,6 +150,12 @@ master:
     #   cpu: 100m
     #   memory: 128Mi
 
+  service:
+    # -- Specifies service type for Celeborn master service
+    type: ClusterIP
+    # -- Specifies service port for Celeborn master service
+    port: 9097
+
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
@@ -277,12 +283,10 @@ worker:
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
-
-service:
-  # -- Specifies service type
-  type: ClusterIP
-  # -- Specifies service port
-  port: 9097
+  
+  service:
+    # -- Specifies service type for Celeborn worker service
+    type: ClusterIP
 
 cluster:
   # -- Specifies Kubernetes cluster name

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -371,5 +371,5 @@ worker:
       portName: metrics
 
 cluster:
-  # -- Specifies Kubernetes cluster name
-  name: cluster
+  # -- Specifies Kubernetes cluster domain
+  domain: cluster.local

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -132,6 +132,15 @@ master:
   - name: TZ
     value: Asia/Shanghai
 
+  # -- Specifies environment variable sources for Celeborn master containers
+  envFrom: []
+  # - configMapRef:
+  #     name: celeborn-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: celeborn-secret
+  #     optional: false
+
   # -- Resources for Celeborn master pods
   resources: {}
     # requests:
@@ -250,6 +259,15 @@ worker:
     value: "1"
   - name: TZ
     value: Asia/Shanghai
+
+  # -- Specifies environment variable sources for Celeborn worker containers
+  envFrom: []
+  # - configMapRef:
+  #     name: celeborn-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: celeborn-secret
+  #     optional: false
 
   # -- Resources for Celeborn worker pods
   resources: {}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -39,10 +39,13 @@ image:
   pullSecrets: []
   # - name: secret-name
 
-# -- Specifies the number of Celeborn master replicas to deploy, master replicas should not less than 3
-masterReplicas: 3
-# -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
-workerReplicas: 5
+master:
+  # -- Number of Celeborn master replicas to deploy, should not less than 3
+  replicas: 3
+
+worker:
+  # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
+  replicas: 5
 
 service:
   # -- Specifies service type

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -39,6 +39,64 @@ image:
   pullSecrets: []
   # - name: secret-name
 
+# -- Celeborn configurations.
+# Ref: [Configuration - Apache Celeborn](https://celeborn.apache.org/docs/latest/configuration)
+celeborn:
+  # ============================================================================
+  # Mater
+  # ============================================================================
+  celeborn.master.http.port: 9098
+  celeborn.master.heartbeat.application.timeout: 300s
+  celeborn.master.heartbeat.worker.timeout: 120s
+
+  # ============================================================================
+  # Mater HA
+  # ============================================================================
+  celeborn.master.ha.enabled: true
+
+  # If not specified, and `celeborn.master.ha.enabled` is set to `true`,
+  # then it will be configured automatically as `master.volumeMounts[0].mountPath`.
+  # celeborn.master.ha.ratis.raft.server.storage.dir: /tmp/ratis
+
+  # Note that, `celeborn.master.ha.node.<id>.host` should be configured automatically by Helm.
+  # celeborn.master.ha.node.<id>.host: ""
+
+  # ============================================================================
+  # Worker
+  # ============================================================================
+
+  # Note that, `celeborn.master.endpoints` should be configured automatically by Helm.
+  # celeborn.master.endpoints: <localhost>:9097
+
+  celeborn.shuffle.chunk.size: 8m
+  celeborn.worker.flusher.buffer.size: 256K
+  celeborn.worker.http.port: 9096
+  celeborn.worker.fetch.io.threads: 32
+  celeborn.worker.monitor.disk.enabled: false
+  celeborn.worker.push.io.threads: 32
+
+  # If not specified, `celeborn.worker.storage.dirs` will be configured automatically by Helm according to `master.worker.volumeMounts`.
+  # celeborn.worker.storage.dirs: ""
+
+  # ============================================================================
+  # Client
+  # ============================================================================
+  celeborn.client.push.stageEnd.timeout: 120s
+
+  # ============================================================================
+  # Network
+  # ============================================================================
+  celeborn.rpc.io.serverThreads: 64
+  celeborn.rpc.io.numConnectionsPerPeer: 2
+  celeborn.rpc.io.clientThreads: 64
+  celeborn.rpc.dispatcher.numThreads: 4
+
+  # ============================================================================
+  # Metrics
+  # ============================================================================
+  celeborn.metrics.enabled: true
+  celeborn.metrics.prometheus.path: /metrics/prometheus
+
 master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3
   replicas: 3
@@ -315,23 +373,3 @@ worker:
 cluster:
   # -- Specifies Kubernetes cluster name
   name: cluster
-
-# -- Celeborn configurations
-celeborn:
-  celeborn.master.ha.enabled: true
-  celeborn.metrics.enabled: true
-  celeborn.metrics.prometheus.path: /metrics/prometheus
-  celeborn.master.http.port: 9098
-  celeborn.worker.http.port: 9096
-  celeborn.worker.monitor.disk.enabled: false
-  celeborn.shuffle.chunk.size: 8m
-  celeborn.rpc.io.serverThreads: 64
-  celeborn.rpc.io.numConnectionsPerPeer: 2
-  celeborn.rpc.io.clientThreads: 64
-  celeborn.rpc.dispatcher.numThreads: 4
-  celeborn.worker.flusher.buffer.size: 256K
-  celeborn.worker.fetch.io.threads: 32
-  celeborn.worker.push.io.threads: 32
-  celeborn.push.stageEnd.timeout: 120s
-  celeborn.application.heartbeat.timeout: 120s
-  celeborn.worker.heartbeat.timeout: 120s

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -101,6 +101,11 @@ master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3
   replicas: 3
 
+  # -- Labels for Celeborn master pods
+  labels: {}
+    # key1: value1
+    # key2: value2
+
   # -- Annotations for Celeborn master pods
   annotations: {}
     # key1: value1
@@ -229,6 +234,11 @@ master:
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
+
+  # -- Labels for Celeborn worker pods
+  labels: {}
+    # key1: value1
+    # key2: value2
 
   # -- Annotations for Celeborn worker pods
   annotations: {}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -103,6 +103,9 @@ master:
   # -- Specifies the DNS policy for Celeborn master pods
   dnsPolicy: ClusterFirst
 
+  # -- Specifies whether to use the host's network namespace for Celeborn master pods
+  hostNetwork: false
+
   # -- Resources for Celeborn master pods
   resources: {}
     # requests:
@@ -191,6 +194,9 @@ worker:
   # -- Specifies the DNS policy for Celeborn worker pods
   dnsPolicy: ClusterFirst
 
+  # -- Specifies whether to use the host's network namespace for Celeborn worker pods
+  hostNetwork: false
+
   # -- Resources for Celeborn worker pods
   resources: {}
     # requests:
@@ -239,9 +245,6 @@ environments:
   CELEBORN_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
   CELEBORN_NO_DAEMONIZE: 1
   TZ: "Asia/Shanghai"
-
-# -- Specifies whether to use the host's network namespace
-hostNetwork: false
 
 # -- Container security context
 securityContext:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -43,9 +43,27 @@ master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3
   replicas: 3
 
+  # -- Resources for Celeborn master pods
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+
 worker:
   # -- Specifies the number of Celeborn worker replicas to deploy, should less than node number
   replicas: 5
+
+  # -- Resources for Celeborn worker pods
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 service:
   # -- Specifies service type
@@ -127,25 +145,6 @@ dnsPolicy: ClusterFirst
 
 # -- Specifies whether to use the host's network namespace
 hostNetwork: false
-
-resources:
-  # -- Pod resources for Celeborn master pods
-  master: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  # -- Pod resources for Celeborn worker pods
-  worker: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
 
 # -- Container security context
 securityContext:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Add `image.registry` and rename `imagePullSecrets` to `image.pullSecrets`
- Rename `masterReplicas`/`workerReplicas` to `master.replicas`/`worker.replicas`
- Add `master.labels`/`worker.labels`
- Rename `podAnnotations` to `master.annotations`/`worker.annotations`
- Rename `nodeSelector` to `master.nodeSelector`/`worker.nodeSelector`
- Rename `affinity.master`/`affinity.worker` to `master.affinity`/`worker.affinity`
- Rename `tolerations` to `master.tolerations`/`worker.tolerations`
- Rename `environments` to `master.env`/`worker.env`
- Add `master.envFrom`/`worker.envFrom`
- Rename `priorityClass.master`/`priorityClass.worker` to `master.priorityClass`/`worker.priorityClass`
- Rename `resources.master`/`resources.worker` to `master.resources`/`worker.resources`
- Rename `dnsPolicy` to `master.dnsPolicy`/`worker.dnsPolicy`
- Rename `hostNetwork` to `master.hostNetwork`/`worker.hostNetwork`
- Rename `service` to `master.service`/`worker.service`
- Rename `podMonitor` to `master.podMonitor`/`worker.podMonitor`
- Rename `securityContext` to `master.podSecurityContext`/`worker.podSecurityContext`
- Add `master.securityContext`/`worker.securityContext`

### Why are the changes needed?

- Make the Celeborn Helm charts more customizable and improve the maintenance.
- Unified the various configurations, all master/worker related configurations are prefixed with `master`/`worker`.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Locally test.