### PR TITLE
[CELEBORN-1560] Remove usages of deprecated Files.createTempDir of Guava

### DIFF
--- a/common/src/test/java/org/apache/celeborn/common/network/StreamTestHelper.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/StreamTestHelper.java
@@ -21,9 +21,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.Random;
-
-import com.google.common.io.Files;
 
 import org.apache.celeborn.common.network.buffer.FileSegmentManagedBuffer;
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -51,7 +50,7 @@ class StreamTestHelper {
   }
 
   StreamTestHelper() throws Exception {
-    tempDir = Files.createTempDir();
+    tempDir = Files.createTempDirectory(null).toFile();
     emptyBuffer = createBuffer(0);
     smallBuffer = createBuffer(100);
     largeBuffer = createBuffer(100000);

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/ApiMasterResourceAuthenticationSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/ApiMasterResourceAuthenticationSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.service.deploy.master
 
-import com.google.common.io.Files
+import java.nio.file.Files
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
@@ -30,7 +30,7 @@ class ApiMasterResourceAuthenticationSuite extends ApiBaseResourceAuthentication
   override protected def httpService: HttpService = master
 
   def getTmpDir(): String = {
-    val tmpDir = Files.createTempDir()
+    val tmpDir = Files.createTempDirectory(null).toFile
     tmpDir.deleteOnExit()
     tmpDir.getAbsolutePath
   }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.celeborn.service.deploy.master
 
-import com.google.common.io.Files
+import java.nio.file.Files
+
 import org.mockito.Mockito.{mock, times, verify}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
@@ -34,7 +35,7 @@ class MasterSuite extends AnyFunSuite
   with Logging {
 
   def getTmpDir(): String = {
-    val tmpDir = Files.createTempDir()
+    val tmpDir = Files.createTempDirectory(null).toFile
     tmpDir.deleteOnExit()
     tmpDir.getAbsolutePath
   }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResourceSuite.scala
@@ -17,10 +17,9 @@
 
 package org.apache.celeborn.service.deploy.master.http.api
 
+import java.nio.file.Files
 import javax.ws.rs.client.Entity
 import javax.ws.rs.core.{Form, MediaType}
-
-import com.google.common.io.Files
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
@@ -34,7 +33,7 @@ class ApiMasterResourceSuite extends ApiBaseResourceSuite {
   override protected def httpService: HttpService = master
 
   def getTmpDir(): String = {
-    val tmpDir = Files.createTempDir()
+    val tmpDir = Files.createTempDirectory(null).toFile
     tmpDir.deleteOnExit()
     tmpDir.getAbsolutePath
   }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -17,12 +17,11 @@
 
 package org.apache.celeborn.service.deploy.master.http.api.v1
 
+import java.nio.file.Files
 import java.util.Collections
 import javax.servlet.http.HttpServletResponse
 import javax.ws.rs.client.Entity
 import javax.ws.rs.core.MediaType
-
-import com.google.common.io.Files
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
@@ -37,7 +36,7 @@ class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite {
   override protected def httpService: HttpService = master
 
   def getTmpDir(): String = {
-    val tmpDir = Files.createTempDir()
+    val tmpDir = Files.createTempDirectory(null).toFile
     tmpDir.deleteOnExit()
     tmpDir.getAbsolutePath
   }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
@@ -19,13 +19,13 @@ package org.apache.celeborn.service.deploy.worker.storage;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import scala.Function0;
 import scala.Tuple4;
 
-import org.apache.hadoop.shaded.com.google.common.io.Files;
 import org.mockito.Mockito;
 
 import org.apache.celeborn.common.CelebornConf;
@@ -102,7 +102,7 @@ public class PartitionDataWriterSuiteUtils {
       memoryFileInfo.replaceFileMeta(new MapFileMeta(32 * 1024, 10));
     }
 
-    File tempDir = Files.createTempDir();
+    File tempDir = Files.createTempDirectory(null).toFile();
     tempDir.deleteOnExit();
     File file = getTemporaryFile(tempDir);
     DiskFileInfo fileInfo = new DiskFileInfo(file, userIdentifier, celebornConf);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?



### Why are the changes needed?

`com.google.common.io.Files#createTempDir` has been deprecated since long ago.
`java.nio.file.Files#createTempDirectory` should be used instead, as suggested in Guava's API Javadoc. (https://guava.dev/releases/33.1.0-jre/api/docs/com/google/common/io/Files.html)

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

