### PR TITLE
[CELEBORN-1607] Enable `useEnumCaseInsensitive` for openapi-generator

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -425,11 +425,11 @@ object ControlMessages extends Logging {
   object WorkerEventRequest {
     def apply(
         workers: util.List[WorkerInfo],
-        eventType: String,
+        eventType: WorkerEventType,
         requestId: String): PbWorkerEventRequest =
       PbWorkerEventRequest.newBuilder()
         .setRequestId(requestId)
-        .setWorkerEventType(WorkerEventType.valueOf(eventType))
+        .setWorkerEventType(eventType)
         .addAllWorkers(workers.asScala.map { workerInfo =>
           PbSerDeUtils.toPbWorkerInfo(workerInfo, true, false)
         }.toList.asJava)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1218,7 +1218,7 @@ private[celeborn] class Master(
   }
 
   override def handleWorkerEvent(
-      workerEventType: String,
+      workerEventType: WorkerEventType,
       workers: Seq[WorkerInfo]): HandleResponse = {
     val sb = new StringBuilder()
     try {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResource.scala
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.celeborn.common.meta.WorkerInfo
+import org.apache.celeborn.common.protocol.WorkerEventType
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 
 @Tag(name = "Deprecated")
@@ -136,7 +137,9 @@ class ApiMasterResource extends ApiRequestContext {
     }
     sb.append("============================ Handle Worker Event =============================\n")
     val workerList = workers.split(",").filter(_.nonEmpty).map(WorkerInfo.fromUniqueId)
-    sb.append(httpService.handleWorkerEvent(normalizeParam(eventType), workerList)._2)
+    sb.append(httpService.handleWorkerEvent(
+      WorkerEventType.valueOf(normalizeParam(eventType)),
+      workerList)._2)
     sb.toString()
   }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -26,7 +26,9 @@ import io.swagger.v3.oas.annotations.media.{Content, Schema}
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 
+import org.apache.celeborn.common.protocol.WorkerEventType
 import org.apache.celeborn.rest.v1.model._
+import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest.EventTypeEnum
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 import org.apache.celeborn.server.common.http.api.v1.ApiUtils
 import org.apache.celeborn.service.deploy.master.Master
@@ -122,7 +124,7 @@ class WorkerResource extends ApiRequestContext {
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[HandleResponse]))),
     description =
-      "For Master(Leader) can send worker event to manager workers. Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'.")
+      "For Master(Leader) can send worker event to manager workers. Legal types are 'NONE', 'IMMEDIATELY', 'DECOMMISSION', 'DECOMMISSIONTHENIDLE', 'GRACEFUL', 'RECOMMISSION'.")
   @POST
   @Path("/events")
   def sendWorkerEvents(request: SendWorkerEventRequest): HandleResponse =
@@ -137,7 +139,8 @@ class WorkerResource extends ApiRequestContext {
         throw new BadRequestException(
           s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")
       }
-      val (success, msg) = httpService.handleWorkerEvent(request.getEventType.toString, workers)
+      val (success, msg) =
+        httpService.handleWorkerEvent(toWorkerEventType(request.getEventType), workers)
       val finalMsg =
         if (unknownWorkers.isEmpty) {
           msg
@@ -146,4 +149,16 @@ class WorkerResource extends ApiRequestContext {
         }
       new HandleResponse().success(success).message(finalMsg)
     }
+
+  private def toWorkerEventType(enum: EventTypeEnum): String = {
+    enum match {
+      case EventTypeEnum.NONE => WorkerEventType.None.toString
+      case EventTypeEnum.IMMEDIATELY => WorkerEventType.Immediately.toString
+      case EventTypeEnum.DECOMMISSION => WorkerEventType.Decommission.toString
+      case EventTypeEnum.DECOMMISSIONTHENIDLE => WorkerEventType.DecommissionThenIdle.toString
+      case EventTypeEnum.GRACEFUL => WorkerEventType.Graceful.toString
+      case EventTypeEnum.RECOMMISSION => WorkerEventType.Recommission.toString
+      case _ => WorkerEventType.UNRECOGNIZED.toString
+    }
+  }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -124,7 +124,7 @@ class WorkerResource extends ApiRequestContext {
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[HandleResponse]))),
     description =
-      "For Master(Leader) can send worker event to manager workers. Legal types are 'NONE', 'IMMEDIATELY', 'DECOMMISSION', 'DECOMMISSIONTHENIDLE', 'GRACEFUL', 'RECOMMISSION'.")
+      "For Master(Leader) can send worker event to manager workers. Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'.")
   @POST
   @Path("/events")
   def sendWorkerEvents(request: SendWorkerEventRequest): HandleResponse =

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -150,15 +150,15 @@ class WorkerResource extends ApiRequestContext {
       new HandleResponse().success(success).message(finalMsg)
     }
 
