### PR TITLE
[CELEBORN-1615][FOLLOWUP][0.5] Sleep for http server initialization in UT

### DIFF
--- a/service/src/test/scala/org/apache/celeborn/server/common/http/HttpTestHelper.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/HttpTestHelper.scala
@@ -64,6 +64,7 @@ trait HttpTestHelper extends AnyFunSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
     restApiBaseSuite.setUp()
+    Thread.sleep(1000) // sleep for http server initialization
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title.
### Why are the changes needed?

The  branch-0.5 UT failed  with connection refused issue after merging https://github.com/apache/celeborn/pull/2764, which starts the http server later than before, seems the http server initialization was not finished during UT execution. 

The RC is that, there is no sleep after the master init thread start.
https://github.com/apache/celeborn/blob/c3d33daabc6360f9ac7a8c397ae57d71fab094e4/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResourceSuite.scala#L54-L59 

And in main branch,  it will sleep 1 second for initialization before UT execution.

https://github.com/apache/celeborn/blob/c3d33daabc6360f9ac7a8c397ae57d71fab094e4/service/src/test/scala/org/apache/celeborn/server/common/http/HttpTestHelper.scala#L64-L68

So, the UT is stable in main branch but failed in branch-0.5.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

GA