### PR TITLE
[CELEBORN-1664] Fix secret fetch failures after LEADER master failover

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/MasterSecretRegistryImpl.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/MasterSecretRegistryImpl.java
@@ -48,12 +48,14 @@ public class MasterSecretRegistryImpl extends SecretRegistryImpl {
   public String getSecretKey(String appId) {
     String secret = super.getSecretKey(appId);
     if (secret == null && metadataHandler != null) {
-      LOG.info("Fetching secret from AbstractMetaManager for appId: {}", appId);
+      LOG.info("Fetching secret from metadata manager for appId: {}", appId);
       ApplicationMeta applicationMeta = metadataHandler.applicationMetas.get(appId);
       if (applicationMeta != null) {
         secret = applicationMeta.secret();
+        LOG.debug("Found Secret from metadata manager for appId: {}, register secret", appId);
+        super.register(appId, secret);
       } else {
-        LOG.warn("Secret not found from AbstractMetaManager for appId: {}", appId);
+        LOG.warn("Secret not found from metadata manager for appId: {}", appId);
       }
     }
     return secret;
@@ -63,8 +65,12 @@ public class MasterSecretRegistryImpl extends SecretRegistryImpl {
   public boolean isRegistered(String appId) {
     boolean isRegistered = super.isRegistered(appId);
     if (!isRegistered && metadataHandler != null) {
-      LOG.info("Fetching registration status from AbstractMetaManager for appId: {}", appId);
+      LOG.info("Fetching registration status from metadata manager for appId: {}", appId);
       isRegistered = metadataHandler.applicationMetas.containsKey(appId);
+      if (isRegistered) {
+        LOG.debug("Found Secret from metadata manager for appId: {}, register secret", appId);
+        super.register(appId, metadataHandler.applicationMetas.get(appId).secret());
+      }
     }
     return isRegistered;
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/MasterSecretRegistryImpl.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/MasterSecretRegistryImpl.java
@@ -32,25 +32,25 @@ import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager
 public class MasterSecretRegistryImpl implements SecretRegistry {
 
   private static final Logger LOG = LoggerFactory.getLogger(MasterSecretRegistryImpl.class);
-  private AbstractMetaManager metadataHandler;
+  private AbstractMetaManager statusSystem;
 
   @Override
   public void register(String appId, String secret) {
     LOG.info("Persisting metadata for appId: {}", appId);
-    metadataHandler.handleApplicationMeta(new ApplicationMeta(appId, secret));
+    statusSystem.handleApplicationMeta(new ApplicationMeta(appId, secret));
   }
 
   @Override
   public void unregister(String appId) {
     LOG.info("Removing metadata for appId: {}", appId);
-    metadataHandler.removeApplicationMeta(appId);
+    statusSystem.removeApplicationMeta(appId);
   }
 
   @Override
   public String getSecretKey(String appId) {
     String secret = null;
     LOG.info("Fetching secret from metadata manager for appId: {}", appId);
-    ApplicationMeta applicationMeta = metadataHandler.applicationMetas.get(appId);
+    ApplicationMeta applicationMeta = statusSystem.applicationMetas.get(appId);
     if (applicationMeta != null) {
       secret = applicationMeta.secret();
     }
@@ -60,10 +60,10 @@ public class MasterSecretRegistryImpl implements SecretRegistry {
   @Override
   public boolean isRegistered(String appId) {
     LOG.info("Fetching registration status from metadata manager for appId: {}", appId);
-    return metadataHandler.applicationMetas.containsKey(appId);
+    return statusSystem.applicationMetas.containsKey(appId);
   }
 
-  void setMetadataHandler(AbstractMetaManager metadataHandler) {
-    this.metadataHandler = metadataHandler;
+  void setMetadataHandler(AbstractMetaManager statusSystem) {
+    this.statusSystem = statusSystem;
   }
 }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/MasterSecretRegistryImpl.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/MasterSecretRegistryImpl.java
@@ -49,7 +49,7 @@ public class MasterSecretRegistryImpl implements SecretRegistry {
   @Override
   public String getSecretKey(String appId) {
     String secret = null;
-    LOG.info("Fetching secret from metadata manager for appId: {}", appId);
+    LOG.debug("Fetching secret from metadata manager for appId: {}", appId);
     ApplicationMeta applicationMeta = statusSystem.applicationMetas.get(appId);
     if (applicationMeta != null) {
       secret = applicationMeta.secret();

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -504,4 +504,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public void updateApplicationMeta(ApplicationMeta applicationMeta) {
     applicationMetas.putIfAbsent(applicationMeta.appId(), applicationMeta);
   }
+
+  public void removeApplicationMeta(String appId) {
+    applicationMetas.remove(appId);
+  }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1036,6 +1036,7 @@ private[celeborn] class Master(
     nonEagerHandler.submit(new Runnable {
       override def run(): Unit = {
         workersAssignedToApp.remove(appId)
+        secretRegistry.unregister(appId);
         statusSystem.handleAppLost(appId, requestId)
         logInfo(s"Removed application $appId")
         if (hasHDFSStorage || hasS3Storage) {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1036,7 +1036,6 @@ private[celeborn] class Master(
     nonEagerHandler.submit(new Runnable {
       override def run(): Unit = {
         workersAssignedToApp.remove(appId)
-        secretRegistry.unregister(appId);
         statusSystem.handleAppLost(appId, requestId)
         logInfo(s"Removed application $appId")
         if (hasHDFSStorage || hasS3Storage) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix a bug related to auth under master HA mode which would cause app failures when leader master restarts. Also, remove the secrets from memory after app lost.

Previous implementation add the registration & secret info in leader Master's memory, and push to other masters though https://github.com/apache/celeborn/pull/2346. After leader restarts, the info will only be in Ratis (AbstractMetaManager), however app still fetch it from new leader's memory, and would fail to get it.

Fix this by checking AbstractMetaManager's registration info if not found in memory, and properly authorize the app.


### Why are the changes needed?
When auth enabled, and leader master restart, there will be "Registration information not found" error on app side, and failed to send heartbeat to master. It will cause app to be removed on server side after heartbeat timeout, causing job to fail.
```
24/10/14 01:56:55 ERROR [celeborn-netty-rpc-connection-executor-3] client.TransportClientFactory: Exception while bootstrapping client after 71.4 ms
java.lang.RuntimeException: java.io.IOException: Exception in sendRpcSync to: celeborn-moka-test-manager-3/{ip}:9097
    at org.apache.celeborn.common.network.sasl.SaslClientBootstrap.doBootstrap(SaslClientBootstrap.java:110)
    at org.apache.celeborn.common.network.sasl.registration.RegistrationClientBootstrap.doSaslBootstrap(RegistrationClientBootstrap.java:228)
    at org.apache.celeborn.common.network.sasl.registration.RegistrationClientBootstrap.doBootstrap(RegistrationClientBootstrap.java:103)
    at org.apache.celeborn.common.network.client.TransportClientFactory.internalCreateClient(TransportClientFactory.java:307)
    at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:205)
    at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:133)
    at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:212)
    at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.createClient(NettyRpcEnv.scala:232)
    at org.apache.celeborn.common.rpc.netty.Outbox$$anon$1.call(Outbox.scala:194)
    at org.apache.celeborn.common.rpc.netty.Outbox$$anon$1.call(Outbox.scala:190)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.io.IOException: Exception in sendRpcSync to: celeborn-moka-test-manager-3/{ip}:9097
    at org.apache.celeborn.common.network.client.TransportClient.sendRpcSync(TransportClient.java:324)
    at org.apache.celeborn.common.network.sasl.SaslClientBootstrap.doBootstrap(SaslClientBootstrap.java:95)
    ... 13 more
Caused by: java.util.concurrent.ExecutionException: java.io.IOException: java.lang.RuntimeException: Registration information not found for spark-402a80be70f74455b01
    at org.apache.celeborn.common.network.sasl.CelebornSaslServer$DigestCallbackHandler.handle(CelebornSaslServer.java:142)
    at java.security.sasl/com.sun.security.sasl.digest.DigestMD5Server.validateClientResponse(DigestMD5Server.java:589)
    at java.security.sasl/com.sun.security.sasl.digest.DigestMD5Server.evaluateResponse(DigestMD5Server.java:244)
    at org.apache.celeborn.common.network.sasl.CelebornSaslServer.response(CelebornSaslServer.java:84)
    at org.apache.celeborn.common.network.sasl.SaslRpcHandler.doAuthChallenge(SaslRpcHandler.java:99)
    at org.apache.celeborn.common.network.server.AbstractAuthRpcHandler.receive(AbstractAuthRpcHandler.java:58)
    at org.apache.celeborn.common.network.sasl.registration.RegistrationRpcHandler.processRpcMessage(RegistrationRpcHandler.java:175) 
```
### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested on dev cluster and job can properly get the secrets after master failover
