### PR TITLE
[CELEBORN-1660] Using map for workers to find worker fast and WokerInfo pool to reuse objects

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -461,10 +461,10 @@ object PbSerDeUtils {
       partitionTotalFileCount: java.lang.Long,
       appDiskUsageMetricSnapshots: Array[AppDiskUsageSnapShot],
       currentAppDiskUsageMetricsSnapshot: AppDiskUsageSnapShot,
-      lostWorkers: ConcurrentHashMap[WorkerInfo, java.lang.Long],
+      lostWorkers: java.util.Map[WorkerInfo, java.lang.Long],
       shutdownWorkers: java.util.Set[WorkerInfo],
-      workerEventInfos: ConcurrentHashMap[WorkerInfo, WorkerEventInfo],
-      applicationMetas: ConcurrentHashMap[String, ApplicationMeta],
+      workerEventInfos: java.util.Map[WorkerInfo, WorkerEventInfo],
+      applicationMetas: java.util.Map[String, ApplicationMeta],
       decommissionWorkers: java.util.Set[WorkerInfo]): PbSnapshotMetaInfo = {
     val builder = PbSnapshotMetaInfo.newBuilder()
       .setEstimatedPartitionSize(estimatedPartitionSize)

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -477,7 +477,7 @@ object PbSerDeUtils {
         .map(toPbWorkerInfo(_, true, false)).asJava)
       .addAllWorkerLostEvents(workerLostEvent.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .putAllAppHeartbeatTime(appHeartbeatTime)
-      .addAllWorkers(workers.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
+      .addAllWorkers(workers.values().asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .setPartitionTotalWritten(partitionTotalWritten)
       .setPartitionTotalFileCount(partitionTotalFileCount)
       // appDiskUsageMetricSnapshots can have null values,

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -477,7 +477,7 @@ object PbSerDeUtils {
         .map(toPbWorkerInfo(_, true, false)).asJava)
       .addAllWorkerLostEvents(workerLostEvent.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .putAllAppHeartbeatTime(appHeartbeatTime)
-      .addAllWorkers(workers.values().asScala.map(toPbWorkerInfo(_, true, false)).asJava)
+      .addAllWorkers(workers.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .setPartitionTotalWritten(partitionTotalWritten)
       .setPartitionTotalFileCount(partitionTotalFileCount)
       // appDiskUsageMetricSnapshots can have null values,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -66,7 +66,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public final Map<String, Set<Integer>> registeredAppAndShuffles =
       JavaUtils.newConcurrentHashMap();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
-  private final Map<Integer, WorkerInfo> workersMap = JavaUtils.newConcurrentHashMap();
+  private final Map<String, WorkerInfo> workersMap = JavaUtils.newConcurrentHashMap();
 
   public final ConcurrentHashMap<WorkerInfo, Long> lostWorkers = JavaUtils.newConcurrentHashMap();
   public final ConcurrentHashMap<WorkerInfo, WorkerEventInfo> workerEventInfos =
@@ -103,19 +103,19 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   public boolean containsWorker(WorkerInfo worker) {
-    return workersMap.containsKey(worker.hashCode());
+    return workersMap.containsKey(worker.toUniqueId());
   }
 
   public WorkerInfo getWorker(WorkerInfo worker) {
-    return workersMap.get(worker.hashCode());
+    return workersMap.get(worker.toUniqueId());
   }
 
   public void updateWorker(WorkerInfo worker) {
-    workersMap.put(worker.hashCode(), worker);
+    workersMap.put(worker.toUniqueId(), worker);
   }
 
   public void removeWorker(WorkerInfo worker) {
-    workersMap.remove(worker.hashCode());
+    workersMap.remove(worker.toUniqueId());
   }
 
   @VisibleForTesting
@@ -424,7 +424,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                           resolveMap.get(workerInfo.host()).get().getNetworkLocation());
                     }
                   })
-              .collect(Collectors.toMap(WorkerInfo::hashCode, w -> w)));
+              .collect(Collectors.toMap(WorkerInfo::toUniqueId, w -> w)));
 
       snapshotMetaInfo
           .getLostWorkersMap()

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -213,7 +213,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   @VisibleForTesting
-  public void addExcludeWorker(WorkerInfo workerInfo) {
+  public void addExcludedWorker(WorkerInfo workerInfo) {
     excludedWorkers.add(workerInfo.toUniqueId());
   }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -628,6 +628,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     registeredAppAndShuffles.clear();
     hostnameSet.clear();
     workersMap.clear();
+    workerInfoPool.clear();
     lostWorkers.clear();
     appHeartbeatTime.clear();
     excludedWorkers.clear();

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -144,6 +144,11 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
         .collect(Collectors.toSet());
   }
 
+  @VisibleForTesting
+  public void clearManuallyExcludedWorkers() {
+    manuallyExcludedWorkers.clear();
+  }
+
   public Set<String> getShutdownWorkerIds() {
     return Collections.unmodifiableSet(shutdownWorkers);
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -23,11 +23,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import scala.Option;
@@ -96,9 +96,9 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     return workersMap.values();
   }
 
