### PR TITLE
[CELEBORN-1652] Throw TransportableError for failure of sending PbReadAddCredit to avoid flink task get stuck

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
@@ -100,10 +100,12 @@ public class CelebornBufferStream {
 
           @Override
           public void onFailure(Throwable e) {
-            logger.warn(
-                "Send PbReadAddCredit to {} failed, detail {}",
+            logger.error(
+                "Send PbReadAddCredit to {} failed, streamId {}, detail {}",
                 NettyUtils.getRemoteAddress(client.getChannel()),
+                streamId,
                 e.getCause());
+            messageConsumer.accept(new TransportableError(streamId, e));
           }
         });
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Throw `TransportableError` for failure of sending `PbReadAddCredit` to avoid flink task get stuck.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

by manual verification
