### PR TITLE
[CELEBORN-1561] Make compressor closable and close native Lz4Compressor when ShuffleClient shutdown

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1796,6 +1796,10 @@ public class ShuffleClientImpl extends ShuffleClient {
     if (null != lifecycleManagerRef) {
       lifecycleManagerRef = null;
     }
+    try {
+      compressorThreadLocal.get().close();
+    } catch (IOException ignored) {
+    }
 
     shuffleIdCache.clear();
     pushExcludedWorkers.clear();

--- a/client/src/main/java/org/apache/celeborn/client/compress/Compressor.java
+++ b/client/src/main/java/org/apache/celeborn/client/compress/Compressor.java
@@ -17,10 +17,13 @@
 
 package org.apache.celeborn.client.compress;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.CompressionCodec;
 
-public interface Compressor {
+public interface Compressor extends Closeable {
 
   void initCompressBuffer(int maxDestLength);
 
@@ -29,6 +32,9 @@ public interface Compressor {
   int getCompressedTotalSize();
 
   byte[] getCompressedBuffer();
+
+  @Override
+  default void close() throws IOException {}
 
   default void writeIntLE(int i, byte[] buf, int off) {
     buf[off++] = (byte) i;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
- close the Compressor instance when ShuffleClient shutdown
- as the Lz4Compressor may create native compressor instance when `liblz4-java.so` available on OS, the StreamingXXHash32JNI class provides the close method for memory releasing.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

