### PR TITLE
[CELEBORN-1588] Use Platform.allocateDirectBuffer instead of ByteBuffer.allocateDirect

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
@@ -49,6 +49,7 @@ import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.common.protocol.MessageType;
 import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
 import org.apache.celeborn.common.protocol.StreamType;
+import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.ExceptionUtils;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.memory.BufferQueue;
@@ -115,9 +116,9 @@ public class MapPartitionDataReader implements Comparable<MapPartitionDataReader
     this.endPartitionIndex = endPartitionIndex;
 
     int indexBufferSize = 16 * (endPartitionIndex - startPartitionIndex + 1);
-    this.indexBuffer = ByteBuffer.allocateDirect(indexBufferSize);
+    this.indexBuffer = Platform.allocateDirectBuffer(indexBufferSize);
 
-    this.headerBuffer = ByteBuffer.allocateDirect(16);
+    this.headerBuffer = Platform.allocateDirectBuffer(16);
     this.streamId = streamId;
     this.associatedChannel = associatedChannel;
     this.recycleStream = recycleStream;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
@@ -34,6 +34,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.meta.MapFileMeta;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.protocol.StorageInfo;
+import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.FileChannelUtils;
 import org.apache.celeborn.common.util.Utils;
 
@@ -282,7 +283,7 @@ public final class MapPartitionDataWriter extends PartitionDataWriter {
 
     int indexRegionSize = numSubpartitions * (8 + 8);
     if (indexRegionSize >= minBufferSize) {
-      ByteBuffer buffer = ByteBuffer.allocateDirect(indexRegionSize);
+      ByteBuffer buffer = Platform.allocateDirectBuffer(indexRegionSize);
       buffer.order(ByteOrder.BIG_ENDIAN);
       return buffer;
     }
@@ -291,7 +292,7 @@ public final class MapPartitionDataWriter extends PartitionDataWriter {
     if (minBufferSize % indexRegionSize != 0) {
       ++numRegions;
     }
-    ByteBuffer buffer = ByteBuffer.allocateDirect(numRegions * indexRegionSize);
+    ByteBuffer buffer = Platform.allocateDirectBuffer(numRegions * indexRegionSize);
     buffer.order(ByteOrder.BIG_ENDIAN);
 
     return buffer;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -707,7 +707,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         int batchHeaderLen = 16;
         ByteBuffer headerBuf = ByteBuffer.allocate(batchHeaderLen);
         ByteBuffer paddingBuf =
-            isPrefetch ? ByteBuffer.allocateDirect((int) reservedMemoryPerPartition) : null;
+            isPrefetch ? Platform.allocateDirectBuffer((int) reservedMemoryPerPartition) : null;
 
         long index = 0;
         while (index != originFileLen) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `Platform.allocateDirectBuffer` instead of `ByteBuffer.allocateDirect`.

### Why are the changes needed?

The difference between `ByteBuffer.allocateDirect` and `Platform.allocateDirectBuffer` is that the latter bypasses / ignores the JVM's `-XX:MaxDirectMemorySize` limit. It's recommend to replace `ByteBuffer.allocateDirect` with `Platform.allocateDirectBuffer`, which way has already been mentitioned in https://github.com/apache/spark/pull/47733#pullrequestreview-2251276385.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.