### PR TITLE
[CELEBORN-1568] Support worker retries in MiniCluster

### DIFF
--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -20,6 +20,7 @@ package org.apache.celeborn.service.deploy
 import java.io.IOException
 import java.net.BindException
 import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.{Lock, ReentrantLock}
 
 import scala.collection.mutable
@@ -202,16 +203,16 @@ trait MiniClusterFeature extends Logging {
                 logError(s"cannot start worker $i, reached to max retrying", ex)
                 throw ex
               } else {
-                Thread.sleep(math.pow(2000, workerStartRetry).toInt)
+                TimeUnit.SECONDS.sleep(Math.pow(2, workerStartRetry).toLong)
               }
           }
         }
       })
-      workerThread.setName(s"worker ${i} starter thread")
+      workerThread.setName(s"worker $i starter thread")
       workerThread
     }
     threads.foreach(_.start())
-    Thread.sleep(5000)
+    Thread.sleep(15000)
     var allWorkersStarted = false
     var workersWaitingTime = 0
     while (!allWorkersStarted) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -212,7 +212,7 @@ trait MiniClusterFeature extends Logging {
       workerThread
     }
     threads.foreach(_.start())
-    Thread.sleep(15000)
+    Thread.sleep(5000)
     var allWorkersStarted = false
     var workersWaitingTime = 0
     while (!allWorkersStarted) {
@@ -229,7 +229,7 @@ trait MiniClusterFeature extends Logging {
         workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
         allWorkersStarted = true
       } catch {
-        case ex: Exception =>
+        case ex: Throwable =>
           logError("all workers haven't been started retrying", ex)
           Thread.sleep(5000)
           workersWaitingTime += 5000


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
https://github.com/apache/celeborn/actions/runs/10417785546/job/28852691241#step:4:5804

Now the worker retry logic, the first time of sleep is 2000, the second time is 4000000, and the third time is 8000000000 milliseconds. It is estimated that it will be difficult to complete the retry.


```scala
Thread.sleep(math.pow(2000, workerStartRetry).toInt)
```




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
