### PR TITLE
[CELEBORN-1632] Support to apply ratis local raft_meta_conf command with RESTful api

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
@@ -17,27 +17,29 @@
 
 package org.apache.celeborn.service.deploy.master.http.api.v1
 
+import java.nio.charset.StandardCharsets
 import javax.ws.rs.{BadRequestException, Consumes, Path, POST, Produces}
-import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.{MediaType, Response}
 
 import scala.collection.JavaConverters._
 
 import io.swagger.v3.oas.annotations.media.{Content, Schema}
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.apache.ratis.proto.RaftProtos.{LogEntryProto, RaftConfigurationProto, RaftPeerProto, RaftPeerRole}
 import org.apache.ratis.protocol.{LeaderElectionManagementRequest, RaftClientReply, RaftPeer, SetConfigurationRequest, SnapshotManagementRequest, TransferLeadershipRequest}
 import org.apache.ratis.rpc.CallId
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.rest.v1.model.{HandleResponse, RatisElectionTransferRequest, RatisPeerAddRequest, RatisPeerRemoveRequest, RatisPeerSetPriorityRequest}
+import org.apache.celeborn.rest.v1.model.{HandleResponse, RatisElectionTransferRequest, RatisLocalRaftMetaConfRequest, RatisPeerAddRequest, RatisPeerRemoveRequest, RatisPeerSetPriorityRequest}
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 import org.apache.celeborn.service.deploy.master.Master
 import org.apache.celeborn.service.deploy.master.clustermeta.ha.{HAMasterMetaManager, HARaftServer}
 import org.apache.celeborn.service.deploy.master.http.api.MasterHttpResourceUtils.{ensureMasterHAEnabled, ensureMasterIsLeader}
 
 @Tag(name = "Ratis")
