### PR TITLE
fix offerSlotsLoadAware's actualUsableSpace condition on diskInfo

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -92,6 +92,10 @@ class DiskInfo(
     this.storageType = storageType
   }
 
+  def setConfiguredUsableSpace(configuredUsableSpace : Long): Unit = {
+    this.configuredUsableSpace = configuredUsableSpace
+  }
+
   def setStatus(status: DiskStatus): this.type = this.synchronized {
     this.status = status
     this

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -35,7 +35,6 @@ import org.apache.celeborn.common.meta.DiskStatus;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.protocol.StorageInfo;
-import org.apache.celeborn.common.util.DiskUtils;
 
 public class SlotsAllocator {
   static class UsableDiskInfo {
@@ -112,8 +111,6 @@ public class SlotsAllocator {
           List<Integer> partitionIds,
           boolean shouldReplicate,
           boolean shouldRackAware,
-          long diskReserveSize,
-          Option<Double> diskReserveRatio,
           int diskGroupCount,
           double diskGroupGradient,
           double flushTimeWeight,
@@ -143,13 +140,7 @@ public class SlotsAllocator {
                 .forEach(
                     (key, diskInfo) -> {
                       diskToWorkerMap.put(diskInfo, i);
-                      if (diskInfo.actualUsableSpace()
-                              > DiskUtils.getMinimumUsableSize(
-                                  diskInfo,
-                                  diskReserveSize,
-                                  diskReserveRatio.isEmpty()
-                                      ? Option.empty()
-                                      : Option.apply(diskReserveRatio.get()))
+                      if (diskInfo.actualUsableSpace() > 0
                           && diskInfo.status().equals(DiskStatus.HEALTHY)
                           && diskInfo.storageType() != StorageInfo.Type.HDFS
                           && diskInfo.storageType() != StorageInfo.Type.S3) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
-import scala.Option;
 import scala.Tuple2;
 
 import org.junit.Test;
@@ -232,8 +231,6 @@ public class SlotsAllocatorSuiteJ {
             partitionIds,
             shouldReplicate,
             false,
-            10 * 1024 * 1024 * 1024L,
-            Option.empty(),
             conf.masterSlotAssignLoadAwareDiskGroupNum(),
             conf.masterSlotAssignLoadAwareDiskGroupGradient(),
             conf.masterSlotAssignLoadAwareFlushTimeWeight(),
@@ -313,8 +310,6 @@ public class SlotsAllocatorSuiteJ {
               partitionIds,
               shouldReplicate,
               false,
-              1000_000_000,
-              Option.empty(),
               3,
               0.1,
               0,

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
@@ -20,9 +20,15 @@ package org.apache.celeborn.service.deploy.worker.storage
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.{WORKER_GRACEFUL_SHUTDOWN_ENABLED, WORKER_GRACEFUL_SHUTDOWN_RECOVER_PATH}
+import org.apache.celeborn.common.meta.DiskInfo
 import org.apache.celeborn.service.deploy.worker.WorkerSource
+import org.mockito.ArgumentMatchersSugar.any
+import org.mockito.Mockito.doAnswer
+import org.mockito.MockitoSugar.spy
 
 class StorageManagerSuite extends CelebornFunSuite {
+
+  val conf = new CelebornConf()
 
   test("[CELEBORN-926] saveAllCommittedFileInfosToDB cause IllegalMonitorStateException") {
     val conf = new CelebornConf().set(WORKER_GRACEFUL_SHUTDOWN_ENABLED, true)
@@ -30,5 +36,43 @@ class StorageManagerSuite extends CelebornFunSuite {
     val storageManager = new StorageManager(conf, new WorkerSource(conf))
     // should not throw IllegalMonitorStateException exception
     storageManager.saveAllCommittedFileInfosToDB()
+  }
+
+  test("updateDiskInfosWithDiskReserveSize") {
+
+    val storageManager = new StorageManager(conf, new WorkerSource(conf))
+    val spyStorageManager = spy(storageManager)
+
+    val disks = prepareDisks()
+    val diskSetSpace = 80 * 1024 * 1024 * 1024L
+
+    doAnswer(_ => disks).when(spyStorageManager).disksSnapshot()
+    doAnswer(_ => diskSetSpace).when(spyStorageManager).getFileSystemReportedUsableSpace(any)
+    spyStorageManager.updateDiskInfos()
+    for (disk <- disks) {
+      assert(disk.actualUsableSpace == diskSetSpace - conf.workerDiskReserveSize)
+    }
+  }
+
+  def prepareDisks(): List[DiskInfo] = {
+    val diskSetSpaces = Array(
+      90L * 1024 * 1024 * 1024,
+      95L * 1024 * 1024 * 1024,
+      100L * 1024 * 1024 * 1024
+    )
+
+    val diskInfo1 = new DiskInfo("/mnt/disk1", List.empty, null, conf)
+    diskInfo1.setConfiguredUsableSpace(Long.MaxValue)
+    diskInfo1.setUsableSpace(diskSetSpaces(0))
+
+    val diskInfo2 = new DiskInfo("/mnt/disk2", List.empty, null, conf)
+    diskInfo2.setConfiguredUsableSpace(Long.MaxValue)
+    diskInfo2.setUsableSpace(diskSetSpaces(1))
+
+    val diskInfo3 = new DiskInfo("/mnt/disk3", List.empty, null, conf)
+    diskInfo3.setConfiguredUsableSpace(Long.MaxValue)
+    diskInfo3.setUsableSpace(diskSetSpaces(2))
+
+    List(diskInfo1, diskInfo2, diskInfo3)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
fix offerSlotsLoadAware's actualUsableSpace condition on diskInfo.
update StorageManager.updateDiskInfos, considering diskReserveSize when setting usableSpace,
so master can get the usableSpace of diskInfo from worker without computing.

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
