### PR TITLE
[CELEBORN-1563] Log networkLocation in WorkerInfo

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -280,6 +280,7 @@ class WorkerInfo(
        |UserResourceConsumption: $userResourceConsumptionString
        |WorkerRef: $endpoint
        |WorkerStatus: $workerStatus
+       |NetworkLocation: $networkLocation
        |""".stripMargin
   }
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -234,6 +234,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
     val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, 10004)
     val worker2 =
       new WorkerInfo("h2", 20001, 20002, 20003, 2000, 20004, null, null)
+    worker2.networkLocation_$eq("/1")
 
     val worker3 = new WorkerInfo(
       "h3",
@@ -307,6 +308,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |Disks: empty
            |UserResourceConsumption: empty
            |WorkerRef: null
+           |NetworkLocation: /default-rack
            |""".stripMargin
 
       val exp2 =
@@ -322,6 +324,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
           |Disks: empty
           |UserResourceConsumption: empty
           |WorkerRef: null
+          |NetworkLocation: /1
           |""".stripMargin
       val exp3 =
         s"""
@@ -336,6 +339,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |Disks: empty
            |UserResourceConsumption: empty
            |WorkerRef: null
+           |NetworkLocation: /default-rack
            |""".stripMargin
       val exp4 =
         s"""
@@ -354,6 +358,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |UserResourceConsumption: $placeholder
            |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MiB, diskFileCount: 1, hdfsBytesWritten: 50.0 MiB, hdfsFileCount: 1, subResourceConsumptions: (application_1697697127390_2171854 -> ResourceConsumption(diskBytesWritten: 20.0 MiB, diskFileCount: 1, hdfsBytesWritten: 50.0 MiB, hdfsFileCount: 1, subResourceConsumptions: empty)))
            |WorkerRef: null
+           |NetworkLocation: /default-rack
            |""".stripMargin
 
       assertEquals(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Log networkLocation so that it appears during worker registration


### Why are the changes needed?
in the case of custom network location, it would be good to log it


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
updated unit tests
