### PR TITLE
[CELEBORN-1595] Support quota low watermark for checking quota available

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -5059,7 +5059,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.quota.lowWatermark")
       .categories("quota")
       .dynamic
-      .doc("Quota dynamic configuration for lowWatermark.")
+      .doc("Quota configuration for quota lowWatermark.")
       .version("0.6.0")
       .doubleConf
       .checkValue(v => v > 0.0 && v <= 1.0, "Should be in [0.0, 1.0].")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -876,6 +876,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def quotaUserSpecificTenant: String = get(QUOTA_USER_SPECIFIC_TENANT)
   def quotaUserSpecificUserName: String = get(QUOTA_USER_SPECIFIC_USERNAME)
 
+  def quotaLowWatermark: Double = get(QUOTA_LOW_WATERMARK)
+
   // //////////////////////////////////////////////////////
   //                      Client                         //
   // //////////////////////////////////////////////////////
@@ -5052,6 +5054,16 @@ object CelebornConf extends Logging {
       .version("0.5.0")
       .longConf
       .createWithDefault(Long.MaxValue)
+
+  val QUOTA_LOW_WATERMARK: ConfigEntry[Double] =
+    buildConf("celeborn.quota.lowWatermark")
+      .categories("quota")
+      .dynamic
+      .doc("Quota dynamic configuration for lowWatermark.")
+      .version("0.6.0")
+      .doubleConf
+      .checkValue(v => v > 0.0 && v <= 1.0, "Should be in [0.0, 1.0].")
+      .createWithDefault(1.0)
 
   val COLUMNAR_SHUFFLE_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.columnarShuffle.enabled")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1154,6 +1154,8 @@ private[celeborn] class Master(
       context: RpcCallContext): Unit = {
     val userResourceConsumption = handleResourceConsumption(userIdentifier)
     if (conf.quotaEnabled) {
+      val quotaWatermark = conf.quotaLowWatermark.getOrElse(1L)
+
       val (isAvailable, reason) =
         quotaManager.checkQuotaSpaceAvailable(userIdentifier, userResourceConsumption)
       context.reply(CheckQuotaResponse(isAvailable, reason))

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1154,7 +1154,7 @@ private[celeborn] class Master(
       context: RpcCallContext): Unit = {
     val userResourceConsumption = handleResourceConsumption(userIdentifier)
     if (conf.quotaEnabled) {
-      val quotaWatermark = conf.quotaLowWatermark.getOrElse(1L)
+      val quotaWatermark = conf.quotaLowWatermark
 
       val (isAvailable, reason) =
         quotaManager.checkQuotaSpaceAvailable(userIdentifier, userResourceConsumption)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManager.scala
@@ -39,10 +39,23 @@ class QuotaManager(celebornConf: CelebornConf, configService: ConfigService) ext
     }
   }
 
+  private def getQuotaWithWatermark(
+      userIdentifier: UserIdentifier,
+      quotaWatermark: Double): Quota = {
+    val quota = getQuota(userIdentifier)
+    Quota(
+      (quota.diskBytesWritten * quotaWatermark).toLong,
+      (quota.diskFileCount * quotaWatermark).toLong,
+      (quota.hdfsBytesWritten * quotaWatermark).toLong,
+      (quota.hdfsFileCount * quotaWatermark).toLong)
+  }
+
   def checkQuotaSpaceAvailable(
       userIdentifier: UserIdentifier,
-      resourceResumption: ResourceConsumption): (Boolean, String) = {
-    val quota = getQuota(userIdentifier)
+      resourceResumption: ResourceConsumption,
+      quotaWatermark: Double = 1.0): (Boolean, String) = {
+    val quota = getQuotaWithWatermark(userIdentifier, quotaWatermark)
+
     val checkResults = Seq(
       checkDiskBytesWritten(userIdentifier, resourceResumption.diskBytesWritten, quota),
       checkDiskFileCount(userIdentifier, resourceResumption.diskFileCount, quota),

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
@@ -100,9 +100,9 @@ class QuotaManagerSuite extends AnyFunSuite
     val user = UserIdentifier("tenant_01", "Jerry")
     val rc1 =
       ResourceConsumption(
-        Utils.byteStringAsBytes("100G"),
-        10000,
-        Utils.byteStringAsBytes("10G"),
+        Utils.byteStringAsBytes("99G"),
+        9999,
+        Utils.byteStringAsBytes("9999M"),
         40)
 
     val res1 = quotaManager.checkQuotaSpaceAvailable(user, rc1)
@@ -111,9 +111,9 @@ class QuotaManagerSuite extends AnyFunSuite
     val exp1 = (true, "")
     val exp2 = (
       false,
-      s"User $user used diskBytesWritten (100.0 GiB) exceeds quota (90.0 GiB). " +
-        s"User $user used diskFileCount(10000) exceeds quota(9000). " +
-        s"User $user used hdfsBytesWritten(10.0 GiB) exceeds quota(9.0 GiB). ")
+      s"User $user used diskBytesWritten (99.0 GiB) exceeds quota (90.0 GiB). " +
+        s"User $user used diskFileCount(9999) exceeds quota(9000). " +
+        s"User $user used hdfsBytesWritten(9.8 GiB) exceeds quota(9.0 GiB). ")
 
     assert(res1 == exp1)
     assert(res2 == exp2)

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
@@ -95,4 +95,27 @@ class QuotaManagerSuite extends AnyFunSuite
     assert(res2 == exp2)
     assert(res3 == exp3)
   }
+
+  test("test check quota return result with low watermark") {
+    val user = UserIdentifier("tenant_01", "Jerry")
+    val rc1 =
+      ResourceConsumption(
+        Utils.byteStringAsBytes("100G"),
+        10000,
+        Utils.byteStringAsBytes("10G"),
+        40)
+
+    val res1 = quotaManager.checkQuotaSpaceAvailable(user, rc1)
+    val res2 = quotaManager.checkQuotaSpaceAvailable(user, rc1, 0.9)
+
+    val exp1 = (true, "")
+    val exp2 = (
+      false,
+      s"User $user used diskBytesWritten (100.0 GiB) exceeds quota (90.0 GiB). " +
+        s"User $user used diskFileCount(10000) exceeds quota(9000). " +
+        s"User $user used hdfsBytesWritten(10.0 GiB) exceeds quota(9.0 GiB). ")
+
+    assert(res1 == exp1)
+    assert(res2 == exp2)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Support quota low watermark for checking quota available. This will not allow new jobs to run on Celeborn if quota used is above lowWatermark.

### Why are the changes needed?

Currently we allow jobs to run even if we're just about to breach quota limits. This is not ideal behaviour, ideally we should not allow any new jobs to run on Celeborn after certain threshold (called lowWatermark here). This will ensure current running jobs will use the quota and will not go way beyond quota usage. 

I'll also follow up with a PR to throw CelebornIOException, if quota is breached.

### Does this PR introduce _any_ user-facing change?

NA

### How was this patch tested?

UTs