### PR TITLE
[CELEBORN-1586] Add available workers Metrics in AbstractMetaManager

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -656,6 +656,7 @@ message PbSnapshotMetaInfo {
   map<string, PbWorkerEventInfo> workerEventInfos = 15;
   map<string, PbApplicationMeta> applicationMetas = 16;
   repeated PbWorkerInfo decommissionWorkers = 17;
+  repeated PbWorkerInfo availableWorkers = 18;
 }
 
 message PbOpenStream {

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -439,7 +439,8 @@ object PbSerDeUtils {
       shutdownWorkers: java.util.Set[WorkerInfo],
       workerEventInfos: ConcurrentHashMap[WorkerInfo, WorkerEventInfo],
       applicationMetas: ConcurrentHashMap[String, ApplicationMeta],
-      decommissionWorkers: java.util.Set[WorkerInfo]): PbSnapshotMetaInfo = {
+      decommissionWorkers: java.util.Set[WorkerInfo],
+      availableWorkers: java.util.Set[WorkerInfo]): PbSnapshotMetaInfo = {
     val builder = PbSnapshotMetaInfo.newBuilder()
       .setEstimatedPartitionSize(estimatedPartitionSize)
       .addAllRegisteredShuffle(registeredShuffle)
@@ -450,6 +451,7 @@ object PbSerDeUtils {
       .addAllWorkerLostEvents(workerLostEvent.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .putAllAppHeartbeatTime(appHeartbeatTime)
       .addAllWorkers(workers.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
+      .addAllAvailableWorkers(availableWorkers.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .setPartitionTotalWritten(partitionTotalWritten)
       .setPartitionTotalFileCount(partitionTotalFileCount)
       // appDiskUsageMetricSnapshots can have null values,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -382,9 +382,9 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
               .collect(Collectors.toSet()));
 
       availableWorkers.addAll(
-              snapshotMetaInfo.getAvailableWorkersList().stream()
-                      .map(PbSerDeUtils::fromPbWorkerInfo)
-                      .collect(Collectors.toSet()));
+          snapshotMetaInfo.getAvailableWorkersList().stream()
+              .map(PbSerDeUtils::fromPbWorkerInfo)
+              .collect(Collectors.toSet()));
 
       decommissionWorkers.addAll(
           snapshotMetaInfo.getDecommissionWorkersList().stream()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -23,15 +23,12 @@ import java.util
 import java.util.concurrent.{ExecutorService, ScheduledFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.ToLongFunction
-
 import scala.collection.JavaConverters._
 import scala.util.Random
-
 import com.google.common.annotations.VisibleForTesting
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.ratis.proto.RaftProtos
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole
-
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.client.MasterClient
 import org.apache.celeborn.common.exception.CelebornException
@@ -1178,7 +1175,7 @@ private[celeborn] class Master(
   private def workersAvailable(
       tmpExcludedWorkerList: Set[WorkerInfo] = Set.empty): util.List[WorkerInfo] = {
     statusSystem.workers.asScala.filter { w =>
-      statusSystem.isWorkerAvailable(w) && !tmpExcludedWorkerList.contains(w)
+      statusSystem.updateAvailableWorkerMeta(w) && !tmpExcludedWorkerList.contains(w)
     }.toList.asJava
   }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -23,12 +23,15 @@ import java.util
 import java.util.concurrent.{ExecutorService, ScheduledFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.ToLongFunction
+
 import scala.collection.JavaConverters._
 import scala.util.Random
+
 import com.google.common.annotations.VisibleForTesting
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.ratis.proto.RaftProtos
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.client.MasterClient
 import org.apache.celeborn.common.exception.CelebornException

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -216,6 +216,65 @@ public class DefaultMetaSystemSuiteJ {
   }
 
   @Test
+  public void testHandleWorkerAvailable() {
+    WorkerInfo workerInfo1 =
+            new WorkerInfo(
+                    HOSTNAME1,
+                    RPCPORT1,
+                    PUSHPORT1,
+                    FETCHPORT1,
+                    REPLICATEPORT1,
+                    INTERNALPORT1,
+                    disks1,
+                    userResourceConsumption1);
+    WorkerInfo workerInfo2 =
+            new WorkerInfo(
+                    HOSTNAME2,
+                    RPCPORT2,
+                    PUSHPORT2,
+                    FETCHPORT2,
+                    REPLICATEPORT2,
+                    INTERNALPORT2,
+                    disks2,
+                    userResourceConsumption2);
+
+    statusSystem.handleRegisterWorker(
+            workerInfo1.host(),
+            workerInfo1.rpcPort(),
+            workerInfo1.pushPort(),
+            workerInfo1.fetchPort(),
+            workerInfo1.replicatePort(),
+            workerInfo1.internalPort(),
+            workerInfo1.networkLocation(),
+            workerInfo1.diskInfos(),
+            workerInfo1.userResourceConsumption(),
+            getNewReqeustId());
+    statusSystem.handleRegisterWorker(
+            workerInfo2.host(),
+            workerInfo2.rpcPort(),
+            workerInfo2.pushPort(),
+            workerInfo2.fetchPort(),
+            workerInfo2.replicatePort(),
+            workerInfo2.internalPort(),
+            workerInfo2.networkLocation(),
+            workerInfo2.diskInfos(),
+            workerInfo2.userResourceConsumption(),
+            getNewReqeustId());
+
+    // updateRegisterWorkerMeta will update availableWorkers
+    assertEquals(2, statusSystem.workers.size());
+    assertEquals(2, statusSystem.availableWorkers.size());
+
+    statusSystem.handleWorkerExclude(
+            Collections.singletonList(workerInfo1), Collections.emptyList(), getNewReqeustId());
+    assertEquals(1, statusSystem.manuallyExcludedWorkers.size());
+    assertEquals(1, statusSystem.availableWorkers.size());
+
+
+
+  }
+
+  @Test
   public void testHandleWorkerLost() {
     statusSystem.handleRegisterWorker(
         HOSTNAME1,

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -218,60 +218,57 @@ public class DefaultMetaSystemSuiteJ {
   @Test
   public void testHandleWorkerAvailable() {
     WorkerInfo workerInfo1 =
-            new WorkerInfo(
-                    HOSTNAME1,
-                    RPCPORT1,
-                    PUSHPORT1,
-                    FETCHPORT1,
-                    REPLICATEPORT1,
-                    INTERNALPORT1,
-                    disks1,
-                    userResourceConsumption1);
+        new WorkerInfo(
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            INTERNALPORT1,
+            disks1,
+            userResourceConsumption1);
     WorkerInfo workerInfo2 =
-            new WorkerInfo(
-                    HOSTNAME2,
-                    RPCPORT2,
-                    PUSHPORT2,
-                    FETCHPORT2,
-                    REPLICATEPORT2,
-                    INTERNALPORT2,
-                    disks2,
-                    userResourceConsumption2);
+        new WorkerInfo(
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            INTERNALPORT2,
+            disks2,
+            userResourceConsumption2);
 
     statusSystem.handleRegisterWorker(
-            workerInfo1.host(),
-            workerInfo1.rpcPort(),
-            workerInfo1.pushPort(),
-            workerInfo1.fetchPort(),
-            workerInfo1.replicatePort(),
-            workerInfo1.internalPort(),
-            workerInfo1.networkLocation(),
-            workerInfo1.diskInfos(),
-            workerInfo1.userResourceConsumption(),
-            getNewReqeustId());
+        workerInfo1.host(),
+        workerInfo1.rpcPort(),
+        workerInfo1.pushPort(),
+        workerInfo1.fetchPort(),
+        workerInfo1.replicatePort(),
+        workerInfo1.internalPort(),
+        workerInfo1.networkLocation(),
+        workerInfo1.diskInfos(),
+        workerInfo1.userResourceConsumption(),
+        getNewReqeustId());
     statusSystem.handleRegisterWorker(
-            workerInfo2.host(),
-            workerInfo2.rpcPort(),
-            workerInfo2.pushPort(),
-            workerInfo2.fetchPort(),
-            workerInfo2.replicatePort(),
-            workerInfo2.internalPort(),
-            workerInfo2.networkLocation(),
-            workerInfo2.diskInfos(),
-            workerInfo2.userResourceConsumption(),
-            getNewReqeustId());
+        workerInfo2.host(),
+        workerInfo2.rpcPort(),
+        workerInfo2.pushPort(),
+        workerInfo2.fetchPort(),
+        workerInfo2.replicatePort(),
+        workerInfo2.internalPort(),
+        workerInfo2.networkLocation(),
+        workerInfo2.diskInfos(),
+        workerInfo2.userResourceConsumption(),
+        getNewReqeustId());
 
     // updateRegisterWorkerMeta will update availableWorkers
     assertEquals(2, statusSystem.workers.size());
     assertEquals(2, statusSystem.availableWorkers.size());
 
     statusSystem.handleWorkerExclude(
-            Collections.singletonList(workerInfo1), Collections.emptyList(), getNewReqeustId());
+        Collections.singletonList(workerInfo1), Collections.emptyList(), getNewReqeustId());
     assertEquals(1, statusSystem.manuallyExcludedWorkers.size());
     assertEquals(1, statusSystem.availableWorkers.size());
-
-
-
   }
 
   @Test

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -207,7 +207,8 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
 
     masterStatusSystem.excludedWorkers.add(info1);
     masterStatusSystem.excludedWorkers.add(info2);
-    masterStatusSystem.excludedWorkers.add(info3);
+
+    masterStatusSystem.availableWorkers.add(info3);
 
     masterStatusSystem.manuallyExcludedWorkers.add(info1);
     masterStatusSystem.manuallyExcludedWorkers.add(info2);
@@ -242,13 +243,15 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     masterStatusSystem.excludedWorkers.clear();
     masterStatusSystem.manuallyExcludedWorkers.clear();
     masterStatusSystem.workers.clear();
+    masterStatusSystem.availableWorkers.clear();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
     Assert.assertEquals(3, masterStatusSystem.workers.size());
-    Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
+    Assert.assertEquals(2, masterStatusSystem.excludedWorkers.size());
     Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
+    Assert.assertEquals(1, masterStatusSystem.availableWorkers.size());
     Assert.assertEquals(
         conf.metricsAppTopDiskUsageWindowSize(),
         masterStatusSystem.appDiskUsageMetric.snapShots().length);

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -437,6 +437,82 @@ public class RatisMasterStatusSystemSuiteJ {
   }
 
   @Test
+  public void testHandleWorkerAvailable() throws InterruptedException {
+    AbstractMetaManager statusSystem = pickLeaderStatusSystem();
+    Assert.assertNotNull(statusSystem);
+
+    WorkerInfo workerInfo1 =
+            new WorkerInfo(
+                    HOSTNAME1,
+                    RPCPORT1,
+                    PUSHPORT1,
+                    FETCHPORT1,
+                    REPLICATEPORT1,
+                    INTERNALPORT1,
+                    disks1,
+                    userResourceConsumption1);
+    WorkerInfo workerInfo2 =
+            new WorkerInfo(
+                    HOSTNAME2,
+                    RPCPORT2,
+                    PUSHPORT2,
+                    FETCHPORT2,
+                    REPLICATEPORT2,
+                    INTERNALPORT2,
+                    disks2,
+                    userResourceConsumption2);
+
+    statusSystem.handleRegisterWorker(
+            workerInfo1.host(),
+            workerInfo1.rpcPort(),
+            workerInfo1.pushPort(),
+            workerInfo1.fetchPort(),
+            workerInfo1.replicatePort(),
+            workerInfo1.internalPort(),
+            workerInfo1.networkLocation(),
+            workerInfo1.diskInfos(),
+            workerInfo1.userResourceConsumption(),
+            getNewReqeustId());
+    statusSystem.handleRegisterWorker(
+            workerInfo2.host(),
+            workerInfo2.rpcPort(),
+            workerInfo2.pushPort(),
+            workerInfo2.fetchPort(),
+            workerInfo2.replicatePort(),
+            workerInfo2.internalPort(),
+            workerInfo2.networkLocation(),
+            workerInfo2.diskInfos(),
+            workerInfo2.userResourceConsumption(),
+            getNewReqeustId());
+
+    statusSystem.handleWorkerExclude(
+            Collections.singletonList(workerInfo1), Collections.emptyList(), getNewReqeustId());
+    Thread.sleep(3000L);
+
+    Assert.assertEquals(1, STATUSSYSTEM1.manuallyExcludedWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.manuallyExcludedWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.manuallyExcludedWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
+
+    statusSystem.handleWorkerExclude(
+            Collections.singletonList(workerInfo2), Collections.emptyList(), getNewReqeustId());
+    Thread.sleep(3000L);
+
+    Assert.assertEquals(2, STATUSSYSTEM1.manuallyExcludedWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.manuallyExcludedWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.manuallyExcludedWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM3.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.workers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.workers.size());
+
+  }
+
+  @Test
   public void testHandleWorkerLost() throws InterruptedException {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -442,51 +442,51 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertNotNull(statusSystem);
 
     WorkerInfo workerInfo1 =
-            new WorkerInfo(
-                    HOSTNAME1,
-                    RPCPORT1,
-                    PUSHPORT1,
-                    FETCHPORT1,
-                    REPLICATEPORT1,
-                    INTERNALPORT1,
-                    disks1,
-                    userResourceConsumption1);
+        new WorkerInfo(
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            INTERNALPORT1,
+            disks1,
+            userResourceConsumption1);
     WorkerInfo workerInfo2 =
-            new WorkerInfo(
-                    HOSTNAME2,
-                    RPCPORT2,
-                    PUSHPORT2,
-                    FETCHPORT2,
-                    REPLICATEPORT2,
-                    INTERNALPORT2,
-                    disks2,
-                    userResourceConsumption2);
+        new WorkerInfo(
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            INTERNALPORT2,
+            disks2,
+            userResourceConsumption2);
 
     statusSystem.handleRegisterWorker(
-            workerInfo1.host(),
-            workerInfo1.rpcPort(),
-            workerInfo1.pushPort(),
-            workerInfo1.fetchPort(),
-            workerInfo1.replicatePort(),
-            workerInfo1.internalPort(),
-            workerInfo1.networkLocation(),
-            workerInfo1.diskInfos(),
-            workerInfo1.userResourceConsumption(),
-            getNewReqeustId());
+        workerInfo1.host(),
+        workerInfo1.rpcPort(),
+        workerInfo1.pushPort(),
+        workerInfo1.fetchPort(),
+        workerInfo1.replicatePort(),
+        workerInfo1.internalPort(),
+        workerInfo1.networkLocation(),
+        workerInfo1.diskInfos(),
+        workerInfo1.userResourceConsumption(),
+        getNewReqeustId());
     statusSystem.handleRegisterWorker(
-            workerInfo2.host(),
-            workerInfo2.rpcPort(),
-            workerInfo2.pushPort(),
-            workerInfo2.fetchPort(),
-            workerInfo2.replicatePort(),
-            workerInfo2.internalPort(),
-            workerInfo2.networkLocation(),
-            workerInfo2.diskInfos(),
-            workerInfo2.userResourceConsumption(),
-            getNewReqeustId());
+        workerInfo2.host(),
+        workerInfo2.rpcPort(),
+        workerInfo2.pushPort(),
+        workerInfo2.fetchPort(),
+        workerInfo2.replicatePort(),
+        workerInfo2.internalPort(),
+        workerInfo2.networkLocation(),
+        workerInfo2.diskInfos(),
+        workerInfo2.userResourceConsumption(),
+        getNewReqeustId());
 
     statusSystem.handleWorkerExclude(
-            Collections.singletonList(workerInfo1), Collections.emptyList(), getNewReqeustId());
+        Collections.singletonList(workerInfo1), Collections.emptyList(), getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(1, STATUSSYSTEM1.manuallyExcludedWorkers.size());
@@ -497,7 +497,7 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
 
     statusSystem.handleWorkerExclude(
-            Collections.singletonList(workerInfo2), Collections.emptyList(), getNewReqeustId());
+        Collections.singletonList(workerInfo2), Collections.emptyList(), getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(2, STATUSSYSTEM1.manuallyExcludedWorkers.size());
@@ -509,7 +509,6 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
     Assert.assertEquals(2, STATUSSYSTEM2.workers.size());
     Assert.assertEquals(2, STATUSSYSTEM3.workers.size());
-
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Currently MetaManager have workers Set and excludedWorkers Set and other metadata for master service but don't have metadata for available workers. This PR supplemented this part.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT and Local test.
