### PR TITLE
[CELEBORN-1668] Fix NPE when handle closed file writers

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
@@ -84,6 +84,7 @@ public class DiskFileInfo extends FileInfo {
     return new File(filePath);
   }
 
+  @Override
   public String getFilePath() {
     return filePath;
   }
@@ -158,10 +159,5 @@ public class DiskFileInfo extends FileInfo {
 
   public boolean isDFS() {
     return Utils.isS3Path(filePath) || Utils.isHdfsPath(filePath);
-  }
-
-  @Override
-  public String toString() {
-    return "DiskFileInfo{" + "filePath='" + filePath + '}';
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
@@ -159,4 +159,9 @@ public class DiskFileInfo extends FileInfo {
   public boolean isDFS() {
     return Utils.isS3Path(filePath) || Utils.isHdfsPath(filePath);
   }
+
+  @Override
+  public String toString() {
+    return "DiskFileInfo{" + "filePath='" + filePath + '}';
+  }
 }

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -106,4 +106,6 @@ public abstract class FileInfo {
       return streams.isEmpty();
     }
   }
+
+  public abstract String getFilePath();
 }

--- a/common/src/main/java/org/apache/celeborn/common/meta/MemoryFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MemoryFileInfo.java
@@ -80,4 +80,9 @@ public class MemoryFileInfo extends FileInfo {
     logger.info("Memory File Info {} expire, removed {}", this, bufferSize);
     return bufferSize;
   }
+
+  @Override
+  public String getFilePath() {
+    return "";
+  }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -541,7 +541,7 @@ public abstract class PartitionDataWriter implements DeviceObserver {
     }
   }
 
-  protected FileInfo getCurrentFileInfo() {
+  public FileInfo getCurrentFileInfo() {
     if (!isMemoryShuffleFile.get()) {
       return diskFileInfo;
     } else {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -265,10 +265,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     fileWriter.incrementPendingWrites()
 
     if (fileWriter.isClosed) {
-      val fileinfo = fileWriter.getCurrentFileInfo
+      val fileInfo = fileWriter.getCurrentFileInfo
       logWarning(
-        s"[handlePushData] FileWriter is already closed! File path ${fileinfo.getFilePath} " +
-          s"length ${fileinfo.getFileLength}")
+        s"[handlePushData] FileWriter is already closed! File path ${fileInfo.getFilePath} " +
+          s"length ${fileInfo.getFileLength}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return
@@ -547,10 +547,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     val closedFileWriter = fileWriters.find(_.isClosed)
     if (closedFileWriter.isDefined) {
-      val fileinfo = closedFileWriter.get.getCurrentFileInfo
+      val fileInfo = closedFileWriter.get.getCurrentFileInfo
       logWarning(
-        s"[handlePushMergedData] FileWriter is already closed! File path ${fileinfo.getFilePath} " +
-          s"length ${fileinfo.getFileLength}")
+        s"[handlePushMergedData] FileWriter is already closed! File path ${fileInfo.getFilePath} " +
+          s"length ${fileInfo.getFileLength}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriters.foreach(_.decrementPendingWrites())
       return
@@ -825,10 +825,10 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     fileWriter.incrementPendingWrites()
 
     if (fileWriter.isClosed) {
-      val fileinfo = fileWriter.getCurrentFileInfo
+      val fileInfo = fileWriter.getCurrentFileInfo
       logWarning(
-        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${fileinfo.getFilePath} " +
-          s"length ${fileinfo.getFileLength}")
+        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${fileInfo.getFilePath} " +
+          s"length ${fileInfo.getFileLength}")
       callback.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -267,7 +267,8 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     if (fileWriter.isClosed) {
       val fileinfo = fileWriter.getCurrentFileInfo
       logWarning(
-        s"[handlePushData] FileWriter is already closed! FileInfo ${fileinfo}")
+        s"[handlePushData] FileWriter is already closed! File path ${fileinfo.getFilePath} " +
+          s"length ${fileinfo.getFileLength}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return
@@ -548,7 +549,8 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     if (closedFileWriter.isDefined) {
       val fileinfo = closedFileWriter.get.getCurrentFileInfo
       logWarning(
-        s"[handlePushMergedData] FileWriter is already closed! FileInfo ${fileinfo}")
+        s"[handlePushMergedData] FileWriter is already closed! File path ${fileinfo.getFilePath} " +
+          s"length ${fileinfo.getFileLength}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriters.foreach(_.decrementPendingWrites())
       return
@@ -825,7 +827,8 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     if (fileWriter.isClosed) {
       val fileinfo = fileWriter.getCurrentFileInfo
       logWarning(
-        s"[handleMapPartitionPushData] FileWriter is already closed! FileInfo ${fileinfo}")
+        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${fileinfo.getFilePath} " +
+          s"length ${fileinfo.getFileLength}")
       callback.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return
@@ -1246,7 +1249,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
          |partitionSplitMinimumSize:$partitionSplitMinimumSize,
          |splitThreshold:${fileWriter.getSplitThreshold},
          |fileLength:${fileWriter.getCurrentFileInfo.getFileLength}
-         |fileInfo:${fileWriter.getCurrentFileInfo}
+         |fileName:${fileWriter.getCurrentFileInfo.getFilePath}
          |""".stripMargin)
     if (fileWriter.needHardSplitForMemoryShuffleStorage()) {
       return true


### PR DESCRIPTION
### What changes were proposed in this pull request?
To fix an NPE when handling the closed file writers.


### Why are the changes needed?
If a file writer stores its shuffle data in memory, the disk file info object will be null, causing NPE.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA.
