### PR TITLE
[CELEBORN-1670] Avoid swallowing InterruptedException in ShuffleClientImpl

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -354,8 +354,12 @@ public class ShuffleClientImpl extends ShuffleClient {
             batchId,
             newLoc,
             e);
-        pushDataRpcResponseCallback.onFailure(
-            new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        } else {
+          pushDataRpcResponseCallback.onFailure(
+              new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
+        }
       }
     }
   }
@@ -691,6 +695,9 @@ public class ShuffleClientImpl extends ShuffleClient {
               numRetries - 1);
         }
       } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         logger.error(
             "Exception raised while registering shuffle {} with {} mapper and {} partitions.",
             shuffleId,
@@ -876,6 +883,9 @@ public class ShuffleClientImpl extends ShuffleClient {
 
       return results;
     } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       StringBuilder partitionIds = new StringBuilder();
       StringBuilder epochs = new StringBuilder();
       requests.forEach(
@@ -1232,8 +1242,12 @@ public class ShuffleClientImpl extends ShuffleClient {
             nextBatchId,
             loc,
             e);
-        wrappedCallback.onFailure(
-            new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        } else {
+          wrappedCallback.onFailure(
+              new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
+        }
       }
     } else {
       // add batch data
@@ -1586,8 +1600,12 @@ public class ShuffleClientImpl extends ShuffleClient {
           Arrays.toString(batchIds),
           addressPair,
           e);
-      wrappedCallback.onFailure(
-          new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      } else {
+        wrappedCallback.onFailure(
+            new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
+      }
     }
   }
 
@@ -1700,6 +1718,9 @@ public class ShuffleClientImpl extends ShuffleClient {
           }
         }
       } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         logger.error("Exception raised while call GetReducerFileGroup for {}.", shuffleId, e);
         exceptionMsg = e.getMessage();
       }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -355,7 +355,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             newLoc,
             e);
         if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
+          pushDataRpcResponseCallback.onFailure(e);
         } else {
           pushDataRpcResponseCallback.onFailure(
               new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
@@ -883,9 +883,6 @@ public class ShuffleClientImpl extends ShuffleClient {
 
       return results;
     } catch (Exception e) {
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
       StringBuilder partitionIds = new StringBuilder();
       StringBuilder epochs = new StringBuilder();
       requests.forEach(
@@ -899,6 +896,9 @@ public class ShuffleClientImpl extends ShuffleClient {
           partitionIds,
           epochs,
           e);
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       return null;
     }
   }
@@ -1161,6 +1161,11 @@ public class ShuffleClientImpl extends ShuffleClient {
               if (pushState.exception.get() != null) {
                 return;
               }
+              if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                callback.onFailure(e);
+                return;
+              }
               StatusCode cause = getPushDataFailCause(e.getMessage());
               if (remainReviveTimes <= 0) {
                 if (e instanceof CelebornIOException) {
@@ -1243,7 +1248,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             loc,
             e);
         if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
+          wrappedCallback.onFailure(e);
         } else {
           wrappedCallback.onFailure(
               new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));
@@ -1520,6 +1525,11 @@ public class ShuffleClientImpl extends ShuffleClient {
             if (pushState.exception.get() != null) {
               return;
             }
+            if (e instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+              callback.onFailure(e);
+              return;
+            }
             StatusCode cause = getPushDataFailCause(e.getMessage());
             if (remainReviveTimes <= 0) {
               if (e instanceof CelebornIOException) {
@@ -1601,7 +1611,7 @@ public class ShuffleClientImpl extends ShuffleClient {
           addressPair,
           e);
       if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
+        wrappedCallback.onFailure(e);
       } else {
         wrappedCallback.onFailure(
             new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY, e));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
In the ShuffleClientImpl, methods such as pushData and pushMergedData might encounter interruptions during message transmission via the TransportClient. However, the InterruptedException may be ignored, as it is handled as a standard exception. As a result, the ShuffleClientImpl continues its operation(retry or revive) even when an InterruptedException occurs.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add UT: org.apache.celeborn.client.ShuffleClientSuiteJ#testPushDataAndInterrupted