-@Produces(Array(MediaType.APPLICATION_JSON))
 @Consumes(Array(MediaType.APPLICATION_JSON))
 class RatisResource extends ApiRequestContext with Logging {
   private def master = httpService.asInstanceOf[Master]
@@ -51,6 +53,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Transfer the group leader to the specified server.")
   @POST
   @Path("/election/transfer")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def electionTransfer(request: RatisElectionTransferRequest): HandleResponse =
     ensureMasterIsLeader(master) {
       transferLeadership(request.getPeerAddress)
@@ -64,6 +67,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Make the group leader step down its leadership.")
   @POST
   @Path("/election/step_down")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def electionStepDown(): HandleResponse = ensureMasterIsLeader(master) {
     transferLeadership(null)
   }
@@ -77,6 +81,7 @@ class RatisResource extends ApiRequestContext with Logging {
       " Then, the current server would not start a leader election.")
   @POST
   @Path("/election/pause")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def electionPause(): HandleResponse = ensureMasterHAEnabled(master) {
     applyElectionOp(new LeaderElectionManagementRequest.Pause)
   }
@@ -89,6 +94,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Resume leader election at the current server.")
   @POST
   @Path("/election/resume")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def electionResume(): HandleResponse = ensureMasterHAEnabled(master) {
     applyElectionOp(new LeaderElectionManagementRequest.Resume)
   }
@@ -101,6 +107,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Add new peers to the raft group.")
   @POST
   @Path("/peer/add")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def peerAdd(request: RatisPeerAddRequest): HandleResponse =
     ensureLeaderElectionMemberMajorityAddEnabled(master) {
       if (request.getPeers.isEmpty) {
@@ -146,6 +153,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Remove peers from the raft group.")
   @POST
   @Path("/peer/remove")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def peerRemove(request: RatisPeerRemoveRequest): HandleResponse =
     ensureLeaderElectionMemberMajorityAddEnabled(master) {
       if (request.getPeers.isEmpty) {
@@ -183,6 +191,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Set the priority of the peers in the raft group.")
   @POST
   @Path("/peer/set_priority")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def peerSetPriority(request: RatisPeerSetPriorityRequest): HandleResponse =
     ensureLeaderElectionMemberMajorityAddEnabled(master) {
       if (request.getAddressPriorities.isEmpty) {
@@ -218,6 +227,7 @@ class RatisResource extends ApiRequestContext with Logging {
     description = "Trigger the current server to take snapshot.")
   @POST
   @Path("/snapshot/create")
+  @Produces(Array(MediaType.APPLICATION_JSON))
   def createSnapshot(): HandleResponse = ensureMasterHAEnabled(master) {
     val request = SnapshotManagementRequest.newCreate(
       ratisServer.getClientId,
@@ -234,6 +244,46 @@ class RatisResource extends ApiRequestContext with Logging {
         s"Failed to create snapshot at ${ratisServer.getLocalAddress}. $reply")
     }
   }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_OCTET_STREAM,
+      schema = new Schema(implementation = classOf[Response]))),
+    description = "Generate a new-raft-meta.conf file based on original raft-meta.conf" +
+      " and new peers, which is used to move a raft node to a new node.")
+  @POST
+  @Path("/local/raft_meta_conf")
+  @Produces(Array(MediaType.APPLICATION_OCTET_STREAM))
+  def localRaftMeteConf(request: RatisLocalRaftMetaConfRequest): Response =
+    ensureMasterHAEnabled(master) {
+      val groupInfo = ratisServer.getGroupInfo
+
+      val existingPeers = getRaftPeers().map(_.getRaftPeerProto)
+      val newPeers = request.getPeers.asScala.map { peer =>
+        if (existingPeers.exists(e =>
+            e.getId.toStringUtf8 == peer.getId || e.getAddress == peer.getAddress)) {
+          throw new IllegalArgumentException(
+            s"Peer $peer with same id or address already exists in group $groupInfo.")
+        }
+        RaftPeerProto.newBuilder()
+          .setId(ByteString.copyFrom(peer.getId.getBytes(StandardCharsets.UTF_8)))
+          .setAddress(peer.getAddress)
+          .setStartupRole(RaftPeerRole.FOLLOWER)
+          .build()
+      }
+      val allPeers = existingPeers ++ newPeers
+
+      logInfo(s"Generating new-raft-meta.conf with peers: $allPeers.")
+
+      val generateLogEntryProto = LogEntryProto.newBuilder()
+        .setConfigurationEntry(RaftConfigurationProto.newBuilder()
+          .addAllPeers(allPeers.asJava).build())
+        .setIndex(groupInfo.getLogIndex + 1).build()
+      Response.ok(generateLogEntryProto.toByteArray)
+        .header("Content-Disposition", "attachment; filename=\"new-raft-meta.conf\"")
+        .build()
+    }
 
   private def transferLeadership(peerAddress: String): HandleResponse = {
     val newLeaderId = Option(peerAddress).map { addr =>

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
@@ -25,8 +25,10 @@ import org.apache.celeborn.rest.v1.master.invoker.BaseApi;
 import org.apache.celeborn.rest.v1.master.invoker.Configuration;
 import org.apache.celeborn.rest.v1.master.invoker.Pair;
 
+import java.io.File;
 import org.apache.celeborn.rest.v1.model.HandleResponse;
 import org.apache.celeborn.rest.v1.model.RatisElectionTransferRequest;
+import org.apache.celeborn.rest.v1.model.RatisLocalRaftMetaConfRequest;
 import org.apache.celeborn.rest.v1.model.RatisPeerAddRequest;
 import org.apache.celeborn.rest.v1.model.RatisPeerRemoveRequest;
 import org.apache.celeborn.rest.v1.model.RatisPeerSetPriorityRequest;
@@ -169,6 +171,75 @@ public class RatisApi extends BaseApi {
     String[] localVarAuthNames = new String[] { "basic" };
 
     TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Generate a new-raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
+   * @param ratisLocalRaftMetaConfRequest  (optional)
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File generateLocalRaftMetaConf(RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest) throws ApiException {
+    return this.generateLocalRaftMetaConf(ratisLocalRaftMetaConfRequest, Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Generate a new-raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
+   * @param ratisLocalRaftMetaConfRequest  (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File generateLocalRaftMetaConf(RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = ratisLocalRaftMetaConfRequest;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/ratis/local_raft_meta_conf";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/octet-stream"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<File> localVarReturnType = new TypeReference<File>() {};
     return apiClient.invokeAPI(
         localVarPath,
         "POST",

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/RatisApi.java
@@ -195,8 +195,8 @@ public class RatisApi extends BaseApi {
    * @return File
    * @throws ApiException if fails to make API call
    */
-  public File generateLocalRaftMetaConf(RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest) throws ApiException {
-    return this.generateLocalRaftMetaConf(ratisLocalRaftMetaConfRequest, Collections.emptyMap());
+  public File generateNewRaftMetaConf(RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest) throws ApiException {
+    return this.generateNewRaftMetaConf(ratisLocalRaftMetaConfRequest, Collections.emptyMap());
   }
 
 
@@ -208,11 +208,11 @@ public class RatisApi extends BaseApi {
    * @return File
    * @throws ApiException if fails to make API call
    */
-  public File generateLocalRaftMetaConf(RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest, Map<String, String> additionalHeaders) throws ApiException {
+  public File generateNewRaftMetaConf(RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = ratisLocalRaftMetaConfRequest;
     
     // create path and map variables
-    String localVarPath = "/api/v1/ratis/local_raft_meta_conf";
+    String localVarPath = "/api/v1/ratis/local/raft_meta_conf";
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -243,6 +243,73 @@ public class RatisApi extends BaseApi {
     return apiClient.invokeAPI(
         localVarPath,
         "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Get the raft-meta.conf file of the current server.
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File getLocalRaftMetaConf() throws ApiException {
+    return this.getLocalRaftMetaConf(Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Get the raft-meta.conf file of the current server.
+   * @param additionalHeaders additionalHeaders for this call
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File getLocalRaftMetaConf(Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/ratis/local/raft_meta_conf";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/octet-stream"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<File> localVarReturnType = new TypeReference<File>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "GET",
         localVarQueryParams,
         localVarCollectionQueryParams,
         localVarQueryStringJoiner.toString(),

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ContainerInfo.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/ContainerInfo.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   ContainerInfo.JSON_PROPERTY_CONTAINER_CLUSTER,
   ContainerInfo.JSON_PROPERTY_CONTAINER_TAGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.7.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class ContainerInfo {
   public static final String JSON_PROPERTY_CONTAINER_NAME = "containerName";
   private String containerName;

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RatisLocalRaftMetaConfRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RatisLocalRaftMetaConfRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.celeborn.rest.v1.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.celeborn.rest.v1.model.RatisPeer;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * RatisLocalRaftMetaConfRequest
+ */
+@JsonPropertyOrder({
+  RatisLocalRaftMetaConfRequest.JSON_PROPERTY_PEERS
+})
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
+public class RatisLocalRaftMetaConfRequest {
+  public static final String JSON_PROPERTY_PEERS = "peers";
+  private List<RatisPeer> peers = new ArrayList<>();
+
+  public RatisLocalRaftMetaConfRequest() {
+  }
+
+  public RatisLocalRaftMetaConfRequest peers(List<RatisPeer> peers) {
+    
+    this.peers = peers;
+    return this;
+  }
+
+  public RatisLocalRaftMetaConfRequest addPeersItem(RatisPeer peersItem) {
+    if (this.peers == null) {
+      this.peers = new ArrayList<>();
+    }
+    this.peers.add(peersItem);
+    return this;
+  }
+
+  /**
+   * The new peers to generate a new-raft-meta.conf file with existing peers.
+   * @return peers
+   */
+  @javax.annotation.Nonnull
+  @JsonProperty(JSON_PROPERTY_PEERS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public List<RatisPeer> getPeers() {
+    return peers;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PEERS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPeers(List<RatisPeer> peers) {
+    this.peers = peers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RatisLocalRaftMetaConfRequest ratisLocalRaftMetaConfRequest = (RatisLocalRaftMetaConfRequest) o;
+    return Objects.equals(this.peers, ratisLocalRaftMetaConfRequest.peers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(peers);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class RatisLocalRaftMetaConfRequest {\n");
+    sb.append("    peers: ").append(toIndentedString(peers)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -402,6 +402,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
+  /api/v1/ratis/local_raft_meta_conf:
+    post:
+      tags:
+        - Ratis
+      operationId: generateLocalRaftMetaConf
+      description: Generate a new-raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RatisLocalRaftMetaConfRequest'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
 components:
   schemas:
     ConfigData:
@@ -980,6 +1000,17 @@ components:
           description: The peer address and priority of the peer.
           additionalProperties:
             type: integer
+
+    RatisLocalRaftMetaConfRequest:
+      type: object
+      properties:
+        peers:
+          type: array
+          description: The new peers to generate a new-raft-meta.conf file with existing peers.
+          items:
+            $ref: '#/components/schemas/RatisPeer'
+      required:
+        - peers
 
     HandleResponse:
       type: object

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -402,11 +402,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
-  /api/v1/ratis/local_raft_meta_conf:
+  /api/v1/ratis/local/raft_meta_conf:
+    get:
+      tags:
+        - Ratis
+      operationId: getLocalRaftMetaConf
+      description: Get the raft-meta.conf file of the current server.
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
     post:
       tags:
         - Ratis
-      operationId: generateLocalRaftMetaConf
+      operationId: generateNewRaftMetaConf
       description: Generate a new-raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
       requestBody:
         content:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Sub-task of CELEBORN-1628.

Support to apply ratis local raft_meta_conf with RESTful api.

See https://celeborn.apache.org/docs/latest/celeborn_ratis_shell/#local-raftmetaconf
```
$ celeborn-ratis sh local raftMetaConf -peers <[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
```

The implementation is same with https://github.com/apache/ratis/blob/e96ed1a33840385446f4e647864a169467da5ab7/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java#L122-L133

### Why are the changes needed?

We have implemented the RESTful implementation for all the others ratis-shell command.

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/4367ddbd-3c55-449a-a1bc-75d6c18e8918">

| Ratis Shell               | RESTful api                        |
|----------------------|---------------------------------|
| election transfer    | `/ratis/election/transfer`      |
| election stepDown    | `/ratis/election/step_down`     |
| election pause       | `/ratis/election/pause`         |
| election resume      | `/ratis/election/resume`        |
| group info           | `/masters`                      |
| peer add             | `/ratis/peer/add`               |
| peer remove          | `/ratis/peer/remove`            |
| peer setPriority     | `/ratis/peer/set_priority`      |
| snapshot create      | `/ratis/snapshot/create`        |



And the local raftMetaConf command is the last one.

I closed the ticket CELEBORN-1632 before, I thought it is a local command and wonder whether it is necessary to implement it with RESTful api.

But we have implemented all the others, so I decide to implement it as well.



### Does this PR introduce _any_ user-facing change?

A new API.

The implementation is same with https://github.com/apache/ratis/blob/e96ed1a33840385446f4e647864a169467da5ab7/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java#L122-L133

### How was this patch tested?
![image](https://github.com/user-attachments/assets/088d8523-e5f5-4546-9159-e12191fd8a29)
![image](https://github.com/user-attachments/assets/ce9c4284-fd61-45de-93e7-d38e3b6afac9)
<img width="960" alt="image" src="https://github.com/user-attachments/assets/b302a680-baea-4709-b77f-a2b1946b8dff">

<img width="1471" alt="image" src="https://github.com/user-attachments/assets/4bf090ba-c6f4-4f49-aa57-8dd2c897ff30">
<img width="871" alt="image" src="https://github.com/user-attachments/assets/9959072c-5e96-48f5-911e-546c05a0c443">
