### PR TITLE
[CELEBORN-932][FOLLOWUP] Remove StatusSystem#handleWorkerRemove from RegisterWorker to avoid duplicated behavior in RegisterWorker

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -47,9 +47,6 @@ public interface IMetadataHandler {
   void handleWorkerLost(
       String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId);
 
-  void handleWorkerRemove(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId);
-
   void handleRemoveWorkersUnavailableInfo(List<WorkerInfo> unavailableWorkers, String requestId);
 
   void handleWorkerHeartbeat(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -89,12 +89,6 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
   }
 
   @Override
-  public void handleWorkerRemove(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId) {
-    updateWorkerRemoveMeta(host, rpcPort, pushPort, fetchPort, replicatePort);
-  }
-
-  @Override
   public void handleRemoveWorkersUnavailableInfo(
       List<WorkerInfo> unavailableWorkers, String requestId) {
     removeWorkersUnavailableInfoMeta(unavailableWorkers);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -200,29 +200,6 @@ public class HAMasterMetaManager extends AbstractMetaManager {
   }
 
   @Override
-  public void handleWorkerRemove(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId) {
-    try {
-      ratisServer.submitRequest(
-          ResourceRequest.newBuilder()
-              .setCmdType(Type.WorkerRemove)
-              .setRequestId(requestId)
-              .setWorkerRemoveRequest(
-                  ResourceProtos.WorkerRemoveRequest.newBuilder()
-                      .setHost(host)
-                      .setRpcPort(rpcPort)
-                      .setPushPort(pushPort)
-                      .setFetchPort(fetchPort)
-                      .setReplicatePort(replicatePort)
-                      .build())
-              .build());
-    } catch (CelebornRuntimeException e) {
-      LOG.error("Handle worker lost for {} failed!", host, e);
-      throw e;
-    }
-  }
-
-  @Override
   public void handleRemoveWorkersUnavailableInfo(
       List<WorkerInfo> unavailableWorkers, String requestId) {
     try {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -156,6 +156,7 @@ public class MetaHandler {
           break;
 
         case WorkerRemove:
+          // TODO: Remove `WorkerRemove` in 0.7.x version to guarantee upgrade compatibility.
           host = request.getWorkerRemoveRequest().getHost();
           rpcPort = request.getWorkerRemoveRequest().getRpcPort();
           pushPort = request.getWorkerRemoveRequest().getPushPort();

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -771,9 +771,6 @@ private[celeborn] class Master(
     if (statusSystem.workers.contains(workerToRegister)) {
       logWarning(s"Receive RegisterWorker while worker" +
         s" ${workerToRegister.toString()} already exists, re-register.")
-      // TODO: remove `WorkerRemove` because we have improve register logic to cover `WorkerRemove`
-      statusSystem.handleWorkerRemove(host, rpcPort, pushPort, fetchPort, replicatePort, requestId)
-      val newRequestId = MasterClient.genRequestId()
       statusSystem.handleRegisterWorker(
         host,
         rpcPort,
@@ -784,7 +781,7 @@ private[celeborn] class Master(
         networkLocation,
         disks,
         userResourceConsumption,
-        newRequestId)
+        requestId)
       context.reply(RegisterWorkerResponse(true, "Worker in snapshot, re-register."))
     } else if (statusSystem.workerLostEvents.contains(workerToRegister)) {
       logWarning(s"Receive RegisterWorker while worker $workerToRegister " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove `StatusSystem#handleWorkerRemove` from `RegisterWorker` to avoid duplicated behavior in `RegisterWorker`.

### Why are the changes needed?

`RegisterWorker` has already been improved to cover the behavior of `StatusSystem#handleWorkerRemove`. Therefore, `StatusSystem#handleWorkerRemove` is recommend to remove from `RegisterWorker` for avoiding duplicated behavior in `RegisterWorker`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.