### PR TITLE
[CELEBORN-1513] Support wildcard bind in dual stack environments

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/protocol/TransportModuleConstants.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/TransportModuleConstants.java
@@ -44,4 +44,6 @@ public class TransportModuleConstants {
   @Deprecated public static final String RPC_MODULE = "rpc";
 
   public static final String DATA_MODULE = "data";
+
+  public static final String WILDCARD_BIND_ADDRESS = null;
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -505,6 +505,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   //                      Network                        //
   // //////////////////////////////////////////////////////
   def bindPreferIP: Boolean = get(NETWORK_BIND_PREFER_IP)
+  def advertisePreferIP: Boolean = get(NETWORK_ADVERTISE_PREFER_IP)
+  def bindWildcardAddress: Boolean = get(NETWORK_WILDCARD_ADDRESS_BIND)
   def portMaxRetries: Int = get(PORT_MAX_RETRY)
   def networkTimeout: RpcTimeout =
     new RpcTimeout(get(NETWORK_TIMEOUT).milli, NETWORK_TIMEOUT.key)
@@ -1722,6 +1724,23 @@ object CelebornConf extends Logging {
       .doc("Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2.")
       .intConf
       .createOptional
+
+  val NETWORK_WILDCARD_ADDRESS_BIND: ConfigEntry[Boolean] =
+    buildConf("celeborn.network.bind.wildcardAddress")
+      .categories("network")
+      .version("0.6.0")
+      .doc("When `true`, the bind address will be set to a wildcard address, while the advertise address will " +
+        "remain as whatever is set by `celeborn.network.advertise.preferIpAddress`. This is helpful in dual-stack " +
+        "environments, where the service must listen to both IPv4 and IPv6 clients.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val NETWORK_ADVERTISE_PREFER_IP: ConfigEntry[Boolean] =
+    buildConf("celeborn.network.advertise.preferIpAddress")
+      .categories("network")
+      .version("0.6.0")
+      .doc("When `true`, prefer to use IP address, otherwise FQDN for advertise address.")
+      .fallbackConf(NETWORK_BIND_PREFER_IP)
 
   val NETWORK_MEMORY_ALLOCATOR_VERBOSE_METRIC: ConfigEntry[Boolean] =
     buildConf("celeborn.network.memory.allocator.verbose.metric")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1740,8 +1740,7 @@ object CelebornConf extends Logging {
       .categories("network")
       .version("0.6.0")
       .doc("When `true`, prefer to use IP address, otherwise FQDN for advertise address.")
-      .booleanConf
-      .createWithDefault(true)
+      .fallbackConf(NETWORK_BIND_PREFER_IP)
 
   val NETWORK_MEMORY_ALLOCATOR_VERBOSE_METRIC: ConfigEntry[Boolean] =
     buildConf("celeborn.network.memory.allocator.verbose.metric")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1740,7 +1740,8 @@ object CelebornConf extends Logging {
       .categories("network")
       .version("0.6.0")
       .doc("When `true`, prefer to use IP address, otherwise FQDN for advertise address.")
-      .fallbackConf(NETWORK_BIND_PREFER_IP)
+      .booleanConf
+      .createWithDefault(true)
 
   val NETWORK_MEMORY_ALLOCATOR_VERBOSE_METRIC: ConfigEntry[Boolean] =
     buildConf("celeborn.network.memory.allocator.verbose.metric")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -677,6 +677,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
 
   def masterHost: String = get(MASTER_HOST).replace("<localhost>", Utils.localHostName(this))
 
+  def advertiseAddressMasterHost: String = get(MASTER_HOST)
+    .replace("<localhost>", Utils.getHostName(this.advertisePreferIP))
+
   def masterHttpHost: String =
     get(MASTER_HTTP_HOST).replace("<localhost>", Utils.localHostName(this))
 

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -50,8 +50,8 @@ object RpcEnv {
     port: Int,
     conf: CelebornConf,
     numUsableCores: Int,
-    securityContext: Option[RpcSecurityContext] = None,
-    source: Option[AbstractSource] = None): RpcEnv = {
+    securityContext: Option[RpcSecurityContext],
+    source: Option[AbstractSource]): RpcEnv = {
     val bindAddress =
       if (conf.bindWildcardAddress) TransportModuleConstants.WILDCARD_BIND_ADDRESS else host
     val advertiseAddress = Utils.localHostNameForAdvertiseAddress(conf)

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -44,18 +44,27 @@ object RpcEnv {
   }
 
   def create(
-    name: String,
-    transportModule: String,
-    host: String,
-    port: Int,
-    conf: CelebornConf,
-    numUsableCores: Int,
-    securityContext: Option[RpcSecurityContext],
-    source: Option[AbstractSource]): RpcEnv = {
+      name: String,
+      transportModule: String,
+      host: String,
+      port: Int,
+      conf: CelebornConf,
+      numUsableCores: Int,
+      securityContext: Option[RpcSecurityContext],
+      source: Option[AbstractSource]): RpcEnv = {
     val bindAddress =
       if (conf.bindWildcardAddress) TransportModuleConstants.WILDCARD_BIND_ADDRESS else host
     val advertiseAddress = Utils.localHostNameForAdvertiseAddress(conf)
-    create(name, transportModule, bindAddress, advertiseAddress, port, conf, numUsableCores, securityContext, source)
+    create(
+      name,
+      transportModule,
+      bindAddress,
+      advertiseAddress,
+      port,
+      conf,
+      numUsableCores,
+      securityContext,
+      source)
   }
 
   def create(

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -44,6 +44,21 @@ object RpcEnv {
   }
 
   def create(
+    name: String,
+    transportModule: String,
+    host: String,
+    port: Int,
+    conf: CelebornConf,
+    numUsableCores: Int,
+    securityContext: Option[RpcSecurityContext] = None,
+    source: Option[AbstractSource] = None): RpcEnv = {
+    val bindAddress =
+      if (conf.bindWildcardAddress) TransportModuleConstants.WILDCARD_BIND_ADDRESS else host
+    val advertiseAddress = Utils.localHostNameForAdvertiseAddress(conf)
+    create(name, transportModule, bindAddress, advertiseAddress, port, conf, numUsableCores, securityContext, source)
+  }
+
+  def create(
       name: String,
       transportModule: String,
       bindAddress: String,
@@ -53,15 +68,13 @@ object RpcEnv {
       numUsableCores: Int,
       securityContext: Option[RpcSecurityContext] = None,
       source: Option[AbstractSource] = None): RpcEnv = {
-    val resolvedBindAddress =
-      if (conf.bindWildcardAddress) TransportModuleConstants.WILDCARD_BIND_ADDRESS else bindAddress
     val config =
       RpcEnvConfig(
         conf,
         name,
         transportModule,
-        resolvedBindAddress,
-        Utils.localHostNameForAdvertiseAddress(conf),
+        bindAddress,
+        advertiseAddress,
         port,
         numUsableCores,
         securityContext,

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -61,7 +61,7 @@ object RpcEnv {
         name,
         transportModule,
         resolvedBindAddress,
-        advertiseAddress,
+        Utils.localHostNameForAdvertiseAddress(conf),
         port,
         numUsableCores,
         securityContext,

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -54,7 +54,7 @@ object RpcEnv {
       source: Option[AbstractSource]): RpcEnv = {
     val bindAddress =
       if (conf.bindWildcardAddress) TransportModuleConstants.WILDCARD_BIND_ADDRESS else host
-    val advertiseAddress = Utils.localHostNameForAdvertiseAddress(conf)
+    val advertiseAddress = Utils.localHostNameForAdvertiseAddress(conf, name)
     create(
       name,
       transportModule,

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -61,7 +61,7 @@ object RpcEnv {
         name,
         transportModule,
         resolvedBindAddress,
-        Utils.localHostNameForAdvertiseAddress(conf),
+        advertiseAddress,
         port,
         numUsableCores,
         securityContext,

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcEnv.scala
@@ -25,6 +25,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.protocol.TransportModuleConstants
 import org.apache.celeborn.common.rpc.netty.NettyRpcEnvFactory
+import org.apache.celeborn.common.util.Utils
 
 /**
  * A RpcEnv implementation must have a [[RpcEnvFactory]] implementation with an empty constructor
@@ -52,13 +53,15 @@ object RpcEnv {
       numUsableCores: Int,
       securityContext: Option[RpcSecurityContext] = None,
       source: Option[AbstractSource] = None): RpcEnv = {
+    val resolvedBindAddress =
+      if (conf.bindWildcardAddress) TransportModuleConstants.WILDCARD_BIND_ADDRESS else bindAddress
     val config =
       RpcEnvConfig(
         conf,
         name,
         transportModule,
-        bindAddress,
-        advertiseAddress,
+        resolvedBindAddress,
+        Utils.localHostNameForAdvertiseAddress(conf),
         port,
         numUsableCores,
         securityContext,

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
@@ -395,8 +395,13 @@ private[celeborn] class NettyRpcEnvFactory extends RpcEnvFactory with Logging {
       new JavaSerializer(celebornConf).newInstance().asInstanceOf[JavaSerializerInstance]
     val nettyEnv = new NettyRpcEnv(config, javaSerializerInstance)
     val startNettyRpcEnv: Int => (NettyRpcEnv, Int) = { actualPort =>
-      logInfo(s"Starting RPC Server [${config.name}] on ${config.bindAddress}:$actualPort " +
-        s"with advisor endpoint ${config.advertiseAddress}:$actualPort")
+      if (celebornConf.bindWildcardAddress) {
+        logInfo(s"Starting RPC Server [${config.name}] on wildcard address with port" +
+          s" $actualPort, and advertised endpoint ${config.advertiseAddress}:$actualPort")
+      } else {
+        logInfo(s"Starting RPC Server [${config.name}] on ${config.bindAddress}:$actualPort " +
+          s"with advertised endpoint ${config.advertiseAddress}:$actualPort")
+      }
       nettyEnv.startServer(config.bindAddress, actualPort)
       (nettyEnv, nettyEnv.address.port)
     }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -26,19 +26,22 @@ import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
 import java.util
 import java.util.{Locale, Properties, Random, UUID}
-import java.util.concurrent.{Callable, ThreadPoolExecutor, TimeUnit, TimeoutException}
+import java.util.concurrent.{Callable, ThreadPoolExecutor, TimeoutException, TimeUnit}
+
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.io.Source
 import scala.reflect.ClassTag
-import scala.util.{Try, Random => ScalaRandom}
+import scala.util.{Random => ScalaRandom, Try}
 import scala.util.control.{ControlThrowable, NonFatal}
 import scala.util.matching.Regex
+
 import com.google.protobuf.{ByteString, GeneratedMessageV3}
 import io.netty.channel.unix.Errors.NativeIoException
 import org.apache.commons.lang3.SystemUtils
 import org.apache.commons.lang3.time.FastDateFormat
 import org.roaringbitmap.RoaringBitmap
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.PORT_MAX_RETRY
 import org.apache.celeborn.common.exception.CelebornException
@@ -417,13 +420,11 @@ object Utils extends Logging {
   }
 
   def localHostNameForAdvertiseAddress(conf: CelebornConf, env: String): String = {
-    if (env.equals(RpcNameConstants.MASTER_SYS) || env.equals(RpcNameConstants.MASTER_INTERNAL_SYS)) {
+    if (env.equals(RpcNameConstants.MASTER_SYS) || env.equals(
+        RpcNameConstants.MASTER_INTERNAL_SYS)) {
       getAdvertiseAddressForMaster(conf)
-    } else if (env.equals(RpcNameConstants.WORKER_SYS) || env.equals(RpcNameConstants.WORKER_INTERNAL_SYS)) {
-      getAdvertiseAddressForWorker(conf)
     } else {
-      throw new IllegalArgumentException(s"Unknown env to get advertise address: $env. Expected one of MASTER_SYS," +
-        s" MASTER_INTERNAL_SYS, WORKER_SYS, or WORKER_INTERNAL_SYS.")
+      getAdvertiseAddressForWorker(conf)
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -429,7 +429,7 @@ object Utils extends Logging {
   }
 
   private def getAdvertiseAddressForMaster(conf: CelebornConf) = {
-    if (conf.masterHost != "<localhost>") {
+    if (conf.masterHost.equals("localhost")) {
       conf.masterHost
     } else {
       getHostName(conf.advertisePreferIP)

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -420,7 +420,12 @@ object Utils extends Logging {
   }
 
   def localHostNameForAdvertiseAddress(conf: CelebornConf): String = {
-    getHostName(conf.advertisePreferIP)
+    if (conf.masterHost != "<localhost>") {
+      conf.masterHost
+    } else {
+      getHostName(conf.advertisePreferIP)
+    }
+
   }
 
   private def getHostName(preferIP: Boolean): String = customHostname.getOrElse {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -429,18 +429,14 @@ object Utils extends Logging {
   }
 
   private def getAdvertiseAddressForMaster(conf: CelebornConf) = {
-    if (conf.masterHost.equals("localhost")) {
-      conf.masterHost
-    } else {
-      getHostName(conf.advertisePreferIP)
-    }
+    conf.advertiseAddressMasterHost
   }
 
   private def getAdvertiseAddressForWorker(conf: CelebornConf) = {
     getHostName(conf.advertisePreferIP)
   }
 
-  private def getHostName(preferIP: Boolean): String = customHostname.getOrElse {
+  def getHostName(preferIP: Boolean): String = customHostname.getOrElse {
     if (preferIP) {
       localIpAddress match {
         case ipv6Address: Inet6Address =>

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -415,8 +415,16 @@ object Utils extends Logging {
     customHostname = Some(hostname)
   }
 
-  def localHostName(conf: CelebornConf): String = customHostname.getOrElse {
-    if (conf.bindPreferIP) {
+  def localHostName(conf: CelebornConf): String = {
+    getHostName(conf.bindPreferIP)
+  }
+
+  def localHostNameForAdvertiseAddress(conf: CelebornConf): String = {
+    getHostName(conf.advertisePreferIP)
+  }
+
+  private def getHostName(preferIP: Boolean): String = customHostname.getOrElse {
+    if (preferIP) {
       localIpAddress match {
         case ipv6Address: Inet6Address =>
           val ip = ipv6Address.getHostAddress

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -282,7 +282,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
         "localhost",
         12345,
         conf,
-        64)
+        64,
+        None,
+        None)
       val worker4 = new WorkerInfo(
         "h4",
         40001,

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -280,7 +280,6 @@ class WorkerInfoSuite extends CelebornFunSuite {
         "mockEnv",
         TransportModuleConstants.RPC_SERVICE_MODULE,
         "localhost",
-        "localhost",
         12345,
         conf,
         64)

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -41,7 +41,9 @@ license: |
 | celeborn.&lt;module&gt;.push.timeoutCheck.threads | 4 | false | Threads num for checking push data timeout. If setting <module> to `data`, it works for shuffle client push data. If setting <module> to `push`, it works for Flink shuffle client push data. If setting <module> to `replicate`, it works for replicate client of worker replicating data to peer worker. | 0.3.0 |  | 
 | celeborn.&lt;role&gt;.rpc.dispatcher.threads | &lt;value of celeborn.rpc.dispatcher.threads&gt; | false | Threads number of message dispatcher event loop for roles |  |  | 
 | celeborn.io.maxDefaultNettyThreads | 64 | false | Max default netty threads | 0.3.2 |  | 
+| celeborn.network.advertise.preferIpAddress | &lt;value of celeborn.network.bind.preferIpAddress&gt; | false | When `true`, prefer to use IP address, otherwise FQDN for advertise address. | 0.6.0 |  | 
 | celeborn.network.bind.preferIpAddress | true | false | When `true`, prefer to use IP address, otherwise FQDN. This configuration only takes effects when the bind hostname is not set explicitly, in such case, Celeborn will find the first non-loopback address to bind. | 0.3.0 |  | 
+| celeborn.network.bind.wildcardAddress | false | false | When `true`, the bind address will be set to a wildcard address, while the advertise address will remain as whatever is set by `celeborn.network.advertise.preferIpAddress`. This is helpful in dual-stack environments, where the service must listen to both IPv4 and IPv6 clients. | 0.6.0 |  | 
 | celeborn.network.connect.timeout | 10s | false | Default socket connect timeout. | 0.2.0 |  | 
 | celeborn.network.memory.allocator.numArenas | &lt;undefined&gt; | false | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 |  | 
 | celeborn.network.memory.allocator.verbose.metric | false | false | Whether to enable verbose metric for pooled allocator. | 0.3.0 |  | 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -96,7 +96,6 @@ private[celeborn] class Master(
         RpcNameConstants.MASTER_SYS,
         TransportModuleConstants.RPC_SERVICE_MODULE,
         masterArgs.host,
-        masterArgs.host,
         masterArgs.port,
         conf,
         Math.max(64, Runtime.getRuntime.availableProcessors()))
@@ -111,7 +110,6 @@ private[celeborn] class Master(
       RpcEnv.create(
         RpcNameConstants.MASTER_SYS,
         TransportModuleConstants.RPC_SERVICE_MODULE,
-        masterArgs.host,
         masterArgs.host,
         masterArgs.port,
         conf,
@@ -129,7 +127,6 @@ private[celeborn] class Master(
       RpcEnv.create(
         RpcNameConstants.MASTER_INTERNAL_SYS,
         TransportModuleConstants.RPC_SERVICE_MODULE,
-        masterArgs.host,
         masterArgs.host,
         masterArgs.internalPort,
         conf,

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -98,7 +98,9 @@ private[celeborn] class Master(
         masterArgs.host,
         masterArgs.port,
         conf,
-        Math.max(64, Runtime.getRuntime.availableProcessors()))
+        Math.max(64, Runtime.getRuntime.availableProcessors()),
+        None,
+        None)
     } else {
       val externalSecurityContext = new RpcSecurityContextBuilder()
         .withServerSaslContext(
@@ -114,7 +116,8 @@ private[celeborn] class Master(
         masterArgs.port,
         conf,
         Math.max(64, Runtime.getRuntime.availableProcessors()),
-        Some(externalSecurityContext))
+        Some(externalSecurityContext),
+        None)
     }
 
   // Visible for testing
@@ -130,7 +133,9 @@ private[celeborn] class Master(
         masterArgs.host,
         masterArgs.internalPort,
         conf,
-        Math.max(64, Runtime.getRuntime.availableProcessors()))
+        Math.max(64, Runtime.getRuntime.availableProcessors()),
+        None,
+        None)
     }
 
   private val rackResolver = new CelebornRackResolver(conf)

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -27,6 +27,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.WorkerInfo
+import org.apache.celeborn.common.protocol.TransportModuleConstants
 import org.apache.celeborn.common.util.Utils
 import org.apache.celeborn.server.common.http.HttpServer
 import org.apache.celeborn.server.common.http.api.ApiRootResource
@@ -210,11 +211,15 @@ abstract class HttpService extends Service with Logging {
   }
 
   private def httpHost(): String = {
-    serviceName match {
-      case Service.MASTER =>
-        conf.masterHttpHost
-      case Service.WORKER =>
-        conf.workerHttpHost
+    if (conf.bindWildcardAddress) {
+      TransportModuleConstants.WILDCARD_BIND_ADDRESS
+    } else {
+      serviceName match {
+        case Service.MASTER =>
+          conf.masterHttpHost
+        case Service.WORKER =>
+          conf.workerHttpHost
+      }
     }
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -96,7 +96,6 @@ private[celeborn] class Worker(
         RpcNameConstants.WORKER_SYS,
         TransportModuleConstants.RPC_SERVICE_MODULE,
         workerArgs.host,
-        workerArgs.host,
         workerArgs.port,
         conf,
         Math.min(64, Math.max(4, Runtime.getRuntime.availableProcessors())),
@@ -114,7 +113,6 @@ private[celeborn] class Worker(
         RpcNameConstants.WORKER_SYS,
         TransportModuleConstants.RPC_SERVICE_MODULE,
         workerArgs.host,
-        workerArgs.host,
         workerArgs.port,
         conf,
         Math.max(64, Runtime.getRuntime.availableProcessors()),
@@ -129,7 +127,6 @@ private[celeborn] class Worker(
       RpcEnv.create(
         RpcNameConstants.WORKER_INTERNAL_SYS,
         TransportModuleConstants.RPC_SERVICE_MODULE,
-        workerArgs.host,
         workerArgs.host,
         workerArgs.internalPort,
         conf,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Support wildcard bind for RPC and HTTP servers. When wildcard address is used, the service is able to listen to both ipv4 and ipv6 traffic in dual-stack environments. 

The specific scenario where this becomes relevant is as follows:

If some of the compute infrastructure is IPv4 only, some v6 only and others dual stack - the way we can have a single Celeborn infra to cater to all is by:
a) Set bind.preferip to false - so that advertised address is the host and not IP.

b) bind to wild card address

With both in place, the v4 only compute nodes will resolve the v4 address and connect to v4 ip/port.
Likewise, for v6 only.
Dual stack compute nodes will use prefer ipv6 Java flag to resolve to either v4 or v6.

This is how we are handling the combination of scenarios internally.


### Why are the changes needed?
see above. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested on a server using netstat, and tried connecting to via `nc -4` and `nc -6` to ensure connection was there. 
