### PR TITLE
[CELEBORN-1546] Support authorization on swagger UI

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
@@ -28,8 +28,9 @@ import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder
 import io.swagger.v3.jaxrs2.integration.resources.BaseOpenApiResource
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.integration.api.OpenApiContext
-import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.{Components, OpenAPI}
 import io.swagger.v3.oas.models.info.{Info, License}
+import io.swagger.v3.oas.models.security.{SecurityRequirement, SecurityScheme}
 import io.swagger.v3.oas.models.servers.Server
 import org.apache.commons.lang3.StringUtils
 
@@ -91,6 +92,21 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
           new License().name("Apache License 2.0")
             .url("https://www.apache.org/licenses/LICENSE-2.0.txt")))
       .servers(List(new Server().url(apiUrl)).asJava)
+      .components(Option(openApi.getComponents).getOrElse(new Components())
+        .addSecuritySchemes(
+          "BasicAuth",
+          new SecurityScheme()
+            .`type`(SecurityScheme.Type.HTTP)
+            .scheme("Basic"))
+        .addSecuritySchemes(
+          "BearerAuth",
+          new SecurityScheme()
+            .`type`(SecurityScheme.Type.HTTP)
+            .scheme("Bearer")
+            .bearerFormat("JWT")))
+      .addSecurityItem(new SecurityRequirement()
+        .addList("BasicAuth")
+        .addList("BearerAuth"))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title.

### Why are the changes needed?
Since celeborn already supports http authorization, it is better to enable authorization on swagger UI as well.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Integration testing.
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/80b6fef4-2ace-4ec3-80aa-4b9bc98131d6">
<img width="1334" alt="image" src="https://github.com/user-attachments/assets/57e53db0-8d24-4568-add8-4c3b01f05404">

And it will not impact the service without authentication enabled.

<img width="1569" alt="image" src="https://github.com/user-attachments/assets/2a21e9c4-aa3d-43b6-875b-51c55bb93789">
