### PR TITLE
[CELEBORN-1596] Tolerate empty config field in dynamicConfig.yaml

### DIFF
--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/FsConfigServiceImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/FsConfigServiceImpl.java
@@ -20,6 +20,7 @@ package org.apache.celeborn.server.common.service.config;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,9 +81,10 @@ public class FsConfigServiceImpl extends BaseConfigServiceImpl implements Config
   }
 
   private Map<String, String> getConfigs(Map<String, Object> configMap) {
-    return ((Map<String, Object>) configMap.get(CONF_CONFIG))
-        .entrySet().stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, config -> config.getValue().toString()));
+    Map<String, Object> configs = (Map<String, Object>) configMap.get(CONF_CONFIG);
+    if (configs == null) return Collections.emptyMap();
+    return configs.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, config -> config.getValue().toString()));
   }
 
   private File getConfigFile(Map<String, String> env) throws IOException {

--- a/service/src/test/resources/dynamicConfig_2.yaml
+++ b/service/src/test/resources/dynamicConfig_2.yaml
@@ -18,3 +18,9 @@
    config:
      celeborn.test.int.only: 100
 
+-  tenantId: tenant_id
+   level: TENANT
+   config:
+   users:
+     - name: Jerry
+       config:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Currently, if the config filed is empty in the dynamic config file.

It will throw NPE.

In this PR, it will return empty map and do not throw NPE.


### Why are the changes needed?

Do not fail in this use case.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

org.apache.celeborn.server.common.service.config.ConfigServiceSuiteJ