### PR TITLE
[CELEBORN-1541] Enhance the readable address for internal port

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -156,7 +156,8 @@ class WorkerInfo(
 
   def readableAddress(): String = {
     s"Host:$host:RpcPort:$rpcPort:PushPort:$pushPort:" +
-      s"FetchPort:$fetchPort:ReplicatePort:$replicatePort:$internalPort"
+      s"FetchPort:$fetchPort:ReplicatePort:$replicatePort" +
+      (if (internalPort > 0) s":InternalPort:$internalPort" else "")
   }
 
   def toUniqueId(): String = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
If the internal port is not defined, do not show the internal port(-1) in the readable address.

### Why are the changes needed?

If the workerInfo is applied for the RESTful request, such as curl `/api/v1/workers/exclude`, the internal port is always `-1`.

It is not necessary to show the `-1` in the readable address.

### Does this PR introduce _any_ user-facing change?
Just reduce the unnecessary info.


### How was this patch tested?

Not needed.