### PR TITLE
[CELEBORN-1613] Bump Spark from 3.5.2 to 3.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1486,7 +1486,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.5.2</spark.version>
+        <spark.version>3.5.3</spark.version>
         <zstd-jni.version>1.5.5-4</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -770,7 +770,7 @@ object Spark35 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.12.18"
 
-  val sparkVersion = "3.5.2"
+  val sparkVersion = "3.5.3"
   val zstdJniVersion = "1.5.5-4"
 
   override val sparkColumnarShuffleVersion: String = "3.5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Spark from 3.5.2 to 3.5.3.

### Why are the changes needed?

Spark 3.5.3 has been announced to release: [Spark 3.5.3 released](https://spark.apache.org/news/spark-3-5-3-released.html). The profile spark-3.5 could bump Spark from 3.5.2 to 3.5.3.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.