### PR TITLE
[CELEBORN-1665] CommitHandler should process CommitFilesResponse with COMMIT_FILE_EXCEPTION status

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -315,7 +315,7 @@ abstract class CommitHandler(
           status.future.value.get match {
             case scala.util.Success(res) =>
               res.status match {
-                case StatusCode.SUCCESS | StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.REQUEST_FAILED | StatusCode.WORKER_EXCLUDED =>
+                case StatusCode.SUCCESS | StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.REQUEST_FAILED | StatusCode.WORKER_EXCLUDED | StatusCode.COMMIT_FILE_EXCEPTION =>
                   logInfo(s"Request commitFiles return ${res.status} for " +
                     s"${Utils.makeShuffleKey(appUniqueId, shuffleId)}")
                   if (res.status != StatusCode.SUCCESS && res.status != StatusCode.WORKER_EXCLUDED) {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -1102,10 +1102,24 @@ object Utils extends Logging {
         StatusCode.WORKER_EXCLUDED
       case 28 =>
         StatusCode.WORKER_UNKNOWN
+      case 29 =>
+        StatusCode.COMMIT_FILE_EXCEPTION
       case 30 =>
         StatusCode.PUSH_DATA_SUCCESS_PRIMARY_CONGESTED
       case 31 =>
         StatusCode.PUSH_DATA_SUCCESS_REPLICA_CONGESTED
+      case 32 =>
+        StatusCode.PUSH_DATA_HANDSHAKE_FAIL_REPLICA
+      case 33 =>
+        StatusCode.PUSH_DATA_HANDSHAKE_FAIL_PRIMARY
+      case 34 =>
+        StatusCode.REGION_START_FAIL_REPLICA
+      case 35 =>
+        StatusCode.REGION_START_FAIL_PRIMARY
+      case 36 =>
+        StatusCode.REGION_FINISH_FAIL_REPLICA
+      case 37 =>
+        StatusCode.REGION_FINISH_FAIL_PRIMARY
       case 38 =>
         StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY
       case 39 =>
@@ -1132,6 +1146,12 @@ object Utils extends Logging {
         StatusCode.COMMIT_FILES_MOCK_FAILURE
       case 50 =>
         StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_REPLICA
+      case 51 =>
+        StatusCode.OPEN_STREAM_FAILED
+      case 52 =>
+        StatusCode.SEGMENT_START_FAIL_REPLICA
+      case 53 =>
+        StatusCode.SEGMENT_START_FAIL_PRIMARY
       case _ =>
         null
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CommitHandler` should process `CommitFilesResponse` with `COMMIT_FILE_EXCEPTION` status.

### Why are the changes needed?

`CommitHandler` processes `CommitFilesResponse` with statuses including `SUCCESS`, `PARTIAL_SUCCESS`, `SHUFFLE_NOT_REGISTERED`, `REQUEST_FAILED` and `WORKER_EXCLUDED` at present. Meanwhile, Controller replies `CommitFilesResponse` with `COMMIT_FILE_EXCEPTION` status for throwable. Therefore, `CommitHandler` should process `COMMIT_FILE_EXCEPTION` status.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.