### PR TITLE
[CELEBORN-1640] NettyMemoryMetrics supports numHeapArenas, numDirectArenas, tinyCacheSize, smallCacheSize, normalCacheSize, numThreadLocalCaches and chunkSize

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -81,7 +81,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -95,7 +94,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -117,8 +115,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -175,7 +172,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -189,7 +185,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -211,8 +206,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -269,7 +263,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -283,7 +276,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -305,8 +297,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -364,7 +355,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -378,7 +368,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -400,8 +389,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -459,7 +447,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -473,7 +460,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -495,8 +481,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -567,7 +552,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -581,7 +565,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -603,8 +586,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -664,7 +646,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -678,7 +659,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -700,8 +680,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -761,7 +740,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -775,7 +753,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -797,8 +774,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -856,7 +832,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -870,7 +845,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -892,8 +866,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -952,7 +925,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -966,7 +938,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -988,8 +959,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1048,7 +1018,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1062,7 +1031,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1084,8 +1052,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1142,7 +1109,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1156,7 +1122,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1236,7 +1201,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1250,7 +1214,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1331,7 +1294,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1345,7 +1307,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1381,8 +1342,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 26
+            "x": 0,
+            "y": 34
           },
           "id": 194,
           "options": {
@@ -1426,7 +1387,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1440,7 +1400,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1476,7 +1435,7 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 34
           },
           "id": 36,
@@ -1533,7 +1492,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1547,7 +1505,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1625,7 +1582,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1639,7 +1595,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1718,7 +1673,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1732,7 +1686,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1813,7 +1766,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1827,7 +1779,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1906,7 +1857,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -1920,7 +1870,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1999,7 +1948,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2013,7 +1961,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2093,7 +2040,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2107,7 +2053,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2188,7 +2133,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2202,7 +2146,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2285,7 +2228,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2299,7 +2241,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2380,7 +2321,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2394,7 +2334,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2473,7 +2412,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2487,7 +2425,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2566,7 +2503,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -2580,7 +2516,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2820,7 +2755,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 145
+            "y": 4
           },
           "id": 68,
           "options": {
@@ -2910,7 +2845,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 145
+            "y": 4
           },
           "id": 70,
           "options": {
@@ -3000,7 +2935,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 154
+            "y": 13
           },
           "id": 72,
           "options": {
@@ -3090,7 +3025,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 154
+            "y": 13
           },
           "id": 74,
           "options": {
@@ -3179,7 +3114,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 163
+            "y": 22
           },
           "id": 83,
           "options": {
@@ -3270,7 +3205,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 163
+            "y": 22
           },
           "id": 76,
           "options": {
@@ -3361,7 +3296,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 171
+            "y": 30
           },
           "id": 128,
           "options": {
@@ -3452,7 +3387,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 171
+            "y": 30
           },
           "id": 129,
           "options": {
@@ -3543,7 +3478,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 179
+            "y": 38
           },
           "id": 130,
           "options": {
@@ -3634,7 +3569,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 179
+            "y": 38
           },
           "id": 132,
           "options": {
@@ -3725,7 +3660,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 187
+            "y": 46
           },
           "id": 131,
           "options": {
@@ -3816,7 +3751,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 187
+            "y": 46
           },
           "id": 133,
           "options": {
@@ -3907,7 +3842,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 166
+            "y": 54
           },
           "id": 79,
           "options": {
@@ -4013,7 +3948,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 196
+            "y": 5
           },
           "id": 66,
           "options": {
@@ -4103,7 +4038,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 196
+            "y": 5
           },
           "id": 96,
           "options": {
@@ -4193,7 +4128,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 204
+            "y": 13
           },
           "id": 17,
           "options": {
@@ -4283,7 +4218,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 204
+            "y": 13
           },
           "id": 18,
           "options": {
@@ -4372,7 +4307,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 212
+            "y": 21
           },
           "id": 81,
           "options": {
@@ -4463,7 +4398,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 212
+            "y": 21
           },
           "id": 77,
           "options": {
@@ -4554,7 +4489,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 220
+            "y": 29
           },
           "id": 82,
           "options": {
@@ -4645,7 +4580,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 220
+            "y": 29
           },
           "id": 75,
           "options": {
@@ -4736,7 +4671,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 228
+            "y": 37
           },
           "id": 73,
           "options": {
@@ -4842,7 +4777,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 163
+            "y": 6
           },
           "id": 78,
           "options": {
@@ -4932,7 +4867,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 163
+            "y": 6
           },
           "id": 80,
           "options": {
@@ -5022,7 +4957,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 171
+            "y": 14
           },
           "id": 4,
           "options": {
@@ -5112,7 +5047,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 171
+            "y": 14
           },
           "id": 6,
           "options": {
@@ -5202,7 +5137,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 180
+            "y": 23
           },
           "id": 56,
           "options": {
@@ -5292,7 +5227,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 180
+            "y": 23
           },
           "id": 58,
           "options": {
@@ -5346,7 +5281,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5360,7 +5294,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5441,7 +5374,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5455,7 +5387,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5537,7 +5468,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5551,7 +5481,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5633,7 +5562,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5647,7 +5575,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -6130,6 +6057,615 @@
                 "steps": [
                   {
                     "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 39
+          },
+          "id": 158,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_numHeapArenas_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_numHeapArenas_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 39
+          },
+          "id": 164,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_numDirectArenas_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_numDirectArenas_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 47
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_tinyCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_tinyCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 47
+          },
+          "id": 202,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_smallCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_smallCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 55
+          },
+          "id": 171,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_normalCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_normalCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 55
+          },
+          "id": 173,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_numThreadLocalCaches_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_numThreadLocalCaches_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 63
+          },
+          "id": 178,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_push_chunkSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_push_chunkSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6144,8 +6680,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 39
+            "x": 12,
+            "y": 63
           },
           "id": 167,
           "options": {
@@ -6236,8 +6772,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 39
+            "x": 0,
+            "y": 71
           },
           "id": 168,
           "options": {
@@ -6314,6 +6850,615 @@
                 "steps": [
                   {
                     "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 71
+          },
+          "id": 203,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_numHeapArenas_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_numHeapArenas_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 79
+          },
+          "id": 204,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_numDirectArenas_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_numDirectArenas_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 79
+          },
+          "id": 205,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_tinyCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_tinyCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 87
+          },
+          "id": 206,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_smallCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_smallCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 87
+          },
+          "id": 207,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_normalCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_normalCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 95
+          },
+          "id": 208,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_numThreadLocalCaches_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_numThreadLocalCaches_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 95
+          },
+          "id": 209,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_fetch_chunkSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_fetch_chunkSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6329,7 +7474,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 103
           },
           "id": 169,
           "options": {
@@ -6421,7 +7566,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 103
           },
           "id": 170,
           "options": {
@@ -6498,6 +7643,615 @@
                 "steps": [
                   {
                     "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 111
+          },
+          "id": 210,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_numHeapArenas_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_numHeapArenas_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 111
+          },
+          "id": 211,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_numDirectArenas_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_numDirectArenas_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 119
+          },
+          "id": 212,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_tinyCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_tinyCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 119
+          },
+          "id": 213,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_smallCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_smallCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 127
+          },
+          "id": 214,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_normalCacheSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_normalCacheSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 127
+          },
+          "id": 215,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_numThreadLocalCaches_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_numThreadLocalCaches_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 135
+          },
+          "id": 216,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_replicate_chunkSize_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_replicate_chunkSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6511,8 +8265,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 55
+            "x": 12,
+            "y": 135
           },
           "id": 108,
           "options": {
@@ -6603,8 +8357,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 55
+            "x": 0,
+            "y": 143
           },
           "id": 104,
           "options": {
@@ -6694,8 +8448,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 63
+            "x": 12,
+            "y": 143
           },
           "id": 106,
           "options": {
@@ -6801,7 +8555,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 238
+            "y": 885
           },
           "id": 44,
           "options": {
@@ -6891,7 +8645,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 238
+            "y": 885
           },
           "id": 46,
           "options": {
@@ -6980,7 +8734,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 246
+            "y": 893
           },
           "id": 192,
           "options": {
@@ -7070,7 +8824,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 246
+            "y": 893
           },
           "id": 180,
           "options": {
@@ -7161,7 +8915,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 254
+            "y": 901
           },
           "id": 88,
           "options": {
@@ -7251,7 +9005,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 254
+            "y": 901
           },
           "id": 135,
           "options": {
@@ -7358,7 +9112,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 263
+            "y": 910
           },
           "id": 159,
           "options": {
@@ -7451,7 +9205,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 263
+            "y": 910
           },
           "id": 160,
           "options": {
@@ -7544,7 +9298,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 271
+            "y": 918
           },
           "id": 161,
           "options": {
@@ -7650,7 +9404,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 593
           },
           "id": 139,
           "options": {
@@ -7742,7 +9496,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 593
           },
           "id": 141,
           "options": {
@@ -7834,7 +9588,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 666
           },
           "id": 142,
           "options": {
@@ -7926,7 +9680,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 666
           },
           "id": 143,
           "options": {
@@ -8018,7 +9772,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 675
           },
           "id": 144,
           "options": {
@@ -8110,7 +9864,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 675
           },
           "id": 145,
           "options": {
@@ -8202,7 +9956,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 684
           },
           "id": 146,
           "options": {
@@ -8294,7 +10048,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 684
           },
           "id": 147,
           "options": {
@@ -8386,7 +10140,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 693
           },
           "id": 148,
           "options": {
@@ -8478,7 +10232,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 693
           },
           "id": 149,
           "options": {
@@ -8570,7 +10324,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 702
           },
           "id": 150,
           "options": {
@@ -8662,7 +10416,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 55
+            "y": 702
           },
           "id": 151,
           "options": {
@@ -8753,7 +10507,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 711
           },
           "id": 153,
           "options": {
@@ -8844,7 +10598,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 711
           },
           "id": 154,
           "options": {
@@ -8935,7 +10689,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 719
           },
           "id": 155,
           "options": {
@@ -9026,7 +10780,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 719
           },
           "id": 200,
           "options": {
@@ -9118,7 +10872,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 727
           },
           "id": 198,
           "options": {
@@ -9210,7 +10964,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 727
           },
           "id": 199,
           "options": {
@@ -9302,7 +11056,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 736
           },
           "id": 196,
           "options": {
@@ -9394,7 +11148,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 736
           },
           "id": 197,
           "options": {
@@ -9499,7 +11253,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 351
+            "y": 998
           },
           "id": 112,
           "options": {
@@ -9590,7 +11344,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 351
+            "y": 998
           },
           "id": 116,
           "options": {
@@ -9696,7 +11450,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 360
+            "y": 1007
           },
           "id": 125,
           "options": {
@@ -9789,7 +11543,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 360
+            "y": 1007
           },
           "id": 126,
           "options": {
@@ -9882,7 +11636,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 368
+            "y": 1015
           },
           "id": 163,
           "options": {
@@ -9975,7 +11729,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 368
+            "y": 1015
           },
           "id": 162,
           "options": {
@@ -10068,7 +11822,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 376
+            "y": 1023
           },
           "id": 127,
           "options": {
@@ -10174,7 +11928,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 385
+            "y": 1032
           },
           "id": 174,
           "options": {
@@ -10267,7 +12021,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 385
+            "y": 1032
           },
           "id": 176,
           "options": {
@@ -10359,7 +12113,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 394
+            "y": 1041
           },
           "id": 175,
           "options": {
@@ -10452,7 +12206,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 394
+            "y": 1041
           },
           "id": 177,
           "options": {

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyMemoryMetrics.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyMemoryMetrics.java
@@ -97,6 +97,32 @@ public class NettyMemoryMetrics {
           MetricRegistry.name(metricPrefix, "usedDirectMemory"),
           labels,
           pooledAllocatorMetric::usedDirectMemory);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "numHeapArenas"),
