### PR TITLE
[CELEBORN-1490][CIP-6] Extends FileMeta to support hybrid shuffle

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -85,7 +85,7 @@ public class RemoteBufferStreamReader extends CreditListener {
     try {
       bufferStream =
           client.readBufferedPartition(
-              shuffleId, partitionId, subPartitionIndexStart, subPartitionIndexEnd);
+              shuffleId, partitionId, subPartitionIndexStart, subPartitionIndexEnd, false);
       bufferStream.open(
           RemoteBufferStreamReader.this::requestBuffer, initialCredit, messageConsumer);
     } catch (Exception e) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -55,6 +55,7 @@ import org.apache.celeborn.common.protocol.PbPartitionLocation.Mode;
 import org.apache.celeborn.common.protocol.PbPushDataHandShake;
 import org.apache.celeborn.common.protocol.PbRegionFinish;
 import org.apache.celeborn.common.protocol.PbRegionStart;
+import org.apache.celeborn.common.protocol.PbSegmentStart;
 import org.apache.celeborn.common.protocol.ReviveRequest;
 import org.apache.celeborn.common.protocol.TransportModuleConstants;
 import org.apache.celeborn.common.protocol.message.ControlMessages;
@@ -164,17 +165,29 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   }
 
   public CelebornBufferStream readBufferedPartition(
-      int shuffleId, int partitionId, int subPartitionIndexStart, int subPartitionIndexEnd)
+      int shuffleId,
+      int partitionId,
+      int subPartitionIndexStart,
+      int subPartitionIndexEnd,
+      boolean isSegmentGranularityVisible)
       throws IOException {
     String shuffleKey = Utils.makeShuffleKey(appUniqueId, shuffleId);
-    ReduceFileGroups fileGroups = updateFileGroup(shuffleId, partitionId);
-    if (fileGroups.partitionGroups.size() == 0
-        || !fileGroups.partitionGroups.containsKey(partitionId)) {
-      logger.error("Shuffle data is empty for shuffle {} partitionId {}.", shuffleId, partitionId);
-      throw new PartitionUnRetryAbleException(partitionId + " may be lost.");
+    PartitionLocation[] partitionLocations =
+        updateFileGroupAndGetLocations(shuffleId, partitionId, isSegmentGranularityVisible);
+    if (partitionLocations.length == 0) {
+      logger.error(
+          "Shuffle data is empty for shuffle {} partitionId {} isSegmentGranularityVisible {}.",
+          shuffleId,
+          partitionId,
+          isSegmentGranularityVisible);
+      if (isSegmentGranularityVisible) {
+        // When the downstream reduce tasks start early than upstream map tasks, the shuffle
+        // partition locations may be found empty, should retry until the upstream task started
+        return CelebornBufferStream.empty();
+      } else {
+        throw new PartitionUnRetryAbleException(partitionId + " may be lost.");
+      }
     } else {
-      PartitionLocation[] partitionLocations =
-          fileGroups.partitionGroups.get(partitionId).toArray(new PartitionLocation[0]);
       Arrays.sort(partitionLocations, Comparator.comparingInt(PartitionLocation::getEpoch));
       logger.debug(
           "readBufferedPartition shuffleKey:{} partitionid:{} partitionLocation:{}",
@@ -193,8 +206,30 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     }
   }
 
+  /**
+   * Update the reduce file groups and obtain the PartitionLocations of the target
+   * shuffleId#partitionId. It is possible to return an empty array if the corresponding reduce file
+   * groups are nonexistent, a scenario likely arising when downstream reduce tasks are start early
+   * than upstream map tasks, e.g. Flink Hybrid Shuffle.
+   */
+  public PartitionLocation[] updateFileGroupAndGetLocations(
+      int shuffleId, int partitionId, boolean isSegmentGranularityVisible) throws IOException {
+    ReduceFileGroups fileGroups =
+        updateFileGroup(shuffleId, partitionId, isSegmentGranularityVisible);
+    if (fileGroups.partitionGroups == null
+        || fileGroups.partitionGroups.isEmpty()
+        || !fileGroups.partitionGroups.containsKey(partitionId)) {
+      return new PartitionLocation[0];
+    } else {
+      PartitionLocation[] partitionLocations =
+          fileGroups.partitionGroups.get(partitionId).toArray(new PartitionLocation[0]);
+      return partitionLocations;
+    }
+  }
+
   @Override
-  public ReduceFileGroups updateFileGroup(int shuffleId, int partitionId)
+  public ReduceFileGroups updateFileGroup(
+      int shuffleId, int partitionId, boolean isSegmentGranularityVisible)
       throws CelebornIOException {
     ReduceFileGroups reduceFileGroups =
         reduceFileGroupsMap.computeIfAbsent(
@@ -213,7 +248,8 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
               Utils.makeReducerKey(shuffleId, partitionId));
         } else {
           // refresh file groups
-          Tuple2<ReduceFileGroups, String> fileGroups = loadFileGroupInternal(shuffleId);
+          Tuple2<ReduceFileGroups, String> fileGroups =
+              loadFileGroupInternal(shuffleId, isSegmentGranularityVisible);
           ReduceFileGroups newGroups = fileGroups._1;
           if (newGroups == null) {
             throw new CelebornIOException(
@@ -508,6 +544,44 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
                           .setShuffleKey(shuffleKey)
                           .setPartitionUniqueId(location.getUniqueId())
                           .setAttemptId(attemptId)
+                          .build()
+                          .toByteArray())
+                  .toByteBuffer(),
+              conf.pushDataTimeoutMs());
+          return null;
+        });
+  }
+
+  public void segmentStart(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int subPartitionId,
+      int segmentId,
+      PartitionLocation location)
+      throws IOException {
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    final PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
+    retrySendMessage(
+        () -> {
+          final String shuffleKey = Utils.makeShuffleKey(appUniqueId, shuffleId);
+          logger.debug(
+              "SegmentStart for shuffle {} map {} attemptId {} locationId {}.",
+              shuffleId,
+              mapId,
+              attemptId,
+              location);
+          TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
+          client.sendRpcSync(
+              new TransportMessage(
+                      MessageType.SEGMENT_START,
+                      PbSegmentStart.newBuilder()
+                          .setMode(Mode.forNumber(PRIMARY_MODE))
+                          .setShuffleKey(shuffleKey)
+                          .setPartitionUniqueId(location.getUniqueId())
+                          .setAttemptId(attemptId)
+                          .setSubPartitionId(subPartitionId)
+                          .setSegmentId(segmentId)
                           .build()
                           .toByteArray())
                   .toByteBuffer(),

--- a/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
@@ -17,16 +17,38 @@
 
 package org.apache.celeborn.common.meta;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class MapFileMeta implements FileMeta {
   private int bufferSize;
   private int numSubPartitions;
   private String mountPoint;
+  private Map<Integer, Integer> subPartitionWritingSegmentId;
+  private List<SegmentIndex> subPartitionSegmentIndexes;
+  private volatile boolean hasWriteFinished;
+  private boolean isSegmentGranularityVisible;
 
   public MapFileMeta() {}
 
   public MapFileMeta(int bufferSize, int numSubPartitions) {
+    this(bufferSize, numSubPartitions, false, Collections.emptyMap(), Collections.emptyList());
+  }
+
+  public MapFileMeta(
+      int bufferSize,
+      int numSubPartitions,
+      boolean isSegmentGranularityVisible,
+      Map<Integer, Integer> subPartitionWritingSegmentId,
+      List<SegmentIndex> subPartitionSegmentIndexes) {
     this.bufferSize = bufferSize;
     this.numSubPartitions = numSubPartitions;
+    this.isSegmentGranularityVisible = isSegmentGranularityVisible;
+    this.subPartitionWritingSegmentId = subPartitionWritingSegmentId;
+    this.subPartitionSegmentIndexes = subPartitionSegmentIndexes;
   }
 
   public int getBufferSize() {
@@ -49,11 +71,108 @@ public class MapFileMeta implements FileMeta {
     this.mountPoint = mountPoint;
   }
 
+  public void setHasWriteFinished(boolean hasWriteFinished) {
+    this.hasWriteFinished = hasWriteFinished;
+  }
+
+  public void setSubPartitionWritingSegmentId(Map<Integer, Integer> subPartitionWritingSegmentId) {
+    this.subPartitionWritingSegmentId = subPartitionWritingSegmentId;
+  }
+
+  public void setSubPartitionSegmentIndexes(List<SegmentIndex> subPartitionSegmentIndexes) {
+    this.subPartitionSegmentIndexes = subPartitionSegmentIndexes;
+  }
+
   public String getMountPoint() {
     return mountPoint;
   }
 
   public int getNumSubpartitions() {
     return numSubPartitions;
+  }
+
+  public Map<Integer, Integer> getSubPartitionWritingSegmentId() {
+    return subPartitionWritingSegmentId;
+  }
+
+  public List<SegmentIndex> getSubPartitionSegmentIndexes() {
+    return subPartitionSegmentIndexes;
+  }
+
+  public boolean hasWriteFinished() {
+    return hasWriteFinished;
+  }
+
+  public boolean isSegmentGranularityVisible() {
+    return isSegmentGranularityVisible;
+  }
+
+  public void setSegmentGranularityVisible(boolean segmentGranularityVisible) {
+    isSegmentGranularityVisible = segmentGranularityVisible;
+  }
+
+  public synchronized void addPartitionSegmentId(int supPartitionId, int segmentId) {
+    if (subPartitionWritingSegmentId == null) {
+      subPartitionWritingSegmentId = new HashMap<>();
+    }
+    subPartitionWritingSegmentId.put(supPartitionId, segmentId);
+  }
+
+  public synchronized boolean hasPartitionSegmentIds() {
+    return subPartitionWritingSegmentId != null;
+  }
+
+  public synchronized int getPartitionWritingSegmentId(int supPartitionId) {
+    return subPartitionWritingSegmentId.get(supPartitionId);
+  }
+
+  public synchronized void addSegmentIdAndFirstBufferIndex(
+      int subPartitionId, int firstBufferIndex, int segmentId) {
+    if (subPartitionSegmentIndexes == null) {
+      subPartitionSegmentIndexes = new ArrayList<>();
+      for (int i = 0; i < numSubPartitions; ++i) {
+        subPartitionSegmentIndexes.add(new SegmentIndex(new HashMap<>()));
+      }
+    }
+    subPartitionSegmentIndexes
+        .get(subPartitionId)
+        .addFirstBufferIndexAndSegmentId(firstBufferIndex, segmentId);
+  }
+
+  public synchronized Integer getSegmentIdByFirstBufferIndex(int subPartitionId, int bufferIndex) {
+    if (subPartitionSegmentIndexes == null) {
+      return null;
+    }
+    return subPartitionSegmentIndexes.size() > subPartitionId
+        ? subPartitionSegmentIndexes
+            .get(subPartitionId)
+            .getFirstBufferIndexToSegment()
+            .get(bufferIndex)
+        : null;
+  }
+
+  /**
+   * The segment indexes of a sub partition. The segment index may contain multiple segments. Each
+   * segment index is an entry (<firstBufferIndex, segmentId>) in the map.
+   */
+  public static class SegmentIndex {
+
+    // This is the map to store the segment indexes of a sub partition.
+    // <firstBufferIndex, segmentId>
+    // where firstBufferIndex is the first buffer index of the segment.
+    // segmentId is the segment id of the segment.
+    private final Map<Integer, Integer> firstBufferIndexToSegment;
+
+    public SegmentIndex(Map<Integer, Integer> firstBufferIndexToSegment) {
+      this.firstBufferIndexToSegment = firstBufferIndexToSegment;
+    }
+
+    public Map<Integer, Integer> getFirstBufferIndexToSegment() {
+      return firstBufferIndexToSegment;
+    }
+
+    void addFirstBufferIndexAndSegmentId(int firstBufferIndex, int segmentId) {
+      firstBufferIndexToSegment.put(firstBufferIndex, segmentId);
+    }
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
@@ -29,7 +29,7 @@ public class MapFileMeta implements FileMeta {
   private String mountPoint;
   private Map<Integer, Integer> subPartitionWritingSegmentId;
   private List<SegmentIndex> subPartitionSegmentIndexes;
-  private volatile boolean hasWriteFinished;
+  private volatile boolean isWriterClosed;
   private boolean isSegmentGranularityVisible;
 
   public MapFileMeta() {}
@@ -71,8 +71,8 @@ public class MapFileMeta implements FileMeta {
     this.mountPoint = mountPoint;
   }
 
-  public void setHasWriteFinished(boolean hasWriteFinished) {
-    this.hasWriteFinished = hasWriteFinished;
+  public void setIsWriterClosed(boolean isWriterClosed) {
+    this.isWriterClosed = isWriterClosed;
   }
 
   public void setSubPartitionWritingSegmentId(Map<Integer, Integer> subPartitionWritingSegmentId) {
@@ -99,8 +99,8 @@ public class MapFileMeta implements FileMeta {
     return subPartitionSegmentIndexes;
   }
 
-  public boolean hasWriteFinished() {
-    return hasWriteFinished;
+  public boolean isWriterClosed() {
+    return isWriterClosed;
   }
 
   public boolean isSegmentGranularityVisible() {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -147,13 +147,15 @@ object ControlMessages extends Logging {
         numMappers: Int,
         mapId: Int,
         attemptId: Int,
-        partitionId: Int): PbRegisterMapPartitionTask =
+        partitionId: Int,
+        isSegmentGranularityVisible: Boolean): PbRegisterMapPartitionTask =
       PbRegisterMapPartitionTask.newBuilder()
         .setShuffleId(shuffleId)
         .setNumMappers(numMappers)
         .setMapId(mapId)
         .setAttemptId(attemptId)
         .setPartitionId(partitionId)
+        .setIsSegmentGranularityVisible(isSegmentGranularityVisible)
         .build()
   }
 
@@ -274,7 +276,8 @@ object ControlMessages extends Logging {
 
   case class MapperEndResponse(status: StatusCode) extends MasterMessage
 
-  case class GetReducerFileGroup(shuffleId: Int) extends MasterMessage
+  case class GetReducerFileGroup(shuffleId: Int, isSegmentGranularityVisible: Boolean)
+    extends MasterMessage
 
   // util.Set[String] -> util.Set[Path.toString]
   // Path can't be serialized
@@ -457,7 +460,8 @@ object ControlMessages extends Logging {
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
       pushDataTimeout: Long,
-      partitionSplitEnabled: Boolean = false)
+      partitionSplitEnabled: Boolean = false,
+      isSegmentGranularityVisible: Boolean = false)
     extends WorkerMessage
 
   case class ReserveSlotsResponse(
@@ -677,9 +681,10 @@ object ControlMessages extends Logging {
         .build().toByteArray
       new TransportMessage(MessageType.MAPPER_END_RESPONSE, payload)
 
-    case GetReducerFileGroup(shuffleId) =>
+    case GetReducerFileGroup(shuffleId, isSegmentGranularityVisible) =>
       val payload = PbGetReducerFileGroup.newBuilder()
         .setShuffleId(shuffleId)
+        .setIsSegmentGranularityVisible(isSegmentGranularityVisible)
         .build().toByteArray
       new TransportMessage(MessageType.GET_REDUCER_FILE_GROUP, payload)
 
@@ -828,7 +833,8 @@ object ControlMessages extends Logging {
           rangeReadFilter,
           userIdentifier,
           pushDataTimeout,
-          partitionSplitEnabled) =>
+          partitionSplitEnabled,
+          isSegmentGranularityVisible) =>
       val payload = PbReserveSlots.newBuilder()
         .setApplicationId(applicationId)
         .setShuffleId(shuffleId)
@@ -841,6 +847,7 @@ object ControlMessages extends Logging {
         .setUserIdentifier(PbSerDeUtils.toPbUserIdentifier(userIdentifier))
         .setPushDataTimeout(pushDataTimeout)
         .setPartitionSplitEnabled(partitionSplitEnabled)
+        .setIsSegmentGranularityVisible(isSegmentGranularityVisible)
         .build().toByteArray
       new TransportMessage(MessageType.RESERVE_SLOTS, payload)
 
@@ -1075,7 +1082,8 @@ object ControlMessages extends Logging {
       case GET_REDUCER_FILE_GROUP_VALUE =>
         val pbGetReducerFileGroup = PbGetReducerFileGroup.parseFrom(message.getPayload)
         GetReducerFileGroup(
-          pbGetReducerFileGroup.getShuffleId)
+          pbGetReducerFileGroup.getShuffleId,
+          pbGetReducerFileGroup.getIsSegmentGranularityVisible)
 
       case GET_REDUCER_FILE_GROUP_RESPONSE_VALUE =>
         val pbGetReducerFileGroupResponse = PbGetReducerFileGroupResponse
@@ -1208,7 +1216,8 @@ object ControlMessages extends Logging {
           pbReserveSlots.getRangeReadFilter,
           userIdentifier,
           pbReserveSlots.getPushDataTimeout,
-          pbReserveSlots.getPartitionSplitEnabled)
+          pbReserveSlots.getPartitionSplitEnabled,
+          pbReserveSlots.getIsSegmentGranularityVisible)
 
       case RESERVE_SLOTS_RESPONSE_VALUE =>
         val pbReserveSlotsResponse = PbReserveSlotsResponse.parseFrom(message.getPayload)

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -104,12 +104,14 @@ object PbSerDeUtils {
       case PartitionType.REDUCE =>
         new ReduceFileMeta(pbFileInfo.getChunkOffsetsList)
       case PartitionType.MAP =>
-        new MapFileMeta(
+        val fileMeta = new MapFileMeta(
           pbFileInfo.getBufferSize,
           pbFileInfo.getNumSubpartitions,
           pbFileInfo.getIsSegmentGranularityVisible,
           pbFileInfo.getPartitionWritingSegmentMap,
           fromPbSegmentIndexList(pbFileInfo.getSegmentIndexList))
+        // writer always closed as this is committed file info.
+        fileMeta.setIsWriterClosed(true)
       case PartitionType.MAPGROUP =>
         throw new NotImplementedError("Map group is not implemented")
     }

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -112,6 +112,7 @@ object PbSerDeUtils {
           fromPbSegmentIndexList(pbFileInfo.getSegmentIndexList))
         // writer always closed as this is committed file info.
         fileMeta.setIsWriterClosed(true)
+        fileMeta
       case PartitionType.MAPGROUP =>
         throw new NotImplementedError("Map group is not implemented")
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -90,7 +90,8 @@ private[deploy] class Controller(
           rangeReadFilter,
           userIdentifier,
           pushDataTimeout,
-          partitionSplitEnabled) =>
+          partitionSplitEnabled,
+          isSegmentGranularityVisible) =>
       checkAuth(context, applicationId)
       val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
       workerSource.sample(WorkerSource.RESERVE_SLOTS_TIME, shuffleKey) {
@@ -109,7 +110,8 @@ private[deploy] class Controller(
           rangeReadFilter,
           userIdentifier,
           pushDataTimeout,
-          partitionSplitEnabled)
+          partitionSplitEnabled,
+          isSegmentGranularityVisible)
         logDebug(s"ReserveSlots for $shuffleKey finished.")
       }
 
@@ -155,7 +157,8 @@ private[deploy] class Controller(
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
       pushDataTimeout: Long,
-      partitionSplitEnabled: Boolean): Unit = {
+      partitionSplitEnabled: Boolean,
+      isSegmentGranularityVisible: Boolean): Unit = {
     val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
     if (shutdown.get()) {
       val msg = "Current worker is shutting down!"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Second PR to support Hybrid Shuffle.

This extends `FileMeta` as hybrid shuffle supports reading while writing at segment-grained. 

We also introduce `isSegmentGranularityVisible` to some message and method to identify segment-based shuffle.

### Does this PR introduce _any_ user-facing change?
no.


### How was this patch tested?
no need.

