### PR TITLE
[CELEBORN-1513][FOLLOWUP] Update advertised endpoint of master service log in startup document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ cd $CELEBORN_HOME
 ```
 You should see `Master`'s ip:port in the log:
 ```log
-INFO [main] NettyRpcEnvFactory: Starting RPC Server [Master] on 192.168.2.109:9097 with advisor endpoint 192.168.2.109:9097
+INFO [main] NettyRpcEnvFactory: Starting RPC Server [Master] on 192.168.2.109:9097 with advertised endpoint 192.168.2.109:9097
 ```
 #### Start Worker
 Use the Master's IP and Port to start Worker:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `advertised endpoint` of master service log in startup document.

### Why are the changes needed?

#2713 has changed the startup log of of master service in `NettyRpcEnv`, which should update the log of startup document.

```
logInfo(s"Starting RPC Server [${config.name}] on ${config.bindAddress}:$actualPort " +
   s"with advertised endpoint ${config.advertiseAddress}:$actualPort")
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.