### PR TITLE
[CELEBORN-1578] Make Worker#timer have thread name and daemon

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -337,7 +337,7 @@ private[celeborn] class Worker(
       conf.workerCleanThreads)
   val asyncReplyPool: ScheduledExecutorService =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("worker-rpc-async-replier")
-  val timer = new HashedWheelTimer()
+  val timer = new HashedWheelTimer(ThreadUtils.namedThreadFactory("worker-timer"))
 
   // Configs
   private val heartbeatInterval = conf.workerHeartbeatTimeout / 4

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -337,7 +337,7 @@ private[celeborn] class Worker(
       conf.workerCleanThreads)
   val asyncReplyPool: ScheduledExecutorService =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("worker-rpc-async-replier")
-  val timer = new HashedWheelTimer(ThreadUtils.namedThreadFactory("worker-timer"))
+  val timer = new HashedWheelTimer(ThreadUtils.namedSingleThreadFactory("worker-timer"))
 
   // Configs
   private val heartbeatInterval = conf.workerHeartbeatTimeout / 4


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
Current jstack
```java
"pool-36-thread-1" #118 prio=5 os_prio=0 tid=0x00007f40cc00d000 nid=0xd3e0 waiting on condition [0x00007f3ecbffe000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
        at java.lang.Thread.sleep(Native Method)
        at io.netty.util.HashedWheelTimer$Worker.waitForNextTick(HashedWheelTimer.java:600)
        at io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:496)
        at java.lang.Thread.run(Thread.java:745)
```



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
