### PR TITLE
[CELEBORN-1553] Using the request base url as swagger server

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -258,10 +258,6 @@ abstract class HttpService extends Service with Logging {
     httpServer.getServerUri
   }
 
-  def externalConnectionUrl: String = {
-    Utils.localHostName(conf) + ":" + httpServer.connector.getLocalPort
-  }
-
   protected def startInternal(): Unit = {
     val contextHandler = ApiRootResource.getServletHandler(this)
     val holder = new FilterHolder(new AuthenticationFilter(conf, serviceName))
@@ -272,7 +268,6 @@ abstract class HttpService extends Service with Logging {
     httpServer.addStaticHandler("org/apache/celeborn/swagger", "/swagger")
     httpServer.addRedirectHandler("/help", "/swagger")
     httpServer.addRedirectHandler("/docs", "/swagger")
-    httpServer.addRedirectHandler("/", "/swagger")
 
     if (metricsSystem.running) {
       metricsSystem.getServletContextHandlers.foreach { handler =>

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -272,6 +272,7 @@ abstract class HttpService extends Service with Logging {
     httpServer.addStaticHandler("org/apache/celeborn/swagger", "/swagger")
     httpServer.addRedirectHandler("/help", "/swagger")
     httpServer.addRedirectHandler("/docs", "/swagger")
+    httpServer.addRedirectHandler("/", "/swagger")
 
     if (metricsSystem.running) {
       metricsSystem.getServletContextHandlers.foreach { handler =>

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -258,6 +258,10 @@ abstract class HttpService extends Service with Logging {
     httpServer.getServerUri
   }
 
+  def externalConnectionUrl: String = {
+    Utils.localHostName(conf) + ":" + httpServer.connector.getLocalPort
+  }
+
   protected def startInternal(): Unit = {
     val contextHandler = ApiRootResource.getServletHandler(this)
     val holder = new FilterHolder(new AuthenticationFilter(conf, serviceName))

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
@@ -83,7 +83,9 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
 
   private def setCelebornOpenAPIDefinition(openApi: OpenAPI): OpenAPI = {
     // TODO: to improve when https is enabled.
-    val apiUrl = s"http://${httpService.connectionUrl}/"
+    val apiUrls = List(httpService.externalConnectionUrl, httpService.connectionUrl)
+      .distinct
+      .map(url => s"http://$url/")
     openApi.info(
       new Info().title(
         s"Apache Celeborn REST API Documentation")
@@ -91,7 +93,7 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
         .license(
           new License().name("Apache License 2.0")
             .url("https://www.apache.org/licenses/LICENSE-2.0.txt")))
-      .servers(List(new Server().url(apiUrl)).asJava)
+      .servers(apiUrls.map(url => new Server().url(url)).asJava)
       .components(Option(openApi.getComponents).getOrElse(new Components())
         .addSecuritySchemes(
           "BasicAuth",

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/CelebornOpenApiResource.scala
@@ -60,7 +60,7 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
       .ctxId(ctxId)
       .buildContext(true)
 
-    val openApi = setCelebornOpenAPIDefinition(ctx.read())
+    val openApi = setCelebornOpenAPIDefinition(ctx.read(), uriInfo.getBaseUri.toString)
 
     if (StringUtils.isNotBlank(tpe) && tpe.trim().equalsIgnoreCase("yaml")) {
       Response.status(Response.Status.OK)
@@ -81,11 +81,9 @@ class CelebornOpenApiResource extends BaseOpenApiResource with ApiRequestContext
     }
   }
 
-  private def setCelebornOpenAPIDefinition(openApi: OpenAPI): OpenAPI = {
+  private def setCelebornOpenAPIDefinition(openApi: OpenAPI, requestBaseUrl: String): OpenAPI = {
     // TODO: to improve when https is enabled.
-    val apiUrls = List(httpService.externalConnectionUrl, httpService.connectionUrl)
-      .distinct
-      .map(url => s"http://$url/")
+    val apiUrls = List(requestBaseUrl, s"http://${httpService.connectionUrl}/").distinct
     openApi.info(
       new Info().title(
         s"Apache Celeborn REST API Documentation")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Using the request base url as swagger server, to prevent the swagger server not reachable and `CORS` error if the swagger server urls do not match. 

Currently, if the http host is bound to local, the swagger server is not reachable.
For example:
```
celeborn.master.http.host=0.0.0.0
celeborn.worker.http.host=0.0.0.0
```

### Why are the changes needed?
![image](https://github.com/user-attachments/assets/3553fb94-c937-4877-bd55-3df0c121bd01)



### Does this PR introduce _any_ user-facing change?

No, just use the request base url as swagger server.

### How was this patch tested?
Integration testing:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/f8465bcb-a266-4532-9f11-52e9374c56a5">

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/84eacd86-7ba3-4f14-907b-6d529c6e0e28">


