### PR TITLE
[CELEBORN-1579] Fix the memory leak of result partition

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -93,6 +93,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.plugin.flink;
 
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkNotNull;
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkState;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +58,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
   RemoteShuffleResultPartitionDelegation delegation;
 
+  private final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
+
   public RemoteShuffleResultPartition(
       String owningTaskName,
       int partitionIndex,
@@ -82,11 +87,17 @@ public class RemoteShuffleResultPartition extends ResultPartition {
     delegation =
         new RemoteShuffleResultPartitionDelegation(
             networkBufferSize, outputGate, this::updateStatistics, numSubpartitions);
+    this.bufferPoolFactory = bufferPoolFactory;
   }
 
   @Override
   public void setup() throws IOException {
-    super.setup();
+    // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // So we copy the logic of `setup` but don't register partition to partition manager.
+    checkState(
+        this.bufferPool == null,
+        "Bug in result partition setup logic: Already registered buffer pool.");
+    this.bufferPool = checkNotNull(bufferPoolFactory.get());
     BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
     delegation.setup(
         bufferPool, bufferCompressor, this::canBeCompressed, this::checkInProduceState);

--- a/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -89,6 +89,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,

--- a/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.plugin.flink;
 
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkNotNull;
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkState;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +54,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
   private final RemoteShuffleResultPartitionDelegation delegation;
 
+  private final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
+
   public RemoteShuffleResultPartition(
       String owningTaskName,
       int partitionIndex,
@@ -78,11 +83,17 @@ public class RemoteShuffleResultPartition extends ResultPartition {
     delegation =
         new RemoteShuffleResultPartitionDelegation(
             networkBufferSize, outputGate, this::updateStatistics, numSubpartitions);
+    this.bufferPoolFactory = bufferPoolFactory;
   }
 
   @Override
   public void setup() throws IOException {
-    super.setup();
+    // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // So we copy the logic of `setup` but don't register partition to partition manager.
+    checkState(
+        this.bufferPool == null,
+        "Bug in result partition setup logic: Already registered buffer pool.");
+    this.bufferPool = checkNotNull(bufferPoolFactory.get());
     BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
     delegation.setup(
         bufferPool, bufferCompressor, this::canBeCompressed, this::checkInProduceState);

--- a/client-flink/flink-1.16/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.16/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -93,6 +93,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,

--- a/client-flink/flink-1.16/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.16/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.plugin.flink;
 
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkNotNull;
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkState;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -52,6 +55,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
   private final RemoteShuffleResultPartitionDelegation delegation;
 
+  private final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
+
   public RemoteShuffleResultPartition(
       String owningTaskName,
       int partitionIndex,
@@ -82,11 +87,19 @@ public class RemoteShuffleResultPartition extends ResultPartition {
             outputGate,
             (bufferWithChannel, isBroadcast) -> updateStatistics(bufferWithChannel, isBroadcast),
             numSubpartitions);
+    this.bufferPoolFactory = bufferPoolFactory;
   }
 
   @Override
   public void setup() throws IOException {
-    super.setup();
+    // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // So we copy the logic of `setup` but don't register partition to partition manager.
+    checkState(
+        this.bufferPool == null,
+        "Bug in result partition setup logic: Already registered buffer pool.");
+    this.bufferPool = checkNotNull(bufferPoolFactory.get());
+    // this is an empty method, but still call it in case of we implement it in the future.
+    setupInternal();
     BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
     delegation.setup(
         bufferPool,

--- a/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -90,6 +90,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,

--- a/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -90,6 +90,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,

--- a/client-flink/flink-1.19/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.19/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -90,6 +90,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -89,6 +89,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @Override
   public void setup() throws IOException {
     // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // The reason is that this partition will be registered to the partition manager during
+    // `super.setup()`.
+    // Since this is a cluster/remote partition(i.e. resources are not stored on the Flink TM),
+    // Flink does not trigger the resource releasing over TM. Therefore, the partition object is
+    // leaked.
     // So we copy the logic of `setup` but don't register partition to partition manager.
     checkState(
         this.bufferPool == null,
@@ -135,7 +140,7 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
   @Override
   public void finish() throws IOException {
-    checkState(!isReleased(), "Result partition is already released.");
+    Utils.checkState(!isReleased(), "Result partition is already released.");
     broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
     delegation.finish();
     super.finish();

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.plugin.flink;
 
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkNotNull;
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkState;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -40,7 +43,6 @@ import org.apache.flink.util.function.SupplierWithException;
 import org.apache.celeborn.plugin.flink.buffer.BufferWithSubpartition;
 import org.apache.celeborn.plugin.flink.buffer.DataBuffer;
 import org.apache.celeborn.plugin.flink.utils.BufferUtils;
-import org.apache.celeborn.plugin.flink.utils.Utils;
 
 /**
  * A {@link ResultPartition} which appends records and events to {@link DataBuffer} and after the
@@ -51,6 +53,8 @@ import org.apache.celeborn.plugin.flink.utils.Utils;
 public class RemoteShuffleResultPartition extends ResultPartition {
 
   private final RemoteShuffleResultPartitionDelegation delegation;
+
+  private final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
 
   public RemoteShuffleResultPartition(
       String owningTaskName,
@@ -79,11 +83,19 @@ public class RemoteShuffleResultPartition extends ResultPartition {
     delegation =
         new RemoteShuffleResultPartitionDelegation(
             networkBufferSize, outputGate, this::updateStatistics, numSubpartitions);
+    this.bufferPoolFactory = bufferPoolFactory;
   }
 
   @Override
   public void setup() throws IOException {
-    super.setup();
+    // We can't call the `setup` method of the base class, otherwise it will cause a partition leak.
+    // So we copy the logic of `setup` but don't register partition to partition manager.
+    checkState(
+        this.bufferPool == null,
+        "Bug in result partition setup logic: Already registered buffer pool.");
+    this.bufferPool = checkNotNull(bufferPoolFactory.get());
+    // this is an empty method, but still call it in case of we implement it in the future.
+    setupInternal();
     BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
     delegation.setup(
         bufferPool, bufferCompressor, this::canBeCompressed, this::checkInProduceState);
@@ -123,7 +135,7 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
   @Override
   public void finish() throws IOException {
-    Utils.checkState(!isReleased(), "Result partition is already released.");
+    checkState(!isReleased(), "Result partition is already released.");
     broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
     delegation.finish();
     super.finish();

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -43,6 +43,7 @@ import org.apache.flink.util.function.SupplierWithException;
 import org.apache.celeborn.plugin.flink.buffer.BufferWithSubpartition;
 import org.apache.celeborn.plugin.flink.buffer.DataBuffer;
 import org.apache.celeborn.plugin.flink.utils.BufferUtils;
+import org.apache.celeborn.plugin.flink.utils.Utils;
 
 /**
  * A {@link ResultPartition} which appends records and events to {@link DataBuffer} and after the


### PR DESCRIPTION
### What changes were proposed in this pull request?
Don't register `RemoteShuffleResultPartition` to partition manager because we don't store resource in TM.

In theory, we could also fix this on the Flink side by no longer registering partitions to the partition manager for remote/cluster partitions, but that will only be released after Flink 2.0 at the soon.

### Why are the changes needed?
`RemoteShuffleResultPartition` will be registered to the partition manager(at setup phase). Since it's a cluster partition(resources are not stored on the Flink TM), Flink does not trigger the resource releasing over TM.

In a session cluster, the partition object is leaked. As a more serious consequence, the failure of the partition to release will result in the idle TM not being reclaimed by the Flink resource manager.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Self tested in a session cluster.

