### PR TITLE
[CELEBORN-1547] Worker#listTopDiskUseApps should return celeborn.metrics.app.topDiskUsage.count applications

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -450,7 +450,7 @@ private[celeborn] class Worker(
     val estimatedAppDiskUsage = new JHashMap[String, JLong]()
     activeShuffleKeys.addAll(partitionLocationInfo.shuffleKeySet)
     activeShuffleKeys.addAll(storageManager.shuffleKeySet())
-    storageManager.topAppDiskUsage.asScala.foreach { case (shuffleId, usage) =>
+    storageManager.topAppDiskUsage(true).asScala.foreach { case (shuffleId, usage) =>
       estimatedAppDiskUsage.put(shuffleId, usage)
     }
     storageManager.updateDiskInfos()
@@ -797,7 +797,7 @@ private[celeborn] class Worker(
   override def listTopDiskUseApps: String = {
     val sb = new StringBuilder
     sb.append("================== Top Disk Usage Applications =======================\n")
-    storageManager.topAppDiskUsage.asScala.foreach { case (appId, usage) =>
+    storageManager.topAppDiskUsage().asScala.foreach { case (appId, usage) =>
       sb.append(s"Application $appId used ${Utils.bytesToString(usage)}\n")
     }
     sb.toString()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApplicationResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApplicationResource.scala
@@ -63,7 +63,7 @@ class ApplicationResource extends ApiRequestContext {
   def topDiskUsedApplications(): AppDiskUsagesResponse = {
     new AppDiskUsagesResponse()
       .appDiskUsages(
-        storageManager.topAppDiskUsage.asScala.map { case (appId, diskUsage) =>
+        storageManager.topAppDiskUsage().asScala.map { case (appId, diskUsage) =>
           new AppDiskUsageData()
             .appId(appId)
             .estimatedUsage(diskUsage)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -527,8 +527,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     hashSet
   }
 
-  def topAppDiskUsage(estimated: Boolean = false): util.Map[String, Long] = {
-    val topCount = if (estimated) topDiskUsageCount * 2 else topDiskUsageCount
+  def topAppDiskUsage(reportToMaster: Boolean = false): util.Map[String, Long] = {
+    val topCount = if (reportToMaster) topDiskUsageCount * 2 else topDiskUsageCount
     diskFileInfos.asScala.map { keyedWriters =>
       {
         keyedWriters._1 -> keyedWriters._2.values().asScala.map(_.getFileLength).sum


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Worker#listTopDiskUseApps` should return `celeborn.metrics.app.topDiskUsage.count` applications.

### Why are the changes needed?

`Worker#listTopDiskUseApps` returns 2x `celeborn.metrics.app.topDiskUsage.count` application, which is not same as `celeborn.metrics.app.topDiskUsage.count` configuration at present. Meanwhile, `Worker#listTopDiskUseApps` reuses `StorageManager#topAppDiskUsage` method to get the top application list used for estimated application disk usage. Therefore, `Worker#listTopDiskUseApps` should return celeborn.metrics.app.topDiskUsage.count applications.

```
$ curl http://celeborn-worker:9096/listTopDiskUsedApps|grep used|wc -l
100
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
$ curl http://celeborn-worker:9096/listTopDiskUsedApps|grep used|wc -l
50
```