### PR TITLE
[CELEBORN-1627] Introduce `instance` variable for celeborn dashboard to filter metrics

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -5426,6 +5426,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_DirectMemoryUsageRatio_Value",
+              "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
               "refId": "A"
@@ -5521,6 +5522,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_MemoryFileStorageSize_Value",
+              "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
               "refId": "A"
@@ -5615,6 +5617,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_MemoryStorageFileCount_Value",
+              "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
               "refId": "A"
@@ -5797,6 +5800,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_EvictedFileCount_Value",
+              "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
               "refId": "A"

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -10430,11 +10430,10 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "__auto",
-          "value": "__auto"
+          "selected": true,
+          "text": "{{instance}}",
+          "value": "{{instance}}"
         },
-        "description": "The base legend format to apply for all metrics",
         "hide": 0,
         "includeAll": false,
         "label": "baseLegend",
@@ -10443,11 +10442,11 @@
         "options": [
           {
             "selected": true,
-            "text": "__auto",
-            "value": "__auto"
+            "text": "{{instance}}",
+            "value": "{{instance}}"
           }
         ],
-        "query": "__auto",
+        "query": "{{instance}}",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -345,7 +345,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\", instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend}",
+              "legendFormat": "${baseLegend} device={{device}}",
               "refId": "A"
             }
           ],
@@ -440,7 +440,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\", instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend}",
+              "legendFormat": "${baseLegend} device={{device}}",
               "refId": "A"
             }
           ],
@@ -2645,7 +2645,7 @@
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "${baseLegend}",
+              "legendFormat": "${baseLegend} mountpoint={{mountpoint}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -9814,7 +9814,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_DeviceOSFreeBytes_Value{instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend}",
+              "legendFormat": "${baseLegend} device={{device}}",
               "range": true,
               "refId": "A"
             }
@@ -9907,7 +9907,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_DeviceCelebornFreeBytes_Value{instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend}",
+              "legendFormat": "${baseLegend} device={{device}}",
               "range": true,
               "refId": "A"
             }

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -155,7 +155,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_RegisteredShuffleCount_Value",
+              "expr": "metrics_RegisteredShuffleCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -249,7 +249,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_WorkerCount_Value",
+              "expr": "metrics_WorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -344,7 +344,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\"}",
+              "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\",instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -439,7 +439,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\"}",
+              "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\",instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -533,7 +533,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_RunningApplicationCount_Value",
+              "expr": "metrics_RunningApplicationCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -643,7 +643,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_IsActiveMaster_Value",
+              "expr": "metrics_IsActiveMaster_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -740,7 +740,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PartitionSize_Value",
+              "expr": "metrics_PartitionSize_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -835,7 +835,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ShutdownWorkerCount_Value",
+              "expr": "metrics_ShutdownWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -931,7 +931,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Master\"}",
+              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Master\",instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1028,7 +1028,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveShuffleSize_Value{role=\"Master\"}",
+              "expr": "metrics_ActiveShuffleSize_Value{role=\"Master\",instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1123,7 +1123,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OfferSlotsTime_Max",
+              "expr": "metrics_OfferSlotsTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1216,7 +1216,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OfferSlotsTime_Mean",
+              "expr": "metrics_OfferSlotsTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1310,7 +1310,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ExcludedWorkerCount_Value",
+              "expr": "metrics_ExcludedWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1405,7 +1405,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableWorkerCount_Value",
+              "expr": "metrics_AvailableWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1499,7 +1499,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_LostWorkerCount_Value",
+              "expr": "metrics_LostWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1606,7 +1606,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "increase(metrics_SlotsAllocated_Count[1h])",
+              "expr": "increase(metrics_SlotsAllocated_Count[1h]){instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1699,7 +1699,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReserveSlotsTime_Mean",
+              "expr": "metrics_ReserveSlotsTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1793,7 +1793,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReserveSlotsTime_Max",
+              "expr": "metrics_ReserveSlotsTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1886,7 +1886,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushData_Value",
+              "expr": "metrics_PausePushData_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1979,7 +1979,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataAndReplicate_Value",
+              "expr": "metrics_PausePushDataAndReplicate_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2073,7 +2073,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataTime_Value",
+              "expr": "metrics_PausePushDataTime_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2167,7 +2167,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataAndReplicateTime_Value",
+              "expr": "metrics_PausePushDataAndReplicateTime_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2263,7 +2263,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveShuffleSize_Value{role=\"Worker\"}",
+              "expr": "metrics_ActiveShuffleSize_Value{role=\"Worker\",instance=~\"${instance}\"}",
               "instant": false,
               "legendFormat": "${baseLegend}",
               "range": true,
@@ -2359,7 +2359,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Worker\"}",
+              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Worker\",instance=~\"${instance}\"}",
               "instant": false,
               "legendFormat": "${baseLegend}",
               "range": true,
