### PR TITLE
[CELEBORN-1639] Fix SlotsAllocatorRackAwareSuiteJ UT

### DIFF
--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import scala.Tuple2;
-import scala.collection.JavaConverters;
+import scala.collection.mutable.ArrayBuffer;
 
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.TableMapping;
@@ -143,7 +143,9 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
   private List<WorkerInfo> prepareWorkers(CelebornRackResolver resolver) {
     ArrayList<WorkerInfo> workers = new ArrayList<>(3);
-    List<File> files = Arrays.asList(new File("/mnt/disk/1"), new File("/mnt/disk/2"));
+    ArrayBuffer<File> files = new ArrayBuffer<>();
+    files.$plus$eq(new File("/mnt/disk/1"));
+    files.$plus$eq(new File("/mnt/disk/2"));
     HashMap<String, DiskInfo> diskInfos = new HashMap<>();
     diskInfos.put(
         "disk1",
@@ -153,7 +155,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
             1000,
             1000,
             1000,
-            JavaConverters.asScalaBuffer(files).toList(),
+            files.toList(),
             null));
     workers.add(new WorkerInfo("host1", 9, 10, 110, 113, 212, diskInfos, null));
     workers.add(new WorkerInfo("host2", 9, 11, 111, 114, 212, diskInfos, null));

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -148,15 +148,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
     files.$plus$eq(new File("/mnt/disk/2"));
     HashMap<String, DiskInfo> diskInfos = new HashMap<>();
     diskInfos.put(
-        "disk1",
-        new DiskInfo(
-            "/mnt/disk/0",
-            1000,
-            1000,
-            1000,
-            1000,
-            files.toList(),
-            null));
+        "disk1", new DiskInfo("/mnt/disk/0", 1000, 1000, 1000, 1000, files.toList(), null));
     workers.add(new WorkerInfo("host1", 9, 10, 110, 113, 212, diskInfos, null));
     workers.add(new WorkerInfo("host2", 9, 11, 111, 114, 212, diskInfos, null));
     workers.add(new WorkerInfo("host3", 9, 12, 112, 115, 212, diskInfos, null));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

In offerSlotsRoundRobinWithRackAware and offerSlotsRoundRobinWithRackAwareWithoutMappingFile method of SlotsAllocatorRackAwareSuiteJ UT, the result slots is empty, so they can not test the slots allocation with rack aware is true.

### Why are the changes needed?

To fix the exists UT

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Fix UT methods: `offerSlotsRoundRobinWithRackAware()` and `offerSlotsRoundRobinWithRackAwareWithoutMappingFile()`
