### PR TITLE
[CELEBORN-1644] Optimize handle merged data on stage end

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1391,10 +1391,16 @@ public class ShuffleClientImpl extends ShuffleClient {
                 groupedBatchId,
                 Arrays.toString(batchIds));
             pushState.removeBatch(groupedBatchId, hostPort);
-            if (response.remaining() > 0 && response.get() == StatusCode.MAP_ENDED.getValue()) {
-              mapperEndMap
-                  .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
-                  .add(mapId);
+            if (response.remaining() > 0) {
+              int retCode = response.get();
+              if (retCode == StatusCode.MAP_ENDED.getValue()) {
+                mapperEndMap
+                    .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
+                    .add(mapId);
+              }
+              if (retCode == StatusCode.STAGE_ENDED.getValue()) {
+                stageEndShuffleSet.add(shuffleId);
+              }
             }
           }
 

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1397,8 +1397,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                 mapperEndMap
                     .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
                     .add(mapId);
-              }
-              if (retCode == StatusCode.STAGE_ENDED.getValue()) {
+              } else if (retCode == StatusCode.STAGE_ENDED.getValue()) {
                 stageEndShuffleSet.add(shuffleId);
               }
             }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -442,7 +442,12 @@ abstract class CommitHandler(
         replicaIds)
     }
 
-    doParallelCommitFiles(shuffleId, shuffleCommittedInfo, params, commitFilesFailedWorkers, true)
+    doParallelCommitFiles(
+      shuffleId,
+      shuffleCommittedInfo,
+      params,
+      commitFilesFailedWorkers,
+      this.isInstanceOf[ReducePartitionCommitHandler])
 
     logInfo(s"Shuffle $shuffleId " +
       s"commit files complete. File count ${shuffleCommittedInfo.currentShuffleFileCount.sum()} " +

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -395,7 +395,8 @@ abstract class CommitHandler(
   def parallelCommitFiles(
       shuffleId: Int,
       allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo],
-      partitionIdOpt: Option[Int] = None): CommitResult = {
+      partitionIdOpt: Option[Int] = None,
+      finalCommit: Boolean = false): CommitResult = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
     val primaryPartMap = JavaUtils.newConcurrentHashMap[String, PartitionLocation]
     val replicaPartMap = JavaUtils.newConcurrentHashMap[String, PartitionLocation]
@@ -447,7 +448,7 @@ abstract class CommitHandler(
       shuffleCommittedInfo,
       params,
       commitFilesFailedWorkers,
-      this.isInstanceOf[ReducePartitionCommitHandler])
+      finalCommit)
 
     logInfo(s"Shuffle $shuffleId " +
       s"commit files complete. File count ${shuffleCommittedInfo.currentShuffleFileCount.sum()} " +

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -166,7 +166,7 @@ class ReducePartitionCommitHandler(
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
 
     // commit files
-    val parallelCommitResult = parallelCommitFiles(shuffleId, allocatedWorkers, None)
+    val parallelCommitResult = parallelCommitFiles(shuffleId, allocatedWorkers, None, true)
 
     // check all inflight request complete
     waitInflightRequestComplete(shuffleCommittedInfo)

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -504,6 +504,7 @@ message PbCommitFiles {
   repeated int32 mapAttempts = 5;
   int64 epoch = 6;
   bool mockFailure = 7;
+  bool stageEnd = 8;
 }
 
 message PbCommitFilesResponse {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -498,7 +498,8 @@ object ControlMessages extends Logging {
       replicaIds: util.List[String],
       mapAttempts: Array[Int],
       epoch: Long,
-      var mockFailure: Boolean = false)
+      var mockFailure: Boolean = false,
+      val isStageEnd: Boolean)
     extends WorkerMessage
 
   case class CommitFilesResponse(
@@ -893,7 +894,8 @@ object ControlMessages extends Logging {
           replicaIds,
           mapAttempts,
           epoch,
-          mockFailure) =>
+          mockFailure,
+          isStageEnd) =>
       val payload = PbCommitFiles.newBuilder()
         .setApplicationId(applicationId)
         .setShuffleId(shuffleId)
@@ -902,6 +904,7 @@ object ControlMessages extends Logging {
         .addAllMapAttempts(mapAttempts.map(Integer.valueOf).toIterable.asJava)
         .setEpoch(epoch)
         .setMockFailure(mockFailure)
+        .setStageEnd(isStageEnd)
         .build().toByteArray
       new TransportMessage(MessageType.COMMIT_FILES, payload)
 
@@ -1269,7 +1272,8 @@ object ControlMessages extends Logging {
           pbCommitFiles.getReplicaIdsList,
           pbCommitFiles.getMapAttemptsList.asScala.map(_.toInt).toArray,
           pbCommitFiles.getEpoch,
-          pbCommitFiles.getMockFailure)
+          pbCommitFiles.getMockFailure,
+          pbCommitFiles.getStageEnd)
 
       case COMMIT_FILES_RESPONSE_VALUE =>
         val pbCommitFilesResponse = PbCommitFilesResponse.parseFrom(message.getPayload)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -498,7 +498,6 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
               ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
           }
         } else {
-          // This means that this stage is ended and invoked commit files by stage end
           if (storageManager.shuffleKeySet().contains(shuffleKey)) {
             // If there is no shuffle key in shuffleMapperAttempts but there is shuffle key
             // in StorageManager. This partition should be HARD_SPLIT partition and

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -301,6 +301,8 @@ private[celeborn] class Worker(
   val registered = new AtomicBoolean(false)
   val shuffleMapperAttempts: ConcurrentHashMap[String, AtomicIntegerArray] =
     JavaUtils.newConcurrentHashMap[String, AtomicIntegerArray]()
+  val presumptiveEndedShuffles: ConcurrentHashMap.KeySetView[String, java.lang.Boolean] =
+    ConcurrentHashMap.newKeySet[String]()
   val shufflePartitionType: ConcurrentHashMap[String, PartitionType] =
     JavaUtils.newConcurrentHashMap[String, PartitionType]
   var shufflePushDataTimeout: ConcurrentHashMap[String, Long] =
@@ -742,6 +744,7 @@ private[celeborn] class Worker(
         shufflePartitionType.remove(shuffleKey)
         shufflePushDataTimeout.remove(shuffleKey)
         shuffleMapperAttempts.remove(shuffleKey)
+        presumptiveEndedShuffles.remove(shuffleKey)
         shuffleCommitInfos.remove(shuffleKey)
         workerInfo.releaseSlots(shuffleKey)
         val applicationId = Utils.splitShuffleKey(shuffleKey)._1


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add worker readable address to commit files response logs, to avoid redundant logs
2. Pass stage end status to the worker to avoid unnecessary retry 


### Why are the changes needed?
Committing files will take a period of time if a speculation task is pushing merged data to the worker. This will cause the client to retry until the committing files is complete or client timeout. This PR intend to optimize the logic to avoid unnecessary retry.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA.
