### PR TITLE
[CELEBORN-1466][FOLLOWUP] Fix RaftPeerId generated by command of raftMetaConf to use real PeerId in celeborn_ratis_shell.md

### DIFF
--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -166,5 +166,5 @@ It has the following subcommands:
 ### local raftMetaConf
 Generate a new raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
 ```
-$ celeborn-ratis sh local raftMetaConf -peers <P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
+$ celeborn-ratis sh local raftMetaConf -peers <[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `RaftPeerId` generated by command of `raftMetaConf` to use real PeerId for `local` command in `celeborn_ratis_shell.md` to sync document [cli.md](https://github.com/apache/ratis/blob/ratis-3.0.1/ratis-docs/src/site/markdown/cli.md).

### Why are the changes needed?

Celeborn has already bumped Ratis version from 3.0.1 to 3.1.0. Ratis v3.1.0 has already fixed RaftPeerId generated by command of "raftMetaConf" to use real PeerId in `raft-meta.conf` and store back to generated `new-raft-meta.conf`.

Backport: https://github.com/apache/ratis/pull/1060

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.