### PR TITLE
[CELEBORN-1593][FOLLOWUP] Support master --show-manual-excluded-workers command to show manual excluded workers

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -61,6 +61,11 @@ final class MasterOptions {
   @Option(names = Array("--show-excluded-workers"), description = Array("Show excluded workers"))
   private[master] var showExcludedWorkers: Boolean = _
 
+  @Option(
+    names = Array("--show-manual-excluded-workers"),
+    description = Array("Show manual excluded workers"))
+  private[master] var showManualExcludedWorkers: Boolean = _
+
   @Option(names = Array("--show-shutdown-workers"), description = Array("Show shutdown workers"))
   private[master] var showShutdownWorkers: Boolean = _
 

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
@@ -90,6 +90,8 @@ trait MasterSubcommand extends CliLogging {
 
   private[master] def runShowExcludedWorkers: Seq[WorkerData]
 
+  private[master] def runShowManualExcludedWorkers: Seq[WorkerData]
+
   private[master] def runShowShutdownWorkers: Seq[WorkerData]
 
   private[master] def runShowDecommissioningWorkers: Seq[WorkerData]

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -42,6 +42,7 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
     if (masterOptions.showWorkerEventInfo) log(runShowWorkerEventInfo)
     if (masterOptions.showLostWorkers) log(runShowLostWorkers)
     if (masterOptions.showExcludedWorkers) log(runShowExcludedWorkers)
+    if (masterOptions.showManualExcludedWorkers) log(runShowManualExcludedWorkers)
     if (masterOptions.showShutdownWorkers) log(runShowShutdownWorkers)
     if (masterOptions.showDecommissioningWorkers) log(runShowDecommissioningWorkers)
     if (masterOptions.showLifecycleManagers) log(runShowLifecycleManagers)
@@ -126,6 +127,16 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
       Seq.empty[WorkerData]
     } else {
       excludedWorkers.sortBy(_.getHost)
+    }
+  }
+
+  private[master] def runShowManualExcludedWorkers: Seq[WorkerData] = {
+    val manualExcludedWorkers = runShowWorkers.getManualExcludedWorkers.asScala.toSeq
+    if (manualExcludedWorkers.isEmpty) {
+      log("No manual excluded workers found.")
+      Seq.empty[WorkerData]
+    } else {
+      manualExcludedWorkers.sortBy(_.getHost)
     }
   }
 

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -166,6 +166,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureOutputAndValidateResponse(args, "No excluded workers found.")
   }
 
+  test("master --show-manual-excluded-workers") {
+    val args = prepareMasterArgs() :+ "--show-manual-excluded-workers"
+    captureOutputAndValidateResponse(args, "No manual excluded workers found.")
+  }
+
   test("master --show-shutdown-workers") {
     val args = prepareMasterArgs() :+ "--show-shutdown-workers"
     captureOutputAndValidateResponse(args, "No shutdown workers found.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support `master --show-manual-excluded-workers` command to show manual excluded workers.

### Why are the changes needed?

`/api/v1/workers` returns the manual excluded workers, which could also be supported in master command.

### Does this PR introduce _any_ user-facing change?

Introduce `master --show-manual-excluded-workers` command.

### How was this patch tested?

`TestCelebornCliCommands#master --show-manual-excluded-workers`