### PR TITLE
[CELEBORN-1477][FOLLOWUP] /api/v1/workers/events should support None eventType to align /sendWorkerEvent

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -127,7 +127,7 @@ class WorkerResource extends ApiRequestContext {
   @Path("/events")
   def sendWorkerEvents(request: SendWorkerEventRequest): HandleResponse =
     ensureMasterIsLeader(master) {
-      if (request.getEventType == SendWorkerEventRequest.EventTypeEnum.NONE || request.getWorkers.isEmpty) {
+      if (request.getEventType == null || request.getWorkers.isEmpty) {
         throw new BadRequestException(
           s"eventType(${request.getEventType}) and workers(${request.getWorkers}) are required")
       }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -133,12 +133,21 @@ class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite {
     assert(response.readEntity(classOf[WorkerEventsResponse]).getWorkerEvents.isEmpty)
 
     val sendWorkerEventRequest = new SendWorkerEventRequest()
-      .eventType(SendWorkerEventRequest.EventTypeEnum.DECOMMISSION)
-      .workers(Collections.singletonList(worker))
     response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
       Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))
     assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
-    assert(response.readEntity(classOf[String]).contains(
-      "None of the workers are known"))
+    assert(
+      response.readEntity(classOf[String]).contains("eventType(null) and workers([]) are required"))
+    sendWorkerEventRequest.eventType(SendWorkerEventRequest.EventTypeEnum.NONE)
+    response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
+    assert(
+      response.readEntity(classOf[String]).contains("eventType(None) and workers([]) are required"))
+    sendWorkerEventRequest.workers(Collections.singletonList(worker))
+    response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
+    assert(response.readEntity(classOf[String]).contains("None of the workers are known"))
   }
 }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -85,7 +85,7 @@ public class SendWorkerEventRequest {
   }
 
   public static final String JSON_PROPERTY_EVENT_TYPE = "eventType";
-  private EventTypeEnum eventType = EventTypeEnum.NONE;
+  private EventTypeEnum eventType;
 
   public static final String JSON_PROPERTY_WORKERS = "workers";
   private List<WorkerId> workers = new ArrayList<>();

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -704,7 +704,6 @@ components:
       properties:
         eventType:
           type: string
-          default: None
           description: The type of the event.
           enum:
             - Immediately


### PR DESCRIPTION
### What changes were proposed in this pull request?

`/api/v1/workers/events` should support `None` `eventType` to align `/sendWorkerEvent`.

### Why are the changes needed?

Legal event types of `/sendWorkerEvent` are `None`, `Immediately`, `Decommission`, `DecommissionThenIdle`, `Graceful`, `Recommission`. But `/api/v1/workers/events` does not support `eventType` with `None` type.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`ApiV1MasterResourceSuite#worker resource`