### PR TITLE
[CELEBORN-1580] ReadBufferDispacther should notify exception to listener

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -462,7 +462,8 @@ public class MemoryManager {
     readBufferCounter.addAndGet(delta);
   }
 
-  protected boolean readBufferAvailable(int requiredBytes) {
+  @VisibleForTesting
+  public boolean readBufferAvailable(int requiredBytes) {
     return readBufferCounter.get() + requiredBytes < readBufferThreshold;
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
@@ -113,6 +113,9 @@ public class ReadBufferDispatcher extends Thread {
         if (buffers != null) {
           buffers.forEach(this::recycle);
         }
+
+        // notify listener has exception
+        request.getBufferListener().notifyBuffers(null, e);
       }
     }
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/ReadBufferDispactherSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/ReadBufferDispactherSuite.scala
@@ -23,6 +23,8 @@ import java.util.concurrent.{CompletableFuture, TimeUnit}
 import io.netty.buffer.ByteBuf
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.{mock, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
@@ -33,9 +35,12 @@ class ReadBufferDispactherSuite extends CelebornFunSuite {
 
   test("[CELEBORN-1580] Test ReadBufferDispacther notify exception to listener") {
     val mockedMemoryManager = mock(classOf[MemoryManager])
-    when(mockedMemoryManager.readBufferAvailable(anyInt())).thenAnswer(_ => {
-      throw new RuntimeException("throw exception for test")
-    })
+    when(mockedMemoryManager.readBufferAvailable(anyInt())).thenAnswer(
+      new Answer[Int] {
+        override def answer(invocation: InvocationOnMock): Int = {
+          throw new RuntimeException("throw exception for test")
+        }
+      })
 
     val conf = new CelebornConf()
     val readBufferDispatcher = new ReadBufferDispatcher(mockedMemoryManager, conf)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/ReadBufferDispactherSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/ReadBufferDispactherSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.memory
+
+import java.util
+import java.util.concurrent.{CompletableFuture, TimeUnit}
+
+import scala.concurrent.duration.DurationInt
+
+import io.netty.buffer.ByteBuf
+import io.netty.channel.ChannelFuture
+import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.Futures.{interval, timeout}
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.CelebornConf.{WORKER_DIRECT_MEMORY_RATIO_FOR_READ_BUFFER, WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE, WORKER_DIRECT_MEMORY_RATIO_PAUSE_REPLICATE}
+import org.apache.celeborn.common.network.client.RpcResponseCallback
+import org.apache.celeborn.common.protocol.TransportModuleConstants
+import org.apache.celeborn.reflect.DynMethods
+import org.apache.celeborn.service.deploy.worker.memory.{MemoryManager, ReadBufferListener, ReadBufferRequest}
+import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.{MemoryPressureListener, ServingState}
+import org.apache.celeborn.service.deploy.worker.memory.ReadBufferDispatcher
+
+class ReadBufferDispactherSuite extends CelebornFunSuite {
+
+  test("[CELEBORN-1580] Test ReadBufferDispacther notify exception to listener") {
+    val mockedMemoryManager = mock(classOf[MemoryManager])
+    when(mockedMemoryManager.readBufferAvailable(anyInt())).thenAnswer(_ => {
+      throw new RuntimeException("throw exception for test")
+    })
+
+    val conf = new CelebornConf()
+    val readBufferDispatcher = new ReadBufferDispatcher(mockedMemoryManager, conf)
+    val requestFuture = new CompletableFuture[Void]()
+
+    val request = new ReadBufferRequest(
+      Integer.MAX_VALUE,
+      Integer.MAX_VALUE,
+      (_: util.List[ByteBuf], throwable: Throwable) => {
+        assert(throwable != null)
+        assert(throwable.isInstanceOf[RuntimeException])
+        assert(throwable.getMessage.equals("throw exception for test"))
+        requestFuture.complete(null);
+      })
+
+    readBufferDispatcher.addBufferRequest(request)
+    requestFuture.get(5, TimeUnit.SECONDS)
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
When the ReadBufferDispatcher encounters an exception, it should notify an exception to listener. The listener is responsible for informing the Celeborn client of the error and initiating some fault tolerance strategies.

### Why are the changes needed?
If the ReadBufferDispatcher don't notify the listener of an exception message, it may result in the listener (MapPartitionDataReader) being stuck in a prolonged wait state, ultimately leading to the job hanging.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add an unit test case.
