### PR TITLE
[CELEBORN-1625] Add parameter `skipCompress` for pushOrMergeData

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -907,7 +907,8 @@ public class ShuffleClientImpl extends ShuffleClient {
       int length,
       int numMappers,
       int numPartitions,
-      boolean doPush)
+      boolean doPush,
+      boolean skipCompress)
       throws IOException {
     // mapKey
     final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
@@ -972,7 +973,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     // increment batchId
     final int nextBatchId = pushState.nextBatchId();
 
-    if (shuffleCompressionEnabled) {
+    if (shuffleCompressionEnabled && !skipCompress) {
       // compress data
       final Compressor compressor = compressorThreadLocal.get();
       compressor.compress(data, offset, length);
@@ -1278,7 +1279,8 @@ public class ShuffleClientImpl extends ShuffleClient {
         length,
         numMappers,
         numPartitions,
-        true);
+        true,
+        false);
   }
 
   @Override
@@ -1312,6 +1314,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         length,
         numMappers,
         numPartitions,
+        false,
         false);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new parameters to the pushOrMergeData method for gluten


### Why are the changes needed?
Currently, in the scenario of Gluten Fallback, it is possible for a stage to have both Native and Java shuffles simultaneously. Since the ShuffleClient is a singleton, the compression settings for the ShuffleClient will only utilize either the Native or Java configuration. By adding new parameters, we aim to allow Gluten to control whether compression should be applied in this scenario.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI
