### PR TITLE
[CELEBORN-1617][CIP-11] Support workers tags in FS Config Service

### DIFF
--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfig.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.server.common.service.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ public abstract class DynamicConfig {
   private static final Logger LOG = LoggerFactory.getLogger(DynamicConfig.class);
   protected Map<String, String> configs = new HashMap<>();
   protected volatile Quota quota = null;
+  protected volatile Map<String, Set<String>> tags = null;
 
   public abstract DynamicConfig getParentLevelConfig();
 
@@ -129,6 +131,21 @@ public abstract class DynamicConfig {
 
   public Map<String, String> getConfigs() {
     return configs;
+  }
+
+  public Map<String, Set<String>> getTags() {
+    if (tags == null) {
+      synchronized (DynamicConfig.class) {
+        if (tags == null) {
+          tags = currentTags();
+        }
+      }
+    }
+    return tags;
+  }
+
+  protected Map<String, Set<String>> currentTags() {
+    return null;
   }
 
   @Override

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/SystemConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/SystemConfig.java
@@ -20,6 +20,7 @@ package org.apache.celeborn.server.common.service.config;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.internal.config.ConfigEntry;
@@ -62,5 +63,18 @@ public class SystemConfig extends DynamicConfig {
     } else {
       return formatValue;
     }
+  }
+
+  public void setConfigs(Map<String, String> configs) {
+    this.configs = configs;
+  }
+
+  public void setTags(Map<String, Set<String>> tags) {
+    this.tags = tags;
+  }
+
+  @Override
+  protected Map<String, Set<String>> currentTags() {
+    return this.tags;
   }
 }

--- a/service/src/test/resources/dynamicConfig_tags.yaml
+++ b/service/src/test/resources/dynamicConfig_tags.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-  level: SYSTEM
+   config:
+     celeborn.test.int.only: 100
+   tags:
+     tag1:
+       - 'host1:1111'
+       - 'host2:2222'
+     tag2:
+       - 'host3:3333'
+       - 'host4:4444'
+
+-  tenantId: tenant_id1
+   level: TENANT
+   config:
+     celeborn.test.int.only: 50
+   # Tags should be null for tenant/user config
+   tags:
+     tag1:
+       - 'host1:1111'
+       - 'host2:2222'
+   users:
+     - name: Jerry
+       config:
+         celeborn.test.int.only: 10
+       # Tags should be null for tenant/user config
+       tags:
+         tag1:
+           - 'host1:1111'
+           - 'host2:2222'

--- a/service/src/test/resources/dynamicConfig_tags2.yaml
+++ b/service/src/test/resources/dynamicConfig_tags2.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-  level: SYSTEM
+   config:
+     celeborn.test.int.only: 100
+   tags:
+     tag1:
+       - 'host1:1111'
+     tag3:
+       - 'host5:5555'
+
+-  tenantId: tenant_id
+   level: TENANT
+   config:
+     celeborn.test.int.only: 50
+   users:
+     - name: tenant1
+       config:
+         celeborn.test.int.only: 10


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Adding support for reading worker tags in FSConfigService. (Will handle DBConfigService in separate PR). Tags will be part of System level config and  dynamic config file structure with tags is shown below:

```
-  level: SYSTEM
   config:
     celeborn.test.int.only: 100
   tags:
     tag1:
       - 'host1:1111'
       - 'host2:2222'
     tag2:
       - 'host3:3333'
       - 'host4:4444'
```

### Why are the changes needed?

https://cwiki.apache.org/confluence/display/CELEBORN/CIP-11+Supporting+Tags+in+Celeborn

### Does this PR introduce _any_ user-facing change?

- Changes are backward compatible.
- User will be able to pass worker tags from dynamicConfig.yaml file.


### How was this patch tested?
UTs

