### PR TITLE
[CELEBORN-914][FOLLOWUP] Add emptyFilePrimaryIds and emptyFileReplicaIds of worker service log in startup document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ And the following message in Celeborn Worker's log:
 ```log
 INFO [dispatcher-event-loop-9] Controller: Reserved 10 primary location and 0 replica location for local-1690000152711-0
 INFO [dispatcher-event-loop-8] Controller: Start commitFiles for local-1690000152711-0
-INFO [async-reply] Controller: CommitFiles for local-1690000152711-0 success with 10 committed primary partitions, 0 empty primary partitions, 0 failed primary partitions, 0 committed replica partitions, 0 empty replica partitions, 0 failed replica partitions.
+INFO [async-reply] Controller: CommitFiles for local-1690000152711-0 success with 10 committed primary partitions, 0 empty primary partitions , 0 failed primary partitions, 0 committed replica partitions, 0 empty replica partitions , 0 failed replica partitions.
 ```
 
 ## Start Flink with Celeborn
@@ -158,7 +158,7 @@ And the following message in Celeborn Worker's log:
 ```log
 INFO [dispatcher-event-loop-4] Controller: Reserved 1 primary location and 0 replica location for local-1690000152711-0
 INFO [dispatcher-event-loop-3] Controller: Start commitFiles for local-1690000152711-0
-INFO [async-reply] Controller: CommitFiles for local-1690000152711-0 success with 1 committed primary partitions, 0 empty primary partitions, 0 failed primary partitions, 0 committed replica partitions, 0 empty replica partitions, 0 failed replica partitions.
+INFO [async-reply] Controller: CommitFiles for local-1690000152711-0 success with 1 committed primary partitions, 0 empty primary partitions , 0 failed primary partitions, 0 committed replica partitions, 0 empty replica partitions , 0 failed replica partitions.
 ```
 
 ## Start MapReduce With Celeborn
@@ -224,5 +224,5 @@ And the following message in Celeborn Worker's log:
 ```log
 INFO [dispatcher-event-loop-4] Controller: Reserved 1 primary location and 0 replica location for application_1694674023293_0003-0
 INFO [dispatcher-event-loop-3] Controller: Start commitFiles for application_1694674023293_0003-0
-INFO [async-reply] Controller: CommitFiles for application_1694674023293_0003-0 success with 1 committed primary partitions, 0 empty primary partitions, 0 failed primary partitions, 0 committed replica partitions, 0 empty replica partitions, 0 failed replica partitions.
+INFO [async-reply] Controller: CommitFiles for application_1694674023293_0003-0 success with 1 committed primary partitions, 0 empty primary partitions , 0 failed primary partitions, 0 committed replica partitions, 0 empty replica partitions , 0 failed replica partitions.
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `emptyFilePrimaryIds` and `emptyFileReplicaIds` of worker service log in startup document.

### Why are the changes needed?

#2300 has added `emptyFilePrimaryIds` and `emptyFileReplicaIds` of startup log of for worker service in `Controller`, which should also add into the log of startup document.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.