### PR TITLE
[CELEBORN-1575] TimeSlidingHub should remove expire node when reading

### DIFF
--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
@@ -125,5 +125,8 @@ public class TestTimeSlidingHub {
     hub.setDummyTimestamp(10000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
     Assert.assertEquals(2, hub.sum().getLeft().getValue());
+
+    hub.setDummyTimestamp(13000L);
+    Assert.assertEquals(0, hub.sum().getLeft().getValue());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
TimeSlidingHub remove expire node when reading.


### Why are the changes needed?
Metrics **UserProduceSpeed** is not correct.

You can see that if a user no longer writes data, UserProduceSpeed ​​still retains the last value until user expires.
![image](https://github.com/user-attachments/assets/885f5b56-3b08-4909-8045-3c7ee3d03771)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.
