### PR TITLE
[CELEBORN-1658] Add Git Commit Info and Build JDK Spec to sbt Manifest

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -245,7 +245,7 @@ object CelebornCommonSettings {
     javacOptions ++= Seq("-encoding", UTF_8.name(), "-source", "1.8", "-g"),
     Compile / packageBin / packageOptions +=  Package.ManifestAttributes(
       "Build-Jdk-Spec" -> System.getProperty("java.version"),
-      "Build-Commit" -> gitHeadCommit.value.getOrElse("N/A"),
+      "Build-Revision" -> gitHeadCommit.value.getOrElse("N/A"),
       "Build-Branch" -> gitCurrentBranch.value,
       "Build-Time" -> java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ISO_DATE_TIME)),
   

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -245,7 +245,7 @@ object CelebornCommonSettings {
     javacOptions ++= Seq("-encoding", UTF_8.name(), "-source", "1.8", "-g"),
     Compile / packageBin / packageOptions +=  Package.ManifestAttributes(
       "Build-Jdk-Spec" -> System.getProperty("java.version"),
-      "Git-Head-Commit" -> gitHeadCommit.value.get),
+      "Git-Head-Commit" -> gitHeadCommit.value.getOrElse("N/A")),
   
     // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
     Compile / compile / javacOptions ++= Seq("-target", "1.8"),

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -23,11 +23,11 @@ import scala.util.Properties
 import scala.xml._
 import scala.xml.transform._
 
+import com.github.sbt.git.SbtGit.GitKeys._
 import org.openapitools.generator.sbt.plugin.OpenApiGeneratorPlugin
 import org.openapitools.generator.sbt.plugin.OpenApiGeneratorPlugin.autoImport._
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtprotoc.ProtocPlugin.autoImport._
-import com.github.sbt.git.SbtGit.GitKeys._
 
 import sbt._
 import sbt.Keys._

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -27,6 +27,7 @@ import org.openapitools.generator.sbt.plugin.OpenApiGeneratorPlugin
 import org.openapitools.generator.sbt.plugin.OpenApiGeneratorPlugin.autoImport._
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtprotoc.ProtocPlugin.autoImport._
+import com.github.sbt.git.SbtGit.GitKeys._
 
 import sbt._
 import sbt.Keys._
@@ -242,7 +243,10 @@ object CelebornCommonSettings {
     fork := true,
     scalacOptions ++= Seq("-target:jvm-1.8"),
     javacOptions ++= Seq("-encoding", UTF_8.name(), "-source", "1.8", "-g"),
-
+    Compile / packageBin / packageOptions +=  Package.ManifestAttributes(
+      "Build-Jdk-Spec" -> System.getProperty("java.version"),
+      "Git-Head-Commit" -> gitHeadCommit.value.get),
+  
     // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
     Compile / compile / javacOptions ++= Seq("-target", "1.8"),
 

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -245,7 +245,9 @@ object CelebornCommonSettings {
     javacOptions ++= Seq("-encoding", UTF_8.name(), "-source", "1.8", "-g"),
     Compile / packageBin / packageOptions +=  Package.ManifestAttributes(
       "Build-Jdk-Spec" -> System.getProperty("java.version"),
-      "Git-Head-Commit" -> gitHeadCommit.value.getOrElse("N/A")),
+      "Build-Commit" -> gitHeadCommit.value.getOrElse("N/A"),
+      "Build-Branch" -> gitCurrentBranch.value,
+      "Build-Time" -> java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ISO_DATE_TIME)),
   
     // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
     Compile / compile / javacOptions ++= Seq("-target", "1.8"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,3 +22,5 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.8.0")
+
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This PR  adding Git commit information and JVM build specifications to package manifest.

the `META-INF/MANIFEST.MF` before this PR:

```
Manifest-Version: 1.0
Specification-Title: celeborn-client-spark-3-shaded
Specification-Version: 0.6.0-SNAPSHOT
Specification-Vendor: org.apache.celeborn
Implementation-Title: celeborn-client-spark-3-shaded
Implementation-Version: 0.6.0-SNAPSHOT
Implementation-Vendor: org.apache.celeborn
Implementation-Vendor-Id: org.apache.celeborn
```

after this PR:

```
Manifest-Version: 1.0
Specification-Title: celeborn-client-spark-3-shaded
Specification-Version: 0.6.0-SNAPSHOT
Specification-Vendor: org.apache.celeborn
Implementation-Title: celeborn-client-spark-3-shaded
Implementation-Version: 0.6.0-SNAPSHOT
Implementation-Vendor: org.apache.celeborn
Implementation-Vendor-Id: org.apache.celeborn
Build-Jdk-Spec: 17.0.9
Build-Revision: 03247c19f1b38096a4080fe97e94dbeb20ebcbe9
Build-Branch: jdk-git-spec
Build-Time: 2024-10-18T17:53:02.723124+08:00[Asia/Shanghai]
```

```
Manifest-Version: 1.0
Specification-Title: celeborn-client-spark-3-shaded
Specification-Version: 0.6.0-SNAPSHOT
Specification-Vendor: org.apache.celeborn
Implementation-Title: celeborn-client-spark-3-shaded
Implementation-Version: 0.6.0-SNAPSHOT
Implementation-Vendor: org.apache.celeborn
Implementation-Vendor-Id: org.apache.celeborn
Build-Jdk-Spec: 17.0.9
Build-Revision: N/A
Build-Branch: 
Build-Time: 2024-10-18T17:54:16.932121+08:00[Asia/Shanghai]
```

### Why are the changes needed?

As title.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

local