### PR TITLE
[CELEBORN-1587] Change to debug logging on client side for SortBasedPusher trigger push

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
@@ -292,7 +292,7 @@ public class SortBasedPusher extends MemoryConsumer {
     long threshold = pushSortMemoryThreshold;
     if (getUsed() > threshold
         && pageCursor + required > currentPage.getBaseOffset() + currentPage.size()) {
-      logger.info(
+      logger.debug(
           "Memory used {} exceeds threshold {}, need to trigger push. currentPage size: {}",
           Utils.bytesToString(getUsed()),
           Utils.bytesToString(pushSortMemoryThreshold),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Changed a noisy log in SortBasedPusher to debug.

### Why are the changes needed?

Current SortBasedPusher logging is too noisy. It keeps on printing below log many times.

```
SortBasedPusher: Memory used 72.0 MiB exceeds threshold 64.0 MiB, need to trigger push. currentPage size: 64.0 MiB 
```

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA
