### PR TITLE
[CELEBORN-1537] Support to remove workers unavailable info with RESTful api

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -509,6 +509,10 @@ message PbRemoveWorkersUnavailableInfo {
   string requestId = 2;
 }
 
+message PbRemoveWorkersUnavailableInfoResponse {
+  bool success = 1;
+}
+
 message PbWorkerExclude {
   repeated PbWorkerInfo workersToAdd = 1;
   repeated PbWorkerInfo workersToRemove = 2;

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -412,6 +412,13 @@ object ControlMessages extends Logging {
         .build()
   }
 
+  object RemoveWorkersUnavailableInfoResponse {
+    def apply(success: Boolean): PbRemoveWorkersUnavailableInfoResponse =
+      PbRemoveWorkersUnavailableInfoResponse.newBuilder()
+        .setSuccess(success)
+        .build()
+  }
+
   object WorkerEventRequest {
     def apply(
         workers: util.List[WorkerInfo],

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -606,13 +606,11 @@ private[celeborn] class Master(
 
     val unavailableInfoTimeoutWorkers = statusSystem.lostWorkers.asScala.filter {
       case (_, lostTime) => currentTime - lostTime > workerUnavailableInfoExpireTimeoutMs
-    }.keySet.toList.asJava
+    }.keySet.toSeq
 
     if (!unavailableInfoTimeoutWorkers.isEmpty) {
-      logDebug(s"Remove unavailable info for workers: $unavailableInfoTimeoutWorkers")
-      self.send(RemoveWorkersUnavailableInfo(
-        unavailableInfoTimeoutWorkers,
-        MasterClient.genRequestId()))
+      val handleResponse = removeWorkersUnavailableInfo(unavailableInfoTimeoutWorkers)
+      logDebug(s"Remove unavailable info for workers response: $handleResponse")
     }
   }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.service.deploy.master.http.api.v1
 
-import javax.ws.rs.{BadRequestException, Consumes, DELETE, GET, Path, POST, Produces}
+import javax.ws.rs.{BadRequestException, Consumes, GET, Path, POST, Produces}
 import javax.ws.rs.core.MediaType
 
 import scala.collection.JavaConverters._
@@ -85,8 +85,8 @@ class WorkerResource extends ApiRequestContext {
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[HandleResponse]))),
     description = "Remove the unavailable workers info from the master.")
