### PR TITLE
[CELEBORN-1656] Remove duplicate UserProduceSpeed metrics

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -196,10 +196,6 @@ public class CongestionController {
           logger.info("New user {} comes, initializing its rate status", user);
           BufferStatusHub bufferStatusHub = new BufferStatusHub(sampleTimeWindowSeconds);
           UserBufferInfo userInfo = new UserBufferInfo(System.currentTimeMillis(), bufferStatusHub);
-          workerSource.addGauge(
-              WorkerSource.USER_PRODUCE_SPEED(),
-              userIdentifier.toJMap(),
-              () -> getUserProduceSpeed(userInfo));
           return userInfo;
         });
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
@@ -45,7 +45,7 @@ public class UserCongestionControlContext {
     workerSource.addGauge(
         WorkerSource.USER_PRODUCE_SPEED(),
         userIdentifier.toJMap(),
-        (Gauge<Long>) () -> userBufferInfo.getBufferStatusHub().avgBytesPerSec());
+            () -> userBufferInfo.getBufferStatusHub().avgBytesPerSec());
   }
 
   public void onCongestionControl() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
@@ -17,8 +17,6 @@
 
 package org.apache.celeborn.service.deploy.worker.congestcontrol;
 
-import com.codahale.metrics.Gauge;
-
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
@@ -45,7 +45,7 @@ public class UserCongestionControlContext {
     workerSource.addGauge(
         WorkerSource.USER_PRODUCE_SPEED(),
         userIdentifier.toJMap(),
-            () -> userBufferInfo.getBufferStatusHub().avgBytesPerSec());
+        () -> userBufferInfo.getBufferStatusHub().avgBytesPerSec());
   }
 
   public void onCongestionControl() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove duplicate UserProduceSpeed metrics

### Why are the changes needed? 
UserProduceSpeed metrics have been added in UserCongestionControlContext

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.
