### PR TITLE
[CELEBORN-1582] Publish metric for unreleased shuffle count when worker was decommissioned

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -2665,13 +2665,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2680,7 +2678,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2702,8 +2699,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2739,16 +2735,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "disableTextWrap": false,
               "editorMode": "builder",
               "expr": "metrics_UnreleasedShuffleCount_Value",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "${baseLegend}",
               "range": true,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "metrics_UnreleasedShuffleCount_Value",

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -2741,7 +2741,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "metrics_UnreleasedShuffleCount_Count",
+              "expr": "metrics_UnreleasedShuffleCount_Value",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -2653,6 +2653,106 @@
           ],
           "title": "metrics_FlushWorkingQueueSize_Value",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 54
+          },
+          "id": 195,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "metrics_UnreleasedShuffleCount_Count",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "metrics_UnreleasedShuffleCount_Value",
+          "type": "timeseries"
         }
       ],
       "title": "Worker",

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -230,7 +230,7 @@ These metrics are exposed by Celeborn worker.
     | UserProduceSpeed                            | The speed of user production for congestion control.                                                            |
     | WorkerConsumeSpeed                          | The speed of worker consumption for congestion control.                                                         |
     | IsDecommissioningWorker                     | 1 means worker decommissioning, 0 means not decommissioning.                                                    |
-    | UnreleasedShuffleCount                      | Unreleased shuffle count when worker was decommissioned.                                                        |
+    | UnreleasedShuffleCount                      | Unreleased shuffle count when worker is decommissioning.                                                        |
     | MemoryStorageFileCount                      | The count of files in Memory Storage of a worker.                                                               |
     | MemoryFileStorageSize                       | The total amount of memory used by Memory Storage.                                                              |
     | EvictedFileCount                            | The count of files evicted from Memory Storage to Disk                                                          |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -230,6 +230,7 @@ These metrics are exposed by Celeborn worker.
     | UserProduceSpeed                            | The speed of user production for congestion control.                                                            |
     | WorkerConsumeSpeed                          | The speed of worker consumption for congestion control.                                                         |
     | IsDecommissioningWorker                     | 1 means worker decommissioning, 0 means not decommissioning.                                                    |
+    | UnreleasedShuffleCount                      | Unreleased shuffle count when worker was decommissioned.                                                        |
     | MemoryStorageFileCount                      | The count of files in Memory Storage of a worker.                                                               |
     | MemoryFileStorageSize                       | The total amount of memory used by Memory Storage.                                                              |
     | EvictedFileCount                            | The count of files evicted from Memory Storage to Disk                                                          |

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -52,7 +52,7 @@ import org.apache.celeborn.common.util.{CelebornExitKind, CollectionUtils, JavaU
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
 import org.apache.celeborn.server.common.{HttpService, Service}
-import org.apache.celeborn.service.deploy.worker.WorkerSource.{ACTIVE_CONNECTION_COUNT, UNRELEASED_SHUFFLE_COUNT}
+import org.apache.celeborn.service.deploy.worker.WorkerSource.ACTIVE_CONNECTION_COUNT
 import org.apache.celeborn.service.deploy.worker.congestcontrol.CongestionController
 import org.apache.celeborn.service.deploy.worker.memory.{ChannelsLimiter, MemoryManager}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.ServingState

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -435,6 +435,7 @@ private[celeborn] class Worker(
       0
     }
   }
