### PR TITLE
[CELEBORN-1558] Fix the incorrect decrement of pendingWrites in handlePushMergeData

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -566,7 +566,7 @@ public abstract class PartitionDataWriter implements DeviceObserver {
       waitTime -= WAIT_INTERVAL_MS;
     }
     if (counter.get() > 0) {
-      IOException ioe = new IOException("Wait pending actions timeout.");
+      IOException ioe = new IOException("Wait pending actions timeout, Counter: " + counter.get());
       notifier.setException(ioe);
       throw ioe;
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -265,8 +265,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     fileWriter.incrementPendingWrites()
 
     if (fileWriter.isClosed) {
+      val diskFileInfo = fileWriter.getDiskFileInfo
       logWarning(
-        s"[handlePushData] FileWriter is already closed! File path ${fileWriter.getDiskFileInfo.getFilePath}")
+        s"[handlePushData] FileWriter is already closed! File path ${diskFileInfo.getFilePath} " +
+          s"length ${diskFileInfo.getFileLength}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return
@@ -536,8 +538,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     val closedFileWriter = fileWriters.find(_.isClosed)
     if (closedFileWriter.isDefined) {
+      val diskFileInfo = closedFileWriter.get.getDiskFileInfo
       logWarning(
-        s"[handlePushMergedData] FileWriter is already closed! File path ${closedFileWriter.get.getDiskFileInfo.getFilePath}")
+        s"[handlePushMergedData] FileWriter is already closed! File path ${diskFileInfo.getFilePath} " +
+          s"length ${diskFileInfo.getFileLength}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriters.foreach(_.decrementPendingWrites())
       return
@@ -812,8 +816,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     fileWriter.incrementPendingWrites()
 
     if (fileWriter.isClosed) {
+      val diskFileInfo = fileWriter.getDiskFileInfo
       logWarning(
-        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${fileWriter.getDiskFileInfo.getFilePath}")
+        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${diskFileInfo.getFilePath} " +
+          s"length ${diskFileInfo.getFileLength}")
       callback.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return
@@ -1224,7 +1230,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
         } else {
           workerSource.incCounter(WorkerSource.WRITE_DATA_HARD_SPLIT_COUNT)
           callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
-          logTrace(
+          logInfo(
             s"""
                |CheckDiskFullAndSplit hardSplit
                |diskFull:$diskFull,
@@ -1288,8 +1294,8 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
         var index = 0
         var fileWriter: PartitionDataWriter = null
         while (index < fileWriters.length) {
+          fileWriter = fileWriters(index)
           if (!writePromise.isCompleted) {
-            fileWriter = fileWriters(index)
             val offset = body.readerIndex() + batchOffsets(index)
             val length =
               if (index == fileWriters.length - 1) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

1. Fix the incorrect decrement of pendingWrites for FileWriter
2. Improve some logs about hardSplit/ExceptionLogs

### Why are the changes needed?
There are multiple file writers that write data in handlePushMergeData. If the previous FileWriter has already been closed, the next decrementPendingWrites will use an incorrect FileWriter. And this will cause timeout when commitFiles.

> java.io.IOException: Wait pending actions timeout, counter 1
at org.apache.celeborn.service.deploy.worker.storage.PartitionDataWriter.waitOnNoPending(PartitionDataWriter.java)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA & manual test