-  private def toWorkerEventType(enum: EventTypeEnum): String = {
+  private def toWorkerEventType(enum: EventTypeEnum): WorkerEventType = {
     enum match {
-      case EventTypeEnum.NONE => WorkerEventType.None.toString
-      case EventTypeEnum.IMMEDIATELY => WorkerEventType.Immediately.toString
-      case EventTypeEnum.DECOMMISSION => WorkerEventType.Decommission.toString
-      case EventTypeEnum.DECOMMISSIONTHENIDLE => WorkerEventType.DecommissionThenIdle.toString
-      case EventTypeEnum.GRACEFUL => WorkerEventType.Graceful.toString
-      case EventTypeEnum.RECOMMISSION => WorkerEventType.Recommission.toString
-      case _ => WorkerEventType.UNRECOGNIZED.toString
+      case EventTypeEnum.NONE => WorkerEventType.None
+      case EventTypeEnum.IMMEDIATELY => WorkerEventType.Immediately
+      case EventTypeEnum.DECOMMISSION => WorkerEventType.Decommission
+      case EventTypeEnum.DECOMMISSIONTHENIDLE => WorkerEventType.DecommissionThenIdle
+      case EventTypeEnum.GRACEFUL => WorkerEventType.Graceful
+      case EventTypeEnum.RECOMMISSION => WorkerEventType.Recommission
+      case _ => WorkerEventType.UNRECOGNIZED
     }
   }
 }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -143,7 +143,7 @@ class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite {
       Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))
     assert(HttpServletResponse.SC_BAD_REQUEST == response.getStatus)
     assert(
-      response.readEntity(classOf[String]).contains("eventType(None) and workers([]) are required"))
+      response.readEntity(classOf[String]).contains("eventType(NONE) and workers([]) are required"))
     sendWorkerEventRequest.workers(Collections.singletonList(worker))
     response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
       Entity.entity(sendWorkerEventRequest, MediaType.APPLICATION_JSON))

--- a/openapi/openapi-client/pom.xml
+++ b/openapi/openapi-client/pom.xml
@@ -244,6 +244,7 @@
                     <hideGenerationTimestamp>true</hideGenerationTimestamp>
                     <supportUrlQuery>false</supportUrlQuery>
                     <annotationLibrary>none</annotationLibrary>
+                    <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
                   </configOptions>
                 </configuration>
               </execution>
@@ -278,6 +279,7 @@
                     <hideGenerationTimestamp>true</hideGenerationTimestamp>
                     <supportUrlQuery>false</supportUrlQuery>
                     <annotationLibrary>none</annotationLibrary>
+                    <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
                   </configOptions>
                 </configuration>
               </execution>

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -325,7 +325,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;NONE&#39;, &#39;IMMEDIATELY&#39;, &#39;DECOMMISSION&#39;, &#39;DECOMMISSIONTHENIDLE&#39;, &#39;GRACEFUL&#39;, &#39;RECOMMISSION&#39;. 
+   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39;. 
    * @param sendWorkerEventRequest  (optional)
    * @return HandleResponse
    * @throws ApiException if fails to make API call
@@ -337,7 +337,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;NONE&#39;, &#39;IMMEDIATELY&#39;, &#39;DECOMMISSION&#39;, &#39;DECOMMISSIONTHENIDLE&#39;, &#39;GRACEFUL&#39;, &#39;RECOMMISSION&#39;. 
+   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39;. 
    * @param sendWorkerEventRequest  (optional)
    * @param additionalHeaders additionalHeaders for this call
    * @return HandleResponse

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -325,7 +325,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39;. 
+   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;NONE&#39;, &#39;IMMEDIATELY&#39;, &#39;DECOMMISSION&#39;, &#39;DECOMMISSIONTHENIDLE&#39;, &#39;GRACEFUL&#39;, &#39;RECOMMISSION&#39;. 
    * @param sendWorkerEventRequest  (optional)
    * @return HandleResponse
    * @throws ApiException if fails to make API call
