### PR TITLE
[CELEBORN-1659][FOLLOWUP] Dockerfile should support copying CLI jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ General package layout:
     ├── conf                            
     ├── jars           // common jars for master and worker                 
     ├── master-jars                     
-    ├── worker-jars                     
+    ├── worker-jars                  
+    ├── cli-jars     
     ├── spark          // Spark client jars if spark profiles are activated
     ├── flink          // Flink client jars if flink profiles are activated
     ├── mr             // MapReduce client jars if mr profile is activated

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,7 @@ COPY conf /opt/celeborn/conf
 COPY jars /opt/celeborn/jars
 COPY master-jars /opt/celeborn/master-jars
 COPY worker-jars /opt/celeborn/worker-jars
+COPY cli-jars /opt/celeborn/cli-jars
 COPY RELEASE /opt/celeborn/RELEASE
 
 RUN chown -R celeborn:celeborn ${CELEBORN_HOME} && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Dockerfile should support copying CLI jars.

### Why are the changes needed?

CLI jars are generated from `make-distribution.sh`. Therefore, Dockerfile could copy CLI jars to `/opt/celeborn/` directory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.