### PR TITLE
[CELEBORN-1318][FOLLOWUP] Authenticate bearer token directly

### DIFF
--- a/service/src/test/scala/org/apache/celeborn/server/common/http/ApiBaseResourceAuthenticationSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/ApiBaseResourceAuthenticationSuite.scala
@@ -57,10 +57,7 @@ abstract class ApiBaseResourceAuthenticationSuite extends HttpTestHelper {
       Base64.getEncoder.encode(s"$user:$password".getBytes()),
       StandardCharsets.UTF_8)
 
-  def bearerAuthorizationHeader(token: String): String =
-    HttpAuthSchemes.BEARER + " " + new String(
-      Base64.getEncoder.encode(token.getBytes()),
-      StandardCharsets.UTF_8)
+  def bearerAuthorizationHeader(token: String): String = HttpAuthSchemes.BEARER + " " + token
 
   Seq("conf", "listDynamicConfigs", "workerInfo", "shuffle", "applications").foreach { api =>
     test(s"API $api authentication") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
I am working on the bearer token authentication integration, and meet the token base64 decode issue.

And found that, for bear token, we shall authenticate it directly.

![image](https://github.com/user-attachments/assets/0270f924-1d57-4ddd-9fdc-632711782078)



### Why are the changes needed?
For bearer authentication issue.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

Integration testing.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/0c03b73b-be08-45b0-81c4-006eebc5ac3b">
