### PR TITLE
[CELEBORN-1661] Make sure that the sortedFilesDb is initialized successfully when worker enable graceful shutdown

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -125,8 +125,8 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         this.sortedFilesDb = DBProvider.initDB(dbBackend, recoverFile, CURRENT_VERSION);
         reloadAndCleanSortedShuffleFiles(this.sortedFilesDb);
       } catch (Exception e) {
-        logger.error("Failed to reload DB for sorted shuffle files from: " + recoverFile, e);
-        this.sortedFilesDb = null;
+        throw new IllegalStateException(
+            "Failed to reload DB for sorted shuffle files from: " + recoverFile, e);
       }
     } else {
       this.sortedFilesDb = null;


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
Similar to CELEBORN-1457, `sortedFilesDb` may also fail to initialize.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
