### PR TITLE
[CELEBORN-1602] do hard split for push merged data RPC with disk full

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -536,7 +536,8 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     if (fileWriters.exists(checkDiskFull(_) == true)) {
       val (mapId, attemptId) = getMapAttempt(body)
-      logWarning(s"return hard split for disk full with shuffle $shuffleKey map $mapId attempt $attemptId")
+      logWarning(
+        s"return hard split for disk full with shuffle $shuffleKey map $mapId attempt $attemptId")
       callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
       return
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -533,6 +533,14 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       callbackWithTimer.onFailure(new CelebornIOException(cause))
       return
     }
+
+    if (fileWriters.exists(checkDiskFull(_) == true)) {
+      val (mapId, attemptId) = getMapAttempt(body)
+      logWarning(s"return hard split for disk full with shuffle $shuffleKey map $mapId attempt $attemptId")
+      callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
+      return
+    }
+
     fileWriters.foreach(_.incrementPendingWrites())
 
     val closedFileWriter = fileWriters.find(_.isClosed)


### PR DESCRIPTION
### What changes were proposed in this pull request?

return hard split for push merged data RPC with disk full

### Why are the changes needed?

prevent worker disk from writing to 100% capacity.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Cluster tested