### PR TITLE
[CELEBORN-1556] Update Github actions to v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh benchmark
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}

--- a/.github/workflows/benchmark_manual.yml
+++ b/.github/workflows/benchmark_manual.yml
@@ -42,7 +42,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh benchmark
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/benchmark_manual.yml
+++ b/.github/workflows/benchmark_manual.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: 8
@@ -93,7 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: 8

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -57,7 +57,7 @@ jobs:
           - 'flink-1.20'
           - 'mr'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK 8
       uses: actions/setup-java@v2
       with:
@@ -91,7 +91,7 @@ jobs:
           - 'flink-1.20'
           - 'mr'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK 8
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 8

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -54,7 +54,7 @@ jobs:
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,mr
       - name: Upload rat report
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: rat-report
           path: "**/target/rat*.txt"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -34,7 +34,7 @@ jobs:
     name: License
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK 8
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -120,7 +120,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -161,7 +161,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -192,7 +192,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
           - 11
           - 17
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -55,7 +55,7 @@ jobs:
         spark:
           - '2.4'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -118,7 +118,7 @@ jobs:
           - shuffle-plugin-class: 'org.apache.spark.shuffle.celeborn.CelebornShuffleDataIO'
             spark: '3.4'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -159,7 +159,7 @@ jobs:
           - '1.19'
           - '1.20'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -190,7 +190,7 @@ jobs:
           - 8
           - 11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
       run: build/mvn -Pgoogle-mirror test
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: service-unit-test-log
         path: |
@@ -73,7 +73,7 @@ jobs:
           build/mvn $PROFILES -pl $TEST_MODULES test
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spark-${{ matrix.spark }}-unit-test-log
           path: |
@@ -136,7 +136,7 @@ jobs:
         build/mvn $PROFILES -pl $TEST_MODULES -Dspark.shuffle.sort.io.plugin.class=${{ matrix.shuffle-plugin-class }} test
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: spark-${{ matrix.spark }}-unit-test-log
         path: |
@@ -175,7 +175,7 @@ jobs:
           build/mvn $PROFILES -pl $TEST_MODULES test
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flink-${{ matrix.flink }}-unit-test-log
           path: |
@@ -206,7 +206,7 @@ jobs:
           build/mvn $PROFILES -pl $TEST_MODULES test
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mr-unit-test-log
           path: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -42,7 +42,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh regression
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: regression result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}

--- a/.github/workflows/regression_manual.yml
+++ b/.github/workflows/regression_manual.yml
@@ -43,7 +43,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh regression
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: regression result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/regression_manual.yml
+++ b/.github/workflows/regression_manual.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -178,7 +178,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -213,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -240,7 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -54,7 +54,7 @@ jobs:
         build/sbt ++${{ matrix.scala }} "clean; test"
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: service-java-${{ matrix.java }}-scala-${{ matrix.scala }}-unit-test-log
           path: |
@@ -85,7 +85,7 @@ jobs:
           build/sbt -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: spark-${{ matrix.spark }}-unit-test-log
             path: |
@@ -188,7 +188,7 @@ jobs:
         build/sbt -Dspark.shuffle.plugin.class=${{ matrix.shuffle-plugin-class }} -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: spark-${{ matrix.spark }}-scala-${{ matrix.scala }}-unit-test-log
           path: |
@@ -223,7 +223,7 @@ jobs:
           build/sbt -Pflink-${{ matrix.flink }} "clean; celeborn-flink-group/test"
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: flink-${{ matrix.flink }}-unit-test-log
             path: |
@@ -250,7 +250,7 @@ jobs:
           build/sbt -Pmr "clean; celeborn-mr-group/test"
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mr-unit-test-log
           path: |

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -42,7 +42,7 @@ jobs:
           - '2.12.15'
           - '2.13.5'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -73,7 +73,7 @@ jobs:
           - '2.11.12'
           - '2.12.10'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -176,7 +176,7 @@ jobs:
             scala-binary: '2.13'
             scala: '2.13.5'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -211,7 +211,7 @@ jobs:
           - '1.19'
           - '1.20'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -238,7 +238,7 @@ jobs:
           - 8
           - 11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK 8
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 8

--- a/.github/workflows/web_lint.yml
+++ b/.github/workflows/web_lint.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
         version: 8
 
@@ -50,7 +50,7 @@ jobs:
         node-version: 20.11.0
 
     - name: Use pnpm v8.14.3
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
         version: 8.14.3
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- update actions/setup-java to v4
- update actions/upload-artifact to v4
- update actions/checkout to v4
- update pnpm/action-setup to v4

### Why are the changes needed?

Mordernize the github actions used, bumping the runtime in actions to NodeJS 20.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Passing the CI jobs.