### PR TITLE
[CELEBORN-1615][FOLLOWUP] Start connector before starting server

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -41,8 +41,8 @@ private[celeborn] case class HttpServer(
   @throws[Exception]
   def start(): Unit = synchronized {
     try {
-      server.start()
       connector.start()
+      server.start()
       server.addConnector(connector)
       logInfo(s"$role: HttpServer started on ${connector.getHost}:${connector.getPort}.")
       isStarted = true

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/HttpTestHelper.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/HttpTestHelper.scala
@@ -64,7 +64,6 @@ trait HttpTestHelper extends AnyFunSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
     restApiBaseSuite.setUp()
-    Thread.sleep(1000) // sleep for http server initialization
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Followup for https://github.com/apache/celeborn/pull/2764

Start the connector before starting the server, to ensure the connector is ready once the server is in `STARTED` state.

### Why are the changes needed?

To fix branch-0.5 UT failure after merged https://github.com/apache/celeborn/pull/2764.

Because in master branch, I add sleep in the `HttpTestHelper`, so it won't meet the issue.
https://github.com/apache/celeborn/commit/5cea9cc7f21577a9b660ec84761efdd82e0ef7e9#diff-dfb4b6e47db765b519b3e03d0f0dcff840cae25ffc6c7dff4948bff28b0d0126 

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

