### PR TITLE
[CELEBORN-1629] Support to apply ratis election operation with RESTful api

### DIFF
--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -22,6 +22,8 @@ license: |
 Celeborn uses Ratis to implement the HA function of the master, Celeborn directly introduces ratis-shell package into the project
 then it's convenient for Celeborn Admin to operate the master ratis service.
 
+Since 0.6.0, the ratis [RESTful API](webapi.md) is supported, which is more convenient to operate the ratis service, see details in the swagger: `http://<CELEBORN_HOST>:<CELEBORN_PORT>/swagger/#/Ratis`.
+
 > **Note**:
 > Ratis-shell is currently only **experimental**.
 > The compatibility story is not considered for the time being.

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.net.ssl.KeyManager;
@@ -76,11 +75,7 @@ public class HARaftServer {
 
   public static final RaftGroupId RAFT_GROUP_ID = RaftGroupId.valueOf(CELEBORN_UUID);
 
-  private static final AtomicLong CALL_ID_COUNTER = new AtomicLong();
-
-  static long nextCallId() {
-    return CALL_ID_COUNTER.getAndIncrement() & Long.MAX_VALUE;
-  }
+  public static final long REQUEST_TIMEOUT_MS = 60_000;
 
   private final MasterNode localNode;
   private final InetSocketAddress ratisAddr;
@@ -596,7 +591,7 @@ public class HARaftServer {
 
   public GroupInfoReply getGroupInfo() throws IOException {
     GroupInfoRequest groupInfoRequest =
-        new GroupInfoRequest(clientId, raftPeerId, RAFT_GROUP_ID, nextCallId());
+        new GroupInfoRequest(clientId, raftPeerId, RAFT_GROUP_ID, CallId.getAndIncrement());
     return server.getGroupInfo(groupInfoRequest);
   }
 
@@ -626,7 +621,7 @@ public class HARaftServer {
               raftGroup.getGroupId(),
               CallId.getAndIncrement(),
               null,
-              60_000);
+              REQUEST_TIMEOUT_MS);
       RaftClientReply reply = server.transferLeadership(request);
       if (reply.isSuccess()) {
         LOG.info("Successfully step down leader {}.", server.getId());
@@ -651,9 +646,20 @@ public class HARaftServer {
     return appTimeoutDeadline;
   }
 
-  @VisibleForTesting
+  public ClientId getClientId() {
+    return clientId;
+  }
+
   public RaftServer getServer() {
     return server;
+  }
+
+  public RaftGroupId getGroupId() {
+    return raftGroup.getGroupId();
+  }
+
+  public String getLocalAddress() {
+    return localNode.ratisEndpoint();
   }
 
   public static class LeaderPeerEndpoints {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/MasterHttpResourceUtils.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/MasterHttpResourceUtils.scala
@@ -31,4 +31,11 @@ object MasterHttpResourceUtils {
     }
     f
   }
+
+  def ensureMasterHAEnabled[T](master: Master)(f: => T): T = {
+    if (!master.conf.haEnabled) {
+      throw new BadRequestException("Master HA is not enabled.")
+    }
+    f
+  }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResource.scala
@@ -35,6 +35,6 @@ class ApiV1MasterResource extends ApiRequestContext {
   @Path("workers")
   def workers: Class[WorkerResource] = classOf[WorkerResource]
 
-  @Path("ratis/election")
-  def ratisElection: Class[RatisElectionResource] = classOf[RatisElectionResource]
+  @Path("ratis")
+  def ratisElection: Class[RatisResource] = classOf[RatisResource]
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResource.scala
@@ -34,4 +34,7 @@ class ApiV1MasterResource extends ApiRequestContext {
 
   @Path("workers")
   def workers: Class[WorkerResource] = classOf[WorkerResource]
+
+  @Path("ratis/election")
+  def ratisElection: Class[RatisElectionResource] = classOf[RatisElectionResource]
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisElectionResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisElectionResource.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.http.api.v1
+
+import javax.ws.rs.{Consumes, Path, POST, Produces}
+import javax.ws.rs.core.MediaType
+
+import scala.collection.JavaConverters._
+
+import io.swagger.v3.oas.annotations.media.{Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.apache.ratis.protocol.{LeaderElectionManagementRequest, RaftPeerId, TransferLeadershipRequest}
+import org.apache.ratis.rpc.CallId
+
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.rest.v1.model.{HandleResponse, RatisElectionTransferRequest}
+import org.apache.celeborn.server.common.http.api.ApiRequestContext
+import org.apache.celeborn.service.deploy.master.Master
+import org.apache.celeborn.service.deploy.master.clustermeta.ha.{HAMasterMetaManager, HARaftServer}
+import org.apache.celeborn.service.deploy.master.http.api.MasterHttpResourceUtils.{ensureMasterHAEnabled, ensureMasterIsLeader}
+
+@Tag(name = "Ratis")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class RatisElectionResource extends ApiRequestContext with Logging {
+  private def master = httpService.asInstanceOf[Master]
+  private def ratisServer = master.statusSystem.asInstanceOf[HAMasterMetaManager].getRatisServer
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))),
+    description = "Transfer the group leader to the specified server.")
+  @POST
+  @Path("/transfer")
+  def electionTransfer(request: RatisElectionTransferRequest): HandleResponse =
+    ensureMasterIsLeader(master) {
+      transferLeadership(request.getPeerAddress)
+    }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))),
+    description = "Make the group leader step down its leadership.")
+  @POST
+  @Path("/step_down")
+  def electionStepDown(): HandleResponse = ensureMasterIsLeader(master) {
+    transferLeadership(null)
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))),
+    description = "Pause leader election at the current server." +
+      " Then, the current server would not start a leader election.")
+  @POST
+  @Path("/pause")
+  def electionPause(): HandleResponse = ensureMasterHAEnabled(master) {
+    applyElectionOp(new LeaderElectionManagementRequest.Pause)
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))),
+    description = "Resume leader election at the current server.")
+  @POST
+  @Path("/resume")
+  def electionResume(): HandleResponse = ensureMasterHAEnabled(master) {
+    applyElectionOp(new LeaderElectionManagementRequest.Resume)
+  }
+
+  private def transferLeadership(peerAddress: String): HandleResponse = {
+    val newLeaderId = Option(peerAddress).map(getRaftPeerId).orNull
+    val op =
+      if (newLeaderId == null) s"step down leader ${ratisServer.getLocalAddress}"
+      else s"transfer leadership from ${ratisServer.getLocalAddress} to $peerAddress"
+    val request = new TransferLeadershipRequest(
+      ratisServer.getClientId,
+      ratisServer.getServer.getId,
+      ratisServer.getGroupId,
+      CallId.getAndIncrement(),
+      newLeaderId,
+      HARaftServer.REQUEST_TIMEOUT_MS)
+    val reply = ratisServer.getServer.transferLeadership(request)
+    if (reply.isSuccess) {
+      new HandleResponse().success(true).message(s"Successfully $op.")
+    } else {
+      new HandleResponse().success(false).message(s"Failed to $op: $reply")
+    }
+  }
+
+  private def applyElectionOp(op: LeaderElectionManagementRequest.Op): HandleResponse = {
+    val request = new LeaderElectionManagementRequest(
+      ratisServer.getClientId,
+      ratisServer.getServer.getId,
+      ratisServer.getGroupId,
+      CallId.getAndIncrement(),
+      op)
+    val reply = ratisServer.getServer.leaderElectionManagement(request)
+    if (reply.isSuccess) {
+      new HandleResponse().success(true).message(
+        s"Successfully applied election $op ${ratisServer.getLocalAddress}.")
+    } else {
+      new HandleResponse().success(false).message(
+        s"Failed to apply election $op ${ratisServer.getLocalAddress}. $reply")
+    }
+  }
+
+  private def getRaftPeerId(peerAddress: String): RaftPeerId = {
+    val groupInfo =
+      master.statusSystem.asInstanceOf[HAMasterMetaManager].getRatisServer.getGroupInfo
+    groupInfo.getCommitInfos.asScala.filter(peer => peer.getServer.getAddress == peerAddress)
+      .map(peer => RaftPeerId.valueOf(peer.getServer.getId)).headOption.getOrElse(
+        throw new IllegalArgumentException(s"Peer $peerAddress not found in group: $groupInfo"))
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
@@ -38,7 +38,7 @@ import org.apache.celeborn.service.deploy.master.http.api.MasterHttpResourceUtil
 @Tag(name = "Ratis")
 @Produces(Array(MediaType.APPLICATION_JSON))
 @Consumes(Array(MediaType.APPLICATION_JSON))
-class RatisElectionResource extends ApiRequestContext with Logging {
+class RatisResource extends ApiRequestContext with Logging {
   private def master = httpService.asInstanceOf[Master]
   private def ratisServer = master.statusSystem.asInstanceOf[HAMasterMetaManager].getRatisServer
 
@@ -49,7 +49,7 @@ class RatisElectionResource extends ApiRequestContext with Logging {
       schema = new Schema(implementation = classOf[HandleResponse]))),
     description = "Transfer the group leader to the specified server.")
   @POST
-  @Path("/transfer")
+  @Path("/election/transfer")
   def electionTransfer(request: RatisElectionTransferRequest): HandleResponse =
     ensureMasterIsLeader(master) {
       transferLeadership(request.getPeerAddress)
@@ -62,7 +62,7 @@ class RatisElectionResource extends ApiRequestContext with Logging {
       schema = new Schema(implementation = classOf[HandleResponse]))),
     description = "Make the group leader step down its leadership.")
   @POST
