### PR TITLE
[CELEBORN-1551] Fix wrong link in quota_management.md

### DIFF
--- a/docs/quota_management.md
+++ b/docs/quota_management.md
@@ -52,7 +52,7 @@ Users can also implement their own identity provider by inheriting the `org.apac
 ## QuotaManager
 
 `QuotaManager` supports to check whether quota is available and manage quota configurations for `Master`.
-`QuotaManager` uses the [dynamic config service](developers/configuration#dynamic-configuration) to store quota settings.
+`QuotaManager` uses the [dynamic config service](https://celeborn.apache.org/docs/latest/developers/configuration/#dynamic-configuration) to store quota settings.
 For example, there are some quota configurations as follows:
 
 The quota for user `tenant_01.Jerry` is
@@ -79,7 +79,7 @@ The quota for `system default` is
 ### FileSystem Store Backend
 
 This backend reads [quota](#quota-indicators) settings from a user-specified dynamic config file.
-For more information on using the database store backend, refer to [filesystem config service](developers/configuration#filesystem-config-service).
+For more information on using the database store backend, refer to [filesystem config service](https://celeborn.apache.org/docs/latest/developers/configuration#filesystem-config-service).
 Here's an example quota setting YAML file of above quota examples:
 
 ```yaml
@@ -105,7 +105,7 @@ Here's an example quota setting YAML file of above quota examples:
 ### Database Store Backend
 
 This backend reads [quota](#quota-indicators) settings from a user-specified database.
-For more information on using the database store backend, refer to [database config service](developers/configuration#database-config-service).
+For more information on using the database store backend, refer to [database config service](https://celeborn.apache.org/docs/latest/developers/configuration#database-config-service).
 Here's an example quota setting sql of above quota examples:
 ```sql
 # SYSTEM level configuration

--- a/docs/quota_management.md
+++ b/docs/quota_management.md
@@ -52,7 +52,7 @@ Users can also implement their own identity provider by inheriting the `org.apac
 ## QuotaManager
 
 `QuotaManager` supports to check whether quota is available and manage quota configurations for `Master`.
-`QuotaManager` uses the [dynamic config service](https://celeborn.apache.org/docs/latest/developers/configuration/#dynamic-configuration) to store quota settings.
+`QuotaManager` uses the [dynamic config service](../developers/configuration/#dynamic-configuration) to store quota settings.
 For example, there are some quota configurations as follows:
 
 The quota for user `tenant_01.Jerry` is
@@ -79,7 +79,7 @@ The quota for `system default` is
 ### FileSystem Store Backend
 
 This backend reads [quota](#quota-indicators) settings from a user-specified dynamic config file.
-For more information on using the database store backend, refer to [filesystem config service](https://celeborn.apache.org/docs/latest/developers/configuration#filesystem-config-service).
+For more information on using the database store backend, refer to [filesystem config service](../developers/configuration#filesystem-config-service).
 Here's an example quota setting YAML file of above quota examples:
 
 ```yaml
@@ -105,7 +105,7 @@ Here's an example quota setting YAML file of above quota examples:
 ### Database Store Backend
 
 This backend reads [quota](#quota-indicators) settings from a user-specified database.
-For more information on using the database store backend, refer to [database config service](https://celeborn.apache.org/docs/latest/developers/configuration#database-config-service).
+For more information on using the database store backend, refer to [database config service](../developers/configuration#database-config-service).
 Here's an example quota setting sql of above quota examples:
 ```sql
 # SYSTEM level configuration

--- a/docs/quota_management.md
+++ b/docs/quota_management.md
@@ -52,7 +52,7 @@ Users can also implement their own identity provider by inheriting the `org.apac
 ## QuotaManager
 
 `QuotaManager` supports to check whether quota is available and manage quota configurations for `Master`.
-`QuotaManager` uses the [dynamic config service](../developers/configuration/#dynamic-configuration) to store quota settings.
+`QuotaManager` uses the [dynamic config service](../developers/configuration#dynamic-configuration) to store quota settings.
 For example, there are some quota configurations as follows:
 
 The quota for user `tenant_01.Jerry` is


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix wrong link in quota_management.md.


### Why are the changes needed?
click `dynamic config service` in QuotaManager tab will jump to the wrong link https://celeborn.apache.org/docs/latest/quota_management/developers/configuration#dynamic-configuration

![image](https://github.com/user-attachments/assets/9c21eeb9-0302-4237-816c-ba5cd4a1cfca)
![image](https://github.com/user-attachments/assets/af9823b9-0d91-436b-ae74-162dfd4b989f)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
