### PR TITLE
[CELEBORN-1562] Bump Spark from 3.5.1 to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1451,7 +1451,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.5.1</spark.version>
+        <spark.version>3.5.2</spark.version>
         <zstd-jni.version>1.5.5-4</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -744,7 +744,7 @@ object Spark35 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.12.18"
 
-  val sparkVersion = "3.5.1"
+  val sparkVersion = "3.5.2"
   val zstdJniVersion = "1.5.5-4"
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Spark from 3.5.1 to 3.5.2. Meanwhile, bump the default `spark.version` from 3.5.1 to 3.5.2.

### Why are the changes needed?

Spark 3.5.2 has been announced to release: [Spark 3.5.2 released](https://spark.apache.org/news/spark-3-5-2-released.html). The profile spark-3.5 could bump Spark from 3.5.1 to 3.5.2.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.