### PR TITLE
[CELEBORN-1614] Remove unused dependencies from openapi-client, spi and cli modules

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -32,6 +32,7 @@
   <properties>
     <hadoop.deps.scope>provided</hadoop.deps.scope>
     <hadoop.deps.optional>true</hadoop.deps.optional>
+    <jdk.tools.optional>true</jdk.tools.optional>
   </properties>
 
   <dependencies>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -29,6 +29,11 @@
   <packaging>jar</packaging>
   <name>Celeborn CLI</name>
 
+  <properties>
+    <hadoop.deps.scope>provided</hadoop.deps.scope>
+    <hadoop.deps.optional>true</hadoop.deps.optional>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>info.picocli</groupId>

--- a/openapi/openapi-client/pom.xml
+++ b/openapi/openapi-client/pom.xml
@@ -32,68 +32,57 @@
   <properties>
     <hadoop.deps.scope>provided</hadoop.deps.scope>
     <hadoop.deps.optional>true</hadoop.deps.optional>
+    <jdk.tools.optional>true</jdk.tools.optional>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5-h2</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.openapitools</groupId>
       <artifactId>jackson-databind-nullable</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/openapi/openapi-client/pom.xml
+++ b/openapi/openapi-client/pom.xml
@@ -29,54 +29,70 @@
   <packaging>jar</packaging>
   <name>Celeborn OpenAPI Client</name>
 
+  <properties>
+    <hadoop.scope>provided</hadoop.scope>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5-h2</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.openapitools</groupId>
       <artifactId>jackson-databind-nullable</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/openapi/openapi-client/pom.xml
+++ b/openapi/openapi-client/pom.xml
@@ -30,7 +30,8 @@
   <name>Celeborn OpenAPI Client</name>
 
   <properties>
-    <hadoop.scope>provided</hadoop.scope>
+    <hadoop.deps.scope>provided</hadoop.deps.scope>
+    <hadoop.deps.optional>true</hadoop.deps.optional>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 
     <!-- use hadoop-3 as default  -->
     <hadoop.version>3.3.6</hadoop.version>
+    <hadoop.scope>compile</hadoop.scope>
     <!--
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
@@ -1278,11 +1279,13 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-api</artifactId>
           <version>${hadoop.version}</version>
+          <scope>${hadoop.scope}</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-runtime</artifactId>
           <version>${hadoop.version}</version>
+          <scope>${hadoop.scope}</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1302,6 +1305,7 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
           <version>${hadoop.version}</version>
+          <scope>${hadoop.scope}</scope>
           <exclusions>
             <exclusion>
               <groupId>org.apache.hadoop</groupId>
@@ -1350,11 +1354,13 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-aws</artifactId>
           <version>${hadoop.version}</version>
+          <scope>${hadoop.scope}</scope>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-bundle</artifactId>
           <version>${aws.version}</version>
+          <scope>${hadoop.scope}</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
 
     <!-- use hadoop-3 as default  -->
     <hadoop.version>3.3.6</hadoop.version>
-    <hadoop.scope>compile</hadoop.scope>
+    <hadoop.deps.scope>compile</hadoop.deps.scope>
+    <hadoop.deps.optional>false</hadoop.deps.optional>
     <!--
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
@@ -1279,13 +1280,15 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-api</artifactId>
           <version>${hadoop.version}</version>
-          <scope>${hadoop.scope}</scope>
+          <scope>${hadoop.deps.scope}</scope>
+          <optional>${hadoop.deps.optional}</optional>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client-runtime</artifactId>
           <version>${hadoop.version}</version>
-          <scope>${hadoop.scope}</scope>
+          <scope>${hadoop.deps.scope}</scope>
+          <optional>${hadoop.deps.optional}</optional>
         </dependency>
       </dependencies>
     </profile>
@@ -1305,7 +1308,8 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
           <version>${hadoop.version}</version>
-          <scope>${hadoop.scope}</scope>
+          <scope>${hadoop.deps.scope}</scope>
+          <optional>${hadoop.deps.optional}</optional>
           <exclusions>
             <exclusion>
               <groupId>org.apache.hadoop</groupId>
@@ -1354,13 +1358,15 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-aws</artifactId>
           <version>${hadoop.version}</version>
-          <scope>${hadoop.scope}</scope>
+          <scope>${hadoop.deps.scope}</scope>
+          <optional>${hadoop.deps.optional}</optional>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-bundle</artifactId>
           <version>${aws.version}</version>
-          <scope>${hadoop.scope}</scope>
+          <scope>${hadoop.deps.scope}</scope>
+          <optional>${hadoop.deps.optional}</optional>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,12 @@
 
     <!-- use hadoop-3 as default  -->
     <hadoop.version>3.3.6</hadoop.version>
+
+    <!-- to make related dependencies optional -->
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <hadoop.deps.optional>false</hadoop.deps.optional>
+    <jdk.tools.optional>false</jdk.tools.optional>
+
     <!--
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
@@ -1516,6 +1520,7 @@
           <groupId>com.github.olivergondza</groupId>
           <artifactId>maven-jdk-tools-wrapper</artifactId>
           <version>0.1</version>
+          <optional>${jdk.tools.optional}</optional>
         </dependency>
       </dependencies>
       <build>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1475,7 +1475,11 @@ object CelebornOpenApi {
       case _ => MergeStrategy.first
     },
     Compile / packageBin := assembly.value,
-    pomPostProcess := removeDependenciesTransformer
+    pomPostProcess := removeDependenciesTransformer,
+    Compile / doc := {
+      // skip due to doc generation failure for openapi modules, see CELEBORN-1477
+      target.value / "none"
+    }
   )
 }
 

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -25,6 +25,11 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <hadoop.deps.scope>provided</hadoop.deps.scope>
+    <hadoop.deps.optional>true</hadoop.deps.optional>
+  </properties>
+
   <artifactId>celeborn-spi</artifactId>
   <packaging>jar</packaging>
   <name>Celeborn SPI</name>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -25,12 +25,12 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <artifactId>celeborn-spi</artifactId>
+  <packaging>jar</packaging>
+  <name>Celeborn SPI</name>
+
   <properties>
     <hadoop.deps.scope>provided</hadoop.deps.scope>
     <hadoop.deps.optional>true</hadoop.deps.optional>
   </properties>
-
-  <artifactId>celeborn-spi</artifactId>
-  <packaging>jar</packaging>
-  <name>Celeborn SPI</name>
 </project>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -32,5 +32,6 @@
   <properties>
     <hadoop.deps.scope>provided</hadoop.deps.scope>
     <hadoop.deps.optional>true</hadoop.deps.optional>
+    <jdk.tools.optional>true</jdk.tools.optional>
   </properties>
 </project>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Make some common dependencies optional for openapi-client, spi and cli modules.

1. set hadoop deps for provided for cli modules
2. set hadoop deps and jdk tools dependency to optional  for cli modules
3. skip openapi-client doc compile, it was missed in https://github.com/apache/celeborn/pull/2641
### Why are the changes needed?

Currently, the hadoop/jdk tools dependencies are define in parent dependencies for maven build.

And all the modules inherit them.
<img width="792" alt="image" src="https://github.com/user-attachments/assets/36cb1928-102a-4a75-adbe-77d374a195eb">


But they are not necessary for the cli modules, and it might cause dependency conflicts if customer app depends on them.
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

<img width="894" alt="image" src="https://github.com/user-attachments/assets/17a1687a-1a6c-4f6e-92e0-2273ba6fd6dc">
