### PR TITLE
[CELEBORN-1570] Fix flaky test - monitor non-critical error metrics in DeviceMonitorSuite

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -112,10 +112,10 @@ class LocalDeviceMonitor(
               val mountPoints = device.diskInfos.keySet.asScala.toList
               // tolerate time accuracy for better performance
               val now = System.currentTimeMillis()
-              for (concurrentSet <- device.nonCriticalErrors.values().asScala) {
-                for (time <- concurrentSet.asScala) {
+              for (concurrentList <- device.nonCriticalErrors.values().asScala) {
+                for (time <- concurrentList.asScala) {
                   if (now - time > device.notifyErrorExpireTimeout) {
-                    concurrentSet.remove(time)
+                    concurrentList.remove(time)
                   }
                 }
               }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala
@@ -21,8 +21,10 @@ import java.io.File
 import java.util
 import java.util.{List => JList, Set => JSet}
 import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+
 import scala.collection.JavaConverters._
 import scala.io.Source
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala
@@ -19,12 +19,10 @@ package org.apache.celeborn.service.deploy.worker.storage
 
 import java.io.File
 import java.util
-import java.util.{Set => JSet}
-import java.util.concurrent.ConcurrentHashMap
-
+import java.util.{List => JList, Set => JSet}
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
 import scala.collection.JavaConverters._
 import scala.io.Source
-
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus}
@@ -45,8 +43,8 @@ class ObservedDevice(val deviceInfo: DeviceInfo, conf: CelebornConf, workerSourc
   val statFile = new File(s"$sysBlockDir/${deviceInfo.name}/stat")
   val inFlightFile = new File(s"$sysBlockDir/${deviceInfo.name}/inflight")
 
-  val nonCriticalErrors: ConcurrentHashMap[DiskStatus, JSet[Long]] =
-    JavaUtils.newConcurrentHashMap[DiskStatus, JSet[Long]]()
+  val nonCriticalErrors: ConcurrentHashMap[DiskStatus, JList[Long]] =
+    JavaUtils.newConcurrentHashMap[DiskStatus, JList[Long]]()
   val notifyErrorThreshold: Int = conf.workerDiskMonitorNotifyErrorThreshold
   val notifyErrorExpireTimeout: Long = conf.workerDiskMonitorNotifyErrorExpireTimeout
 
@@ -83,11 +81,11 @@ class ObservedDevice(val deviceInfo: DeviceInfo, conf: CelebornConf, workerSourc
       nonCriticalErrors.computeIfAbsent(
         diskStatus,
         (_: DiskStatus) => {
-          val set = ConcurrentHashMap.newKeySet[Long]()
+          val list = new CopyOnWriteArrayList[Long]()
           workerSource.addGauge(s"Device_${deviceInfo.name}_${diskStatus.toMetric}_Count") { () =>
-            set.size()
+            list.size()
           }
-          set
+          list
         }).add(System.currentTimeMillis())
       mountPoints.foreach { mountPoint =>
         diskInfos.get(mountPoint).setStatus(diskStatus)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -400,6 +400,8 @@ class DeviceMonitorSuite extends AnyFunSuite {
         assertEquals(1, deviceMonitorMetrics.head.gauge.getValue)
         assertEquals(1, deviceMonitorMetrics.last.gauge.getValue)
 
+        Thread.sleep(5000)
+
         device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.READ_OR_WRITE_FAILURE)
         device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.IO_HANG)
         assertEquals(2, deviceMonitorMetrics.head.gauge.getValue)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -400,8 +400,6 @@ class DeviceMonitorSuite extends AnyFunSuite {
         assertEquals(1, deviceMonitorMetrics.head.gauge.getValue)
         assertEquals(1, deviceMonitorMetrics.last.gauge.getValue)
 
-        Thread.sleep(5000)
-
         device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.READ_OR_WRITE_FAILURE)
         device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.IO_HANG)
         assertEquals(2, deviceMonitorMetrics.head.gauge.getValue)


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
https://github.com/apache/celeborn/actions/runs/10441850633/job/28913478820?pr=2692

```
- monitor non-critical error metrics *** FAILED ***
  java.lang.AssertionError: expected:<2> but was:<1>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:120)
  at org.junit.Assert.assertEquals(Assert.java:146)
  at org.apache.celeborn.service.deploy.worker.storage.DeviceMonitorSuite.$anonfun$new$22(DeviceMonitorSuite.scala:405)
```

Because calling `System.currentTimeMillis()` twice may get the same value. Gauge uses the size of the set, and the same value will be deduplicated.

https://github.com/apache/celeborn/blob/0ee3c3a4bdef3b97fca6be04f03ac36c2e12e1a6/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala#L81-L91




### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GA