-  @Path("/step_down")
+  @Path("/election/step_down")
   def electionStepDown(): HandleResponse = ensureMasterIsLeader(master) {
     transferLeadership(null)
   }
@@ -75,7 +75,7 @@ class RatisElectionResource extends ApiRequestContext with Logging {
     description = "Pause leader election at the current server." +
       " Then, the current server would not start a leader election.")
   @POST
-  @Path("/pause")
+  @Path("/election/pause")
   def electionPause(): HandleResponse = ensureMasterHAEnabled(master) {
     applyElectionOp(new LeaderElectionManagementRequest.Pause)
   }
@@ -87,7 +87,7 @@ class RatisElectionResource extends ApiRequestContext with Logging {
       schema = new Schema(implementation = classOf[HandleResponse]))),
     description = "Resume leader election at the current server.")
   @POST
-  @Path("/resume")
+  @Path("/election/resume")
   def electionResume(): HandleResponse = ensureMasterHAEnabled(master) {
     applyElectionOp(new LeaderElectionManagementRequest.Resume)
   }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
@@ -187,8 +187,8 @@ public class RatisApi extends BaseApi {
    * @return HandleResponse
    * @throws ApiException if fails to make API call
    */
-  public HandleResponse stepdownRatisLeader() throws ApiException {
-    return this.stepdownRatisLeader(Collections.emptyMap());
+  public HandleResponse stepDownRatisLeader() throws ApiException {
+    return this.stepDownRatisLeader(Collections.emptyMap());
   }
 
 
@@ -199,11 +199,11 @@ public class RatisApi extends BaseApi {
    * @return HandleResponse
    * @throws ApiException if fails to make API call
    */
-  public HandleResponse stepdownRatisLeader(Map<String, String> additionalHeaders) throws ApiException {
+  public HandleResponse stepDownRatisLeader(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/api/v1/ratis/election/stepdown";
+    String localVarPath = "/api/v1/ratis/election/step_down";
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.rest.v1.master;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.apache.celeborn.rest.v1.master.invoker.ApiException;
+import org.apache.celeborn.rest.v1.master.invoker.ApiClient;
+import org.apache.celeborn.rest.v1.master.invoker.BaseApi;
+import org.apache.celeborn.rest.v1.master.invoker.Configuration;
+import org.apache.celeborn.rest.v1.master.invoker.Pair;
+
+import org.apache.celeborn.rest.v1.model.HandleResponse;
+import org.apache.celeborn.rest.v1.model.RatisElectionTransferRequest;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
+public class RatisApi extends BaseApi {
+
+  public RatisApi() {
+    super(Configuration.getDefaultApiClient());
+  }
+
+  public RatisApi(ApiClient apiClient) {
+    super(apiClient);
+  }
+
+  /**
+   * 
+   * Pause leader election at the current server. Then, the current server would not start a leader election.
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse pauseRatisElection() throws ApiException {
+    return this.pauseRatisElection(Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Pause leader election at the current server. Then, the current server would not start a leader election.
+   * @param additionalHeaders additionalHeaders for this call
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse pauseRatisElection(Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/ratis/election/pause";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Resume leader election at the current server.
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse resumeRatisElection() throws ApiException {
+    return this.resumeRatisElection(Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Resume leader election at the current server.
+   * @param additionalHeaders additionalHeaders for this call
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse resumeRatisElection(Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/ratis/election/resume";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Make the group leader step down its leadership.
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse stepdownRatisLeader() throws ApiException {
+    return this.stepdownRatisLeader(Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Make the group leader step down its leadership.
+   * @param additionalHeaders additionalHeaders for this call
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse stepdownRatisLeader(Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/ratis/election/stepdown";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Transfer the group leader to the specified server.
+   * @param ratisElectionTransferRequest  (optional)
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse transferRatisLeader(RatisElectionTransferRequest ratisElectionTransferRequest) throws ApiException {
+    return this.transferRatisLeader(ratisElectionTransferRequest, Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Transfer the group leader to the specified server.
+   * @param ratisElectionTransferRequest  (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse transferRatisLeader(RatisElectionTransferRequest ratisElectionTransferRequest, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = ratisElectionTransferRequest;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/ratis/election/transfer";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  @Override
+  public <T> T invokeAPI(String url, String method, Object request, TypeReference<T> returnType, Map<String, String> additionalHeaders) throws ApiException {
+    String localVarPath = url.replace(apiClient.getBaseURL(), "");
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    return apiClient.invokeAPI(
+      localVarPath,
+        method,
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        request,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        returnType
+    );
+  }
+}

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RatisElectionTransferRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RatisElectionTransferRequest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.celeborn.rest.v1.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * RatisElectionTransferRequest
+ */
+@JsonPropertyOrder({
+  RatisElectionTransferRequest.JSON_PROPERTY_PEER_ADDRESS
+})
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
+public class RatisElectionTransferRequest {
+  public static final String JSON_PROPERTY_PEER_ADDRESS = "peerAddress";
+  private String peerAddress;
+
+  public RatisElectionTransferRequest() {
+  }
+
+  public RatisElectionTransferRequest peerAddress(String peerAddress) {
+    
+    this.peerAddress = peerAddress;
+    return this;
+  }
+
+  /**
+   * The address of the peer to transfer the leader.
+   * @return peerAddress
+   */
+  @javax.annotation.Nonnull
+  @JsonProperty(JSON_PROPERTY_PEER_ADDRESS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPeerAddress() {
+    return peerAddress;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PEER_ADDRESS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPeerAddress(String peerAddress) {
+    this.peerAddress = peerAddress;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RatisElectionTransferRequest ratisElectionTransferRequest = (RatisElectionTransferRequest) o;
+    return Objects.equals(this.peerAddress, ratisElectionTransferRequest.peerAddress);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(peerAddress);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class RatisElectionTransferRequest {\n");
+    sb.append("    peerAddress: ").append(toIndentedString(peerAddress)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -277,11 +277,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
-  /api/v1/ratis/election/stepdown:
+  /api/v1/ratis/election/step_down:
     post:
       tags:
         - Ratis
-      operationId: stepdownRatisLeader
+      operationId: stepDownRatisLeader
       description: Make the group leader step down its leadership.
       responses:
         "200":

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -258,6 +258,67 @@ paths:
               schema:
                 $ref: '#/components/schemas/HostnamesResponse'
 
+  /api/v1/ratis/election/transfer:
+    post:
+      tags:
+        - Ratis
+      operationId: transferRatisLeader
+      description: Transfer the group leader to the specified server.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RatisElectionTransferRequest'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandleResponse'
+
+  /api/v1/ratis/election/stepdown:
+    post:
+      tags:
+        - Ratis
+      operationId: stepdownRatisLeader
+      description: Make the group leader step down its leadership.
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandleResponse'
+
+  /api/v1/ratis/election/pause:
+    post:
+      tags:
+        - Ratis
+      operationId: pauseRatisElection
+      description: Pause leader election at the current server. Then, the current server would not start a leader election.
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandleResponse'
+
+  /api/v1/ratis/election/resume:
+    post:
+      tags:
+        - Ratis
+      operationId: resumeRatisElection
+      description: Resume leader election at the current server.
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandleResponse'
+
 components:
   schemas:
     ConfigData:
@@ -720,6 +781,15 @@ components:
       required:
         - eventType
         - worker
+
+    RatisElectionTransferRequest:
+      type: object
+      properties:
+        peerAddress:
+          type: string
+          description: The address of the peer to transfer the leader.
+      required:
+        - peerAddress
 
     HandleResponse:
       type: object


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title, sub task of [CELEBORN-1628](https://issues.apache.org/jira/browse/CELEBORN-1628)
### Why are the changes needed?

It is more friendly for customer experience and necessary for automation integration.

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/b9270bd5-75ee-41a9-b7aa-1db1270b4edb">

Before restart/recreate the celeborn master pod
- call the  ratis/snapshot/create to create the snapshot(will raise another PR for this)
- if need to failover
    - call the ratis/election/pause to pause the election
    - call the ratis/election/step_down or ratis/election/transfer to transfer the leadership
    - call the ratis/election/resume to resume the election finally

### Does this PR introduce _any_ user-facing change?
Introduce new RESTful apis.


### How was this patch tested?

election transfer:
<img width="1614" alt="image" src="https://github.com/user-attachments/assets/42e39478-e6c7-4f8a-91bb-a6b35e2098c5">

election pause and resume:

<img width="727" alt="image" src="https://github.com/user-attachments/assets/5ead4739-d45f-47d4-a951-9784a6495add">

election step down:
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/ebb3b722-147e-4db2-971d-17f4458b98ed">

