### PR TITLE
[CELEBORN-1629][FOLLOWUP] Fix broken RESTful api link

### DIFF
--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -22,7 +22,7 @@ license: |
 Celeborn uses Ratis to implement the HA function of the master, Celeborn directly introduces ratis-shell package into the project
 then it's convenient for Celeborn Admin to operate the master ratis service.
 
-Since 0.6.0, the ratis [RESTful API](webapi.md) is supported, which is more convenient to operate the ratis service, see details in the swagger: `http://<CELEBORN_HOST>:<CELEBORN_PORT>/swagger/#/Ratis`.
+Since 0.6.0, the ratis [RESTful API](restapi.md) is supported, which is more convenient to operate the ratis service, see details in the swagger: `http://<CELEBORN_HOST>:<CELEBORN_PORT>/swagger/#/Ratis`.
 
 > **Note**:
 > Ratis-shell is currently only **experimental**.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix the broken link.


### Why are the changes needed?
Followup for https://github.com/apache/celeborn/pull/2779.
The RESTful api docs was renamed from webapi.md to restapi.md in https://github.com/apache/celeborn/pull/2775.

And due these two PRs were merged in sequence nearly, so I did not aware this change. 


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/a09aecf8-6e7e-458b-871d-f8dd5a0ac6b2">
<img width="937" alt="image" src="https://github.com/user-attachments/assets/bcefeecf-7a24-4616-9f5e-f2a11f464769">