-  @DELETE
-  @Path("/unavailable")
+  @POST
+  @Path("/remove_unavailable")
   def removeWorkersUnavailableInfo(request: RemoveWorkersUnavailableInfoRequest): HandleResponse = {
     val (success, msg) = master.removeWorkersUnavailableInfo(
       request.getWorkers.asScala.map(ApiUtils.toWorkerInfo).toSeq)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -84,7 +84,7 @@ class WorkerResource extends ApiRequestContext {
     content = Array(new Content(
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[HandleResponse]))),
-    description = "Remove the unavailable workers info from the master.")
+    description = "Remove the workers unavailable info from the master.")
   @POST
   @Path("/remove_unavailable")
   def removeWorkersUnavailableInfo(request: RemoveWorkersUnavailableInfoRequest): HandleResponse = {

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -26,7 +26,7 @@ import com.google.common.io.Files
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
-import org.apache.celeborn.rest.v1.model.{AppDiskUsageSnapshotsResponse, ApplicationsResponse, ExcludeWorkerRequest, HandleResponse, HostnamesResponse, SendWorkerEventRequest, ShufflesResponse, WorkerEventsResponse, WorkerId, WorkersResponse}
+import org.apache.celeborn.rest.v1.model.{AppDiskUsageSnapshotsResponse, ApplicationsResponse, ExcludeWorkerRequest, HandleResponse, HostnamesResponse, RemoveWorkersUnavailableInfoRequest, SendWorkerEventRequest, ShufflesResponse, WorkerEventsResponse, WorkerId, WorkersResponse}
 import org.apache.celeborn.server.common.HttpService
 import org.apache.celeborn.server.common.http.api.v1.ApiV1BaseResourceSuite
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
@@ -121,6 +121,13 @@ class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite {
     assert(HttpServletResponse.SC_OK == response.getStatus)
     assert(response.readEntity(classOf[HandleResponse]).getMessage.contains(
       "Unknown workers Host:unknown.celeborn"))
+
+    val removeWorkersUnavailableInfoRequest = new RemoveWorkersUnavailableInfoRequest()
+      .workers(Collections.singletonList(worker))
+    response =
+      webTarget.path("workers/remove_unavailable").request(MediaType.APPLICATION_JSON).post(
+        Entity.entity(removeWorkersUnavailableInfoRequest, MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_OK == response.getStatus)
 
     response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).get()
     assert(HttpServletResponse.SC_OK == response.getStatus)

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -278,7 +278,7 @@ public class WorkerApi extends BaseApi {
     Object localVarPostBody = removeWorkersUnavailableInfoRequest;
     
     // create path and map variables
-    String localVarPath = "/api/v1/workers/unavailable";
+    String localVarPath = "/api/v1/workers/remove_unavailable";
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -308,7 +308,7 @@ public class WorkerApi extends BaseApi {
     TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
     return apiClient.invokeAPI(
         localVarPath,
-        "DELETE",
+        "POST",
         localVarQueryParams,
         localVarCollectionQueryParams,
         localVarQueryStringJoiner.toString(),

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -256,7 +256,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * Remove the unavailable workers info from the master.
+   * Remove the workers unavailable info from the master.
    * @param removeWorkersUnavailableInfoRequest  (optional)
    * @return HandleResponse
    * @throws ApiException if fails to make API call
@@ -268,7 +268,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * Remove the unavailable workers info from the master.
+   * Remove the workers unavailable info from the master.
    * @param removeWorkersUnavailableInfoRequest  (optional)
    * @param additionalHeaders additionalHeaders for this call
    * @return HandleResponse

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -27,6 +27,7 @@ import org.apache.celeborn.rest.v1.master.invoker.Pair;
 
 import org.apache.celeborn.rest.v1.model.ExcludeWorkerRequest;
 import org.apache.celeborn.rest.v1.model.HandleResponse;
+import org.apache.celeborn.rest.v1.model.RemoveWorkersUnavailableInfoRequest;
 import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest;
 import org.apache.celeborn.rest.v1.model.WorkerEventsResponse;
 import org.apache.celeborn.rest.v1.model.WorkersResponse;
@@ -239,6 +240,75 @@ public class WorkerApi extends BaseApi {
     return apiClient.invokeAPI(
         localVarPath,
         "GET",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Remove the unavailable workers info from the master.
+   * @param removeWorkersUnavailableInfoRequest  (optional)
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse removeWorkersUnavailableInfo(RemoveWorkersUnavailableInfoRequest removeWorkersUnavailableInfoRequest) throws ApiException {
+    return this.removeWorkersUnavailableInfo(removeWorkersUnavailableInfoRequest, Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Remove the unavailable workers info from the master.
+   * @param removeWorkersUnavailableInfoRequest  (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse removeWorkersUnavailableInfo(RemoveWorkersUnavailableInfoRequest removeWorkersUnavailableInfoRequest, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = removeWorkersUnavailableInfoRequest;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/workers/unavailable";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "DELETE",
         localVarQueryParams,
         localVarCollectionQueryParams,
         localVarQueryStringJoiner.toString(),

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RemoveWorkersUnavailableInfoRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RemoveWorkersUnavailableInfoRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.celeborn.rest.v1.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.celeborn.rest.v1.model.WorkerId;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * RemoveWorkersUnavailableInfoRequest
+ */
+@JsonPropertyOrder({
+  RemoveWorkersUnavailableInfoRequest.JSON_PROPERTY_WORKERS
+})
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+public class RemoveWorkersUnavailableInfoRequest {
+  public static final String JSON_PROPERTY_WORKERS = "workers";
+  private List<WorkerId> workers = new ArrayList<>();
+
+  public RemoveWorkersUnavailableInfoRequest() {
+  }
+
+  public RemoveWorkersUnavailableInfoRequest workers(List<WorkerId> workers) {
+    
+    this.workers = workers;
+    return this;
+  }
+
+  public RemoveWorkersUnavailableInfoRequest addWorkersItem(WorkerId workersItem) {
+    if (this.workers == null) {
+      this.workers = new ArrayList<>();
+    }
+    this.workers.add(workersItem);
+    return this;
+  }
+
+  /**
+   * The workers to be removed from the master workers unavailable info.
+   * @return workers
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_WORKERS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<WorkerId> getWorkers() {
+    return workers;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_WORKERS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setWorkers(List<WorkerId> workers) {
+    this.workers = workers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RemoveWorkersUnavailableInfoRequest removeWorkersUnavailableInfoRequest = (RemoveWorkersUnavailableInfoRequest) o;
+    return Objects.equals(this.workers, removeWorkersUnavailableInfoRequest.workers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(workers);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class RemoveWorkersUnavailableInfoRequest {\n");
+    sb.append("    workers: ").append(toIndentedString(workers)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -162,24 +162,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
-    /api/v1/workers/unavailable:
-      delete:
-        tags:
-          - Worker
-        operationId: removeUnavailableWorkers
-        description: Remove the unavailable workers from the master.
-        requestBody:
+  /api/v1/workers/unavailable:
+    delete:
+      tags:
+        - Worker
+      operationId: removeWorkersUnavailableInfo
+      description: Remove the unavailable workers info from the master.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoveWorkersUnavailableInfoRequest'
+      responses:
+        "200":
+          description: The request was successful.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RemoveUnavailableWorkersRequest'
-        responses:
-          "200":
-            description: The request was successful.
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/HandleResponse'
+                $ref: '#/components/schemas/HandleResponse'
 
   /api/v1/workers/events:
     get:
@@ -690,11 +690,12 @@ components:
           items:
             $ref: '#/components/schemas/WorkerId'
 
-    RemoveUnavailableWorkersRequest:
+    RemoveWorkersUnavailableInfoRequest:
       type: object
       properties:
         workers:
           type: array
+          description: The workers to be removed from the master workers unavailable info.
           items:
             $ref: '#/components/schemas/WorkerId'
 

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -162,6 +162,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
+    /api/v1/workers/unavailable:
+      delete:
+        tags:
+          - Worker
+        operationId: removeUnavailableWorkers
+        description: Remove the unavailable workers from the master.
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveUnavailableWorkersRequest'
+        responses:
+          "200":
+            description: The request was successful.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HandleResponse'
+
   /api/v1/workers/events:
     get:
       tags:
@@ -668,6 +687,14 @@ components:
         remove:
           type: array
           description: The workers to be removed from the excluded workers.
+          items:
+            $ref: '#/components/schemas/WorkerId'
+
+    RemoveUnavailableWorkersRequest:
+      type: object
+      properties:
+        workers:
+          type: array
           items:
             $ref: '#/components/schemas/WorkerId'
 

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -162,8 +162,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
-  /api/v1/workers/unavailable:
-    delete:
+  /api/v1/workers/remove_unavailable:
+    post:
       tags:
         - Worker
       operationId: removeWorkersUnavailableInfo

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -167,7 +167,7 @@ paths:
       tags:
         - Worker
       operationId: removeWorkersUnavailableInfo
-      description: Remove the unavailable workers info from the master.
+      description: Remove the workers unavailable info from the master.
       requestBody:
         content:
           application/json:

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletResponse
 
 import org.apache.celeborn.rest.v1.master._
 import org.apache.celeborn.rest.v1.master.invoker._
-import org.apache.celeborn.rest.v1.model.{ExcludeWorkerRequest, SendWorkerEventRequest, WorkerId}
+import org.apache.celeborn.rest.v1.model.{ExcludeWorkerRequest, RemoveWorkersUnavailableInfoRequest, SendWorkerEventRequest, WorkerId}
 import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest.EventTypeEnum
 
 class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
@@ -93,6 +93,10 @@ class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
 
     handleResponse = api.excludeWorker(
       new ExcludeWorkerRequest().addRemoveItem(workerId).add(Collections.emptyList()))
+    assert(handleResponse.getSuccess)
+
+    handleResponse = api.removeWorkersUnavailableInfo(
+      new RemoveWorkersUnavailableInfoRequest().addWorkersItem(workerId));
     assert(handleResponse.getSuccess)
 
     workersResponse = api.getWorkers


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
In [CELEBORN-1535](https://issues.apache.org/jira/browse/CELEBORN-1535), we support to disable master workerUnavilableInfo expiration.

 In this PR,  a new RestAPI  introduced for manually remove unavailable workers. Then it can be used on demand.


### Why are the changes needed?
To cleanup the works unavailable info on demand manually if we disable the expiration.


### Does this PR introduce _any_ user-facing change?
Yes, a new RESTful API.

### How was this patch tested?
UT.
