### PR TITLE
[CELEBORN-1544][FOLLOWUP] ShuffleWriter needs to catch exception and call abort to avoid memory leaks

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -155,8 +155,9 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       } else {
         write0(records);
       }
-    } finally {
       close();
+    } catch (Exception e) {
+      abort();
     }
   }
 
@@ -289,6 +290,12 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             numPartitions);
     mapStatusLengths[partitionId].add(bytesWritten);
     writeMetrics.incBytesWritten(bytesWritten);
+  }
+
+  private void abort() throws IOException {
+    if (pusher != null) {
+      pusher.close();
+    }
   }
 
   private void close() throws IOException {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -228,8 +228,9 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   public void write(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
     try {
       doWrite(records);
-    } finally {
       close();
+    } catch (Exception e) {
+      abort();
     }
   }
 
@@ -352,6 +353,12 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             numPartitions);
     mapStatusLengths[partitionId].add(bytesWritten);
     writeMetrics.incBytesWritten(bytesWritten);
+  }
+
+  private void abort() throws IOException {
+    if (pusher != null) {
+      pusher.close();
+    }
   }
 
   private void close() throws IOException {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix a possible memory leak in ShuffleWriter.

Introduce a private abort method, which can be called to release memory when an exception occurs.

### Why are the changes needed?
Https://github.com/apache/celeborn/pull/2661 Call the close method in the finally block, but the close method has `shuffleClient.mapperEnd`, which is dangerous for incomplete tasks, and the data may be inaccurate.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GA
