### PR TITLE
[CELEBORN-1638] Improve the slots allocator performance

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -337,7 +337,7 @@ public class SlotsAllocator {
     // workerInfo -> (diskIndexForPrimary, diskIndexForReplica)
     Map<WorkerInfo, Integer> workerDiskIndexForPrimary = new HashMap<>();
     Map<WorkerInfo, Integer> workerDiskIndexForReplica = new HashMap<>();
-    List<Integer> partitionIdList = new ArrayList<>(partitionIds);
+    List<Integer> partitionIdList = new LinkedList<>(partitionIds);
 
     final int workerSize = workers.size();
     final IntUnaryOperator incrementIndex = v -> (v + 1) % workerSize;


### PR DESCRIPTION
### What changes were proposed in this pull request?

When we try to allocate a large number of slots, the iterator.move of ArrayList partitionIdList will be very slow。

![CPU_time](https://github.com/user-attachments/assets/e33fedbc-14bc-43fe-a3fb-21424cdc3032)

We can use LinkedList instead of ArrayList to optimize slots allocator.
The execution time dropped from 97 secs to 12 secs

<img width="845" alt="image" src="https://github.com/user-attachments/assets/3053bb1c-830e-44d4-88c5-3cc017e91994">


### Why are the changes needed?

To improve the slot allocator performance

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

We can test this PR with `SlotsAllocatorRackAwareSuiteJ.testRackAwareRoundRobinReplicaDistribution()`
