### PR TITLE
[CELEBORN-1657] Throw exception to client when exception occurred in reading sort shuffle files

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -774,7 +774,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         logger.error(
             "Sorting shuffle file for " + fileId + " " + originFilePath + " failed, detail: ", e);
         sortExceptions
-            .computeIfAbsent(fileId, v -> JavaUtils.newConcurrentHashMap())
+            .computeIfAbsent(shuffleKey, v -> JavaUtils.newConcurrentHashMap())
             .put(fileId, new IOException(e));
       } finally {
         closeFiles();


### PR DESCRIPTION
### What changes were proposed in this pull request?
To report errors in sorting shuffle files.


### Why are the changes needed?
Report errors to client as soon as possible when a shuffle file is corrupted.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
Cluster test.