+          labels,
+          pooledAllocatorMetric::numHeapArenas);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "numDirectArenas"),
+          labels,
+          pooledAllocatorMetric::numDirectArenas);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "tinyCacheSize"),
+          labels,
+          pooledAllocatorMetric::tinyCacheSize);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "smallCacheSize"),
+          labels,
+          pooledAllocatorMetric::smallCacheSize);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "normalCacheSize"),
+          labels,
+          pooledAllocatorMetric::normalCacheSize);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "numThreadLocalCaches"),
+          labels,
+          pooledAllocatorMetric::numThreadLocalCaches);
+      source.addGauge(
+          MetricRegistry.name(metricPrefix, "chunkSize"), labels, pooledAllocatorMetric::chunkSize);
       if (verboseMetricsEnabled) {
         int directArenaIndex = 0;
         for (PoolArenaMetric metric : pooledAllocatorMetric.directArenas()) {

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -164,134 +164,155 @@ These metrics are exposed by Celeborn worker.
 
   - namespace=worker
     
-    | Metric Name                                 | Description                                                                                                     |
-    |---------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-    | RegisteredShuffleCount                      | The count of registered shuffle.                                                                                |
-    | RunningApplicationCount                     | The count of running applications.                                                                              |
-    | ActiveShuffleSize                           | The active shuffle size of a worker including master replica and slave replica.                                 |
-    | ActiveShuffleFileCount                      | The active shuffle file count of a worker including master replica and slave replica.                           |
-    | OpenStreamTime                              | The time for a worker to process openStream RPC and return StreamHandle.                                        |
-    | FetchChunkTime                              | The time for a worker to fetch a chunk which is 8MB by default from a reduced partition.                        |
-    | ActiveChunkStreamCount                      | Active stream count for reduce partition reading streams.                                                       |
-    | OpenStreamSuccessCount                      | The count of opening stream succeed in current worker.                                                          |
-    | OpenStreamFailCount                         | The count of opening stream failed in current worker.                                                           |
-    | FetchChunkSuccessCount                      | The count of fetching chunk succeed in current worker.                                                          |
-    | FetchChunkFailCount                         | The count of fetching chunk failed in current worker.                                                           |
-    | PrimaryPushDataTime                         | The time for a worker to handle a pushData RPC sent from a celeborn client.                                     |
-    | ReplicaPushDataTime                         | The time for a worker to handle a pushData RPC sent from a celeborn worker by replicating.                      |
-    | PrimarySegmentStartTime                     | The time for a worker to handle a segmentStart RPC sent from a celeborn client.                                 |
-    | ReplicaSegmentStartTime                     | The time for a worker to handle a segmentStart RPC sent from a celeborn worker by replicating.                  |
-    | WriteDataHardSplitCount                     | The count of writing PushData or PushMergedData to HARD_SPLIT partition in current worker.                      |
-    | WriteDataSuccessCount                       | The count of writing PushData or PushMergedData succeed in current worker.                                      |
-    | WriteDataFailCount                          | The count of writing PushData or PushMergedData failed in current worker.                                       |
-    | ReplicateDataFailCount                      | The count of replicating PushData or PushMergedData failed in current worker.                                   |
-    | ReplicateDataWriteFailCount                 | The count of replicating PushData or PushMergedData failed caused by write failure in peer worker.              |
-    | ReplicateDataCreateConnectionFailCount      | The count of replicating PushData or PushMergedData failed caused by creating connection failed in peer worker. |
-    | ReplicateDataConnectionExceptionCount       | The count of replicating PushData or PushMergedData failed caused by connection exception in peer worker.       |
-    | ReplicateDataFailNonCriticalCauseCount      | The count of replicating PushData or PushMergedData failed caused by non-critical exception in peer worker.     |
-    | ReplicateDataTimeoutCount                   | The count of replicating PushData or PushMergedData failed caused by push timeout in peer worker.               |
-    | PushDataHandshakeFailCount                  | The count of PushDataHandshake failed in current worker.                                                        |
-    | RegionStartFailCount                        | The count of RegionStart failed in current worker.                                                              |
-    | RegionFinishFailCount                       | The count of RegionFinish failed in current worker.                                                             |
-    | SegmentStartFailCount                       | The count of SegmentStart failed in current worker.                                                             |
-    | PrimaryPushDataHandshakeTime                | PrimaryPushDataHandshake means handle PushData of primary partition location.                                   |
-    | ReplicaPushDataHandshakeTime                | ReplicaPushDataHandshake means handle PushData of replica partition location.                                   |
-    | PrimaryRegionStartTime                      | PrimaryRegionStart means handle RegionStart of primary partition location.                                      |
-    | ReplicaRegionStartTime                      | ReplicaRegionStart means handle RegionStart of replica partition location.                                      |
-    | PrimaryRegionFinishTime                     | PrimaryRegionFinish means handle RegionFinish of primary partition location.                                    |
-    | ReplicaRegionFinishTime                     | ReplicaRegionFinish means handle RegionFinish of replica partition location.                                    |
-    | PausePushDataTime                           | The time for a worker to stop receiving pushData from clients because of back pressure.                         |
-    | PausePushDataAndReplicateTime               | The time for a worker to stop receiving pushData from clients and other workers because of back pressure.       |
-    | PausePushData                               | The count for a worker to stop receiving pushData from clients because of back pressure.                        |
-    | PausePushDataAndReplicate                   | The count for a worker to stop receiving pushData from clients and other workers because of back pressure.      |
-    | TakeBufferTime                              | The time for a worker to take out a buffer from a disk flusher.                                                 |
-    | FlushDataTime                               | The time for a worker to write a buffer which is 256KB by default to storage.                                   |
-    | CommitFilesTime                             | The time for a worker to flush buffers and close files related to specified shuffle.                            |
-    | SlotsAllocated                              | Slots allocated in last hour.                                                                                   |
-    | ActiveSlotsCount                            | The number of slots currently being used in a worker.                                                           |
-    | ReserveSlotsTime                            | ReserveSlots means acquire a disk buffer and record partition location.                                         |
-    | ActiveConnectionCount                       | The count of active network connection.                                                                         |
-    | NettyMemory                                 | The total amount of off-heap memory used by celeborn worker.                                                    |
-    | SortTime                                    | The time for a worker to sort a shuffle file.                                                                   |
-    | SortMemory                                  | The memory used by sorting shuffle files.                                                                       |
-    | SortingFiles                                | The count of sorting shuffle files.                                                                             |
-    | SortedFiles                                 | The count of sorted shuffle files.                                                                              |
-    | SortedFileSize                              | The count of sorted shuffle files 's total size.                                                                |
-    | DiskBuffer                                  | The memory occupied by pushData and pushMergedData which should be written to disk.                             |
-    | BufferStreamReadBuffer                      | The memory used by credit stream read buffer.                                                                   |
-    | ReadBufferDispatcherRequestsLength          | The queue size of read buffer allocation requests.                                                              |
-    | ReadBufferAllocatedCount                    | Allocated read buffer count.                                                                                    |
-    | ActiveCreditStreamCount                     | Active stream count for map partition reading streams.                                                          |
-    | ActiveMapPartitionCount                     | The count of active map partition reading streams.                                                              |
-    | CleanTaskQueueSize                          | The count of task for cleaning up expired shuffle keys.                                                         |
-    | CleanExpiredShuffleKeysTime                 | The time for a worker to clean up shuffle data of expired shuffle keys.                                         |
-    | DeviceOSFreeBytes                           | The actual usable space of OS for device monitor.                                                               |
-    | DeviceOSTotalBytes                          | The total usable space of OS for device monitor.                                                                |
-    | DeviceCelebornFreeBytes                     | The actual usable space of Celeborn for device.                                                                 |
-    | DeviceCelebornTotalBytes                    | The total space of Celeborn for device.                                                                         |
-    | PotentialConsumeSpeed                       | The speed of potential consumption for congestion control.                                                      |
-    | UserProduceSpeed                            | The speed of user production for congestion control.                                                            |
-    | WorkerConsumeSpeed                          | The speed of worker consumption for congestion control.                                                         |
-    | IsDecommissioningWorker                     | 1 means worker decommissioning, 0 means not decommissioning.                                                    |
-    | UnreleasedShuffleCount                      | Unreleased shuffle count when worker is decommissioning.                                                        |
-    | MemoryStorageFileCount                      | The count of files in Memory Storage of a worker.                                                               |
-    | MemoryFileStorageSize                       | The total amount of memory used by Memory Storage.                                                              |
-    | EvictedFileCount                            | The count of files evicted from Memory Storage to Disk                                                          |
-    | DirectMemoryUsageRatio                      | Ratio of direct memory used and max direct memory.                                                              |
-    | push_server_usedHeapMemory                  |                                                                                                                 |
-    | push_server_usedDirectMemory                |                                                                                                                 |
-    | push_server_numAllocations                  |                                                                                                                 |
-    | push_server_numTinyAllocations              |                                                                                                                 |
-    | push_server_numSmallAllocations             |                                                                                                                 |
-    | push_server_numNormalAllocations            |                                                                                                                 |
-    | push_server_numHugeAllocations              |                                                                                                                 |
-    | push_server_numDeallocations                |                                                                                                                 |
-    | push_server_numTinyDeallocations            |                                                                                                                 |
-    | push_server_numSmallDeallocations           |                                                                                                                 |
-    | push_server_numNormalDeallocations          |                                                                                                                 |
-    | push_server_numHugeDeallocations            |                                                                                                                 |
-    | push_server_numActiveAllocations            |                                                                                                                 |
-    | push_server_numActiveTinyAllocations        |                                                                                                                 |
-    | push_server_numActiveSmallAllocations       |                                                                                                                 |
-    | push_server_numActiveNormalAllocations      |                                                                                                                 |
-    | push_server_numActiveHugeAllocations        |                                                                                                                 |
-    | push_server_numActiveBytes                  |                                                                                                                 |
-    | replicate_server_usedHeapMemory             |                                                                                                                 |
-    | replicate_server_usedDirectMemory           |                                                                                                                 |
-    | replicate_server_numAllocations             |                                                                                                                 |
-    | replicate_server_numTinyAllocations         |                                                                                                                 |
-    | replicate_server_numSmallAllocations        |                                                                                                                 |
-    | replicate_server_numNormalAllocations       |                                                                                                                 |
-    | replicate_server_numHugeAllocations         |                                                                                                                 |
-    | replicate_server_numDeallocations           |                                                                                                                 |
-    | replicate_server_numTinyDeallocations       |                                                                                                                 |
-    | replicate_server_numSmallDeallocations      |                                                                                                                 |
-    | replicate_server_numNormalDeallocations     |                                                                                                                 |
-    | replicate_server_numHugeDeallocations       |                                                                                                                 |
-    | replicate_server_numActiveAllocations       |                                                                                                                 |
-    | replicate_server_numActiveTinyAllocations   |                                                                                                                 |
-    | replicate_server_numActiveSmallAllocations  |                                                                                                                 |
-    | replicate_server_numActiveNormalAllocations |                                                                                                                 |
-    | replicate_server_numActiveHugeAllocations   |                                                                                                                 |
-    | replicate_server_numActiveBytes             |                                                                                                                 |
-    | fetch_server_usedHeapMemory                 |                                                                                                                 |
-    | fetch_server_usedDirectMemory               |                                                                                                                 |
-    | fetch_server_numAllocations                 |                                                                                                                 |
-    | fetch_server_numTinyAllocations             |                                                                                                                 |
-    | fetch_server_numSmallAllocations            |                                                                                                                 |
-    | fetch_server_numNormalAllocations           |                                                                                                                 |
-    | fetch_server_numHugeAllocations             |                                                                                                                 |
-    | fetch_server_numDeallocations               |                                                                                                                 |
-    | fetch_server_numTinyDeallocations           |                                                                                                                 |
-    | fetch_server_numSmallDeallocations          |                                                                                                                 |
-    | fetch_server_numNormalDeallocations         |                                                                                                                 |
-    | fetch_server_numHugeDeallocations           |                                                                                                                 |
-    | fetch_server_numActiveAllocations           |                                                                                                                 |
-    | fetch_server_numActiveTinyAllocations       |                                                                                                                 |
-    | fetch_server_numActiveSmallAllocations      |                                                                                                                 |
-    | fetch_server_numActiveNormalAllocations     |                                                                                                                 |
-    | fetch_server_numActiveHugeAllocations       |                                                                                                                 |
-    | fetch_server_numActiveBytes                 |                                                                                                                 |
+    | Metric Name                            | Description                                                                                                     |
+    |----------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+    | RegisteredShuffleCount                 | The count of registered shuffle.                                                                                |
+    | RunningApplicationCount                | The count of running applications.                                                                              |
+    | ActiveShuffleSize                      | The active shuffle size of a worker including master replica and slave replica.                                 |
+    | ActiveShuffleFileCount                 | The active shuffle file count of a worker including master replica and slave replica.                           |
+    | OpenStreamTime                         | The time for a worker to process openStream RPC and return StreamHandle.                                        |
+    | FetchChunkTime                         | The time for a worker to fetch a chunk which is 8MB by default from a reduced partition.                        |
+    | ActiveChunkStreamCount                 | Active stream count for reduce partition reading streams.                                                       |
+    | OpenStreamSuccessCount                 | The count of opening stream succeed in current worker.                                                          |
+    | OpenStreamFailCount                    | The count of opening stream failed in current worker.                                                           |
+    | FetchChunkSuccessCount                 | The count of fetching chunk succeed in current worker.                                                          |
+    | FetchChunkFailCount                    | The count of fetching chunk failed in current worker.                                                           |
+    | PrimaryPushDataTime                    | The time for a worker to handle a pushData RPC sent from a celeborn client.                                     |
+    | ReplicaPushDataTime                    | The time for a worker to handle a pushData RPC sent from a celeborn worker by replicating.                      |
+    | PrimarySegmentStartTime                | The time for a worker to handle a segmentStart RPC sent from a celeborn client.                                 |
+    | ReplicaSegmentStartTime                | The time for a worker to handle a segmentStart RPC sent from a celeborn worker by replicating.                  |
+    | WriteDataHardSplitCount                | The count of writing PushData or PushMergedData to HARD_SPLIT partition in current worker.                      |
+    | WriteDataSuccessCount                  | The count of writing PushData or PushMergedData succeed in current worker.                                      |
+    | WriteDataFailCount                     | The count of writing PushData or PushMergedData failed in current worker.                                       |
+    | ReplicateDataFailCount                 | The count of replicating PushData or PushMergedData failed in current worker.                                   |
+    | ReplicateDataWriteFailCount            | The count of replicating PushData or PushMergedData failed caused by write failure in peer worker.              |
+    | ReplicateDataCreateConnectionFailCount | The count of replicating PushData or PushMergedData failed caused by creating connection failed in peer worker. |
+    | ReplicateDataConnectionExceptionCount  | The count of replicating PushData or PushMergedData failed caused by connection exception in peer worker.       |
+    | ReplicateDataFailNonCriticalCauseCount | The count of replicating PushData or PushMergedData failed caused by non-critical exception in peer worker.     |
+    | ReplicateDataTimeoutCount              | The count of replicating PushData or PushMergedData failed caused by push timeout in peer worker.               |
+    | PushDataHandshakeFailCount             | The count of PushDataHandshake failed in current worker.                                                        |
+    | RegionStartFailCount                   | The count of RegionStart failed in current worker.                                                              |
+    | RegionFinishFailCount                  | The count of RegionFinish failed in current worker.                                                             |
+    | SegmentStartFailCount                  | The count of SegmentStart failed in current worker.                                                             |
+    | PrimaryPushDataHandshakeTime           | PrimaryPushDataHandshake means handle PushData of primary partition location.                                   |
+    | ReplicaPushDataHandshakeTime           | ReplicaPushDataHandshake means handle PushData of replica partition location.                                   |
+    | PrimaryRegionStartTime                 | PrimaryRegionStart means handle RegionStart of primary partition location.                                      |
+    | ReplicaRegionStartTime                 | ReplicaRegionStart means handle RegionStart of replica partition location.                                      |
+    | PrimaryRegionFinishTime                | PrimaryRegionFinish means handle RegionFinish of primary partition location.                                    |
+    | ReplicaRegionFinishTime                | ReplicaRegionFinish means handle RegionFinish of replica partition location.                                    |
+    | PausePushDataTime                      | The time for a worker to stop receiving pushData from clients because of back pressure.                         |
+    | PausePushDataAndReplicateTime          | The time for a worker to stop receiving pushData from clients and other workers because of back pressure.       |
+    | PausePushData                          | The count for a worker to stop receiving pushData from clients because of back pressure.                        |
+    | PausePushDataAndReplicate              | The count for a worker to stop receiving pushData from clients and other workers because of back pressure.      |
+    | TakeBufferTime                         | The time for a worker to take out a buffer from a disk flusher.                                                 |
+    | FlushDataTime                          | The time for a worker to write a buffer which is 256KB by default to storage.                                   |
+    | CommitFilesTime                        | The time for a worker to flush buffers and close files related to specified shuffle.                            |
+    | SlotsAllocated                         | Slots allocated in last hour.                                                                                   |
+    | ActiveSlotsCount                       | The number of slots currently being used in a worker.                                                           |
+    | ReserveSlotsTime                       | ReserveSlots means acquire a disk buffer and record partition location.                                         |
+    | ActiveConnectionCount                  | The count of active network connection.                                                                         |
+    | NettyMemory                            | The total amount of off-heap memory used by celeborn worker.                                                    |
+    | SortTime                               | The time for a worker to sort a shuffle file.                                                                   |
+    | SortMemory                             | The memory used by sorting shuffle files.                                                                       |
+    | SortingFiles                           | The count of sorting shuffle files.                                                                             |
+    | SortedFiles                            | The count of sorted shuffle files.                                                                              |
+    | SortedFileSize                         | The count of sorted shuffle files 's total size.                                                                |
+    | DiskBuffer                             | The memory occupied by pushData and pushMergedData which should be written to disk.                             |
+    | BufferStreamReadBuffer                 | The memory used by credit stream read buffer.                                                                   |
+    | ReadBufferDispatcherRequestsLength     | The queue size of read buffer allocation requests.                                                              |
+    | ReadBufferAllocatedCount               | Allocated read buffer count.                                                                                    |
+    | ActiveCreditStreamCount                | Active stream count for map partition reading streams.                                                          |
+    | ActiveMapPartitionCount                | The count of active map partition reading streams.                                                              |
+    | CleanTaskQueueSize                     | The count of task for cleaning up expired shuffle keys.                                                         |
+    | CleanExpiredShuffleKeysTime            | The time for a worker to clean up shuffle data of expired shuffle keys.                                         |
+    | DeviceOSFreeBytes                      | The actual usable space of OS for device monitor.                                                               |
+    | DeviceOSTotalBytes                     | The total usable space of OS for device monitor.                                                                |
+    | DeviceCelebornFreeBytes                | The actual usable space of Celeborn for device.                                                                 |
+    | DeviceCelebornTotalBytes               | The total space of Celeborn for device.                                                                         |
+    | PotentialConsumeSpeed                  | The speed of potential consumption for congestion control.                                                      |
+    | UserProduceSpeed                       | The speed of user production for congestion control.                                                            |
+    | WorkerConsumeSpeed                     | The speed of worker consumption for congestion control.                                                         |
+    | IsDecommissioningWorker                | 1 means worker decommissioning, 0 means not decommissioning.                                                    |
+    | UnreleasedShuffleCount                 | Unreleased shuffle count when worker is decommissioning.                                                        |
+    | MemoryStorageFileCount                 | The count of files in Memory Storage of a worker.                                                               |
+    | MemoryFileStorageSize                  | The total amount of memory used by Memory Storage.                                                              |
+    | EvictedFileCount                       | The count of files evicted from Memory Storage to Disk                                                          |
+    | DirectMemoryUsageRatio                 | Ratio of direct memory used and max direct memory.                                                              |
+    | push_usedHeapMemory                    |                                                                                                                 |
+    | push_usedDirectMemory                  |                                                                                                                 |
+    | push_numHeapArenas                     |                                                                                                                 |
+    | push_numDirectArenas                   |                                                                                                                 |
+    | push_tinyCacheSize                     |                                                                                                                 |
+    | push_smallCacheSize                    |                                                                                                                 |
+    | push_normalCacheSize                   |                                                                                                                 |
+    | push_numThreadLocalCaches              |                                                                                                                 |
+    | push_chunkSize                         |                                                                                                                 |
+    | push_numAllocations                    |                                                                                                                 |
+    | push_numTinyAllocations                |                                                                                                                 |
+    | push_numSmallAllocations               |                                                                                                                 |
+    | push_numNormalAllocations              |                                                                                                                 |
+    | push_numHugeAllocations                |                                                                                                                 |
+    | push_numDeallocations                  |                                                                                                                 |
+    | push_numTinyDeallocations              |                                                                                                                 |
+    | push_numSmallDeallocations             |                                                                                                                 |
+    | push_numNormalDeallocations            |                                                                                                                 |
+    | push_numHugeDeallocations              |                                                                                                                 |
+    | push_numActiveAllocations              |                                                                                                                 |
+    | push_numActiveTinyAllocations          |                                                                                                                 |
+    | push_numActiveSmallAllocations         |                                                                                                                 |
+    | push_numActiveNormalAllocations        |                                                                                                                 |
+    | push_numActiveHugeAllocations          |                                                                                                                 |
+    | push_numActiveBytes                    |                                                                                                                 |
+    | replicate_usedHeapMemory               |                                                                                                                 |
+    | replicate_usedDirectMemory             |                                                                                                                 |
+    | replicate_numHeapArenas                |                                                                                                                 |
+    | replicate_numDirectArenas              |                                                                                                                 |
+    | replicate_tinyCacheSize                |                                                                                                                 |
+    | replicate_smallCacheSize               |                                                                                                                 |
+    | replicate_normalCacheSize              |                                                                                                                 |
+    | replicate_numThreadLocalCaches         |                                                                                                                 |
+    | replicate_chunkSize                    |                                                                                                                 |
+    | replicate_numAllocations               |                                                                                                                 |
+    | replicate_numTinyAllocations           |                                                                                                                 |
+    | replicate_numSmallAllocations          |                                                                                                                 |
+    | replicate_numNormalAllocations         |                                                                                                                 |
+    | replicate_numHugeAllocations           |                                                                                                                 |
+    | replicate_numDeallocations             |                                                                                                                 |
+    | replicate_numTinyDeallocations         |                                                                                                                 |
+    | replicate_numSmallDeallocations        |                                                                                                                 |
+    | replicate_numNormalDeallocations       |                                                                                                                 |
+    | replicate_numHugeDeallocations         |                                                                                                                 |
+    | replicate_numActiveAllocations         |                                                                                                                 |
+    | replicate_numActiveTinyAllocations     |                                                                                                                 |
+    | replicate_numActiveSmallAllocations    |                                                                                                                 |
+    | replicate_numActiveNormalAllocations   |                                                                                                                 |
+    | replicate_numActiveHugeAllocations     |                                                                                                                 |
+    | replicate_numActiveBytes               |                                                                                                                 |
+    | fetch_usedHeapMemory                   |                                                                                                                 |
+    | fetch_usedDirectMemory                 |                                                                                                                 |
+    | fetch_numHeapArenas                    |                                                                                                                 |
+    | fetch_numDirectArenas                  |                                                                                                                 |
+    | fetch_tinyCacheSize                    |                                                                                                                 |
+    | fetch_smallCacheSize                   |                                                                                                                 |
+    | fetch_normalCacheSize                  |                                                                                                                 |
+    | fetch_numThreadLocalCaches             |                                                                                                                 |
+    | fetch_chunkSize                        |                                                                                                                 |
+    | fetch_numAllocations                   |                                                                                                                 |
+    | fetch_numTinyAllocations               |                                                                                                                 |
+    | fetch_numSmallAllocations              |                                                                                                                 |
+    | fetch_numNormalAllocations             |                                                                                                                 |
+    | fetch_numHugeAllocations               |                                                                                                                 |
+    | fetch_numDeallocations                 |                                                                                                                 |
+    | fetch_numTinyDeallocations             |                                                                                                                 |
+    | fetch_numSmallDeallocations            |                                                                                                                 |
+    | fetch_numNormalDeallocations           |                                                                                                                 |
+    | fetch_numHugeDeallocations             |                                                                                                                 |
+    | fetch_numActiveAllocations             |                                                                                                                 |
+    | fetch_numActiveTinyAllocations         |                                                                                                                 |
+    | fetch_numActiveSmallAllocations        |                                                                                                                 |
+    | fetch_numActiveNormalAllocations       |                                                                                                                 |
+    | fetch_numActiveHugeAllocations         |                                                                                                                 |
+    | fetch_numActiveBytes                   |                                                                                                                 |
 
   - namespace=CPU
     
@@ -341,7 +362,7 @@ These metrics are exposed by Celeborn worker.
 
 **Note:**
 
-The Netty DirectArenaMetrics named like `push/fetch/replicate_server_numXX` are not exposed by default, nor in Grafana dashboard.
+The Netty DirectArenaMetrics named like `push/fetch/replicate_numXX` are not exposed by default, nor in Grafana dashboard.
 If there is a need, you can enable `celeborn.network.memory.allocator.verbose.metric` to expose these metrics.
 
 ### Setup Prometheus dashboard


### PR DESCRIPTION
### What changes were proposed in this pull request?

`NettyMemoryMetrics` supports `numHeapArenas`, `numDirectArenas`, `tinyCacheSize`, `smallCacheSize`, `normalCacheSize`, `numThreadLocalCaches` and `chunkSize` from `PooledByteBufAllocatorMetric`. Meanwhile, remove `server_` prefix from metric name of netty memory metric in `monitoring.md`.

### Why are the changes needed?

`PooledByteBufAllocatorMetric` provides the following API to support netty memory metrics:

```
public int numHeapArenas() {
  return this.allocator.numHeapArenas();
}

public int numDirectArenas() {
  return this.allocator.numDirectArenas();
}

public List<PoolArenaMetric> heapArenas() {
  return this.allocator.heapArenas();
}

public List<PoolArenaMetric> directArenas() {
  return this.allocator.directArenas();
}

public int numThreadLocalCaches() {
  return this.allocator.numThreadLocalCaches();
}

public int tinyCacheSize() {
  return this.allocator.tinyCacheSize();
}

public int smallCacheSize() {
  return this.allocator.smallCacheSize();
}

public int normalCacheSize() {
  return this.allocator.normalCacheSize();
}

public int chunkSize() {
  return this.allocator.chunkSize();
}

public long usedHeapMemory() {
  return this.allocator.usedHeapMemory();
}

public long usedDirectMemory() {
  return this.allocator.usedDirectMemory();
}
```

`NettyMemoryMetrics` only supports `usedHeapMemory` and `usedDirectMemory`, which could support `numHeapArenas`, `numDirectArenas`, `tinyCacheSize`, `smallCacheSize`, `normalCacheSize`, `numThreadLocalCaches` and `chunkSize` from `PooledByteBufAllocatorMetric`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

[Celeborn Grafana Dashboard](https://stenicholas.grafana.net/public-dashboards/a520ca36a33843a38bbde28387023f97)