### PR TITLE
[CELEBORN-1477][FOLLOWUP] Upgrade openapi-generator to 7.8.0

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -37,5 +37,3 @@ build/scala-*/**
 build/sbt-config/**
 **/benchmarks/**
 **/node_modules/**
-**/src/main/java/org/apache/celeborn/rest/v1/**/ServerConfiguration.java
-**/src/main/java/org/apache/celeborn/rest/v1/**/ServerVariable.java

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApplicationApi extends BaseApi {
 
   public ApplicationApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ConfApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ConfApi.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ConfApi extends BaseApi {
 
   public ConfApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/DefaultApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/DefaultApi.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class DefaultApi extends BaseApi {
 
   public DefaultApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/MasterApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/MasterApi.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class MasterApi extends BaseApi {
 
   public MasterApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ShuffleApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ShuffleApi.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ShuffleApi extends BaseApi {
 
   public ShuffleApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerApi extends BaseApi {
 
   public WorkerApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ApiClient.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ApiClient.java
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.function.Supplier;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,7 +85,7 @@ import java.text.DateFormat;
 import org.apache.celeborn.rest.v1.master.invoker.auth.Authentication;
 import org.apache.celeborn.rest.v1.master.invoker.auth.HttpBasicAuth;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApiClient extends JavaTimeFormatter {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private Map<String, String> defaultCookieMap = new HashMap<String, String>();
@@ -107,8 +108,8 @@ public class ApiClient extends JavaTimeFormatter {
 
   private Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  private Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
+  private Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
 
   private DateFormat dateFormat;
 
@@ -253,16 +254,18 @@ public class ApiClient extends JavaTimeFormatter {
    *
    * @return Status code
    */
+  @Deprecated
   public int getStatusCode() {
-    return statusCode;
+    return lastStatusCodeByThread.get(Thread.currentThread().getId());
   }
 
   /**
    * Gets the response headers of the previous request
    * @return Response headers
    */
+  @Deprecated
   public Map<String, List<String>> getResponseHeaders() {
-    return responseHeaders;
+    return lastResponseHeadersByThread.get(Thread.currentThread().getId());
   }
 
   /**
@@ -755,6 +758,7 @@ public class ApiClient extends JavaTimeFormatter {
       // convert input stream to string
       return (T) EntityUtils.toString(entity);
     } else {
+      Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
       throw new ApiException(
           "Deserialization for content type '" + mimeType + "' not supported for type '" + valueType + "'",
           response.getCode(),
@@ -900,12 +904,15 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   protected <T> T processResponse(CloseableHttpResponse response, TypeReference<T> returnType) throws ApiException, IOException, ParseException {
-    statusCode = response.getCode();
+    int statusCode = response.getCode();
+    lastStatusCodeByThread.put(Thread.currentThread().getId(), statusCode);
     if (statusCode == HttpStatus.SC_NO_CONTENT) {
       return null;
     }
 
-    responseHeaders = transformResponseHeaders(response.getHeaders());
+    Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
+    lastResponseHeadersByThread.put(Thread.currentThread().getId(), responseHeaders);
+
     if (isSuccessfulStatus(statusCode)) {
       return this.deserialize(response, returnType);
     } else {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ApiException.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ApiException.java
@@ -21,7 +21,7 @@ package org.apache.celeborn.rest.v1.master.invoker;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApiException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/BaseApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/BaseApi.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Collections;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public abstract class BaseApi {
 
   protected ApiClient apiClient;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/Configuration.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/Configuration.java
@@ -18,7 +18,7 @@
 
 package org.apache.celeborn.rest.v1.master.invoker;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class Configuration {
     public static final String VERSION = "0.6.0-SNAPSHOT";
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/JavaTimeFormatter.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/JavaTimeFormatter.java
@@ -25,7 +25,7 @@ import java.time.format.DateTimeParseException;
  * Class that add parsing/formatting support for Java 8+ {@code OffsetDateTime} class.
  * It's generated for java clients when {@code AbstractJavaCodegen#dateLibrary} specified as {@code java8}.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class JavaTimeFormatter {
 
     private DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/Pair.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/Pair.java
@@ -18,7 +18,7 @@
 
 package org.apache.celeborn.rest.v1.master.invoker;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/RFC3339DateFormat.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/RFC3339DateFormat.java
@@ -27,7 +27,7 @@ import java.text.DecimalFormat;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class RFC3339DateFormat extends DateFormat {
   private static final long serialVersionUID = 1L;
   private static final TimeZone TIMEZONE_Z = TimeZone.getTimeZone("UTC");

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ServerConfiguration.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ServerConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.apache.celeborn.rest.v1.master.invoker;
 
 import java.util.Map;
@@ -5,7 +23,7 @@ import java.util.Map;
 /**
  * Representing a Server configuration.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ServerConfiguration {
     public String URL;
     public String description;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ServerVariable.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/ServerVariable.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.apache.celeborn.rest.v1.master.invoker;
 
 import java.util.HashSet;
@@ -5,7 +23,7 @@ import java.util.HashSet;
 /**
  * Representing a Server Variable for server URL template substitution.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ServerVariable {
     public String description;
     public String defaultValue;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/StringUtil.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/StringUtil.java
@@ -21,7 +21,7 @@ package org.apache.celeborn.rest.v1.master.invoker;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/auth/ApiKeyAuth.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/auth/ApiKeyAuth.java
@@ -23,7 +23,7 @@ import org.apache.celeborn.rest.v1.master.invoker.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/auth/HttpBasicAuth.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/auth/HttpBasicAuth.java
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/auth/HttpBearerAuth.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/invoker/auth/HttpBearerAuth.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private Supplier<String> tokenSupplier;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsageData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsageData.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   AppDiskUsageData.JSON_PROPERTY_ESTIMATED_USAGE,
   AppDiskUsageData.JSON_PROPERTY_ESTIMATED_USAGE_STR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class AppDiskUsageData {
   public static final String JSON_PROPERTY_APP_ID = "appId";
   private String appId;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsageSnapshotData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsageSnapshotData.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   AppDiskUsageSnapshotData.JSON_PROPERTY_END,
   AppDiskUsageSnapshotData.JSON_PROPERTY_TOP_N_ITEMS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class AppDiskUsageSnapshotData {
   public static final String JSON_PROPERTY_START = "start";
   private Long start;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsageSnapshotsResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsageSnapshotsResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   AppDiskUsageSnapshotsResponse.JSON_PROPERTY_SNAPSHOTS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class AppDiskUsageSnapshotsResponse {
   public static final String JSON_PROPERTY_SNAPSHOTS = "snapshots";
   private List<AppDiskUsageSnapshotData> snapshots = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsagesResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/AppDiskUsagesResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   AppDiskUsagesResponse.JSON_PROPERTY_APP_DISK_USAGES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class AppDiskUsagesResponse {
   public static final String JSON_PROPERTY_APP_DISK_USAGES = "appDiskUsages";
   private List<AppDiskUsageData> appDiskUsages = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ApplicationHeartbeatData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ApplicationHeartbeatData.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   ApplicationHeartbeatData.JSON_PROPERTY_APP_ID,
   ApplicationHeartbeatData.JSON_PROPERTY_LAST_HEARTBEAT_TIMESTAMP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApplicationHeartbeatData {
   public static final String JSON_PROPERTY_APP_ID = "appId";
   private String appId;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ApplicationsHeartbeatResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ApplicationsHeartbeatResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   ApplicationsHeartbeatResponse.JSON_PROPERTY_APPLICATIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApplicationsHeartbeatResponse {
   public static final String JSON_PROPERTY_APPLICATIONS = "applications";
   private List<ApplicationHeartbeatData> applications = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ApplicationsResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ApplicationsResponse.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   ApplicationsResponse.JSON_PROPERTY_APPLICATIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApplicationsResponse {
   public static final String JSON_PROPERTY_APPLICATIONS = "applications";
   private List<String> applications = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ConfResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ConfResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   ConfResponse.JSON_PROPERTY_CONFIGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ConfResponse {
   public static final String JSON_PROPERTY_CONFIGS = "configs";
   private List<ConfigData> configs = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ConfigData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ConfigData.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   ConfigData.JSON_PROPERTY_NAME,
   ConfigData.JSON_PROPERTY_VALUE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ConfigData {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfig.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfig.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   DynamicConfig.JSON_PROPERTY_DESC,
   DynamicConfig.JSON_PROPERTY_CONFIGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class DynamicConfig {
   /**
    * the config level of dynamic configs.

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfigResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfigResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   DynamicConfigResponse.JSON_PROPERTY_CONFIGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class DynamicConfigResponse {
   public static final String JSON_PROPERTY_CONFIGS = "configs";
   private List<DynamicConfig> configs = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ExcludeWorkerRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ExcludeWorkerRequest.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   ExcludeWorkerRequest.JSON_PROPERTY_ADD,
   ExcludeWorkerRequest.JSON_PROPERTY_REMOVE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ExcludeWorkerRequest {
   public static final String JSON_PROPERTY_ADD = "add";
   private List<WorkerId> add = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/HandleResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/HandleResponse.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   HandleResponse.JSON_PROPERTY_SUCCESS,
   HandleResponse.JSON_PROPERTY_MESSAGE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class HandleResponse {
   public static final String JSON_PROPERTY_SUCCESS = "success";
   private Boolean success;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/HostnamesResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/HostnamesResponse.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   HostnamesResponse.JSON_PROPERTY_HOSTNAMES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class HostnamesResponse {
   public static final String JSON_PROPERTY_HOSTNAMES = "hostnames";
   private List<String> hostnames = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/MasterCommitData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/MasterCommitData.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   MasterCommitData.JSON_PROPERTY_CLIENT_ADDRESS,
   MasterCommitData.JSON_PROPERTY_START_UP_ROLE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class MasterCommitData {
   public static final String JSON_PROPERTY_COMMIT_INDEX = "commitIndex";
   private Long commitIndex;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/MasterInfoResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/MasterInfoResponse.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   MasterInfoResponse.JSON_PROPERTY_LEADER,
   MasterInfoResponse.JSON_PROPERTY_MASTER_COMMIT_INFO
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class MasterInfoResponse {
   public static final String JSON_PROPERTY_GROUP_ID = "groupId";
   private String groupId;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/MasterLeader.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/MasterLeader.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   MasterLeader.JSON_PROPERTY_ID,
   MasterLeader.JSON_PROPERTY_ADDRESS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class MasterLeader {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/PartitionLocationData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/PartitionLocationData.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   PartitionLocationData.JSON_PROPERTY_STORAGE,
   PartitionLocationData.JSON_PROPERTY_MAP_ID_BIT_MAP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class PartitionLocationData {
   public static final String JSON_PROPERTY_ID_EPOCH = "idEpoch";
   private String idEpoch;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RemoveWorkersUnavailableInfoRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RemoveWorkersUnavailableInfoRequest.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   RemoveWorkersUnavailableInfoRequest.JSON_PROPERTY_WORKERS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class RemoveWorkersUnavailableInfoRequest {
   public static final String JSON_PROPERTY_WORKERS = "workers";
   private List<WorkerId> workers = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   SendWorkerEventRequest.JSON_PROPERTY_EVENT_TYPE,
   SendWorkerEventRequest.JSON_PROPERTY_WORKERS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class SendWorkerEventRequest {
   /**
    * The type of the event.

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ShufflePartitionsResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ShufflePartitionsResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   ShufflePartitionsResponse.JSON_PROPERTY_PRIMARY_PARTITIONS,
   ShufflePartitionsResponse.JSON_PROPERTY_REPLICA_PARTITIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ShufflePartitionsResponse {
   public static final String JSON_PROPERTY_PRIMARY_PARTITIONS = "primaryPartitions";
   private Map<String, Map<String, PartitionLocationData>> primaryPartitions = new HashMap<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ShufflesResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ShufflesResponse.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   ShufflesResponse.JSON_PROPERTY_SHUFFLE_IDS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ShufflesResponse {
   public static final String JSON_PROPERTY_SHUFFLE_IDS = "shuffleIds";
   private List<String> shuffleIds = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ThreadStack.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ThreadStack.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   ThreadStack.JSON_PROPERTY_BLOCKED_BY_LOCK,
   ThreadStack.JSON_PROPERTY_HOLDING_LOCKS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ThreadStack {
   public static final String JSON_PROPERTY_THREAD_ID = "threadId";
   private Long threadId;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ThreadStackResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ThreadStackResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   ThreadStackResponse.JSON_PROPERTY_THREAD_STACKS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ThreadStackResponse {
   public static final String JSON_PROPERTY_THREAD_STACKS = "threadStacks";
   private List<ThreadStack> threadStacks = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/UnAvailablePeersResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/UnAvailablePeersResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   UnAvailablePeersResponse.JSON_PROPERTY_PEERS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class UnAvailablePeersResponse {
   public static final String JSON_PROPERTY_PEERS = "peers";
   private List<WorkerTimestampData> peers = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerData.JSON_PROPERTY_WORKER_STATE,
   WorkerData.JSON_PROPERTY_WORKER_STATE_START_TIME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerData {
   public static final String JSON_PROPERTY_HOST = "host";
   private String host;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventData.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerEventData.JSON_PROPERTY_WORKER,
   WorkerEventData.JSON_PROPERTY_EVENT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerEventData {
   public static final String JSON_PROPERTY_WORKER = "worker";
   private WorkerData worker;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventInfoData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventInfoData.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerEventInfoData.JSON_PROPERTY_EVENT_TYPE,
   WorkerEventInfoData.JSON_PROPERTY_EVENT_TIME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerEventInfoData {
   public static final String JSON_PROPERTY_EVENT_TYPE = "eventType";
   private String eventType;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventsResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventsResponse.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   WorkerEventsResponse.JSON_PROPERTY_WORKER_EVENTS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerEventsResponse {
   public static final String JSON_PROPERTY_WORKER_EVENTS = "workerEvents";
   private List<WorkerEventData> workerEvents = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   WorkerExitRequest.JSON_PROPERTY_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerExitRequest {
   /**
    * The type of the worker exit request.

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerId.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerId.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerId.JSON_PROPERTY_FETCH_PORT,
   WorkerId.JSON_PROPERTY_REPLICATE_PORT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerId {
   public static final String JSON_PROPERTY_HOST = "host";
   private String host;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
@@ -52,7 +52,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerInfoResponse.JSON_PROPERTY_IS_SHUTDOWN,
   WorkerInfoResponse.JSON_PROPERTY_IS_DECOMMISSIONING
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerInfoResponse {
   public static final String JSON_PROPERTY_HOST = "host";
   private String host;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerTimestampData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerTimestampData.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerTimestampData.JSON_PROPERTY_WORKER,
   WorkerTimestampData.JSON_PROPERTY_TIMESTAMP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerTimestampData {
   public static final String JSON_PROPERTY_WORKER = "worker";
   private WorkerData worker;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkersResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkersResponse.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkersResponse.JSON_PROPERTY_SHUTDOWN_WORKERS,
   WorkersResponse.JSON_PROPERTY_DECOMMISSIONING_WORKERS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkersResponse {
   public static final String JSON_PROPERTY_WORKERS = "workers";
   private List<WorkerData> workers = new ArrayList<>();

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/ApplicationApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/ApplicationApi.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApplicationApi extends BaseApi {
 
   public ApplicationApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/ConfApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/ConfApi.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ConfApi extends BaseApi {
 
   public ConfApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/DefaultApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/DefaultApi.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class DefaultApi extends BaseApi {
 
   public DefaultApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/ShuffleApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/ShuffleApi.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ShuffleApi extends BaseApi {
 
   public ShuffleApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerApi extends BaseApi {
 
   public WorkerApi() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ApiClient.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ApiClient.java
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.function.Supplier;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,7 +85,7 @@ import java.text.DateFormat;
 import org.apache.celeborn.rest.v1.worker.invoker.auth.Authentication;
 import org.apache.celeborn.rest.v1.worker.invoker.auth.HttpBasicAuth;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApiClient extends JavaTimeFormatter {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private Map<String, String> defaultCookieMap = new HashMap<String, String>();
@@ -107,8 +108,8 @@ public class ApiClient extends JavaTimeFormatter {
 
   private Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  private Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
+  private Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
 
   private DateFormat dateFormat;
 
@@ -253,16 +254,18 @@ public class ApiClient extends JavaTimeFormatter {
    *
    * @return Status code
    */
+  @Deprecated
   public int getStatusCode() {
-    return statusCode;
+    return lastStatusCodeByThread.get(Thread.currentThread().getId());
   }
 
   /**
    * Gets the response headers of the previous request
    * @return Response headers
    */
+  @Deprecated
   public Map<String, List<String>> getResponseHeaders() {
-    return responseHeaders;
+    return lastResponseHeadersByThread.get(Thread.currentThread().getId());
   }
 
   /**
@@ -755,6 +758,7 @@ public class ApiClient extends JavaTimeFormatter {
       // convert input stream to string
       return (T) EntityUtils.toString(entity);
     } else {
+      Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
       throw new ApiException(
           "Deserialization for content type '" + mimeType + "' not supported for type '" + valueType + "'",
           response.getCode(),
@@ -900,12 +904,15 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   protected <T> T processResponse(CloseableHttpResponse response, TypeReference<T> returnType) throws ApiException, IOException, ParseException {
-    statusCode = response.getCode();
+    int statusCode = response.getCode();
+    lastStatusCodeByThread.put(Thread.currentThread().getId(), statusCode);
     if (statusCode == HttpStatus.SC_NO_CONTENT) {
       return null;
     }
 
-    responseHeaders = transformResponseHeaders(response.getHeaders());
+    Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
+    lastResponseHeadersByThread.put(Thread.currentThread().getId(), responseHeaders);
+
     if (isSuccessfulStatus(statusCode)) {
       return this.deserialize(response, returnType);
     } else {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ApiException.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ApiException.java
@@ -21,7 +21,7 @@ package org.apache.celeborn.rest.v1.worker.invoker;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApiException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/BaseApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/BaseApi.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Collections;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public abstract class BaseApi {
 
   protected ApiClient apiClient;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/Configuration.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/Configuration.java
@@ -18,7 +18,7 @@
 
 package org.apache.celeborn.rest.v1.worker.invoker;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class Configuration {
     public static final String VERSION = "0.6.0-SNAPSHOT";
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/JavaTimeFormatter.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/JavaTimeFormatter.java
@@ -25,7 +25,7 @@ import java.time.format.DateTimeParseException;
  * Class that add parsing/formatting support for Java 8+ {@code OffsetDateTime} class.
  * It's generated for java clients when {@code AbstractJavaCodegen#dateLibrary} specified as {@code java8}.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class JavaTimeFormatter {
 
     private DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/Pair.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/Pair.java
@@ -18,7 +18,7 @@
 
 package org.apache.celeborn.rest.v1.worker.invoker;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/RFC3339DateFormat.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/RFC3339DateFormat.java
@@ -27,7 +27,7 @@ import java.text.DecimalFormat;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class RFC3339DateFormat extends DateFormat {
   private static final long serialVersionUID = 1L;
   private static final TimeZone TIMEZONE_Z = TimeZone.getTimeZone("UTC");

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ServerConfiguration.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ServerConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.apache.celeborn.rest.v1.worker.invoker;
 
 import java.util.Map;
@@ -5,7 +23,7 @@ import java.util.Map;
 /**
  * Representing a Server configuration.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ServerConfiguration {
     public String URL;
     public String description;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ServerVariable.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/ServerVariable.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.apache.celeborn.rest.v1.worker.invoker;
 
 import java.util.HashSet;
@@ -5,7 +23,7 @@ import java.util.HashSet;
 /**
  * Representing a Server Variable for server URL template substitution.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ServerVariable {
     public String description;
     public String defaultValue;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/StringUtil.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/StringUtil.java
@@ -21,7 +21,7 @@ package org.apache.celeborn.rest.v1.worker.invoker;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/auth/ApiKeyAuth.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/auth/ApiKeyAuth.java
@@ -23,7 +23,7 @@ import org.apache.celeborn.rest.v1.worker.invoker.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/auth/HttpBasicAuth.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/auth/HttpBasicAuth.java
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/auth/HttpBearerAuth.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/invoker/auth/HttpBearerAuth.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private Supplier<String> tokenSupplier;

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <maven.plugin.surefire.version>3.0.0-M7</maven.plugin.surefire.version>
     <maven.plugin.silencer.version>1.7.13</maven.plugin.silencer.version>
     <maven.plugin.resources.version>3.3.1</maven.plugin.resources.version>
-    <openapi.generator.version>7.7.0</openapi.generator.version>
+    <openapi.generator.version>7.8.0</openapi.generator.version>
 
     <!-- Allow modules to enable / disable certain build plugins easily. -->
     <testJarPhase>prepare-package</testJarPhase>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,4 +21,4 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.7.0")
+addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.8.0")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This pr is a followup for https://github.com/apache/celeborn/pull/2641

In above PR, I upgrade the version to 7.7.0, and there were two generated java files not with apache licenses.

And then I raised a PR in https://github.com/OpenAPITools/openapi-generator/pull/19273 to followup it, and it is released in https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.8.0.

### Why are the changes needed?

Upgrade to the latest openapi-generator version to resolve the unlicensed java files.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing GA.