@@ -2453,7 +2453,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ActiveConnectionCount_Count",
+              "expr": "metrics_ActiveConnectionCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2546,7 +2546,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ActiveSlotsCount_Value",
+              "expr": "metrics_ActiveSlotsCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2641,7 +2641,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "metrics_FlushWorkingQueueSize_Value",
+              "expr": "metrics_FlushWorkingQueueSize_Value{instance=~\"${instance}\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -2750,7 +2750,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PrimaryPushDataTime_Mean",
+              "expr": "metrics_PrimaryPushDataTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -2840,7 +2840,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PrimaryPushDataTime_Max",
+              "expr": "metrics_PrimaryPushDataTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -2930,7 +2930,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReplicaPushDataTime_Mean",
+              "expr": "metrics_ReplicaPushDataTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -3020,7 +3020,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReplicaPushDataTime_Max",
+              "expr": "metrics_ReplicaPushDataTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -3110,7 +3110,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataSuccessCount_Count",
+              "expr": "metrics_WriteDataSuccessCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3201,7 +3201,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataFailCount_Count",
+              "expr": "metrics_WriteDataFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3292,7 +3292,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataFailCount_Count",
+              "expr": "metrics_ReplicateDataFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3383,7 +3383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataWriteFailCount_Count",
+              "expr": "metrics_ReplicateDataWriteFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3474,7 +3474,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count",
+              "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3565,7 +3565,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataConnectionExceptionCount_Count",
+              "expr": "metrics_ReplicateDataConnectionExceptionCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3656,7 +3656,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataTimeoutCount_Count",
+              "expr": "metrics_ReplicateDataTimeoutCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3747,7 +3747,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataFailNonCriticalCauseCount_Count",
+              "expr": "metrics_ReplicateDataFailNonCriticalCauseCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3838,7 +3838,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataHardSplitCount_Count",
+              "expr": "metrics_WriteDataHardSplitCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3943,7 +3943,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OpenStreamTime_Mean",
+              "expr": "metrics_OpenStreamTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4033,7 +4033,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OpenStreamTime_Max",
+              "expr": "metrics_OpenStreamTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4123,7 +4123,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FetchChunkTime_Mean",
+              "expr": "metrics_FetchChunkTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4213,7 +4213,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FetchChunkTime_Max",
+              "expr": "metrics_FetchChunkTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4303,7 +4303,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_OpenStreamSuccessCount_Count",
+              "expr": "metrics_OpenStreamSuccessCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4394,7 +4394,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_OpenStreamFailCount_Count",
+              "expr": "metrics_OpenStreamFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4485,7 +4485,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_FetchChunkSuccessCount_Count",
+              "expr": "metrics_FetchChunkSuccessCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4576,7 +4576,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_FetchChunkFailCount_Count",
+              "expr": "metrics_FetchChunkFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4667,7 +4667,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveChunkStreamCount_Value",
+              "expr": "metrics_ActiveChunkStreamCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4772,7 +4772,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_TakeBufferTime_Mean",
+              "expr": "metrics_TakeBufferTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4862,7 +4862,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_TakeBufferTime_Max",
+              "expr": "metrics_TakeBufferTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4952,7 +4952,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FlushDataTime_Mean",
+              "expr": "metrics_FlushDataTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5042,7 +5042,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FlushDataTime_Max",
+              "expr": "metrics_FlushDataTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5132,7 +5132,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_CommitFilesTime_Mean",
+              "expr": "metrics_CommitFilesTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5222,7 +5222,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_CommitFilesTime_Max",
+              "expr": "metrics_CommitFilesTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5330,7 +5330,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_NettyMemory_Value",
+              "expr": "metrics_NettyMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5425,7 +5425,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_DirectMemoryUsageRatio_Value",
+              "expr": "metrics_DirectMemoryUsageRatio_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5521,7 +5521,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_MemoryFileStorageSize_Value",
+              "expr": "metrics_MemoryFileStorageSize_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5616,7 +5616,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_MemoryStorageFileCount_Value",
+              "expr": "metrics_MemoryStorageFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5708,7 +5708,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DiskBuffer_Value",
+              "expr": "metrics_DiskBuffer_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5799,7 +5799,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_EvictedFileCount_Value",
+              "expr": "metrics_EvictedFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5892,7 +5892,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_push_usedHeapMemory_Value",
+              "expr": "metrics_push_usedHeapMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5984,7 +5984,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_push_usedDirectMemory_Value",
+              "expr": "metrics_push_usedDirectMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6076,7 +6076,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_fetch_usedHeapMemory_Value",
+              "expr": "metrics_fetch_usedHeapMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6168,7 +6168,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_fetch_usedDirectMemory_Value",
+              "expr": "metrics_fetch_usedDirectMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6260,7 +6260,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_replicate_usedHeapMemory_Value",
+              "expr": "metrics_replicate_usedHeapMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6352,7 +6352,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_replicate_usedDirectMemory_Value",
+              "expr": "metrics_replicate_usedDirectMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6443,7 +6443,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ReadBufferAllocatedCount_Value",
+              "expr": "metrics_ReadBufferAllocatedCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6535,7 +6535,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_BufferStreamReadBuffer_Value",
+              "expr": "metrics_BufferStreamReadBuffer_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6626,7 +6626,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ReadBufferDispatcherRequestsLength_Value",
+              "expr": "metrics_ReadBufferDispatcherRequestsLength_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6731,7 +6731,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortTime_Mean",
+              "expr": "metrics_SortTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -6821,7 +6821,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortTime_Max",
+              "expr": "metrics_SortTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -6910,7 +6910,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortingFiles_Value",
+              "expr": "metrics_SortingFiles_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7000,7 +7000,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortedFiles_Value",
+              "expr": "metrics_SortedFiles_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7091,7 +7091,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortMemory_Value",
+              "expr": "metrics_SortMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7182,7 +7182,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_SortedFileSize_Value",
+              "expr": "metrics_SortedFileSize_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7289,7 +7289,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PotentialConsumeSpeed_Value",
+              "expr": "metrics_PotentialConsumeSpeed_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7382,7 +7382,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WorkerConsumeSpeed_Value",
+              "expr": "metrics_WorkerConsumeSpeed_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7475,7 +7475,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_UserProduceSpeed_Value",
+              "expr": "metrics_UserProduceSpeed_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7581,7 +7581,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryPushDataHandshakeTime_Mean",
+              "expr": "metrics_PrimaryPushDataHandshakeTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7673,7 +7673,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryPushDataHandshakeTime_Max",
+              "expr": "metrics_PrimaryPushDataHandshakeTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7765,7 +7765,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaPushDataHandshakeTime_Mean",
+              "expr": "metrics_ReplicaPushDataHandshakeTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7857,7 +7857,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaPushDataHandshakeTime_Max",
+              "expr": "metrics_ReplicaPushDataHandshakeTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7949,7 +7949,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionStartTime_Mean",
+              "expr": "metrics_PrimaryRegionStartTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8041,7 +8041,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionStartTime_Max",
+              "expr": "metrics_PrimaryRegionStartTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8133,7 +8133,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionStartTime_Mean",
+              "expr": "metrics_ReplicaRegionStartTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8225,7 +8225,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionStartTime_Max",
+              "expr": "metrics_ReplicaRegionStartTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8317,7 +8317,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionFinishTime_Mean",
+              "expr": "metrics_PrimaryRegionFinishTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8409,7 +8409,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionFinishTime_Max",
+              "expr": "metrics_PrimaryRegionFinishTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8501,7 +8501,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionFinishTime_Mean",
+              "expr": "metrics_ReplicaRegionFinishTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8593,7 +8593,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionFinishTime_Max",
+              "expr": "metrics_ReplicaRegionFinishTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8684,7 +8684,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PushDataHandshakeFailCount_Count",
+              "expr": "metrics_PushDataHandshakeFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8775,7 +8775,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_RegionStartFailCount_Count",
+              "expr": "metrics_RegionStartFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8866,7 +8866,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_RegionStartFailCount_Count",
+              "expr": "metrics_RegionStartFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9430,7 +9430,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveCreditStreamCount_Value",
+              "expr": "metrics_ActiveCreditStreamCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9521,7 +9521,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveMapPartitionCount_Value",
+              "expr": "metrics_ActiveMapPartitionCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9627,7 +9627,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_JVMCPUTime_Value",
+              "expr": "metrics_JVMCPUTime_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9720,7 +9720,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_LastMinuteSystemLoad_Value",
+              "expr": "metrics_LastMinuteSystemLoad_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9813,7 +9813,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_DeviceOSFreeBytes_Value",
+              "expr": "metrics_DeviceOSFreeBytes_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9906,7 +9906,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_DeviceCelebornFreeBytes_Value",
+              "expr": "metrics_DeviceCelebornFreeBytes_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9999,7 +9999,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableProcessors_Value",
+              "expr": "metrics_AvailableProcessors_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10105,7 +10105,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_diskFileCount_Value",
+              "expr": "metrics_diskFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10198,7 +10198,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_diskBytesWritten_Value",
+              "expr": "metrics_diskBytesWritten_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10290,7 +10290,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_hdfsFileCount_Value",
+              "expr": "metrics_hdfsFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10383,7 +10383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_hdfsBytesWritten_Value",
+              "expr": "metrics_hdfsBytesWritten_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10403,6 +10403,31 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(metrics_JVMCPUTime_Value, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "instance",
+        "mapping": "",
+        "mappingOnLegend": true,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(metrics_JVMCPUTime_Value, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
       {
         "current": {
           "selected": false,

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -155,7 +155,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_RegisteredShuffleCount_Value",
+              "expr": "metrics_RegisteredShuffleCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -249,7 +249,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_WorkerCount_Value",
+              "expr": "metrics_WorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -344,7 +344,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\"}",
+              "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\", instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -439,7 +439,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\"}",
+              "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\", instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -533,7 +533,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_RunningApplicationCount_Value",
+              "expr": "metrics_RunningApplicationCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -643,7 +643,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_IsActiveMaster_Value",
+              "expr": "metrics_IsActiveMaster_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -740,7 +740,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PartitionSize_Value",
+              "expr": "metrics_PartitionSize_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -835,7 +835,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ShutdownWorkerCount_Value",
+              "expr": "metrics_ShutdownWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -931,7 +931,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Master\"}",
+              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Master\", instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1028,7 +1028,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveShuffleSize_Value{role=\"Master\"}",
+              "expr": "metrics_ActiveShuffleSize_Value{role=\"Master\", instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1123,7 +1123,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OfferSlotsTime_Max",
+              "expr": "metrics_OfferSlotsTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1216,7 +1216,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OfferSlotsTime_Mean",
+              "expr": "metrics_OfferSlotsTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1310,7 +1310,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ExcludedWorkerCount_Value",
+              "expr": "metrics_ExcludedWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1405,7 +1405,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableWorkerCount_Value",
+              "expr": "metrics_AvailableWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1499,7 +1499,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_LostWorkerCount_Value",
+              "expr": "metrics_LostWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1606,7 +1606,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "increase(metrics_SlotsAllocated_Count[1h])",
+              "expr": "increase(metrics_SlotsAllocated_Count[1h]){instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1699,7 +1699,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReserveSlotsTime_Mean",
+              "expr": "metrics_ReserveSlotsTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1793,7 +1793,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReserveSlotsTime_Max",
+              "expr": "metrics_ReserveSlotsTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1886,7 +1886,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushData_Value",
+              "expr": "metrics_PausePushData_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1979,7 +1979,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataAndReplicate_Value",
+              "expr": "metrics_PausePushDataAndReplicate_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2073,7 +2073,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataTime_Value",
+              "expr": "metrics_PausePushDataTime_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2167,7 +2167,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataAndReplicateTime_Value",
+              "expr": "metrics_PausePushDataAndReplicateTime_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2263,7 +2263,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveShuffleSize_Value{role=\"Worker\"}",
+              "expr": "metrics_ActiveShuffleSize_Value{role=\"Worker\", instance=~\"${instance}\"}",
               "instant": false,
               "legendFormat": "${baseLegend}",
               "range": true,
@@ -2359,7 +2359,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Worker\"}",
+              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Worker\", instance=~\"${instance}\"}",
               "instant": false,
               "legendFormat": "${baseLegend}",
               "range": true,
@@ -2453,7 +2453,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ActiveConnectionCount_Count",
+              "expr": "metrics_ActiveConnectionCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2546,7 +2546,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ActiveSlotsCount_Value",
+              "expr": "metrics_ActiveSlotsCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2641,7 +2641,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "metrics_FlushWorkingQueueSize_Value",
+              "expr": "metrics_FlushWorkingQueueSize_Value{instance=~\"${instance}\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -2750,7 +2750,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PrimaryPushDataTime_Mean",
+              "expr": "metrics_PrimaryPushDataTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -2840,7 +2840,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PrimaryPushDataTime_Max",
+              "expr": "metrics_PrimaryPushDataTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -2930,7 +2930,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReplicaPushDataTime_Mean",
+              "expr": "metrics_ReplicaPushDataTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -3020,7 +3020,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReplicaPushDataTime_Max",
+              "expr": "metrics_ReplicaPushDataTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -3110,7 +3110,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataSuccessCount_Count",
+              "expr": "metrics_WriteDataSuccessCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3201,7 +3201,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataFailCount_Count",
+              "expr": "metrics_WriteDataFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3292,7 +3292,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataFailCount_Count",
+              "expr": "metrics_ReplicateDataFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3383,7 +3383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataWriteFailCount_Count",
+              "expr": "metrics_ReplicateDataWriteFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3474,7 +3474,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count",
+              "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3565,7 +3565,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataConnectionExceptionCount_Count",
+              "expr": "metrics_ReplicateDataConnectionExceptionCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3656,7 +3656,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataTimeoutCount_Count",
+              "expr": "metrics_ReplicateDataTimeoutCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3747,7 +3747,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataFailNonCriticalCauseCount_Count",
+              "expr": "metrics_ReplicateDataFailNonCriticalCauseCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3838,7 +3838,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataHardSplitCount_Count",
+              "expr": "metrics_WriteDataHardSplitCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3943,7 +3943,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OpenStreamTime_Mean",
+              "expr": "metrics_OpenStreamTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4033,7 +4033,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OpenStreamTime_Max",
+              "expr": "metrics_OpenStreamTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4123,7 +4123,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FetchChunkTime_Mean",
+              "expr": "metrics_FetchChunkTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4213,7 +4213,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FetchChunkTime_Max",
+              "expr": "metrics_FetchChunkTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4303,7 +4303,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_OpenStreamSuccessCount_Count",
+              "expr": "metrics_OpenStreamSuccessCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4394,7 +4394,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_OpenStreamFailCount_Count",
+              "expr": "metrics_OpenStreamFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4485,7 +4485,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_FetchChunkSuccessCount_Count",
+              "expr": "metrics_FetchChunkSuccessCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4576,7 +4576,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_FetchChunkFailCount_Count",
+              "expr": "metrics_FetchChunkFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4667,7 +4667,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveChunkStreamCount_Value",
+              "expr": "metrics_ActiveChunkStreamCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4772,7 +4772,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_TakeBufferTime_Mean",
+              "expr": "metrics_TakeBufferTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4862,7 +4862,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_TakeBufferTime_Max",
+              "expr": "metrics_TakeBufferTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4952,7 +4952,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FlushDataTime_Mean",
+              "expr": "metrics_FlushDataTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5042,7 +5042,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FlushDataTime_Max",
+              "expr": "metrics_FlushDataTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5132,7 +5132,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_CommitFilesTime_Mean",
+              "expr": "metrics_CommitFilesTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5222,7 +5222,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_CommitFilesTime_Max",
+              "expr": "metrics_CommitFilesTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5330,7 +5330,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_NettyMemory_Value",
+              "expr": "metrics_NettyMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5425,7 +5425,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_DirectMemoryUsageRatio_Value",
+              "expr": "metrics_DirectMemoryUsageRatio_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5521,7 +5521,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_MemoryFileStorageSize_Value",
+              "expr": "metrics_MemoryFileStorageSize_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5616,7 +5616,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_MemoryStorageFileCount_Value",
+              "expr": "metrics_MemoryStorageFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5708,7 +5708,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DiskBuffer_Value",
+              "expr": "metrics_DiskBuffer_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5799,7 +5799,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_EvictedFileCount_Value",
+              "expr": "metrics_EvictedFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5892,7 +5892,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_push_usedHeapMemory_Value",
+              "expr": "metrics_push_usedHeapMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5984,7 +5984,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_push_usedDirectMemory_Value",
+              "expr": "metrics_push_usedDirectMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6076,7 +6076,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_fetch_usedHeapMemory_Value",
+              "expr": "metrics_fetch_usedHeapMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6168,7 +6168,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_fetch_usedDirectMemory_Value",
+              "expr": "metrics_fetch_usedDirectMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6260,7 +6260,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_replicate_usedHeapMemory_Value",
+              "expr": "metrics_replicate_usedHeapMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6352,7 +6352,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_replicate_usedDirectMemory_Value",
+              "expr": "metrics_replicate_usedDirectMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6443,7 +6443,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ReadBufferAllocatedCount_Value",
+              "expr": "metrics_ReadBufferAllocatedCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6535,7 +6535,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_BufferStreamReadBuffer_Value",
+              "expr": "metrics_BufferStreamReadBuffer_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6626,7 +6626,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ReadBufferDispatcherRequestsLength_Value",
+              "expr": "metrics_ReadBufferDispatcherRequestsLength_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6731,7 +6731,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortTime_Mean",
+              "expr": "metrics_SortTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -6821,7 +6821,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortTime_Max",
+              "expr": "metrics_SortTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -6910,7 +6910,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortingFiles_Value",
+              "expr": "metrics_SortingFiles_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7000,7 +7000,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortedFiles_Value",
+              "expr": "metrics_SortedFiles_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7091,7 +7091,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortMemory_Value",
+              "expr": "metrics_SortMemory_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7182,7 +7182,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_SortedFileSize_Value",
+              "expr": "metrics_SortedFileSize_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7289,7 +7289,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PotentialConsumeSpeed_Value",
+              "expr": "metrics_PotentialConsumeSpeed_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7382,7 +7382,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WorkerConsumeSpeed_Value",
+              "expr": "metrics_WorkerConsumeSpeed_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7475,7 +7475,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_UserProduceSpeed_Value",
+              "expr": "metrics_UserProduceSpeed_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7581,7 +7581,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryPushDataHandshakeTime_Mean",
+              "expr": "metrics_PrimaryPushDataHandshakeTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7673,7 +7673,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryPushDataHandshakeTime_Max",
+              "expr": "metrics_PrimaryPushDataHandshakeTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7765,7 +7765,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaPushDataHandshakeTime_Mean",
+              "expr": "metrics_ReplicaPushDataHandshakeTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7857,7 +7857,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaPushDataHandshakeTime_Max",
+              "expr": "metrics_ReplicaPushDataHandshakeTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7949,7 +7949,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionStartTime_Mean",
+              "expr": "metrics_PrimaryRegionStartTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8041,7 +8041,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionStartTime_Max",
+              "expr": "metrics_PrimaryRegionStartTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8133,7 +8133,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionStartTime_Mean",
+              "expr": "metrics_ReplicaRegionStartTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8225,7 +8225,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionStartTime_Max",
+              "expr": "metrics_ReplicaRegionStartTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8317,7 +8317,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionFinishTime_Mean",
+              "expr": "metrics_PrimaryRegionFinishTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8409,7 +8409,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionFinishTime_Max",
+              "expr": "metrics_PrimaryRegionFinishTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8501,7 +8501,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionFinishTime_Mean",
+              "expr": "metrics_ReplicaRegionFinishTime_Mean{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8593,7 +8593,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionFinishTime_Max",
+              "expr": "metrics_ReplicaRegionFinishTime_Max{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8684,7 +8684,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PushDataHandshakeFailCount_Count",
+              "expr": "metrics_PushDataHandshakeFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8775,7 +8775,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_RegionStartFailCount_Count",
+              "expr": "metrics_RegionStartFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8866,7 +8866,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_RegionStartFailCount_Count",
+              "expr": "metrics_RegionStartFailCount_Count{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9430,7 +9430,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveCreditStreamCount_Value",
+              "expr": "metrics_ActiveCreditStreamCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9521,7 +9521,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveMapPartitionCount_Value",
+              "expr": "metrics_ActiveMapPartitionCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9627,7 +9627,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_JVMCPUTime_Value",
+              "expr": "metrics_JVMCPUTime_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9720,7 +9720,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_LastMinuteSystemLoad_Value",
+              "expr": "metrics_LastMinuteSystemLoad_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9813,7 +9813,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_DeviceOSFreeBytes_Value",
+              "expr": "metrics_DeviceOSFreeBytes_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9906,7 +9906,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_DeviceCelebornFreeBytes_Value",
+              "expr": "metrics_DeviceCelebornFreeBytes_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9999,7 +9999,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableProcessors_Value",
+              "expr": "metrics_AvailableProcessors_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10105,7 +10105,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_diskFileCount_Value",
+              "expr": "metrics_diskFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10198,7 +10198,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_diskBytesWritten_Value",
+              "expr": "metrics_diskBytesWritten_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10290,7 +10290,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_hdfsFileCount_Value",
+              "expr": "metrics_hdfsFileCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10383,7 +10383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_hdfsBytesWritten_Value",
+              "expr": "metrics_hdfsBytesWritten_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10403,6 +10403,31 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(metrics_JVMCPUTime_Value, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "instance",
+        "mapping": "",
+        "mappingOnLegend": true,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(metrics_JVMCPUTime_Value, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
       {
         "current": {
           "selected": false,

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -155,7 +155,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_RegisteredShuffleCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_RegisteredShuffleCount_Value",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -249,7 +249,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_WorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_WorkerCount_Value",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -344,7 +344,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\",instance=~\"${instance}\"}",
+              "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -439,7 +439,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\",instance=~\"${instance}\"}",
+              "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -533,7 +533,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_RunningApplicationCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_RunningApplicationCount_Value",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -643,7 +643,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_IsActiveMaster_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_IsActiveMaster_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -740,7 +740,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PartitionSize_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_PartitionSize_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -835,7 +835,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ShutdownWorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ShutdownWorkerCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -931,7 +931,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Master\",instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Master\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1028,7 +1028,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveShuffleSize_Value{role=\"Master\",instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveShuffleSize_Value{role=\"Master\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1123,7 +1123,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OfferSlotsTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_OfferSlotsTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1216,7 +1216,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OfferSlotsTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_OfferSlotsTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1310,7 +1310,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ExcludedWorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ExcludedWorkerCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1405,7 +1405,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableWorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_AvailableWorkerCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1499,7 +1499,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_LostWorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_LostWorkerCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1606,7 +1606,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "increase(metrics_SlotsAllocated_Count[1h]){instance=~\"${instance}\"}",
+              "expr": "increase(metrics_SlotsAllocated_Count[1h])",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1699,7 +1699,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReserveSlotsTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_ReserveSlotsTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -1793,7 +1793,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReserveSlotsTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_ReserveSlotsTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1886,7 +1886,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushData_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_PausePushData_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -1979,7 +1979,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataAndReplicate_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_PausePushDataAndReplicate_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2073,7 +2073,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataTime_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_PausePushDataTime_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2167,7 +2167,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PausePushDataAndReplicateTime_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_PausePushDataAndReplicateTime_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2263,7 +2263,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveShuffleSize_Value{role=\"Worker\",instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveShuffleSize_Value{role=\"Worker\"}",
               "instant": false,
               "legendFormat": "${baseLegend}",
               "range": true,
@@ -2359,7 +2359,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Worker\",instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveShuffleFileCount_Value{role=\"Worker\"}",
               "instant": false,
               "legendFormat": "${baseLegend}",
               "range": true,
@@ -2453,7 +2453,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ActiveConnectionCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveConnectionCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2546,7 +2546,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ActiveSlotsCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveSlotsCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -2641,7 +2641,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "metrics_FlushWorkingQueueSize_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_FlushWorkingQueueSize_Value",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -2750,7 +2750,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PrimaryPushDataTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryPushDataTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -2840,7 +2840,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_PrimaryPushDataTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryPushDataTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -2930,7 +2930,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReplicaPushDataTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaPushDataTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -3020,7 +3020,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_ReplicaPushDataTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaPushDataTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -3110,7 +3110,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataSuccessCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_WriteDataSuccessCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3201,7 +3201,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_WriteDataFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3292,7 +3292,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicateDataFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3383,7 +3383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataWriteFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicateDataWriteFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3474,7 +3474,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3565,7 +3565,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataConnectionExceptionCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicateDataConnectionExceptionCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3656,7 +3656,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataTimeoutCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicateDataTimeoutCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3747,7 +3747,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicateDataFailNonCriticalCauseCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicateDataFailNonCriticalCauseCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3838,7 +3838,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WriteDataHardSplitCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_WriteDataHardSplitCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -3943,7 +3943,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OpenStreamTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_OpenStreamTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4033,7 +4033,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_OpenStreamTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_OpenStreamTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4123,7 +4123,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FetchChunkTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_FetchChunkTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4213,7 +4213,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FetchChunkTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_FetchChunkTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4303,7 +4303,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_OpenStreamSuccessCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_OpenStreamSuccessCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4394,7 +4394,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_OpenStreamFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_OpenStreamFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4485,7 +4485,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_FetchChunkSuccessCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_FetchChunkSuccessCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4576,7 +4576,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_FetchChunkFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_FetchChunkFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4667,7 +4667,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ActiveChunkStreamCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveChunkStreamCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -4772,7 +4772,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_TakeBufferTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_TakeBufferTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4862,7 +4862,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_TakeBufferTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_TakeBufferTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -4952,7 +4952,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FlushDataTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_FlushDataTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5042,7 +5042,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_FlushDataTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_FlushDataTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5132,7 +5132,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_CommitFilesTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_CommitFilesTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5222,7 +5222,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_CommitFilesTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_CommitFilesTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -5330,7 +5330,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_NettyMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_NettyMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5425,7 +5425,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_DirectMemoryUsageRatio_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_DirectMemoryUsageRatio_Value",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5521,7 +5521,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_MemoryFileStorageSize_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_MemoryFileStorageSize_Value",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5616,7 +5616,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_MemoryStorageFileCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_MemoryStorageFileCount_Value",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5708,7 +5708,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_DiskBuffer_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_DiskBuffer_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5799,7 +5799,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_EvictedFileCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_EvictedFileCount_Value",
               "legendFormat": "${baseLegend}",
               "instant": false,
               "range": true,
@@ -5892,7 +5892,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_push_usedHeapMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_push_usedHeapMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -5984,7 +5984,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_push_usedDirectMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_push_usedDirectMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6076,7 +6076,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_fetch_usedHeapMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_fetch_usedHeapMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6168,7 +6168,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_fetch_usedDirectMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_fetch_usedDirectMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6260,7 +6260,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_replicate_usedHeapMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_replicate_usedHeapMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6352,7 +6352,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_replicate_usedDirectMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_replicate_usedDirectMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6443,7 +6443,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ReadBufferAllocatedCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ReadBufferAllocatedCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6535,7 +6535,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_BufferStreamReadBuffer_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_BufferStreamReadBuffer_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6626,7 +6626,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ReadBufferDispatcherRequestsLength_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ReadBufferDispatcherRequestsLength_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -6731,7 +6731,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_SortTime_Mean",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -6821,7 +6821,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_SortTime_Max",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
@@ -6910,7 +6910,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortingFiles_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_SortingFiles_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7000,7 +7000,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortedFiles_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_SortedFiles_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7091,7 +7091,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SortMemory_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_SortMemory_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7182,7 +7182,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_SortedFileSize_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_SortedFileSize_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7289,7 +7289,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PotentialConsumeSpeed_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_PotentialConsumeSpeed_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7382,7 +7382,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_WorkerConsumeSpeed_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_WorkerConsumeSpeed_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7475,7 +7475,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_UserProduceSpeed_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_UserProduceSpeed_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7581,7 +7581,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryPushDataHandshakeTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryPushDataHandshakeTime_Mean",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7673,7 +7673,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryPushDataHandshakeTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryPushDataHandshakeTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7765,7 +7765,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaPushDataHandshakeTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaPushDataHandshakeTime_Mean",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7857,7 +7857,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaPushDataHandshakeTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaPushDataHandshakeTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -7949,7 +7949,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionStartTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryRegionStartTime_Mean",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8041,7 +8041,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionStartTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryRegionStartTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8133,7 +8133,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionStartTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaRegionStartTime_Mean",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8225,7 +8225,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionStartTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaRegionStartTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8317,7 +8317,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionFinishTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryRegionFinishTime_Mean",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8409,7 +8409,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PrimaryRegionFinishTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_PrimaryRegionFinishTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8501,7 +8501,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionFinishTime_Mean{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaRegionFinishTime_Mean",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8593,7 +8593,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_ReplicaRegionFinishTime_Max{instance=~\"${instance}\"}",
+              "expr": "metrics_ReplicaRegionFinishTime_Max",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8684,7 +8684,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_PushDataHandshakeFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_PushDataHandshakeFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8775,7 +8775,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_RegionStartFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_RegionStartFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -8866,7 +8866,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_RegionStartFailCount_Count{instance=~\"${instance}\"}",
+              "expr": "metrics_RegionStartFailCount_Count",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9430,7 +9430,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveCreditStreamCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveCreditStreamCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9521,7 +9521,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "metrics_ActiveMapPartitionCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_ActiveMapPartitionCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9627,7 +9627,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_JVMCPUTime_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_JVMCPUTime_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9720,7 +9720,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_LastMinuteSystemLoad_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_LastMinuteSystemLoad_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9813,7 +9813,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_DeviceOSFreeBytes_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_DeviceOSFreeBytes_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9906,7 +9906,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_DeviceCelebornFreeBytes_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_DeviceCelebornFreeBytes_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -9999,7 +9999,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableProcessors_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_AvailableProcessors_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10105,7 +10105,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_diskFileCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_diskFileCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10198,7 +10198,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_diskBytesWritten_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_diskBytesWritten_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10290,7 +10290,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_hdfsFileCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_hdfsFileCount_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10383,7 +10383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_hdfsBytesWritten_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_hdfsBytesWritten_Value",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
@@ -10403,31 +10403,6 @@
   "tags": [],
   "templating": {
     "list": [
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(metrics_JVMCPUTime_Value, instance)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "instance",
-        "mapping": "",
-        "mappingOnLegend": true,
-        "multi": true,
-        "name": "instance",
-        "options": [],
-        "query": {
-          "query": "label_values(metrics_JVMCPUTime_Value, instance)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
       {
         "current": {
           "selected": false,

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -345,7 +345,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_DeviceCelebornTotalBytes_Value{role=\"Master\", instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend} device={{device}}",
+              "legendFormat": "${baseLegend}",
               "refId": "A"
             }
           ],
@@ -440,7 +440,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_DeviceCelebornFreeBytes_Value{role=\"Master\", instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend} device={{device}}",
+              "legendFormat": "${baseLegend}",
               "refId": "A"
             }
           ],
@@ -2645,7 +2645,7 @@
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "${baseLegend} mountpoint={{mountpoint}}",
+              "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -9814,7 +9814,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_DeviceOSFreeBytes_Value{instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend} device={{device}}",
+              "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
             }
@@ -9907,7 +9907,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_DeviceCelebornFreeBytes_Value{instance=~\"${instance}\"}",
-              "legendFormat": "${baseLegend} device={{device}}",
+              "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
             }
@@ -10430,10 +10430,11 @@
       },
       {
         "current": {
-          "selected": true,
-          "text": "{{instance}}",
-          "value": "{{instance}}"
+          "selected": false,
+          "text": "__auto",
+          "value": "__auto"
         },
+        "description": "The base legend format to apply for all metrics",
         "hide": 0,
         "includeAll": false,
         "label": "baseLegend",
@@ -10442,11 +10443,11 @@
         "options": [
           {
             "selected": true,
-            "text": "{{instance}}",
-            "value": "{{instance}}"
+            "text": "__auto",
+            "value": "__auto"
           }
         ],
-        "query": "{{instance}}",
+        "query": "__auto",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -65,9 +65,9 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   val roleLabel: (String, String) = "role" -> role
   val instanceLabel: Map[String, String] = role match {
-    case Source.ROLE_MASTER =>
+    case Role.MASTER =>
       Map("instance" -> s"${Utils.localHostName(conf)}:${conf.masterHttpPort}")
-    case Source.ROLE_WORKER =>
+    case Role.WORKER =>
       Map("instance" -> s"${Utils.localHostName(conf)}:${conf.workerHttpPort}")
     case _ => Map.empty
   }

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -64,7 +64,15 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("worker-metrics-cleaner")
 
   val roleLabel: (String, String) = "role" -> role
-  val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel
+
+  val host: String = Utils.localHostName(conf)
+  val port: Int = role match {
+    case Source.ROLE_MASTER => conf.masterHttpPort
+    case Source.ROLE_WORKER => conf.workerHttpPort
+  }
+  val instanceLabel: (String, String) = "instance" -> s"$host:$port"
+
+  val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel + instanceLabel
   val staticLabelsString: String = MetricLabels.labelString(staticLabels)
 
   val applicationLabel = "applicationId"

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -65,8 +65,10 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   val roleLabel: (String, String) = "role" -> role
   val instanceLabel: Map[String, String] = role match {
-    case Source.ROLE_MASTER => Map("instance" -> s"${Utils.localHostName(conf)}:${conf.masterHttpPort}")
-    case Source.ROLE_WORKER => Map("instance" -> s"${Utils.localHostName(conf)}:${conf.workerHttpPort}")
+    case Source.ROLE_MASTER =>
+      Map("instance" -> s"${Utils.localHostName(conf)}:${conf.masterHttpPort}")
+    case Source.ROLE_WORKER =>
+      Map("instance" -> s"${Utils.localHostName(conf)}:${conf.workerHttpPort}")
     case _ => Map.empty
   }
   val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel ++ instanceLabel

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -64,15 +64,12 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("worker-metrics-cleaner")
 
   val roleLabel: (String, String) = "role" -> role
-
-  val host: String = Utils.localHostName(conf)
-  val port: Int = role match {
-    case Source.ROLE_MASTER => conf.masterHttpPort
-    case Source.ROLE_WORKER => conf.workerHttpPort
+  val instanceLabel: Map[String, String] = role match {
+    case Source.ROLE_MASTER => Map("instance" -> s"${Utils.localHostName(conf)}:${conf.masterHttpPort}")
+    case Source.ROLE_WORKER => Map("instance" -> s"${Utils.localHostName(conf)}:${conf.workerHttpPort}")
+    case _ => Map.empty
   }
-  val instanceLabel: (String, String) = "instance" -> s"$host:$port"
-
-  val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel + instanceLabel
+  val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel ++ instanceLabel
   val staticLabelsString: String = MetricLabels.labelString(staticLabels)
 
   val applicationLabel = "applicationId"

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/Role.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/Role.scala
@@ -17,20 +17,7 @@
 
 package org.apache.celeborn.common.metrics.source
 
-import com.codahale.metrics.MetricRegistry
-
-trait Source {
-  def sourceName: String
-  def metricRegistry: MetricRegistry
-  def sample[T](metricsName: String, key: String)(f: => T): T
-  def startTimer(metricsName: String, key: String): Unit
-  def stopTimer(metricsName: String, key: String): Unit
-  def incCounter(metricsName: String, incV: Long): Unit
-  def getMetrics: String
-  def destroy(): Unit
-}
-
-object Source {
+object Role {
   val MASTER = "master"
   val WORKER = "worker"
 }

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/Source.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/Source.scala
@@ -29,8 +29,3 @@ trait Source {
   def getMetrics: String
   def destroy(): Unit
 }
-
-object Source {
-  val MASTER = "master"
-  val WORKER = "worker"
-}

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/Source.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/Source.scala
@@ -29,3 +29,8 @@ trait Source {
   def getMetrics: String
   def destroy(): Unit
 }
+
+object Source {
+  val ROLE_MASTER = "master"
+  val ROLE_WORKER = "worker"
+}

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -24,8 +24,8 @@ class CelebornSourceSuite extends CelebornFunSuite {
 
   test("test getMetrics with customized label") {
     val conf = new CelebornConf()
-    createAbstractSourceAndCheck(conf, "", Source.ROLE_MASTER)
-    createAbstractSourceAndCheck(conf, "", Source.ROLE_WORKER)
+    createAbstractSourceAndCheck(conf, "", Role.MASTER)
+    createAbstractSourceAndCheck(conf, "", Role.WORKER)
   }
 
   def createAbstractSourceAndCheck(

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -28,7 +28,10 @@ class CelebornSourceSuite extends CelebornFunSuite {
     createAbstractSourceAndCheck(conf, "", Source.ROLE_WORKER)
   }
 
-  def createAbstractSourceAndCheck(conf: CelebornConf, extraLabels: String, role: String = "mock"): Unit = {
+  def createAbstractSourceAndCheck(
+      conf: CelebornConf,
+      extraLabels: String,
+      role: String = "mock"): Unit = {
     val mockSource = new AbstractSource(conf, role) {
       override def sourceName: String = "mockSource"
     }
@@ -56,13 +59,17 @@ class CelebornSourceSuite extends CelebornFunSuite {
     if (extraLabels.nonEmpty) {
       extraLabelsStr = extraLabels + ","
     }
-    val instanceLabelStr = mockSource.instanceLabel.map(kv => s"""${kv._1}="${kv._2}",""").mkString(",")
+    val instanceLabelStr =
+      mockSource.instanceLabel.map(kv => s"""${kv._1}="${kv._2}",""").mkString(",")
     val exp1 = s"""metrics_Gauge1_Value{${extraLabelsStr}${instanceLabelStr}role="$role"} 1000"""
-    val exp2 = s"""metrics_Gauge2_Value{${extraLabelsStr}${instanceLabelStr}role="$role",user="user1"} 2000"""
+    val exp2 =
+      s"""metrics_Gauge2_Value{${extraLabelsStr}${instanceLabelStr}role="$role",user="user1"} 2000"""
     val exp3 = s"""metrics_Counter1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 3000"""
-    val exp4 = s"""metrics_Counter2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user2"} 4000"""
+    val exp4 =
+      s"""metrics_Counter2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user2"} 4000"""
     val exp5 = s"""metrics_Timer1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 1"""
-    val exp6 = s"""metrics_Timer2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user3"} 1"""
+    val exp6 =
+      s"""metrics_Timer2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user3"} 1"""
 
     assert(res.contains(exp1))
     assert(res.contains(exp2))

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -24,11 +24,12 @@ class CelebornSourceSuite extends CelebornFunSuite {
 
   test("test getMetrics with customized label") {
     val conf = new CelebornConf()
-    createAbstractSourceAndCheck(conf, "")
+    createAbstractSourceAndCheck(conf, "", Source.ROLE_MASTER)
+    createAbstractSourceAndCheck(conf, "", Source.ROLE_WORKER)
   }
 
-  def createAbstractSourceAndCheck(conf: CelebornConf, extraLabels: String): Unit = {
-    val mockSource = new AbstractSource(conf, "mock") {
+  def createAbstractSourceAndCheck(conf: CelebornConf, extraLabels: String, role: String = "mock"): Unit = {
+    val mockSource = new AbstractSource(conf, role) {
       override def sourceName: String = "mockSource"
     }
     val user1 = Map("user" -> "user1")
@@ -55,12 +56,13 @@ class CelebornSourceSuite extends CelebornFunSuite {
     if (extraLabels.nonEmpty) {
       extraLabelsStr = extraLabels + ","
     }
-    val exp1 = s"""metrics_Gauge1_Value{${extraLabelsStr}role="mock"} 1000"""
-    val exp2 = s"""metrics_Gauge2_Value{${extraLabelsStr}role="mock",user="user1"} 2000"""
-    val exp3 = s"""metrics_Counter1_Count{${extraLabelsStr}role="mock"} 3000"""
-    val exp4 = s"""metrics_Counter2_Count{${extraLabelsStr}role="mock",user="user2"} 4000"""
-    val exp5 = s"""metrics_Timer1_Count{${extraLabelsStr}role="mock"} 1"""
-    val exp6 = s"""metrics_Timer2_Count{${extraLabelsStr}role="mock",user="user3"} 1"""
+    val instanceLabelStr = mockSource.instanceLabel.map(kv => s"""${kv._1}="${kv._2}",""").mkString(",")
+    val exp1 = s"""metrics_Gauge1_Value{${extraLabelsStr}${instanceLabelStr}role="$role"} 1000"""
+    val exp2 = s"""metrics_Gauge2_Value{${extraLabelsStr}${instanceLabelStr}role="$role",user="user1"} 2000"""
+    val exp3 = s"""metrics_Counter1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 3000"""
+    val exp4 = s"""metrics_Counter2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user2"} 4000"""
+    val exp5 = s"""metrics_Timer1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 1"""
+    val exp6 = s"""metrics_Timer2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user3"} 1"""
 
     assert(res.contains(exp1))
     assert(res.contains(exp2))

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -39,7 +39,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerStatus}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, SystemMiscSource, ThreadPoolSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, Source, SystemMiscSource, ThreadPoolSource}
 import org.apache.celeborn.common.network.CelebornRackResolver
 import org.apache.celeborn.common.network.protocol.TransportMessage
 import org.apache.celeborn.common.protocol._
@@ -67,15 +67,15 @@ private[celeborn] class Master(
     MetricsSystem.createMetricsSystem(serviceName, conf)
   // init and register master metrics
   private val resourceConsumptionSource =
-    new ResourceConsumptionSource(conf, MetricsSystem.ROLE_MASTER)
-  private val threadPoolSource = ThreadPoolSource(conf, MetricsSystem.ROLE_MASTER)
+    new ResourceConsumptionSource(conf, Source.ROLE_MASTER)
+  private val threadPoolSource = ThreadPoolSource(conf, Source.ROLE_MASTER)
   private val masterSource = new MasterSource(conf)
   metricsSystem.registerSource(resourceConsumptionSource)
   metricsSystem.registerSource(masterSource)
   metricsSystem.registerSource(threadPoolSource)
-  metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_MASTER))
-  metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_MASTER))
-  metricsSystem.registerSource(new SystemMiscSource(conf, MetricsSystem.ROLE_MASTER))
+  metricsSystem.registerSource(new JVMSource(conf, Source.ROLE_MASTER))
+  metricsSystem.registerSource(new JVMCPUSource(conf, Source.ROLE_MASTER))
+  metricsSystem.registerSource(new SystemMiscSource(conf, Source.ROLE_MASTER))
 
   private val bindPreferIP: Boolean = conf.bindPreferIP
   private val authEnabled = conf.authEnabled

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -39,7 +39,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerStatus}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, Source, SystemMiscSource, ThreadPoolSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, Role, SystemMiscSource, ThreadPoolSource}
 import org.apache.celeborn.common.network.CelebornRackResolver
 import org.apache.celeborn.common.network.protocol.TransportMessage
 import org.apache.celeborn.common.protocol._
@@ -67,15 +67,15 @@ private[celeborn] class Master(
     MetricsSystem.createMetricsSystem(serviceName, conf)
   // init and register master metrics
   private val resourceConsumptionSource =
-    new ResourceConsumptionSource(conf, Source.ROLE_MASTER)
-  private val threadPoolSource = ThreadPoolSource(conf, Source.ROLE_MASTER)
+    new ResourceConsumptionSource(conf, Role.MASTER)
+  private val threadPoolSource = ThreadPoolSource(conf, Role.MASTER)
   private val masterSource = new MasterSource(conf)
   metricsSystem.registerSource(resourceConsumptionSource)
   metricsSystem.registerSource(masterSource)
   metricsSystem.registerSource(threadPoolSource)
-  metricsSystem.registerSource(new JVMSource(conf, Source.ROLE_MASTER))
-  metricsSystem.registerSource(new JVMCPUSource(conf, Source.ROLE_MASTER))
-  metricsSystem.registerSource(new SystemMiscSource(conf, Source.ROLE_MASTER))
+  metricsSystem.registerSource(new JVMSource(conf, Role.MASTER))
+  metricsSystem.registerSource(new JVMCPUSource(conf, Role.MASTER))
+  metricsSystem.registerSource(new SystemMiscSource(conf, Role.MASTER))
 
   private val bindPreferIP: Boolean = conf.bindPreferIP
   private val authEnabled = conf.authEnabled

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -18,10 +18,9 @@
 package org.apache.celeborn.service.deploy.master
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.AbstractSource
+import org.apache.celeborn.common.metrics.source.{AbstractSource, Source}
 
-class MasterSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_MASTER) {
+class MasterSource(conf: CelebornConf) extends AbstractSource(conf, Source.ROLE_MASTER) {
   override val sourceName = "master"
 
   import MasterSource._

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -18,9 +18,9 @@
 package org.apache.celeborn.service.deploy.master
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.metrics.source.{AbstractSource, Source}
+import org.apache.celeborn.common.metrics.source.{AbstractSource, Role}
 
-class MasterSource(conf: CelebornConf) extends AbstractSource(conf, Source.ROLE_MASTER) {
+class MasterSource(conf: CelebornConf) extends AbstractSource(conf, Role.MASTER) {
   override val sourceName = "master"
 
   import MasterSource._

--- a/service/src/main/scala/org/apache/celeborn/common/metrics/MetricsSystem.scala
+++ b/service/src/main/scala/org/apache/celeborn/common/metrics/MetricsSystem.scala
@@ -177,9 +177,6 @@ object MetricsSystem {
   val SINK_REGEX: Regex = "^sink\\.(.+)\\.(.+)".r
   val SOURCE_REGEX: Regex = "^org.apache.celeborn.common.metrics.source\\.(.+)\\.(.+)".r
 
-  val ROLE_WORKER = "Worker"
-  val ROLE_MASTER = "Master"
-
   private[this] val MINIMAL_POLL_UNIT = TimeUnit.SECONDS
   private[this] val MINIMAL_POLL_PERIOD = 1
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, Source, SystemMiscSource, ThreadPoolSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, Role, SystemMiscSource, ThreadPoolSource}
 import org.apache.celeborn.common.network.{CelebornRackResolver, TransportContext}
 import org.apache.celeborn.common.network.sasl.SaslServerBootstrap
 import org.apache.celeborn.common.network.server.TransportServerBootstrap
@@ -73,14 +73,14 @@ private[celeborn] class Worker(
     MetricsSystem.createMetricsSystem(serviceName, conf)
   val workerSource = new WorkerSource(conf)
   private val resourceConsumptionSource =
-    new ResourceConsumptionSource(conf, Source.ROLE_WORKER)
-  private val threadPoolSource = ThreadPoolSource(conf, Source.ROLE_WORKER)
+    new ResourceConsumptionSource(conf, Role.WORKER)
+  private val threadPoolSource = ThreadPoolSource(conf, Role.WORKER)
   metricsSystem.registerSource(workerSource)
   metricsSystem.registerSource(threadPoolSource)
   metricsSystem.registerSource(resourceConsumptionSource)
-  metricsSystem.registerSource(new JVMSource(conf, Source.ROLE_WORKER))
-  metricsSystem.registerSource(new JVMCPUSource(conf, Source.ROLE_WORKER))
-  metricsSystem.registerSource(new SystemMiscSource(conf, Source.ROLE_WORKER))
+  metricsSystem.registerSource(new JVMSource(conf, Role.WORKER))
+  metricsSystem.registerSource(new JVMCPUSource(conf, Role.WORKER))
+  metricsSystem.registerSource(new SystemMiscSource(conf, Role.WORKER))
 
   private val topResourceConsumptionCount = conf.metricsWorkerAppTopResourceConsumptionCount
   private val topApplicationUserIdentifiers =

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, SystemMiscSource, ThreadPoolSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, Source, SystemMiscSource, ThreadPoolSource}
 import org.apache.celeborn.common.network.{CelebornRackResolver, TransportContext}
 import org.apache.celeborn.common.network.sasl.SaslServerBootstrap
 import org.apache.celeborn.common.network.server.TransportServerBootstrap
@@ -73,14 +73,14 @@ private[celeborn] class Worker(
     MetricsSystem.createMetricsSystem(serviceName, conf)
   val workerSource = new WorkerSource(conf)
   private val resourceConsumptionSource =
-    new ResourceConsumptionSource(conf, MetricsSystem.ROLE_WORKER)
-  private val threadPoolSource = ThreadPoolSource(conf, MetricsSystem.ROLE_WORKER)
+    new ResourceConsumptionSource(conf, Source.ROLE_WORKER)
+  private val threadPoolSource = ThreadPoolSource(conf, Source.ROLE_WORKER)
   metricsSystem.registerSource(workerSource)
   metricsSystem.registerSource(threadPoolSource)
   metricsSystem.registerSource(resourceConsumptionSource)
-  metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_WORKER))
-  metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_WORKER))
-  metricsSystem.registerSource(new SystemMiscSource(conf, MetricsSystem.ROLE_WORKER))
+  metricsSystem.registerSource(new JVMSource(conf, Source.ROLE_WORKER))
+  metricsSystem.registerSource(new JVMCPUSource(conf, Source.ROLE_WORKER))
+  metricsSystem.registerSource(new SystemMiscSource(conf, Source.ROLE_WORKER))
 
   private val topResourceConsumptionCount = conf.metricsWorkerAppTopResourceConsumptionCount
   private val topApplicationUserIdentifiers =

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -25,12 +25,11 @@ import scala.collection.JavaConverters._
 import com.google.common.collect.Sets
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.AbstractSource
+import org.apache.celeborn.common.metrics.source.{AbstractSource, Source}
 import org.apache.celeborn.common.network.client.TransportClient
 import org.apache.celeborn.common.util.{JavaUtils, Utils}
 
-class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_WORKER) {
+class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Source.ROLE_WORKER) {
   override val sourceName = "worker"
 
   val appActiveConnections: ConcurrentHashMap[String, util.Set[String]] =

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -25,11 +25,11 @@ import scala.collection.JavaConverters._
 import com.google.common.collect.Sets
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.metrics.source.{AbstractSource, Source}
+import org.apache.celeborn.common.metrics.source.{AbstractSource, Role}
 import org.apache.celeborn.common.network.client.TransportClient
 import org.apache.celeborn.common.util.{JavaUtils, Utils}
 
-class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Source.ROLE_WORKER) {
+class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER) {
   override val sourceName = "worker"
 
   val appActiveConnections: ConcurrentHashMap[String, util.Set[String]] =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

1. add `instanceLabel` in metrics source, prefer `FQDN:port` than `ip:port` even with `celeborn.network.bind.preferIpAddress=false` before
2. add variable  `instance` with  `label_values(metrics_JVMCPUTime_Value, instance)` same as `celeborn-jvm-dashboard.json`
3. add filter `instance=~"${instance}"` for every metrics
4. add missing `legendFormat` for memory file storage metrics expressions 

### Why are the changes needed?

There should be too many celeborn instances in production use case, it is better to add filter with instance.

### Does this PR introduce _any_ user-facing change?
Yes. introduce new variable.

But the instance default value is `ALL`, same behavior as before.


### How was this patch tested?

Config: `celeborn.network.bind.preferIpAddress=false`
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/c3161069-790a-4cb2-8654-6d52cf8e5fb0">
<img width="944" alt="image" src="https://github.com/user-attachments/assets/293b8bd4-252a-459c-aa86-5f4aa75eb594">

<img width="939" alt="image" src="https://github.com/user-attachments/assets/1e1b28af-dd71-4c5b-8285-57473a6c9650">

For JVM metrics, before it was ip:port, and now it is FQDN:port.
<img width="947" alt="image" src="https://github.com/user-attachments/assets/fe00762f-605d-4b5e-b0a4-c586bdc0ec1a">

