### PR TITLE
[CELEBORN-1604] Bump rocksdbjni version from 8.11.3 to 9.5.2

### DIFF
--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -133,7 +133,7 @@ ratis-server-api/3.1.0//ratis-server-api-3.1.0.jar
 ratis-server/3.1.0//ratis-server-3.1.0.jar
 ratis-shell/3.1.0//ratis-shell-3.1.0.jar
 ratis-thirdparty-misc/1.0.6//ratis-thirdparty-misc-1.0.6.jar
-rocksdbjni/8.11.3//rocksdbjni-8.11.3.jar
+rocksdbjni/9.5.2//rocksdbjni-9.5.2.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <snakeyaml.version>2.2</snakeyaml.version>
     <zstd-jni.version>1.5.2-1</zstd-jni.version>
     <kubernetes-client.version>6.7.0</kubernetes-client.version>
-    <rocksdbjni.version>8.11.3</rocksdbjni.version>
+    <rocksdbjni.version>9.5.2</rocksdbjni.version>
     <jackson.version>2.15.3</jackson.version>
     <snappy.version>1.1.10.5</snappy.version>
     <ap.loader.version>3.0-8</ap.loader.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -61,7 +61,7 @@ object Dependencies {
   val nettyVersion = "4.1.109.Final"
   val ratisVersion = "3.1.0"
   val roaringBitmapVersion = "1.0.6"
-  val rocksdbJniVersion = "8.11.3"
+  val rocksdbJniVersion = "9.5.2"
   val jacksonVersion = "2.15.3"
   val jakartaActivationApiVersion = "1.2.1"
   val scalatestMockitoVersion = "1.17.14"


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
https://github.com/facebook/rocksdb/compare/v8.11.3...v9.5.2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
