### PR TITLE
[CELEBORN-1589] Ensure master is leader for some POST request APIs

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1364,7 +1364,7 @@ private[celeborn] class Master(
     }
   }
 
-  private def isMasterActive: Int = {
+  def isMasterActive: Int = {
     // use int rather than bool for better monitoring on dashboard
     val isActive =
       if (conf.haEnabled) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Ensure that `excludeWorker`, `removeWorkersUnavailableInfo`, and `sendWorkerEvents` can only happen from Master leader node. 


### Why are the changes needed?
prevent inconsistencies from peers


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
tested against a cluster