+  // Unreleased shuffle count when worker was decommissioned
   workerSource.addGauge(WorkerSource.UNRELEASED_SHUFFLE_COUNT) { () =>
     if (shutdown.get() && workerStatusManager.currentWorkerStatus.getState == State.Exit) {
       storageManager.shuffleKeySet().size

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -435,6 +435,13 @@ private[celeborn] class Worker(
       0
     }
   }
+  workerSource.addGauge(WorkerSource.UNRELEASED_SHUFFLE_COUNT) { () =>
+    if (shutdown.get() && workerStatusManager.currentWorkerStatus.getState == State.Exit) {
+      storageManager.shuffleKeySet().size
+    } else {
+      0
+    }
+  }
   workerSource.addGauge(WorkerSource.CLEAN_TASK_QUEUE_SIZE) { () =>
     cleanTaskQueue.size()
   }
@@ -959,7 +966,6 @@ private[celeborn] class Worker(
     } else {
       logWarning(s"Waiting for all shuffle expired cost ${waitTime}ms, " +
         s"unreleased shuffle: \n${unreleasedShuffleKeys.asScala.mkString("[", ", ", "]")}")
-      workerSource.incCounter(UNRELEASED_SHUFFLE_COUNT, unreleasedShuffleKeys.size)
     }
     workerStatusManager.transitionState(State.Exit)
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -957,12 +957,12 @@ private[celeborn] class Worker(
 
     def waitTime: Long = waitTimes * interval
 
-    val unreleasedShuffleKeys = storageManager.shuffleKeySet()
-    while (!unreleasedShuffleKeys.isEmpty && waitTime < timeout) {
+    while (!storageManager.shuffleKeySet().isEmpty && waitTime < timeout) {
       Thread.sleep(interval)
       waitTimes += 1
     }
 
+    val unreleasedShuffleKeys = storageManager.shuffleKeySet()
     if (unreleasedShuffleKeys.isEmpty) {
       logInfo(s"Waiting for all shuffle expired cost ${waitTime}ms.")
     } else {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -52,7 +52,7 @@ import org.apache.celeborn.common.util.{CelebornExitKind, CollectionUtils, JavaU
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
 import org.apache.celeborn.server.common.{HttpService, Service}
-import org.apache.celeborn.service.deploy.worker.WorkerSource.{ACTIVE_CONNECTION_COUNT, UNRELEASED_SHUFFLE_SIZE}
+import org.apache.celeborn.service.deploy.worker.WorkerSource.{ACTIVE_CONNECTION_COUNT, UNRELEASED_SHUFFLE_COUNT}
 import org.apache.celeborn.service.deploy.worker.congestcontrol.CongestionController
 import org.apache.celeborn.service.deploy.worker.memory.{ChannelsLimiter, MemoryManager}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.ServingState
@@ -959,7 +959,7 @@ private[celeborn] class Worker(
     } else {
       logWarning(s"Waiting for all shuffle expired cost ${waitTime}ms, " +
         s"unreleased shuffle: \n${unreleasedShuffleKeys.asScala.mkString("[", ", ", "]")}")
-      workerSource.incCounter(UNRELEASED_SHUFFLE_SIZE, unreleasedShuffleKeys.size)
+      workerSource.incCounter(UNRELEASED_SHUFFLE_COUNT, unreleasedShuffleKeys.size)
     }
     workerStatusManager.transitionState(State.Exit)
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -435,9 +435,10 @@ private[celeborn] class Worker(
       0
     }
   }
-  // Unreleased shuffle count when worker was decommissioned
+  // Unreleased shuffle count when worker is decommissioning
   workerSource.addGauge(WorkerSource.UNRELEASED_SHUFFLE_COUNT) { () =>
-    if (shutdown.get() && workerStatusManager.currentWorkerStatus.getState == State.Exit) {
+    if (shutdown.get() && (workerStatusManager.currentWorkerStatus.getState == State.InDecommission ||
+        workerStatusManager.currentWorkerStatus.getState == State.InDecommissionThenIdle)) {
       storageManager.shuffleKeySet().size
     } else {
       0

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -59,6 +59,9 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
 
   addCounter(SLOTS_ALLOCATED)
 
+  // Unreleased shuffle size when worker was decommissioned
+  addCounter(UNRELEASED_SHUFFLE_SIZE)
+
   // add timers
   addTimer(COMMIT_FILES_TIME)
   addTimer(RESERVE_SLOTS_TIME)
@@ -216,6 +219,7 @@ object WorkerSource {
 
   // decommission
   val IS_DECOMMISSIONING_WORKER = "IsDecommissioningWorker"
+  val UNRELEASED_SHUFFLE_SIZE = "UnreleasedShuffleSize"
 
   // clean
   val CLEAN_TASK_QUEUE_SIZE = "CleanTaskQueueSize"

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -60,7 +60,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
   addCounter(SLOTS_ALLOCATED)
 
   // Unreleased shuffle size when worker was decommissioned
-  addCounter(UNRELEASED_SHUFFLE_SIZE)
+  addCounter(UNRELEASED_SHUFFLE_COUNT)
 
   // add timers
   addTimer(COMMIT_FILES_TIME)
@@ -219,7 +219,7 @@ object WorkerSource {
 
   // decommission
   val IS_DECOMMISSIONING_WORKER = "IsDecommissioningWorker"
-  val UNRELEASED_SHUFFLE_SIZE = "UnreleasedShuffleSize"
+  val UNRELEASED_SHUFFLE_COUNT = "UnreleasedShuffleCount"
 
   // clean
   val CLEAN_TASK_QUEUE_SIZE = "CleanTaskQueueSize"

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -59,7 +59,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
 
   addCounter(SLOTS_ALLOCATED)
 
-  // Unreleased shuffle size when worker was decommissioned
+  // Unreleased shuffle count when worker was decommissioned
   addCounter(UNRELEASED_SHUFFLE_COUNT)
 
   // add timers

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -59,9 +59,6 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
 
   addCounter(SLOTS_ALLOCATED)
 
-  // Unreleased shuffle count when worker was decommissioned
-  addCounter(UNRELEASED_SHUFFLE_COUNT)
-
   // add timers
   addTimer(COMMIT_FILES_TIME)
   addTimer(RESERVE_SLOTS_TIME)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -58,7 +58,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
   addCounter(ACTIVE_CONNECTION_COUNT)
 
   addCounter(SLOTS_ALLOCATED)
-  
+
   // Unreleased shuffle count when worker was decommissioned
   addCounter(UNRELEASED_SHUFFLE_COUNT)
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -58,7 +58,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
   addCounter(ACTIVE_CONNECTION_COUNT)
 
   addCounter(SLOTS_ALLOCATED)
-
+  
   // Unreleased shuffle count when worker was decommissioned
   addCounter(UNRELEASED_SHUFFLE_COUNT)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Adding a worker metrics for publish unreleased shuffle count when worker was decommissioned.

<img width="885" alt="Screenshot 2024-09-16 at 11 12 33 AM" src="https://github.com/user-attachments/assets/c81f36c1-cbed-44fe-814b-88f3ff29875d">


### Why are the changes needed?

Currently celeborn don't publish the count of unreleased shuffle key which gets lost when a worker is decommissioned. This can be useful for monitoring and configuring the `forceExitTimeout`.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?
NA
