### PR TITLE
[CELEBORN-1297][FOLLOWUP] Fix DB config service SQL file

### DIFF
--- a/docs/developers/configuration.md
+++ b/docs/developers/configuration.md
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS celeborn_cluster_tenant_config (
   gmt_create timestamp NOT NULL,
   gmt_modify timestamp NOT NULL,
   PRIMARY KEY (id),
-  UNIQUE KEY `index_unique_tenant_config_key` (`cluster_id`, `tenant_id`, `user`, `config_key`)
+  UNIQUE KEY `index_unique_tenant_config_key` (`cluster_id`, `tenant_id`, `name`, `config_key`)
 );
 
 INSERT INTO celeborn_cluster_info ( `id`, `name`, `namespace`, `endpoint`, `gmt_create`, `gmt_modify` )

--- a/service/src/main/resources/sql/mysql/celeborn-0.5.0-mysql.sql
+++ b/service/src/main/resources/sql/mysql/celeborn-0.5.0-mysql.sql
@@ -52,5 +52,5 @@ CREATE TABLE IF NOT EXISTS celeborn_cluster_tenant_config
     gmt_create   timestamp NOT NULL,
     gmt_modify   timestamp NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY `index_unique_tenant_config_key` (`cluster_id`, `tenant_id`, `user`, `config_key`)
+    UNIQUE KEY `index_unique_tenant_config_key` (`cluster_id`, `tenant_id`, `name`, `config_key`)
 );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix the unique key to reflect correct columns names.

### Why are the changes needed?

Running current DB scripts give below error because `user` column was renamed to `name` (https://github.com/apache/celeborn/pull/2340) but the unique key was not updated correctly.

```
mysql> CREATE TABLE IF NOT EXISTS celeborn_cluster_tenant_config
    -> (
    ->     id           int          NOT NULL AUTO_INCREMENT,
    ->     cluster_id   int          NOT NULL,
    ->     tenant_id    varchar(255) NOT NULL,
    ->     level        varchar(255) NOT NULL COMMENT 'config level, valid level is TENANT,USER',
    ->     name         varchar(255) DEFAULT NULL COMMENT 'tenant sub user',
    ->     config_key   varchar(255) NOT NULL,
    ->     config_value varchar(255) NOT NULL,
    ->     type         varchar(255) DEFAULT NULL COMMENT 'conf categories, such as quota',
    ->     gmt_create   timestamp NOT NULL,
    ->     gmt_modify   timestamp NOT NULL,
    ->     PRIMARY KEY (id),
    ->     UNIQUE KEY `index_unique_tenant_config_key` (`cluster_id`, `tenant_id`, `user`, `config_key`)
    -> );
ERROR 1072 (42000): Key column 'user' doesn't exist in table
```

### Does this PR introduce _any_ user-facing change?

NA

### How was this patch tested?

Tested in local DB
```
mysql> CREATE TABLE IF NOT EXISTS celeborn_cluster_tenant_config
    -> (
    ->     id           int          NOT NULL AUTO_INCREMENT,
    ->     cluster_id   int          NOT NULL,
    ->     tenant_id    varchar(255) NOT NULL,
    ->     level        varchar(255) NOT NULL COMMENT 'config level, valid level is TENANT,USER',
    ->     name         varchar(255) DEFAULT NULL COMMENT 'tenant sub user',
    ->     config_key   varchar(255) NOT NULL,
    ->     config_value varchar(255) NOT NULL,
    ->     type         varchar(255) DEFAULT NULL COMMENT 'conf categories, such as quota',
    ->     gmt_create   timestamp NOT NULL,
    ->     gmt_modify   timestamp NOT NULL,
    ->     PRIMARY KEY (id),
    ->     UNIQUE KEY `index_unique_tenant_config_key` (`cluster_id`, `tenant_id`, `name`, `config_key`)
    -> );
Query OK, 0 rows affected (0.01 sec)
```