@@ -337,7 +337,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;None&#39;, &#39;Immediately&#39;, &#39;Decommission&#39;, &#39;DecommissionThenIdle&#39;, &#39;Graceful&#39;, &#39;Recommission&#39;. 
+   * For Master(Leader) can send worker event to manager workers. Legal types are &#39;NONE&#39;, &#39;IMMEDIATELY&#39;, &#39;DECOMMISSION&#39;, &#39;DECOMMISSIONTHENIDLE&#39;, &#39;GRACEFUL&#39;, &#39;RECOMMISSION&#39;. 
    * @param sendWorkerEventRequest  (optional)
    * @param additionalHeaders additionalHeaders for this call
    * @return HandleResponse

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfig.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/DynamicConfig.java
@@ -71,7 +71,7 @@ public class DynamicConfig {
     @JsonCreator
     public static LevelEnum fromValue(String value) {
       for (LevelEnum b : LevelEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equalsIgnoreCase(value)) {
           return b;
         }
       }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/PartitionLocationData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/PartitionLocationData.java
@@ -74,7 +74,7 @@ public class PartitionLocationData {
     @JsonCreator
     public static ModeEnum fromValue(String value) {
       for (ModeEnum b : ModeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equalsIgnoreCase(value)) {
           return b;
         }
       }
@@ -123,7 +123,7 @@ public class PartitionLocationData {
     @JsonCreator
     public static StorageEnum fromValue(String value) {
       for (StorageEnum b : StorageEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equalsIgnoreCase(value)) {
           return b;
         }
       }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -45,17 +45,17 @@ public class SendWorkerEventRequest {
    * The type of the event.
    */
   public enum EventTypeEnum {
-    IMMEDIATELY("Immediately"),
+    IMMEDIATELY("IMMEDIATELY"),
     
-    DECOMMISSION("Decommission"),
+    DECOMMISSION("DECOMMISSION"),
     
-    DECOMMISSION_THEN_IDLE("DecommissionThenIdle"),
+    DECOMMISSIONTHENIDLE("DECOMMISSIONTHENIDLE"),
     
-    GRACEFUL("Graceful"),
+    GRACEFUL("GRACEFUL"),
     
-    RECOMMISSION("Recommission"),
+    RECOMMISSION("RECOMMISSION"),
     
-    NONE("None");
+    NONE("NONE");
 
     private String value;
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -76,7 +76,7 @@ public class SendWorkerEventRequest {
     @JsonCreator
     public static EventTypeEnum fromValue(String value) {
       for (EventTypeEnum b : EventTypeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equalsIgnoreCase(value)) {
           return b;
         }
       }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java
@@ -67,7 +67,7 @@ public class WorkerExitRequest {
     @JsonCreator
     public static TypeEnum fromValue(String value) {
       for (TypeEnum b : TypeEnum.values()) {
-        if (b.value.equals(value)) {
+        if (b.value.equalsIgnoreCase(value)) {
           return b;
         }
       }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerExitRequest.java
@@ -40,13 +40,13 @@ public class WorkerExitRequest {
    * The type of the worker exit request.
    */
   public enum TypeEnum {
-    DECOMMISSION("Decommission"),
+    DECOMMISSION("DECOMMISSION"),
     
-    GRACEFUL("Graceful"),
+    GRACEFUL("GRACEFUL"),
     
-    IMMEDIATELY("Immediately"),
+    IMMEDIATELY("IMMEDIATELY"),
     
-    NONE("None");
+    NONE("NONE");
 
     private String value;
 

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -200,7 +200,7 @@ paths:
       operationId: sendWorkerEvent
       description: |
         For Master(Leader) can send worker event to manager workers.
-        Legal types are 'NONE', 'IMMEDIATELY', 'DECOMMISSION', 'DECOMMISSIONTHENIDLE', 'GRACEFUL', 'RECOMMISSION'.
+        Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'.
       requestBody:
         content:
           application/json:

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -200,7 +200,7 @@ paths:
       operationId: sendWorkerEvent
       description: |
         For Master(Leader) can send worker event to manager workers.
-        Legal types are 'None', 'Immediately', 'Decommission', 'DecommissionThenIdle', 'Graceful', 'Recommission'.
+        Legal types are 'NONE', 'IMMEDIATELY', 'DECOMMISSION', 'DECOMMISSIONTHENIDLE', 'GRACEFUL', 'RECOMMISSION'.
       requestBody:
         content:
           application/json:
@@ -706,12 +706,12 @@ components:
           type: string
           description: The type of the event.
           enum:
-            - Immediately
-            - Decommission
-            - DecommissionThenIdle
-            - Graceful
-            - Recommission
-            - None
+            - IMMEDIATELY
+            - DECOMMISSION
+            - DECOMMISSIONTHENIDLE
+            - GRACEFUL
+            - RECOMMISSION
+            - NONE
         workers:
           type: array
           description: The workers to send the event.

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -602,13 +602,13 @@ components:
       properties:
         type:
           type: string
-          default: None
+          default: NONE
           description: The type of the worker exit request.
           enum:
-            - Decommission
-            - Graceful
-            - Immediately
-            - None
+            - DECOMMISSION
+            - GRACEFUL
+            - IMMEDIATELY
+            - NONE
 
     HandleResponse:
       type: object

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1364,6 +1364,7 @@ object CelebornOpenApi {
       "supportUrlQuery" -> "false",
       "annotationLibrary" -> "none",
       "templateDir" -> s"$openApiSpecDir/templates",
+      "useEnumCaseInsensitive" -> "true"
     )
   )
 

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -27,7 +27,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.WorkerInfo
-import org.apache.celeborn.common.protocol.TransportModuleConstants
+import org.apache.celeborn.common.protocol.{TransportModuleConstants, WorkerEventType}
 import org.apache.celeborn.common.util.Utils
 import org.apache.celeborn.server.common.http.HttpServer
 import org.apache.celeborn.server.common.http.api.ApiRootResource
@@ -187,7 +187,9 @@ abstract class HttpService extends Service with Logging {
 
   def exit(exitType: String): String = throw new UnsupportedOperationException()
 
-  def handleWorkerEvent(workerEventType: String, workers: Seq[WorkerInfo]): HandleResponse =
+  def handleWorkerEvent(
+      workerEventType: WorkerEventType,
+      workers: Seq[WorkerInfo]): HandleResponse =
     throw new UnsupportedOperationException()
 
   def getWorkerEventInfo(): String = throw new UnsupportedOperationException()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
@@ -108,7 +108,7 @@ class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
 
     handleResponse = api.sendWorkerEvent(
       new SendWorkerEventRequest().addWorkersItem(workerId).eventType(
-        EventTypeEnum.DECOMMISSION_THEN_IDLE))
+        EventTypeEnum.DECOMMISSIONTHENIDLE))
     assert(handleResponse.getSuccess)
 
     assert(!api.getWorkerEvents.getWorkerEvents.isEmpty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Enable `useEnumCaseInsensitive` for openapi-generator.
And then in celeborn server end, the enum will be mapped to celeborn internal WorkerEventType.

### Why are the changes needed?

I met exception when sending worker event with openapi sdk.
```
Exception in thread "main" ApiException{code=400, responseHeaders={Server=[Jetty(9.4.52.v20230823)], Content-Length=[491], Date=[Fri, 20 Sep 2024 23:50:27 GMT], Content-Type=[text/plain]}, responseBody='Cannot deserialize value of type `org.apache.celeborn.rest.v1.model.SendWorkerEventRequest$EventTypeEnum` from String "DecommissionThenIdle": not one of the values accepted for Enum class: [DECOMMISSION_THEN_IDLE, GRACEFUL, NONE, DECOMMISSION, IMMEDIATELY, RECOMMISSION]
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 14] (through reference chain: org.apache.celeborn.rest.v1.model.SendWorkerEventRequest["eventType"])'}
    at org.apache.celeborn.rest.v1.master.invoker.ApiClient.processResponse(ApiClient.java:913)
    at org.apache.celeborn.rest.v1.master.invoker.ApiClient.invokeAPI(ApiClient.java:1000)
    at org.apache.celeborn.rest.v1.master.WorkerApi.sendWorkerEvent(WorkerApi.java:378)
    at org.apache.celeborn.rest.v1.master.WorkerApi.sendWorkerEvent(WorkerApi.java:334)
    at org.example.Main.main(Main.java:22) 

```

The testing code to re-produce:
```
package org.example;

import org.apache.celeborn.rest.v1.master.WorkerApi;
import org.apache.celeborn.rest.v1.master.invoker.ApiClient;
import org.apache.celeborn.rest.v1.model.ExcludeWorkerRequest;
import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest;
import org.apache.celeborn.rest.v1.model.WorkerId;

public class Main {
    public static void main(String[] args) throws Exception {

        String cmUrl = "http://localhost:9098";
        WorkerApi workerApi = new WorkerApi(new ApiClient().setBasePath(cmUrl));
        workerApi.excludeWorker(new ExcludeWorkerRequest()
                .addAddItem(new WorkerId()
                        .host("localhost")
                        .rpcPort(1)
                        .pushPort(2)
                        .fetchPort(3)
                        .replicatePort(4)));
        workerApi.sendWorkerEvent(new SendWorkerEventRequest()
                        .addWorkersItem(new WorkerId()
                                .host("127.0.0.1")
                                .rpcPort(56116)
                                .pushPort(56117)
                                .fetchPort(56119)
                                .replicatePort(56118))
                .eventType(SendWorkerEventRequest.EventTypeEnum.DECOMMISSION_THEN_IDLE));
    }
}
```

Seems because for the EventTypeEnum, the name and value not the same and then cause this issue.

Not sure why the UT passed, but the integration testing failed.

For EventTypeEnum, because its value is case sensitive, so we meet this issue.

https://github.com/apache/celeborn/blob/8734d1663884345477257d2f10f4c19732c6f1c3/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java#L47-L83 


Related issue in jersey end I think, https://github.com/eclipse-ee4j/jersey/issues/5288 

In this PR, `useEnumCaseInsensitive` is enabled for openapi-generator. 

### Does this PR introduce _any_ user-facing change?
No, there is not user facing change and this SDK has not been released yet.

### How was this patch tested?
Existing UT and Integration testing.
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/6a34a0dd-c474-4e8d-b372-19b0fda94972">