-  public <T> T synchronizedWorkers(Supplier<T> s) throws Exception {
+  public <T> T synchronizedWorkers(Callable<T> callable) throws Exception {
     synchronized (workersMap) {
-      return s.get();
+      return callable.call();
     }
   }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -127,7 +127,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   private WorkerInfo getFromWorkerInfoPool(String workerUniqueId) {
-    return workerInfoPool.getOrDefault(workerUniqueId, WorkerInfo.fromUniqueId(workerUniqueId));
+    return workerInfoPool.computeIfAbsent(workerUniqueId, id -> WorkerInfo.fromUniqueId(id));
   }
 
   private void recycleToWorkerInfoPool(WorkerInfo workerInfo) {
@@ -275,7 +275,6 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public void updateWorkerRemoveMeta(
       String host, int rpcPort, int pushPort, int fetchPort, int replicatePort) {
     WorkerInfo worker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
-    recycleToWorkerInfoPool(worker);
     // remove worker from workers
     synchronized (workersMap) {
       removeWorker(worker);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -23,12 +23,15 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import scala.Option;
 import scala.Tuple2;
 
@@ -64,7 +67,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public final Map<String, Set<Integer>> registeredAppAndShuffles =
       JavaUtils.newConcurrentHashMap();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
-  public final Set<WorkerInfo> workers = ConcurrentHashMap.newKeySet();
+  private final Map<Integer, WorkerInfo> workersMap = JavaUtils.newConcurrentHashMap();
 
   public final ConcurrentHashMap<WorkerInfo, Long> lostWorkers = JavaUtils.newConcurrentHashMap();
   public final ConcurrentHashMap<WorkerInfo, WorkerEventInfo> workerEventInfos =
@@ -89,6 +92,37 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
 
   public final ConcurrentHashMap<String, ApplicationMeta> applicationMetas =
       JavaUtils.newConcurrentHashMap();
+
+  public Set<WorkerInfo> workers() {
+    return workersMap.values().stream().collect(Collectors.toSet());
+  }
+
+  public void removeWorker(WorkerInfo worker) {
+    workersMap.remove(worker.hashCode());
+  }
+
+  public void updateWorker(WorkerInfo worker) {
+      workersMap.put(worker.hashCode(), worker);
+  }
+
+  public boolean containsWorker(WorkerInfo worker) {
+    return workersMap.containsKey(worker.hashCode());
+  }
+
+  public WorkerInfo getWorker(WorkerInfo worker) {
+    return workersMap.get(worker.hashCode());
+  }
+
+  @VisibleForTesting
+  public void clearWorkers() {
+    workersMap.clear();
+  }
+
+  public <T> T synchronizedWorkers(Callable<T> f) throws Exception {
+    synchronized (workersMap) {
+      return f.call();
+    }
+  }
 
   public void updateRequestSlotsMeta(
       String shuffleKey, String hostName, Map<String, Map<String, Integer>> workerWithAllocations) {
@@ -170,8 +204,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     WorkerInfo worker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
     workerLostEvents.add(worker);
     // remove worker from workers
-    synchronized (workers) {
-      workers.remove(worker);
+    synchronized (workersMap) {
+      removeWorker(worker);
       lostWorkers.put(worker, System.currentTimeMillis());
     }
     excludedWorkers.remove(worker);
@@ -182,15 +216,15 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       String host, int rpcPort, int pushPort, int fetchPort, int replicatePort) {
     WorkerInfo worker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
     // remove worker from workers
-    synchronized (workers) {
-      workers.remove(worker);
+    synchronized (workersMap) {
+      removeWorker(worker);
       lostWorkers.put(worker, System.currentTimeMillis());
     }
     excludedWorkers.remove(worker);
   }
 
   public void removeWorkersUnavailableInfoMeta(List<WorkerInfo> unavailableWorkers) {
-    synchronized (workers) {
+    synchronized (workersMap) {
       for (WorkerInfo workerInfo : unavailableWorkers) {
         if (lostWorkers.containsKey(workerInfo)) {
           lostWorkers.remove(workerInfo);
@@ -219,8 +253,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
             host, rpcPort, pushPort, fetchPort, replicatePort, -1, disks, userResourceConsumption);
     AtomicLong availableSlots = new AtomicLong();
     LOG.debug("update worker {}:{} heartbeat {}", host, rpcPort, disks);
-    synchronized (workers) {
-      Optional<WorkerInfo> workerInfo = workers.stream().filter(w -> w.equals(worker)).findFirst();
+    synchronized (workersMap) {
+      Optional<WorkerInfo> workerInfo = Optional.ofNullable(getWorker(worker));
       workerInfo.ifPresent(
           info -> {
             info.updateThenGetDiskInfos(disks, Option.apply(estimatedPartitionSize));
@@ -287,9 +321,9 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       workerInfo.networkLocation_$eq(rackResolver.resolve(host).getNetworkLocation());
     }
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
-    synchronized (workers) {
-      if (!workers.contains(workerInfo)) {
-        workers.add(workerInfo);
+    synchronized (workersMap) {
+      if (!containsWorker(workerInfo)) {
+        updateWorker(workerInfo);
       }
       shutdownWorkers.remove(workerInfo);
       lostWorkers.remove(workerInfo);
@@ -315,7 +349,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                 manuallyExcludedWorkers,
                 workerLostEvents,
                 appHeartbeatTime,
-                workers,
+                workers(),
                 partitionTotalWritten.sum(),
                 partitionTotalFileCount.sum(),
                 appDiskUsageMetric.snapShots(),
@@ -381,7 +415,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
               .collect(Collectors.toList());
       scala.collection.immutable.Map<String, Node> resolveMap =
           rackResolver.resolveToMap(workerHostList);
-      workers.addAll(
+      workersMap.putAll(
           workerInfoSet.stream()
               .peek(
                   workerInfo -> {
@@ -391,7 +425,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                           resolveMap.get(workerInfo.host()).get().getNetworkLocation());
                     }
                   })
-              .collect(Collectors.toSet()));
+              .collect(Collectors.toMap(WorkerInfo::hashCode, w -> w)));
 
       snapshotMetaInfo
           .getLostWorkersMap()
@@ -437,11 +471,11 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     LOG.info("Successfully restore meta info from snapshot {}", file.getAbsolutePath());
     LOG.info(
         "Worker size: {}, Registered shuffle size: {}. Worker excluded list size: {}. Manually Excluded list size: {}",
-        workers.size(),
+        workersMap.size(),
         registeredAppAndShuffles.size(),
         excludedWorkers.size(),
         manuallyExcludedWorkers.size());
-    workers.forEach(workerInfo -> LOG.info(workerInfo.toString()));
+    workers().forEach(workerInfo -> LOG.info(workerInfo.toString()));
     registeredAppAndShuffles.forEach(
         (appId, shuffleId) -> LOG.info("RegisteredShuffle {}-{}", appId, shuffleId));
   }
@@ -449,7 +483,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   private void cleanUpState() {
     registeredAppAndShuffles.clear();
     hostnameSet.clear();
-    workers.clear();
+    workersMap.clear();
     lostWorkers.clear();
     appHeartbeatTime.clear();
     excludedWorkers.clear();
@@ -464,7 +498,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   public void updateMetaByReportWorkerUnavailable(List<WorkerInfo> failedWorkers) {
-    synchronized (this.workers) {
+    synchronized (this.workersMap) {
       shutdownWorkers.addAll(failedWorkers);
     }
   }
@@ -473,7 +507,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     long eventTime = System.currentTimeMillis();
     ResourceProtos.WorkerEventType eventType =
         ResourceProtos.WorkerEventType.forNumber(workerEventTypeValue);
-    synchronized (this.workers) {
+    synchronized (this.workersMap) {
       for (WorkerInfo workerInfo : workerInfoList) {
         WorkerEventInfo workerEventInfo = workerEventInfos.get(workerInfo);
         LOG.info("Received worker event: {} for worker: {}", eventType, workerInfo.toUniqueId());
@@ -489,7 +523,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   public void updateMetaByReportWorkerDecommission(List<WorkerInfo> workers) {
-    synchronized (this.workers) {
+    synchronized (this.workersMap) {
       decommissionWorkers.addAll(workers);
     }
   }
@@ -520,7 +554,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
         "Celeborn cluster estimated partition size changed from {} to {}",
         Utils.bytesToString(oldEstimatedPartitionSize),
         Utils.bytesToString(estimatedPartitionSize));
-    workers.stream()
+    workers().stream()
         .filter(
             worker ->
                 !excludedWorkers.contains(worker) && !manuallyExcludedWorkers.contains(worker))

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -456,7 +456,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                 getManuallyExcludedWorkerInfos(),
                 getWorkerLostEventWorkerInfos(),
                 appHeartbeatTime,
-                new HashSet(getWorkers()),
+                new HashSet(workersMap.values()),
                 partitionTotalWritten.sum(),
                 partitionTotalFileCount.sum(),
                 appDiskUsageMetric.snapShots(),
@@ -614,7 +614,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
         registeredAppAndShuffles.size(),
         excludedWorkers.size(),
         manuallyExcludedWorkers.size());
-    getWorkers().forEach(workerInfo -> LOG.info(workerInfo.toString()));
+    workersMap.values().forEach(workerInfo -> LOG.info(workerInfo.toString()));
     registeredAppAndShuffles.forEach(
         (appId, shuffleId) -> LOG.info("RegisteredShuffle {}-{}", appId, shuffleId));
   }
@@ -705,7 +705,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
         "Celeborn cluster estimated partition size changed from {} to {}",
         Utils.bytesToString(oldEstimatedPartitionSize),
         Utils.bytesToString(estimatedPartitionSize));
-    getWorkers().stream()
+    workersMap.values().stream()
         .filter(
             worker -> {
               String workerId = worker.toUniqueId();

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -23,11 +23,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import scala.Option;
@@ -96,9 +96,9 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     return workersMap.values();
   }
 
-  public <T> T synchronizedWorkers(Callable<T> callable) throws Exception {
+  public <T> T synchronizedWorkers(Supplier<T> s) {
     synchronized (workersMap) {
-      return callable.call();
+      return s.get();
     }
   }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -908,7 +908,7 @@ private[celeborn] class Master(
     // offer slots
     val slots =
       masterSource.sample(MasterSource.OFFER_SLOTS_TIME, s"offerSlots-${Random.nextInt()}") {
-        statusSystem.synchronizedWorkers { () =>
+        statusSystem.synchronizedWorkers(() => {
           if (slotsAssignPolicy == SlotsAssignPolicy.LOADAWARE) {
             SlotsAllocator.offerSlotsLoadAware(
               selectedWorkers,
@@ -928,7 +928,7 @@ private[celeborn] class Master(
               requestSlots.shouldRackAware,
               requestSlots.availableStorageTypes)
           }
-        }
+        })
       }
 
     if (log.isDebugEnabled()) {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -228,9 +228,9 @@ private[celeborn] class Master(
     statusSystem.registeredShuffleCount
   }
   masterSource.addGauge(MasterSource.WORKER_COUNT) { () => statusSystem.getWorkers.size }
-  masterSource.addGauge(MasterSource.LOST_WORKER_COUNT) { () => statusSystem.lostWorkers.size }
+  masterSource.addGauge(MasterSource.LOST_WORKER_COUNT) { () => statusSystem.getLostWorkerIds.size }
   masterSource.addGauge(MasterSource.EXCLUDED_WORKER_COUNT) { () =>
-    statusSystem.excludedWorkers.size + statusSystem.getManuallyExcludedWorkerIds().size
+    statusSystem.getExcludedWorkerIds.size + statusSystem.getManuallyExcludedWorkerIds().size
   }
   masterSource.addGauge(MasterSource.AVAILABLE_WORKER_COUNT) { () =>
     statusSystem.getWorkers.asScala.count { w =>
@@ -622,7 +622,7 @@ private[celeborn] class Master(
       return
     }
 
-    val unavailableInfoTimeoutWorkers = statusSystem.lostWorkers.asScala.filter {
+    val unavailableInfoTimeoutWorkers = statusSystem.getLostWorkerInfos.asScala.filter {
       case (_, lostTime) => currentTime - lostTime > workerUnavailableInfoExpireTimeoutMs
     }.keySet.toSeq
 
@@ -638,18 +638,18 @@ private[celeborn] class Master(
     if (HAHelper.getAppTimeoutDeadline(statusSystem) > currentTime) {
       return
     }
-    statusSystem.appHeartbeatTime.keySet().asScala.foreach { key =>
-      if (statusSystem.appHeartbeatTime.get(key) < currentTime - appHeartbeatTimeoutMs) {
-        logWarning(s"Application $key timeout, trigger applicationLost event.")
+    statusSystem.appHeartbeatTime.asScala.foreach { case (appId, heartbeatTime) =>
+      if (heartbeatTime < currentTime - appHeartbeatTimeoutMs) {
+        logWarning(s"Application $appId timeout, trigger applicationLost event.")
         val requestId = MasterClient.genRequestId()
-        var res = self.askSync[ApplicationLostResponse](ApplicationLost(key, requestId))
+        var res = self.askSync[ApplicationLostResponse](ApplicationLost(appId, requestId))
         var retry = 1
         while (res.status != StatusCode.SUCCESS && retry <= 3) {
-          res = self.askSync[ApplicationLostResponse](ApplicationLost(key, requestId))
+          res = self.askSync[ApplicationLostResponse](ApplicationLost(appId, requestId))
           retry += 1
         }
         if (retry > 3) {
-          logWarning(s"Handle ApplicationLost event for $key failed more than 3 times!")
+          logWarning(s"Handle ApplicationLost event for $appId failed more than 3 times!")
         }
       }
     }
@@ -703,7 +703,7 @@ private[celeborn] class Master(
     logDebug(
       s"Shuffle ${expiredShuffleKeys.asScala.mkString("[", " ,", "]")} expired on ${targetWorker.toUniqueId()}.")
 
-    val workerEventInfo = statusSystem.workerEventInfos.get(targetWorker)
+    val workerEventInfo = statusSystem.getWorkerEventInfo(targetWorker)
     if (workerEventInfo == null) {
       context.reply(HeartbeatFromWorkerResponse(
         expiredShuffleKeys,
@@ -1048,7 +1048,7 @@ private[celeborn] class Master(
       failedWorkers: util.List[WorkerInfo],
       requestId: String): Unit = {
     logInfo(s"Receive ReportNodeFailure $failedWorkers, current excluded workers" +
-      s"${statusSystem.excludedWorkers}")
+      s"${statusSystem.getExcludedWorkerIds}")
     statusSystem.handleReportWorkerUnavailable(failedWorkers, requestId)
     context.reply(OneWayMessageResponse)
   }
@@ -1058,7 +1058,7 @@ private[celeborn] class Master(
       workers: util.List[WorkerInfo],
       requestId: String): Unit = {
     logInfo(s"Receive ReportWorkerDecommission $workers, current decommission workers" +
-      s"${statusSystem.excludedWorkers}")
+      s"${statusSystem.getExcludedWorkerIds}")
     statusSystem.handleReportWorkerDecommission(workers, requestId)
     context.reply(OneWayMessageResponse)
   }
@@ -1142,7 +1142,7 @@ private[celeborn] class Master(
       context.reply(HeartbeatFromApplicationResponse(
         StatusCode.SUCCESS,
         new util.ArrayList(
-          (statusSystem.excludedWorkers.asScala ++ statusSystem.getManuallyExcludedWorkerInfos.asScala).asJava),
+          (statusSystem.getExcludedWorkerInfos.asScala ++ statusSystem.getManuallyExcludedWorkerInfos.asScala).asJava),
         needCheckedWorkerList,
         new util.ArrayList[WorkerInfo](
           (statusSystem.getShutdownWorkerInfos.asScala ++ statusSystem.getDecommissionWorkerInfos.asScala).asJava),
@@ -1327,8 +1327,8 @@ private[celeborn] class Master(
   override def getLostWorkers: String = {
     val sb = new StringBuilder
     sb.append("======================= Lost Workers in Master ========================\n")
-    statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2).foreach { case (worker, time) =>
-      sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
+    statusSystem.getLostWorkerIds.asScala.toSeq.sortBy(_._2).foreach { case (workerId, time) =>
+      sb.append(s"${workerId.padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
     }
     sb.toString()
   }
@@ -1354,7 +1354,7 @@ private[celeborn] class Master(
   override def getExcludedWorkers: String = {
     val sb = new StringBuilder
     sb.append("===================== Excluded Workers in Master ======================\n")
-    (statusSystem.excludedWorkers.asScala ++ statusSystem.getManuallyExcludedWorkerIds.asScala).foreach {
+    (statusSystem.getExcludedWorkerIds.asScala ++ statusSystem.getManuallyExcludedWorkerIds.asScala).foreach {
       worker => sb.append(s"$worker\n")
     }
     sb.toString()
@@ -1498,7 +1498,7 @@ private[celeborn] class Master(
   override def getWorkerEventInfo(): String = {
     val sb = new StringBuilder
     sb.append("======================= Workers Event in Master ========================\n")
-    statusSystem.workerEventInfos.asScala.foreach { case (worker, workerEventInfo) =>
+    statusSystem.getWorkerEventInfos.asScala.foreach { case (worker, workerEventInfo) =>
       sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}$workerEventInfo\n")
     }
     sb.toString()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -670,7 +670,7 @@ private[celeborn] class Master(
       workerStatus: WorkerStatus,
       requestId: String): Unit = {
     val targetWorker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
-    val registered = statusSystem.workers.asScala.contains(targetWorker)
+    val registered = statusSystem.containsWorker(targetWorker)
     if (!registered) {
       logWarning(s"Received heartbeat from unknown worker " +
         s"$host:$rpcPort:$pushPort:$fetchPort:$replicatePort.")
@@ -761,10 +761,7 @@ private[celeborn] class Master(
       -1,
       new util.HashMap[String, DiskInfo](),
       JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption]())
-    val worker: WorkerInfo = statusSystem.workers
-      .asScala
-      .find(_ == targetWorker)
-      .orNull
+    val worker: WorkerInfo = statusSystem.getWorker(targetWorker)
     if (worker == null) {
       logWarning(s"Unknown worker $host:$rpcPort:$pushPort:$fetchPort:$replicatePort" +
         s" for WorkerLost handler!")
@@ -809,7 +806,7 @@ private[celeborn] class Master(
       return
     }
 
-    if (statusSystem.workers.contains(workerToRegister)) {
+    if (statusSystem.containsWorker(workerToRegister)) {
       logWarning(s"Receive RegisterWorker while worker" +
         s" ${workerToRegister.toString()} already exists, re-register.")
       statusSystem.handleRegisterWorker(
@@ -911,7 +908,7 @@ private[celeborn] class Master(
     // offer slots
     val slots =
       masterSource.sample(MasterSource.OFFER_SLOTS_TIME, s"offerSlots-${Random.nextInt()}") {
-        statusSystem.workers.synchronized {
+        statusSystem.synchronizedWorkers { () =>
           if (slotsAssignPolicy == SlotsAssignPolicy.LOADAWARE) {
             SlotsAllocator.offerSlotsLoadAware(
               selectedWorkers,
@@ -1413,7 +1410,7 @@ private[celeborn] class Master(
           ",")} and remove ${removeWorkers.map(_.readableAddress).mkString(",")}.\n")
     }
     val unknownExcludedWorkers =
-      (addWorkers ++ removeWorkers).filter(!statusSystem.workers.contains(_))
+      (addWorkers ++ removeWorkers).filter(!statusSystem.containsWorker(_))
     if (unknownExcludedWorkers.nonEmpty) {
       sb.append(
         s"Unknown workers ${unknownExcludedWorkers.map(_.readableAddress).mkString(",")}." +

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -52,11 +52,11 @@ class WorkerResource extends ApiRequestContext {
   def workers: WorkersResponse = {
     new WorkersResponse()
       .workers(statusSystem.getWorkers.asScala.map(ApiUtils.workerData).toSeq.asJava)
-      .lostWorkers(statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
+      .lostWorkers(statusSystem.getLostWorkerInfos.asScala.toSeq.sortBy(_._2)
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)
       .excludedWorkers(
-        (statusSystem.excludedWorkers.asScala ++ statusSystem.getManuallyExcludedWorkerInfos.asScala)
+        (statusSystem.getExcludedWorkerInfos.asScala ++ statusSystem.getManuallyExcludedWorkerInfos.asScala)
           .map(ApiUtils.workerData).toSeq.asJava)
       .manualExcludedWorkers(statusSystem.getManuallyExcludedWorkerInfos.asScala.map(
         ApiUtils.workerData).toSeq.asJava)
@@ -108,7 +108,7 @@ class WorkerResource extends ApiRequestContext {
   @Path("/events")
   def workerEvents(): WorkerEventsResponse = {
     new WorkerEventsResponse().workerEvents(
-      statusSystem.workerEventInfos.asScala.map { case (worker, event) =>
+      statusSystem.getWorkerEventInfos.asScala.map { case (worker, event) =>
         new WorkerEventData()
           .worker(
             ApiUtils.workerData(worker)).event(

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -51,7 +51,7 @@ class WorkerResource extends ApiRequestContext {
   @GET
   def workers: WorkersResponse = {
     new WorkersResponse()
-      .workers(statusSystem.workers.asScala.map(ApiUtils.workerData).toSeq.asJava)
+      .workers(statusSystem.workers().asScala.map(ApiUtils.workerData).toSeq.asJava)
       .lostWorkers(statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)
@@ -134,7 +134,7 @@ class WorkerResource extends ApiRequestContext {
           s"eventType(${request.getEventType}) and workers(${request.getWorkers}) are required")
       }
       val workers = request.getWorkers.asScala.map(ApiUtils.toWorkerInfo).toSeq
-      val (filteredWorkers, unknownWorkers) = workers.partition(statusSystem.workers.contains)
+      val (filteredWorkers, unknownWorkers) = workers.partition(statusSystem.containsWorker)
       if (filteredWorkers.isEmpty) {
         throw new BadRequestException(
           s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -51,7 +51,7 @@ class WorkerResource extends ApiRequestContext {
   @GET
   def workers: WorkersResponse = {
     new WorkersResponse()
-      .workers(statusSystem.workers().asScala.map(ApiUtils.workerData).toSeq.asJava)
+      .workers(statusSystem.workers.asScala.map(ApiUtils.workerData).toSeq.asJava)
       .lostWorkers(statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -56,13 +56,13 @@ class WorkerResource extends ApiRequestContext {
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)
       .excludedWorkers(
-        (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala)
+        (statusSystem.excludedWorkers.asScala ++ statusSystem.getManuallyExcludedWorkerInfos.asScala)
           .map(ApiUtils.workerData).toSeq.asJava)
-      .manualExcludedWorkers(statusSystem.manuallyExcludedWorkers.asScala.map(
+      .manualExcludedWorkers(statusSystem.getManuallyExcludedWorkerInfos.asScala.map(
         ApiUtils.workerData).toSeq.asJava)
-      .shutdownWorkers(statusSystem.shutdownWorkers.asScala.map(
+      .shutdownWorkers(statusSystem.getShutdownWorkerInfos.asScala.map(
         ApiUtils.workerData).toSeq.asJava)
-      .decommissioningWorkers(statusSystem.decommissionWorkers.asScala.map(
+      .decommissioningWorkers(statusSystem.getDecommissionWorkerInfos.asScala.map(
         ApiUtils.workerData).toSeq.asJava)
   }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -51,7 +51,7 @@ class WorkerResource extends ApiRequestContext {
   @GET
   def workers: WorkersResponse = {
     new WorkersResponse()
-      .workers(statusSystem.workers.asScala.map(ApiUtils.workerData).toSeq.asJava)
+      .workers(statusSystem.getWorkers.asScala.map(ApiUtils.workerData).toSeq.asJava)
       .lostWorkers(statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -157,7 +157,7 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.workers().size());
+    assertEquals(3, statusSystem.getWorkers().size());
   }
 
   @Test
@@ -253,7 +253,7 @@ public class DefaultMetaSystemSuiteJ {
 
     statusSystem.handleWorkerLost(
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
-    assertEquals(2, statusSystem.workers().size());
+    assertEquals(2, statusSystem.getWorkers().size());
   }
 
   private static final String APPID1 = "appId1";
@@ -376,20 +376,20 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.workers().size());
+    assertEquals(3, statusSystem.getWorkers().size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
     allocation.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocation);
     workersToAllocate.put(
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -399,7 +399,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
     assertEquals(
         0,
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -697,7 +697,7 @@ public class DefaultMetaSystemSuiteJ {
         workerStatus,
         getNewReqeustId());
 
-    assertEquals(statusSystem.excludedWorkers.size(), 1);
+    assertEquals(statusSystem.getExcludedWorkerIds().size(), 1);
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME2,
@@ -713,7 +713,7 @@ public class DefaultMetaSystemSuiteJ {
         workerStatus,
         getNewReqeustId());
 
-    assertEquals(statusSystem.excludedWorkers.size(), 2);
+    assertEquals(statusSystem.getExcludedWorkerIds().size(), 2);
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME3,
@@ -729,7 +729,7 @@ public class DefaultMetaSystemSuiteJ {
         workerStatus,
         getNewReqeustId());
 
-    assertEquals(statusSystem.excludedWorkers.size(), 2);
+    assertEquals(statusSystem.getExcludedWorkerIds().size(), 2);
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME3,
@@ -745,7 +745,7 @@ public class DefaultMetaSystemSuiteJ {
         workerStatus,
         getNewReqeustId());
 
-    assertEquals(statusSystem.excludedWorkers.size(), 3);
+    assertEquals(statusSystem.getExcludedWorkerIds().size(), 3);
   }
 
   @Test
@@ -798,7 +798,7 @@ public class DefaultMetaSystemSuiteJ {
 
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
     assertEquals(1, statusSystem.getShutdownWorkerIds().size());
-    assertTrue(statusSystem.excludedWorkers.isEmpty());
+    assertTrue(statusSystem.getExcludedWorkerIds().isEmpty());
   }
 
   @Test
@@ -895,6 +895,6 @@ public class DefaultMetaSystemSuiteJ {
             userResourceConsumption1));
     statusSystem.handleReportWorkerDecommission(workers, getNewReqeustId());
     assertEquals(1, statusSystem.getDecommissionWorkerIds().size());
-    assertTrue(statusSystem.excludedWorkers.isEmpty());
+    assertTrue(statusSystem.getExcludedWorkerIds().isEmpty());
   }
 }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -208,11 +208,11 @@ public class DefaultMetaSystemSuiteJ {
 
     statusSystem.handleWorkerExclude(
         Arrays.asList(workerInfo1, workerInfo2), Collections.emptyList(), getNewReqeustId());
-    assertEquals(2, statusSystem.manuallyExcludedWorkers.size());
+    assertEquals(2, statusSystem.getManuallyExcludedWorkerIds().size());
 
     statusSystem.handleWorkerExclude(
         Collections.emptyList(), Collections.singletonList(workerInfo1), getNewReqeustId());
-    assertEquals(1, statusSystem.manuallyExcludedWorkers.size());
+    assertEquals(1, statusSystem.getManuallyExcludedWorkerIds().size());
   }
 
   @Test
@@ -797,7 +797,7 @@ public class DefaultMetaSystemSuiteJ {
             userResourceConsumption1));
 
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
-    assertEquals(1, statusSystem.shutdownWorkers.size());
+    assertEquals(1, statusSystem.getShutdownWorkerIds().size());
     assertTrue(statusSystem.excludedWorkers.isEmpty());
   }
 
@@ -894,7 +894,7 @@ public class DefaultMetaSystemSuiteJ {
             disks1,
             userResourceConsumption1));
     statusSystem.handleReportWorkerDecommission(workers, getNewReqeustId());
-    assertEquals(1, statusSystem.decommissionWorkers.size());
+    assertEquals(1, statusSystem.getDecommissionWorkerIds().size());
     assertTrue(statusSystem.excludedWorkers.isEmpty());
   }
 }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -157,7 +157,7 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.workers.size());
+    assertEquals(3, statusSystem.workers().size());
   }
 
   @Test
@@ -253,7 +253,7 @@ public class DefaultMetaSystemSuiteJ {
 
     statusSystem.handleWorkerLost(
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
-    assertEquals(2, statusSystem.workers.size());
+    assertEquals(2, statusSystem.workers().size());
   }
 
   private static final String APPID1 = "appId1";
@@ -376,20 +376,20 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.workers.size());
+    assertEquals(3, statusSystem.workers().size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
     allocation.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocation);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -399,7 +399,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
     assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -209,8 +209,8 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     masterStatusSystem.excludedWorkers.add(info2);
     masterStatusSystem.excludedWorkers.add(info3);
 
-    masterStatusSystem.manuallyExcludedWorkers.add(info1);
-    masterStatusSystem.manuallyExcludedWorkers.add(info2);
+    masterStatusSystem.updateWorkerExcludeMeta(
+        Arrays.asList(info1, info2), Collections.emptyList());
 
     masterStatusSystem.hostnameSet.add(host1);
     masterStatusSystem.hostnameSet.add(host2);
@@ -240,14 +240,14 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
 
     masterStatusSystem.hostnameSet.clear();
     masterStatusSystem.excludedWorkers.clear();
-    masterStatusSystem.manuallyExcludedWorkers.clear();
+    masterStatusSystem.getManuallyExcludedWorkerIds().clear();
     masterStatusSystem.clearWorkers();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
     Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
     Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
-    Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
+    Assert.assertEquals(2, masterStatusSystem.getManuallyExcludedWorkerIds().size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
     Assert.assertEquals(
         conf.metricsAppTopDiskUsageWindowSize(),

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -232,20 +232,20 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     AppDiskUsageSnapShot originCurrentSnapshot =
         masterStatusSystem.appDiskUsageMetric.currentSnapShot().get();
 
-    masterStatusSystem.workers.add(new WorkerInfo(host1, 9095, 9094, 9093, 9092, 9091));
-    masterStatusSystem.workers.add(new WorkerInfo(host2, 9095, 9094, 9093, 9092, 9091));
-    masterStatusSystem.workers.add(new WorkerInfo(host3, 9095, 9094, 9093, 9092, 9091));
+    masterStatusSystem.updateWorker(new WorkerInfo(host1, 9095, 9094, 9093, 9092, 9091));
+    masterStatusSystem.updateWorker(new WorkerInfo(host2, 9095, 9094, 9093, 9092, 9091));
+    masterStatusSystem.updateWorker(new WorkerInfo(host3, 9095, 9094, 9093, 9092, 9091));
 
     masterStatusSystem.writeMetaInfoToFile(tmpFile);
 
     masterStatusSystem.hostnameSet.clear();
     masterStatusSystem.excludedWorkers.clear();
     masterStatusSystem.manuallyExcludedWorkers.clear();
-    masterStatusSystem.workers.clear();
+    masterStatusSystem.clearWorkers();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
-    Assert.assertEquals(3, masterStatusSystem.workers.size());
+    Assert.assertEquals(3, masterStatusSystem.workers().size());
     Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
     Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
@@ -260,7 +260,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     Assert.assertArrayEquals(originSnapshots, masterStatusSystem.appDiskUsageMetric.snapShots());
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
-    Assert.assertEquals(3, masterStatusSystem.workers.size());
+    Assert.assertEquals(3, masterStatusSystem.workers().size());
   }
 
   private String getNewReqeustId() {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -240,7 +240,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
 
     masterStatusSystem.hostnameSet.clear();
     masterStatusSystem.clearExcludedWorkers();
-    masterStatusSystem.getManuallyExcludedWorkerIds().clear();
+    masterStatusSystem.clearManuallyExcludedWorkers();
     masterStatusSystem.clearWorkers();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -205,9 +205,9 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     String host2 = "host2";
     String host3 = "host3";
 
-    masterStatusSystem.excludedWorkers.add(info1);
-    masterStatusSystem.excludedWorkers.add(info2);
-    masterStatusSystem.excludedWorkers.add(info3);
+    masterStatusSystem.addExcludeWorker(info1);
+    masterStatusSystem.addExcludeWorker(info2);
+    masterStatusSystem.addExcludeWorker(info3);
 
     masterStatusSystem.updateWorkerExcludeMeta(
         Arrays.asList(info1, info2), Collections.emptyList());
@@ -239,14 +239,14 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     masterStatusSystem.writeMetaInfoToFile(tmpFile);
 
     masterStatusSystem.hostnameSet.clear();
-    masterStatusSystem.excludedWorkers.clear();
+    masterStatusSystem.clearExcludedWorkers();
     masterStatusSystem.getManuallyExcludedWorkerIds().clear();
     masterStatusSystem.clearWorkers();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
     Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
-    Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
+    Assert.assertEquals(3, masterStatusSystem.getExcludedWorkerIds().size());
     Assert.assertEquals(2, masterStatusSystem.getManuallyExcludedWorkerIds().size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
     Assert.assertEquals(

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -245,7 +245,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
-    Assert.assertEquals(3, masterStatusSystem.workers().size());
+    Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
     Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
     Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
@@ -260,7 +260,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     Assert.assertArrayEquals(originSnapshots, masterStatusSystem.appDiskUsageMetric.snapShots());
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
-    Assert.assertEquals(3, masterStatusSystem.workers().size());
+    Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
   }
 
   private String getNewReqeustId() {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -205,9 +205,9 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     String host2 = "host2";
     String host3 = "host3";
 
-    masterStatusSystem.addExcludeWorker(info1);
-    masterStatusSystem.addExcludeWorker(info2);
-    masterStatusSystem.addExcludeWorker(info3);
+    masterStatusSystem.addExcludedWorker(info1);
+    masterStatusSystem.addExcludedWorker(info2);
+    masterStatusSystem.addExcludedWorker(info3);
 
     masterStatusSystem.updateWorkerExcludeMeta(
         Arrays.asList(info1, info2), Collections.emptyList());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1019,9 +1019,9 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getExcludedWorkerIds().size());
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME2,
@@ -1038,10 +1038,10 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(2, statusSystem.excludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(2, statusSystem.getExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.getExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.getExcludedWorkerIds().size());
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME1,
@@ -1058,10 +1058,10 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(1, statusSystem.excludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(1, statusSystem.getExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getExcludedWorkerIds().size());
 
     statusSystem.handleWorkerHeartbeat(
         HOSTNAME1,
@@ -1077,10 +1077,10 @@ public class RatisMasterStatusSystemSuiteJ {
         workerStatus,
         getNewReqeustId());
     Thread.sleep(3000L);
-    Assert.assertEquals(2, statusSystem.excludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(2, statusSystem.getExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.getExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.getExcludedWorkerIds().size());
   }
 
   @Before
@@ -1089,21 +1089,21 @@ public class RatisMasterStatusSystemSuiteJ {
     STATUSSYSTEM1.hostnameSet.clear();
     STATUSSYSTEM1.getWorkers().clear();
     STATUSSYSTEM1.appHeartbeatTime.clear();
-    STATUSSYSTEM1.excludedWorkers.clear();
+    STATUSSYSTEM1.clearExcludedWorkers();
     STATUSSYSTEM1.clearWorkerLostEvents();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
     STATUSSYSTEM2.getWorkers().clear();
     STATUSSYSTEM2.appHeartbeatTime.clear();
-    STATUSSYSTEM2.excludedWorkers.clear();
+    STATUSSYSTEM2.clearExcludedWorkers();
     STATUSSYSTEM2.clearWorkerLostEvents();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
     STATUSSYSTEM3.getWorkers().clear();
     STATUSSYSTEM3.appHeartbeatTime.clear();
-    STATUSSYSTEM3.excludedWorkers.clear();
+    STATUSSYSTEM3.clearExcludedWorkers();
     STATUSSYSTEM3.clearWorkerLostEvents();
 
     disks1.clear();
@@ -1217,9 +1217,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM1.getShutdownWorkerIds().size());
     Assert.assertEquals(1, STATUSSYSTEM2.getShutdownWorkerIds().size());
     Assert.assertEquals(1, STATUSSYSTEM3.getShutdownWorkerIds().size());
-    Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM1.getExcludedWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM2.getExcludedWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM3.getExcludedWorkerIds().size());
   }
 
   @Test
@@ -1286,9 +1286,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM2.getShutdownWorkerIds().size());
     Assert.assertEquals(1, STATUSSYSTEM3.getShutdownWorkerIds().size());
 
-    Assert.assertEquals(1, STATUSSYSTEM1.lostWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.lostWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.lostWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getLostWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getLostWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getLostWorkerIds().size());
 
     statusSystem.handleRemoveWorkersUnavailableInfo(unavailableWorkers, getNewReqeustId());
     Thread.sleep(3000L);
@@ -1297,9 +1297,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(0, STATUSSYSTEM2.getShutdownWorkerIds().size());
     Assert.assertEquals(0, STATUSSYSTEM3.getShutdownWorkerIds().size());
 
-    Assert.assertEquals(0, STATUSSYSTEM1.lostWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM2.lostWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM3.lostWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM1.getLostWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM2.getLostWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM3.getLostWorkerIds().size());
   }
 
   @Test
@@ -1389,29 +1389,29 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
 
     Thread.sleep(3000L);
-    Assert.assertEquals(2, STATUSSYSTEM1.workerEventInfos.size());
-    Assert.assertEquals(2, STATUSSYSTEM2.workerEventInfos.size());
-    Assert.assertEquals(2, STATUSSYSTEM3.workerEventInfos.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getWorkerEventInfos().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.getWorkerEventInfos().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.getWorkerEventInfos().size());
 
-    Assert.assertTrue(STATUSSYSTEM1.workerEventInfos.containsKey(workerInfo1));
-    Assert.assertTrue(STATUSSYSTEM1.workerEventInfos.containsKey(workerInfo2));
+    Assert.assertTrue(STATUSSYSTEM1.getWorkerEventInfos().containsKey(workerInfo1));
+    Assert.assertTrue(STATUSSYSTEM1.getWorkerEventInfos().containsKey(workerInfo2));
 
     Assert.assertEquals(
         WorkerEventType.Decommission,
-        STATUSSYSTEM1.workerEventInfos.get(workerInfo1).getEventType());
+        STATUSSYSTEM1.getWorkerEventInfos().get(workerInfo1).getEventType());
 
     statusSystem.handleWorkerEvent(
         ResourceProtos.WorkerEventType.None_VALUE,
         Lists.newArrayList(workerInfo1),
         getNewReqeustId());
     Thread.sleep(3000L);
-    Assert.assertEquals(1, STATUSSYSTEM1.workerEventInfos.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.workerEventInfos.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.workerEventInfos.size());
-    Assert.assertTrue(STATUSSYSTEM1.workerEventInfos.containsKey(workerInfo2));
+    Assert.assertEquals(1, STATUSSYSTEM1.getWorkerEventInfos().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getWorkerEventInfos().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getWorkerEventInfos().size());
+    Assert.assertTrue(STATUSSYSTEM1.getWorkerEventInfos().containsKey(workerInfo2));
     Assert.assertEquals(
         WorkerEventType.Decommission,
-        STATUSSYSTEM1.workerEventInfos.get(workerInfo2).getEventType());
+        STATUSSYSTEM1.getWorkerEventInfos().get(workerInfo2).getEventType());
   }
 
   @Test
@@ -1497,8 +1497,8 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM1.getDecommissionWorkerIds().size());
     Assert.assertEquals(1, STATUSSYSTEM2.getDecommissionWorkerIds().size());
     Assert.assertEquals(1, STATUSSYSTEM3.getDecommissionWorkerIds().size());
-    Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM3.excludedWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM1.getExcludedWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM2.getExcludedWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM3.getExcludedWorkerIds().size());
   }
 }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1087,21 +1087,21 @@ public class RatisMasterStatusSystemSuiteJ {
   public void resetStatus() {
     STATUSSYSTEM1.registeredAppAndShuffles.clear();
     STATUSSYSTEM1.hostnameSet.clear();
-    STATUSSYSTEM1.getWorkers().clear();
+    STATUSSYSTEM1.clearWorkers();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.clearExcludedWorkers();
     STATUSSYSTEM1.clearWorkerLostEvents();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
-    STATUSSYSTEM2.getWorkers().clear();
+    STATUSSYSTEM2.clearWorkers();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.clearExcludedWorkers();
     STATUSSYSTEM2.clearWorkerLostEvents();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
-    STATUSSYSTEM3.getWorkers().clear();
+    STATUSSYSTEM3.clearWorkers();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.clearExcludedWorkers();
     STATUSSYSTEM3.clearWorkerLostEvents();

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -347,13 +347,13 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM2.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM3.workers.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workers().size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workers().size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workers().size());
 
-    assertWorkers(STATUSSYSTEM1.workers);
-    assertWorkers(STATUSSYSTEM2.workers);
-    assertWorkers(STATUSSYSTEM3.workers);
+    assertWorkers(STATUSSYSTEM1.workers());
+    assertWorkers(STATUSSYSTEM2.workers());
+    assertWorkers(STATUSSYSTEM3.workers());
   }
 
   private void assertWorkers(Set<WorkerInfo> workerInfos) {
@@ -479,9 +479,9 @@ public class RatisMasterStatusSystemSuiteJ {
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
-    Assert.assertEquals(2, STATUSSYSTEM2.workers.size());
-    Assert.assertEquals(2, STATUSSYSTEM3.workers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.workers().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.workers().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.workers().size());
   }
 
   @Test
@@ -571,21 +571,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME3))
             .findFirst()
             .get()
@@ -632,22 +632,22 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM2.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM3.workers.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workers().size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workers().size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workers().size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
     allocations.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocations);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -661,21 +661,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        STATUSSYSTEM1.workers.stream()
+        STATUSSYSTEM1.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM2.workers.stream()
+        STATUSSYSTEM2.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM3.workers.stream()
+        STATUSSYSTEM3.workers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
@@ -1087,21 +1087,21 @@ public class RatisMasterStatusSystemSuiteJ {
   public void resetStatus() {
     STATUSSYSTEM1.registeredAppAndShuffles.clear();
     STATUSSYSTEM1.hostnameSet.clear();
-    STATUSSYSTEM1.workers.clear();
+    STATUSSYSTEM1.workers().clear();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.excludedWorkers.clear();
     STATUSSYSTEM1.workerLostEvents.clear();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
-    STATUSSYSTEM2.workers.clear();
+    STATUSSYSTEM2.workers().clear();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.excludedWorkers.clear();
     STATUSSYSTEM2.workerLostEvents.clear();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
-    STATUSSYSTEM3.workers.clear();
+    STATUSSYSTEM3.workers().clear();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.excludedWorkers.clear();
     STATUSSYSTEM3.workerLostEvents.clear();
@@ -1280,7 +1280,7 @@ public class RatisMasterStatusSystemSuiteJ {
     statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
 
     Thread.sleep(3000L);
-    Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.workers().size());
 
     Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -423,17 +423,17 @@ public class RatisMasterStatusSystemSuiteJ {
         Arrays.asList(workerInfo1, workerInfo2), Collections.emptyList(), getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(2, STATUSSYSTEM1.manuallyExcludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM2.manuallyExcludedWorkers.size());
-    Assert.assertEquals(2, STATUSSYSTEM3.manuallyExcludedWorkers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getManuallyExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.getManuallyExcludedWorkerIds().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.getManuallyExcludedWorkerIds().size());
 
     statusSystem.handleWorkerExclude(
         Collections.emptyList(), Collections.singletonList(workerInfo1), getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(1, STATUSSYSTEM1.manuallyExcludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.manuallyExcludedWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.manuallyExcludedWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getManuallyExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getManuallyExcludedWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getManuallyExcludedWorkerIds().size());
   }
 
   @Test
@@ -1090,21 +1090,21 @@ public class RatisMasterStatusSystemSuiteJ {
     STATUSSYSTEM1.getWorkers().clear();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.excludedWorkers.clear();
-    STATUSSYSTEM1.workerLostEvents.clear();
+    STATUSSYSTEM1.clearWorkerLostEvents();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
     STATUSSYSTEM2.getWorkers().clear();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.excludedWorkers.clear();
-    STATUSSYSTEM2.workerLostEvents.clear();
+    STATUSSYSTEM2.clearWorkerLostEvents();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
     STATUSSYSTEM3.getWorkers().clear();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.excludedWorkers.clear();
-    STATUSSYSTEM3.workerLostEvents.clear();
+    STATUSSYSTEM3.clearWorkerLostEvents();
 
     disks1.clear();
     disks1.put(
@@ -1214,9 +1214,9 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
     Thread.sleep(3000L);
-    Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.shutdownWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getShutdownWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getShutdownWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getShutdownWorkerIds().size());
     Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM3.excludedWorkers.size());
@@ -1282,9 +1282,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Thread.sleep(3000L);
     Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
 
-    Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.shutdownWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getShutdownWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getShutdownWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getShutdownWorkerIds().size());
 
     Assert.assertEquals(1, STATUSSYSTEM1.lostWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.lostWorkers.size());
@@ -1293,9 +1293,9 @@ public class RatisMasterStatusSystemSuiteJ {
     statusSystem.handleRemoveWorkersUnavailableInfo(unavailableWorkers, getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(0, STATUSSYSTEM1.shutdownWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM2.shutdownWorkers.size());
-    Assert.assertEquals(0, STATUSSYSTEM3.shutdownWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM1.getShutdownWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM2.getShutdownWorkerIds().size());
+    Assert.assertEquals(0, STATUSSYSTEM3.getShutdownWorkerIds().size());
 
     Assert.assertEquals(0, STATUSSYSTEM1.lostWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.lostWorkers.size());
@@ -1494,9 +1494,9 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleReportWorkerDecommission(workers, getNewReqeustId());
     Thread.sleep(3000L);
-    Assert.assertEquals(1, STATUSSYSTEM1.decommissionWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM2.decommissionWorkers.size());
-    Assert.assertEquals(1, STATUSSYSTEM3.decommissionWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM1.getDecommissionWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM2.getDecommissionWorkerIds().size());
+    Assert.assertEquals(1, STATUSSYSTEM3.getDecommissionWorkerIds().size());
     Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM3.excludedWorkers.size());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -347,16 +347,16 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.workers().size());
-    Assert.assertEquals(3, STATUSSYSTEM2.workers().size());
-    Assert.assertEquals(3, STATUSSYSTEM3.workers().size());
+    Assert.assertEquals(3, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM2.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM3.getWorkers().size());
 
-    assertWorkers(STATUSSYSTEM1.workers());
-    assertWorkers(STATUSSYSTEM2.workers());
-    assertWorkers(STATUSSYSTEM3.workers());
+    assertWorkers(STATUSSYSTEM1.getWorkers());
+    assertWorkers(STATUSSYSTEM2.getWorkers());
+    assertWorkers(STATUSSYSTEM3.getWorkers());
   }
 
-  private void assertWorkers(Set<WorkerInfo> workerInfos) {
+  private void assertWorkers(Collection<WorkerInfo> workerInfos) {
     for (WorkerInfo workerInfo : workerInfos) {
       assertWorker(workerInfo);
     }
@@ -479,9 +479,9 @@ public class RatisMasterStatusSystemSuiteJ {
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(2, STATUSSYSTEM1.workers().size());
-    Assert.assertEquals(2, STATUSSYSTEM2.workers().size());
-    Assert.assertEquals(2, STATUSSYSTEM3.workers().size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.getWorkers().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.getWorkers().size());
   }
 
   @Test
@@ -571,21 +571,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME3))
             .findFirst()
             .get()
@@ -632,22 +632,22 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.workers().size());
-    Assert.assertEquals(3, STATUSSYSTEM2.workers().size());
-    Assert.assertEquals(3, STATUSSYSTEM3.workers().size());
+    Assert.assertEquals(3, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM2.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM3.getWorkers().size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
     allocations.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocations);
     workersToAllocate.put(
-        statusSystem.workers().stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -661,21 +661,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        STATUSSYSTEM1.workers().stream()
+        STATUSSYSTEM1.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM2.workers().stream()
+        STATUSSYSTEM2.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM3.workers().stream()
+        STATUSSYSTEM3.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
@@ -1087,21 +1087,21 @@ public class RatisMasterStatusSystemSuiteJ {
   public void resetStatus() {
     STATUSSYSTEM1.registeredAppAndShuffles.clear();
     STATUSSYSTEM1.hostnameSet.clear();
-    STATUSSYSTEM1.workers().clear();
+    STATUSSYSTEM1.getWorkers().clear();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.excludedWorkers.clear();
     STATUSSYSTEM1.workerLostEvents.clear();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
-    STATUSSYSTEM2.workers().clear();
+    STATUSSYSTEM2.getWorkers().clear();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.excludedWorkers.clear();
     STATUSSYSTEM2.workerLostEvents.clear();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
-    STATUSSYSTEM3.workers().clear();
+    STATUSSYSTEM3.getWorkers().clear();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.excludedWorkers.clear();
     STATUSSYSTEM3.workerLostEvents.clear();
@@ -1280,7 +1280,7 @@ public class RatisMasterStatusSystemSuiteJ {
     statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
 
     Thread.sleep(3000L);
-    Assert.assertEquals(2, STATUSSYSTEM1.workers().size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
 
     Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -132,7 +132,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
       worker.rpcEnv.shutdown()
       // Workers in miniClusterFeature wont update status with master through heartbeat.
       // So update status manually.
-      masterInfo._1.statusSystem.excludedWorkers.add(worker.workerInfo)
+      masterInfo._1.statusSystem.addExcludedWorker(worker.workerInfo)
       workerInfos.remove(worker)
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Using map for workers so that we can find a worker by uniqueId fast.

And using WorkerInfo pool to reuse the objects.
### Why are the changes needed?

For large celeborn cluster, it might be slow.

- updateWorkerHeartbeatMeta
https://github.com/apache/celeborn/blob/1e77f01cd317b1dc885965d6053b391db1d42bc7/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java#L222

- handleWorkerLost
https://github.com/apache/celeborn/blob/1e77f01cd317b1dc885965d6053b391db1d42bc7/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala#L762-L765
### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UT.
