### PR TITLE
[CELEBORN-1607] Fix openapi-client send worker event issue

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -25,7 +25,6 @@ import picocli.CommandLine.{Command, ParameterException}
 
 import org.apache.celeborn.cli.config.CliConfigManager
 import org.apache.celeborn.rest.v1.model._
-import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest.EventTypeEnum
 
 @Command(name = "master", mixinStandardHelpOptions = true)
 class MasterSubcommandImpl extends Runnable with MasterSubcommand {
@@ -90,16 +89,7 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
   }
 
   private[master] def runSendWorkerEvent: HandleResponse = {
-    val eventType = {
-      try {
-        EventTypeEnum.valueOf(masterOptions.sendWorkerEvent.toUpperCase)
-      } catch {
-        case _: IllegalArgumentException => throw new ParameterException(
-            spec.commandLine(),
-            "Worker event type must be " +
-              EventTypeEnum.values().toStream.map(_.name()).mkString(","))
-      }
-    }
+    val eventType = masterOptions.sendWorkerEvent
     val workerIds = getWorkerIds
     val sendWorkerEventRequest =
       new SendWorkerEventRequest().workers(workerIds).eventType(eventType)

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -218,7 +218,7 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
   test("master --send-worker-event") {
     val args = prepareMasterArgs() ++ Array(
       "--send-worker-event",
-      "RECOMMISSION",
+      "Recommission",
       "--worker-ids",
       getWorkerId())
     captureOutputAndValidateResponse(args, "success: true")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -137,7 +137,7 @@ class WorkerResource extends ApiRequestContext {
         throw new BadRequestException(
           s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")
       }
-      val (success, msg) = httpService.handleWorkerEvent(request.getEventType.toString, workers)
+      val (success, msg) = httpService.handleWorkerEvent(request.getEventType, workers)
       val finalMsg =
         if (unknownWorkers.isEmpty) {
           msg

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -138,7 +138,7 @@ class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite {
     assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
     assert(
       response.readEntity(classOf[String]).contains("eventType(null) and workers([]) are required"))
-    sendWorkerEventRequest.eventType(SendWorkerEventRequest.EventTypeEnum.NONE)
+    sendWorkerEventRequest.eventType("None")
     response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
       Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))
     assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -57,7 +57,7 @@ public class SendWorkerEventRequest {
   }
 
   /**
-   * The type of the event. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39;
+   * The type of the event. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39; 
    * @return eventType
    */
   @javax.annotation.Nonnull

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -41,51 +41,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
 public class SendWorkerEventRequest {
-  /**
-   * The type of the event.
-   */
-  public enum EventTypeEnum {
-    IMMEDIATELY("Immediately"),
-    
-    DECOMMISSION("Decommission"),
-    
-    DECOMMISSION_THEN_IDLE("DecommissionThenIdle"),
-    
-    GRACEFUL("Graceful"),
-    
-    RECOMMISSION("Recommission"),
-    
-    NONE("None");
-
-    private String value;
-
-    EventTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static EventTypeEnum fromValue(String value) {
-      for (EventTypeEnum b : EventTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
   public static final String JSON_PROPERTY_EVENT_TYPE = "eventType";
-  private EventTypeEnum eventType;
+  private String eventType;
 
   public static final String JSON_PROPERTY_WORKERS = "workers";
   private List<WorkerId> workers = new ArrayList<>();
@@ -93,28 +50,28 @@ public class SendWorkerEventRequest {
   public SendWorkerEventRequest() {
   }
 
-  public SendWorkerEventRequest eventType(EventTypeEnum eventType) {
+  public SendWorkerEventRequest eventType(String eventType) {
     
     this.eventType = eventType;
     return this;
   }
 
   /**
-   * The type of the event.
+   * The type of the event. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39;
    * @return eventType
    */
   @javax.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EVENT_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
-  public EventTypeEnum getEventType() {
+  public String getEventType() {
     return eventType;
   }
 
 
   @JsonProperty(JSON_PROPERTY_EVENT_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setEventType(EventTypeEnum eventType) {
+  public void setEventType(String eventType) {
     this.eventType = eventType;
   }
 

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -704,14 +704,14 @@ components:
       properties:
         eventType:
           type: string
-          description: The type of the event.
-          enum:
-            - Immediately
-            - Decommission
-            - DecommissionThenIdle
-            - Graceful
-            - Recommission
-            - None
+          description: The type of the event. Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'
+          # enum:
+            # - Immediately
+            # - Decommission
+            # - DecommissionThenIdle
+            # - Graceful
+            # - Recommission
+            # - None
         workers:
           type: array
           description: The workers to send the event.

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -704,7 +704,10 @@ components:
       properties:
         eventType:
           type: string
-          description: The type of the event. Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'
+          description: |
+            The type of the event.
+            Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'
+          # met issue with enum, see details in CELEBORN-1607
           # enum:
             # - Immediately
             # - Decommission

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
@@ -23,7 +23,6 @@ import javax.servlet.http.HttpServletResponse
 import org.apache.celeborn.rest.v1.master._
 import org.apache.celeborn.rest.v1.master.invoker._
 import org.apache.celeborn.rest.v1.model.{ExcludeWorkerRequest, RemoveWorkersUnavailableInfoRequest, SendWorkerEventRequest, WorkerId}
-import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest.EventTypeEnum
 
 class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
   private var masterApiClient: ApiClient = _
@@ -107,8 +106,7 @@ class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
     assert(api.getWorkerEvents.getWorkerEvents.isEmpty)
 
     handleResponse = api.sendWorkerEvent(
-      new SendWorkerEventRequest().addWorkersItem(workerId).eventType(
-        EventTypeEnum.DECOMMISSION_THEN_IDLE))
+      new SendWorkerEventRequest().addWorkersItem(workerId).eventType("DecommissionThenIdle"))
     assert(handleResponse.getSuccess)
 
     assert(!api.getWorkerEvents.getWorkerEvents.isEmpty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

For SendWorkerEventRequest eventType, using `String` instead of `Enum`.


### Why are the changes needed?

I met exception when sending worker event with openapi sdk.
```
Exception in thread "main" ApiException{code=400, responseHeaders={Server=[Jetty(9.4.52.v20230823)], Content-Length=[491], Date=[Fri, 20 Sep 2024 23:50:27 GMT], Content-Type=[text/plain]}, responseBody='Cannot deserialize value of type `org.apache.celeborn.rest.v1.model.SendWorkerEventRequest$EventTypeEnum` from String "DecommissionThenIdle": not one of the values accepted for Enum class: [DECOMMISSION_THEN_IDLE, GRACEFUL, NONE, DECOMMISSION, IMMEDIATELY, RECOMMISSION]
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 14] (through reference chain: org.apache.celeborn.rest.v1.model.SendWorkerEventRequest["eventType"])'}
    at org.apache.celeborn.rest.v1.master.invoker.ApiClient.processResponse(ApiClient.java:913)
    at org.apache.celeborn.rest.v1.master.invoker.ApiClient.invokeAPI(ApiClient.java:1000)
    at org.apache.celeborn.rest.v1.master.WorkerApi.sendWorkerEvent(WorkerApi.java:378)
    at org.apache.celeborn.rest.v1.master.WorkerApi.sendWorkerEvent(WorkerApi.java:334)
    at org.example.Main.main(Main.java:22) 

```

The testing code to re-produce:
```
package org.example;

import org.apache.celeborn.rest.v1.master.WorkerApi;
import org.apache.celeborn.rest.v1.master.invoker.ApiClient;
import org.apache.celeborn.rest.v1.model.ExcludeWorkerRequest;
import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest;
import org.apache.celeborn.rest.v1.model.WorkerId;

public class Main {
    public static void main(String[] args) throws Exception {

        String cmUrl = "http://localhost:9098";
        WorkerApi workerApi = new WorkerApi(new ApiClient().setBasePath(cmUrl));
        workerApi.excludeWorker(new ExcludeWorkerRequest()
                .addAddItem(new WorkerId()
                        .host("localhost")
                        .rpcPort(1)
                        .pushPort(2)
                        .fetchPort(3)
                        .replicatePort(4)));
        workerApi.sendWorkerEvent(new SendWorkerEventRequest()
                        .addWorkersItem(new WorkerId()
                                .host("127.0.0.1")
                                .rpcPort(56116)
                                .pushPort(56117)
                                .fetchPort(56119)
                                .replicatePort(56118))
                .eventType(SendWorkerEventRequest.EventTypeEnum.DECOMMISSION_THEN_IDLE));
    }
}
```

Seems because for the EventTypeEnum, the name and value not the same and then cause this issue.

Not sure why the UT passed, but the integration testing failed.

For EventTypeEnum, because its value is case sensitive, so we meet this issue.

https://github.com/apache/celeborn/blob/8734d1663884345477257d2f10f4c19732c6f1c3/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java#L47-L83 


Related issue in jersey end I think, https://github.com/eclipse-ee4j/jersey/issues/5288 

Not sure how to resolve it, to unblock, in this PR, I use string type instead of enum.

### Does this PR introduce _any_ user-facing change?

Yes, using string for SendWorkerEventRequest eventType.

### How was this patch tested?
Existing UT & IT.

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/3efc0cab-ec09-494e-808d-de08aed86dcd">

