### PR TITLE
[CELEBORN-1662] Handle PUSH_DATA_FAIL_PARTITION_NOT_FOUND in getPushDataFailCause

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1888,7 +1888,7 @@ public class ShuffleClientImpl extends ShuffleClient {
       cause = StatusCode.PUSH_DATA_PRIMARY_WORKER_EXCLUDED;
     } else if (message.startsWith(StatusCode.PUSH_DATA_REPLICA_WORKER_EXCLUDED.name())) {
       cause = StatusCode.PUSH_DATA_REPLICA_WORKER_EXCLUDED;
-    } else if (message.startsWith(StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND.name()) {
+    } else if (message.startsWith(StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND.name())) {
       cause = StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND;
     } else if (ExceptionUtils.connectFail(message)) {
       // Throw when push to primary worker connection causeException.

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1888,6 +1888,8 @@ public class ShuffleClientImpl extends ShuffleClient {
       cause = StatusCode.PUSH_DATA_PRIMARY_WORKER_EXCLUDED;
     } else if (message.startsWith(StatusCode.PUSH_DATA_REPLICA_WORKER_EXCLUDED.name())) {
       cause = StatusCode.PUSH_DATA_REPLICA_WORKER_EXCLUDED;
+    } else if (message.startsWith(StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND.name()) {
+      cause = StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND;
     } else if (ExceptionUtils.connectFail(message)) {
       // Throw when push to primary worker connection causeException.
       cause = StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_PRIMARY;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add a condition at the start of the failure cause logic to check for PUSH_DATA_FAIL_PARTITION_NOT_FOUND.


### Why are the changes needed?
Currently, the getPushDataFailCause method does not identify and handle the PUSH_DATA_FAIL_PARTITION_NOT_FOUND error type. All other failure causes are explicitly checked and managed, but this specific error type is overlooked.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test
