### PR TITLE
[CELEBORN-1581] Fix incorrect metrics of DeviceCelebornFreeBytes and DeviceCelebornTotalBytes

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -256,11 +256,11 @@ private[celeborn] class Master(
   }
 
   masterSource.addGauge(MasterSource.DEVICE_CELEBORN_TOTAL_CAPACITY) { () =>
-    statusSystem.workers.asScala.map(_.totalSpace()).sum
+    statusSystem.workers.asScala.toList.map(_.totalSpace()).sum
   }
 
   masterSource.addGauge(MasterSource.DEVICE_CELEBORN_FREE_CAPACITY) { () =>
-    statusSystem.workers.asScala.map(_.totalActualUsableSpace()).sum
+    statusSystem.workers.asScala.toList.map(_.totalActualUsableSpace()).sum
   }
 
   masterSource.addGauge(MasterSource.IS_ACTIVE_MASTER) { () => isMasterActive }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix incorrect metrics.


### Why are the changes needed?
The variable `statusSystem.workers` is a set that caused metrics output to be incorrect.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA.

<img width="729" alt="截屏2024-08-27 16 48 35" src="https://github.com/user-attachments/assets/c221b680-917a-4207-91fc-c142fac64b65">

