### PR TITLE
[CELEBORN-1660] Cache available workers and only count the available workers device free capacity

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -165,7 +165,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The count of active workers.",
+          "description": "The count of workers in available list.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -243,12 +243,12 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_WorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_AvailableWorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
           ],
-          "title": "metrics_WorkerCount_Value",
+          "title": "metrics_AvailableWorkerCount_Value",
           "type": "timeseries"
         },
         {
@@ -1287,7 +1287,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The count of workers in available list.",
+          "description": "The count of active workers.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1366,13 +1366,13 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "metrics_AvailableWorkerCount_Value{instance=~\"${instance}\"}",
+              "expr": "metrics_WorkerCount_Value{instance=~\"${instance}\"}",
               "legendFormat": "${baseLegend}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "metrics_AvailableWorkerCount_Value",
+          "title": "metrics_WorkerCount_Value",
           "type": "timeseries"
         },
         {

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -95,7 +95,7 @@ These metrics are exposed by Celeborn master.
     | Metric Name              | Description                                                                       |
     |--------------------------|-----------------------------------------------------------------------------------|
     | RegisteredShuffleCount   | The count of registered shuffle.                                                  |
-    | DeviceCelebornFreeBytes  | The actual usable space of Celeborn for device.                                   |
+    | DeviceCelebornFreeBytes  | The actual usable space of Celeborn available workers for device.                 |
     | DeviceCelebornTotalBytes | The total space of Celeborn for device.                                           |
     | RunningApplicationCount  | The count of running applications.                                                |
     | ActiveShuffleSize        | The active shuffle size of workers.                                               |

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -92,7 +92,7 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
   @Override
   public void handleWorkerExclude(
       List<WorkerInfo> workersToAdd, List<WorkerInfo> workersToRemove, String requestId) {
-    updateWorkerExcludeMeta(workersToAdd, workersToRemove);
+    updateManuallyExcludedWorkersMeta(workersToAdd, workersToRemove);
   }
 
   @Override

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -170,7 +170,7 @@ public class MetaHandler {
               addAddresses.stream().map(MetaUtil::addrToInfo).collect(Collectors.toList());
           List<WorkerInfo> workersToRemove =
               removeAddresses.stream().map(MetaUtil::addrToInfo).collect(Collectors.toList());
-          metaSystem.updateWorkerExcludeMeta(workersToAdd, workersToRemove);
+          metaSystem.updateManuallyExcludedWorkersMeta(workersToAdd, workersToRemove);
           break;
 
         case WorkerLost:

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -952,10 +952,9 @@ private[celeborn] class Master(
     logInfo(s"Offer slots successfully for $numReducers reducers of $shuffleKey" +
       s" on ${slots.size()} workers.")
 
-    val workersNotSelectedSize = availableWorkers.size() - slots.size()
-    val offerSlotsExtraSize = Math.min(conf.masterSlotAssignExtraSlots, workersNotSelectedSize)
+    val workersNotSelected = availableWorkers.asScala.filter(!slots.containsKey(_))
+    val offerSlotsExtraSize = Math.min(conf.masterSlotAssignExtraSlots, workersNotSelected.size)
     if (offerSlotsExtraSize > 0) {
-      val workersNotSelected = availableWorkers.asScala.filterNot(slots.containsKey)
       var index = Random.nextInt(workersNotSelected.size)
       (1 to offerSlotsExtraSize).foreach(_ => {
         slots.put(

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -160,6 +160,7 @@ public class DefaultMetaSystemSuiteJ {
         getNewReqeustId());
 
     assertEquals(3, statusSystem.workersMap.size());
+    assertEquals(3, statusSystem.availableWorkers.size());
   }
 
   @Test
@@ -211,10 +212,12 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleWorkerExclude(
         Arrays.asList(workerInfo1, workerInfo2), Collections.emptyList(), getNewReqeustId());
     assertEquals(2, statusSystem.manuallyExcludedWorkers.size());
+    assertEquals(0, statusSystem.availableWorkers.size());
 
     statusSystem.handleWorkerExclude(
         Collections.emptyList(), Collections.singletonList(workerInfo1), getNewReqeustId());
     assertEquals(1, statusSystem.manuallyExcludedWorkers.size());
+    assertEquals(1, statusSystem.availableWorkers.size());
   }
 
   @Test
@@ -256,6 +259,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleWorkerLost(
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
     assertEquals(2, statusSystem.workersMap.size());
+    assertEquals(2, statusSystem.availableWorkers.size());
   }
 
   private static final String APPID1 = "appId1";
@@ -700,6 +704,7 @@ public class DefaultMetaSystemSuiteJ {
         getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 1);
+    assertEquals(statusSystem.availableWorkers.size(), 2);
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME2,
@@ -716,6 +721,7 @@ public class DefaultMetaSystemSuiteJ {
         getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 2);
+    assertEquals(statusSystem.availableWorkers.size(), 1);
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME3,
@@ -732,6 +738,7 @@ public class DefaultMetaSystemSuiteJ {
         getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 2);
+    assertEquals(statusSystem.availableWorkers.size(), 1);
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME3,
@@ -748,6 +755,7 @@ public class DefaultMetaSystemSuiteJ {
         getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 3);
+    assertEquals(statusSystem.availableWorkers.size(), 0);
   }
 
   @Test
@@ -801,6 +809,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
     assertEquals(1, statusSystem.shutdownWorkers.size());
     assertTrue(statusSystem.excludedWorkers.isEmpty());
+    assertEquals(2, statusSystem.availableWorkers.size());
   }
 
   @Test
@@ -900,6 +909,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleReportWorkerDecommission(workers, getNewReqeustId());
     assertEquals(1, statusSystem.decommissionWorkers.size());
     assertTrue(statusSystem.excludedWorkers.isEmpty());
+    assertEquals(2, statusSystem.availableWorkers.size());
   }
 
   @Test

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -205,12 +205,11 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     String host2 = "host2";
     String host3 = "host3";
 
-    masterStatusSystem.excludedWorkers.add(info1);
-    masterStatusSystem.excludedWorkers.add(info2);
-    masterStatusSystem.excludedWorkers.add(info3);
+    masterStatusSystem.updateExcludedWorkersMeta(
+        Arrays.asList(info1, info2, info3), Collections.emptyList());
 
-    masterStatusSystem.manuallyExcludedWorkers.add(info1);
-    masterStatusSystem.manuallyExcludedWorkers.add(info2);
+    masterStatusSystem.updateManuallyExcludedWorkersMeta(
+        Arrays.asList(info1, info2), Collections.emptyList());
 
     masterStatusSystem.hostnameSet.add(host1);
     masterStatusSystem.hostnameSet.add(host2);
@@ -245,10 +244,12 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     masterStatusSystem.excludedWorkers.clear();
     masterStatusSystem.manuallyExcludedWorkers.clear();
     masterStatusSystem.workersMap.clear();
+    masterStatusSystem.availableWorkers.clear();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
     Assert.assertEquals(3, masterStatusSystem.workersMap.size());
+    Assert.assertEquals(3, masterStatusSystem.availableWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
     Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -353,6 +353,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
     Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
 
+    Assert.assertEquals(3, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.availableWorkers.size());
+
     assertWorkers(STATUSSYSTEM1.workersMap.values());
     assertWorkers(STATUSSYSTEM2.workersMap.values());
     assertWorkers(STATUSSYSTEM3.workersMap.values());
@@ -429,6 +433,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM2.manuallyExcludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM3.manuallyExcludedWorkers.size());
 
+    Assert.assertEquals(0, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM3.availableWorkers.size());
+
     statusSystem.handleWorkerExclude(
         Collections.emptyList(), Collections.singletonList(workerInfo1), getNewReqeustId());
     Thread.sleep(3000L);
@@ -436,6 +444,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM1.manuallyExcludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.manuallyExcludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.manuallyExcludedWorkers.size());
+
+    Assert.assertEquals(1, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Test
@@ -484,6 +496,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM1.workersMap.size());
     Assert.assertEquals(2, STATUSSYSTEM2.workersMap.size());
     Assert.assertEquals(2, STATUSSYSTEM3.workersMap.size());
+
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Test
@@ -1025,6 +1041,14 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.excludedWorkers.size());
 
+    Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
+
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
+
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME2,
         RPCPORT2,
@@ -1044,6 +1068,16 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM3.excludedWorkers.size());
+
+    Assert.assertEquals(3, statusSystem.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
+
+    Assert.assertEquals(1, statusSystem.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME1,
@@ -1065,6 +1099,16 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.excludedWorkers.size());
 
+    Assert.assertEquals(3, statusSystem.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
+
+    Assert.assertEquals(2, statusSystem.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
+
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME1,
         RPCPORT1,
@@ -1083,6 +1127,16 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM3.excludedWorkers.size());
+
+    Assert.assertEquals(3, statusSystem.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
+
+    Assert.assertEquals(1, statusSystem.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Before
@@ -1090,6 +1144,7 @@ public class RatisMasterStatusSystemSuiteJ {
     STATUSSYSTEM1.registeredAppAndShuffles.clear();
     STATUSSYSTEM1.hostnameSet.clear();
     STATUSSYSTEM1.workersMap.clear();
+    STATUSSYSTEM1.availableWorkers.clear();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.excludedWorkers.clear();
     STATUSSYSTEM1.workerLostEvents.clear();
@@ -1097,6 +1152,7 @@ public class RatisMasterStatusSystemSuiteJ {
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
     STATUSSYSTEM2.workersMap.clear();
+    STATUSSYSTEM2.availableWorkers.clear();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.excludedWorkers.clear();
     STATUSSYSTEM2.workerLostEvents.clear();
@@ -1104,6 +1160,7 @@ public class RatisMasterStatusSystemSuiteJ {
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
     STATUSSYSTEM3.workersMap.clear();
+    STATUSSYSTEM3.availableWorkers.clear();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.excludedWorkers.clear();
     STATUSSYSTEM3.workerLostEvents.clear();
@@ -1222,6 +1279,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Test
@@ -1292,6 +1352,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM2.lostWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.lostWorkers.size());
 
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
+
     statusSystem.handleRemoveWorkersUnavailableInfo(unavailableWorkers, getNewReqeustId());
     Thread.sleep(3000L);
 
@@ -1302,6 +1366,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(0, STATUSSYSTEM1.lostWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.lostWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM3.lostWorkers.size());
+
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Test
@@ -1397,6 +1465,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM2.workerEventInfos.size());
     Assert.assertEquals(2, STATUSSYSTEM3.workerEventInfos.size());
 
+    Assert.assertEquals(1, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
+
     Assert.assertTrue(STATUSSYSTEM1.workerEventInfos.containsKey(workerInfo1));
     Assert.assertTrue(STATUSSYSTEM1.workerEventInfos.containsKey(workerInfo2));
 
@@ -1416,6 +1488,10 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(
         WorkerEventType.Decommission,
         STATUSSYSTEM1.workerEventInfos.get(workerInfo2).getEventType());
+
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Test
@@ -1504,6 +1580,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
   }
 
   @Test

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.celeborn.tests.client
 
 import java.util
+import java.util.Collections
 
 import scala.collection.JavaConverters.{asScalaSetConverter, mapAsScalaMapConverter}
 
@@ -175,7 +176,9 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
       val (worker, _) = workerInfoList(index)
       // Workers in miniClusterFeature wont update status with master through heartbeat.
       // So update status manually.
-      masterInfo._1.statusSystem.excludedWorkers.add(worker.workerInfo)
+      masterInfo._1.statusSystem.updateExcludedWorkersMeta(
+        Collections.singletonList(worker.workerInfo),
+        Collections.emptyList())
 
       val failedWorker = new ShuffleFailedWorkers()
       failedWorker.put(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. cache the available workers 
2. Only count the available workers device free capacity.
3. place the metrics_AvailableWorkerCount_Value in overall and metrics_WorkerCount_Value in `Master` part


### Why are the changes needed?
Cache  the available workers to reduce the computation that need to loop the workers frequently.
To have an accurate device capacity overview that does not include the excluded workers, decommissioning workers, etc.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?
UT.

<img width="1705" alt="image" src="https://github.com/user-attachments/assets/bee17b4e-785d-4112-8410-dbb684270ec0">
