### PR TITLE
[CELEBORN-1058][FOLLOWUP] Update name of master service from MasterSys to Master in startup document

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ celeborn.worker.readBuffer.allocationWait 10ms
 ```
 22/10/08 19:29:11,805 INFO [main] Dispatcher: Dispatcher numThreads: 64
 22/10/08 19:29:11,875 INFO [main] TransportClientFactory: mode NIO threads 64
-22/10/08 19:29:12,057 INFO [main] Utils: Successfully started service 'MasterSys' on port 9097.
+22/10/08 19:29:12,057 INFO [main] Utils: Successfully started service 'Master' on port 9097.
 22/10/08 19:29:12,113 INFO [main] Master: Metrics system enabled.
 22/10/08 19:29:12,125 INFO [main] HttpServer: master: HttpServer started on port 9098.
 22/10/08 19:29:12,126 INFO [main] Master: Master started.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ cd $CELEBORN_HOME
 ```
 You should see `Master`'s ip:port in the log:
 ```log
-INFO [main] NettyRpcEnvFactory: Starting RPC Server [MasterSys] on 192.168.2.109:9097 with advisor endpoint 192.168.2.109:9097
+INFO [main] NettyRpcEnvFactory: Starting RPC Server [Master] on 192.168.2.109:9097 with advisor endpoint 192.168.2.109:9097
 ```
 #### Start Worker
 Use the Master's IP and Port to start Worker:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -138,7 +138,7 @@ celeborn.worker.readBuffer.allocationWait 10ms
 ```
 22/10/08 19:29:11,805 INFO [main] Dispatcher: Dispatcher numThreads: 64
 22/10/08 19:29:11,875 INFO [main] TransportClientFactory: mode NIO threads 64
-22/10/08 19:29:12,057 INFO [main] Utils: Successfully started service 'MasterSys' on port 9097.
+22/10/08 19:29:12,057 INFO [main] Utils: Successfully started service 'Master' on port 9097.
 22/10/08 19:29:12,113 INFO [main] Master: Metrics system enabled.
 22/10/08 19:29:12,125 INFO [main] HttpServer: master: HttpServer started on port 9098.
 22/10/08 19:29:12,126 INFO [main] Master: Master started.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update name of master service from `MasterSys` to `Master` in startup document to follow up https://github.com/apache/celeborn/pull/2003/files#r1365454256.

### Why are the changes needed?

#2003 has already changed the name of master and worker service, which should also update the name in startup logs of document.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.