### PR TITLE
[CELEBORN-1521][FOLLOWUP] Using AuthenticationException instead of SecurityException

### DIFF
--- a/spi/src/main/java/org/apache/celeborn/spi/authentication/PasswdAuthenticationProvider.java
+++ b/spi/src/main/java/org/apache/celeborn/spi/authentication/PasswdAuthenticationProvider.java
@@ -31,5 +31,5 @@ public interface PasswdAuthenticationProvider {
    * @return The identifier associated with the credential
    * @throws AuthenticationException When a user is found to be invalid by the implementation
    */
-  Principal authenticate(PasswordCredential credential);
+  Principal authenticate(PasswordCredential credential) throws AuthenticationException;
 }

--- a/spi/src/main/java/org/apache/celeborn/spi/authentication/PasswdAuthenticationProvider.java
+++ b/spi/src/main/java/org/apache/celeborn/spi/authentication/PasswdAuthenticationProvider.java
@@ -19,6 +19,8 @@ package org.apache.celeborn.spi.authentication;
 
 import java.security.Principal;
 
+import javax.security.sasl.AuthenticationException;
+
 public interface PasswdAuthenticationProvider {
   /**
    * The authenticate method is called by the celeborn authentication layer to authenticate password
@@ -27,7 +29,7 @@ public interface PasswdAuthenticationProvider {
    *
    * @param credential The credential received over the connection request
    * @return The identifier associated with the credential
-   * @throws SecurityException When a user is found to be invalid by the implementation
+   * @throws AuthenticationException When a user is found to be invalid by the implementation
    */
   Principal authenticate(PasswordCredential credential);
 }

--- a/spi/src/main/java/org/apache/celeborn/spi/authentication/TokenAuthenticationProvider.java
+++ b/spi/src/main/java/org/apache/celeborn/spi/authentication/TokenAuthenticationProvider.java
@@ -32,5 +32,5 @@ public interface TokenAuthenticationProvider {
    * @throws AuthenticationException When the credential is found to be invalid by the
    *     implementation
    */
-  Principal authenticate(TokenCredential credential);
+  Principal authenticate(TokenCredential credential) throws AuthenticationException;
 }

--- a/spi/src/main/java/org/apache/celeborn/spi/authentication/TokenAuthenticationProvider.java
+++ b/spi/src/main/java/org/apache/celeborn/spi/authentication/TokenAuthenticationProvider.java
@@ -19,6 +19,8 @@ package org.apache.celeborn.spi.authentication;
 
 import java.security.Principal;
 
+import javax.security.sasl.AuthenticationException;
+
 public interface TokenAuthenticationProvider {
   /**
    * The authenticate method is called by the celeborn authentication layer to authenticate
@@ -27,7 +29,8 @@ public interface TokenAuthenticationProvider {
    *
    * @param credential The credential received over the connection request
    * @return The identifier associated with the token
-   * @throws SecurityException When the credential is found to be invalid by the implementation
+   * @throws AuthenticationException When the credential is found to be invalid by the
+   *     implementation
    */
   Principal authenticate(TokenCredential credential);
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
Have to use AuthenticationException to return status code 401 on auth failure, otherwise, it is `500`.
https://github.com/apache/celeborn/blob/9fefa66318e5c6e0f2237f63200ade8aba367e75/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/AuthenticationFilter.scala#L159-L160

### Does this PR introduce _any_ user-facing change?
No, this interface has not been released.


### How was this patch tested?
Existing GA.
