### PR TITLE
[CELEBORN-1642][CIP-11] Support multiple worker tags

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -22,7 +22,9 @@ import java.util.{Collections, Set => JSet}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Predicate
 import java.util.stream.Collectors
+
 import scala.collection.JavaConverters.{asScalaIteratorConverter, mapAsScalaConcurrentMapConverter}
+
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.WorkerInfo
 import org.apache.celeborn.common.util.JavaUtils
@@ -44,7 +46,7 @@ class TagsManager extends Logging {
       return Collections.emptyList()
     }
 
-    var workersForTags : Option[JSet[String]] = None
+    var workersForTags: Option[JSet[String]] = None
     tags.foreach { tag =>
       val taggedWorkers = tagStore.getOrDefault(tag, Collections.emptySet())
       workersForTags match {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -62,8 +62,10 @@ class TagsManager extends Logging {
       return Collections.emptyList()
     }
 
-    workers.stream().filter(w => workersForTags.get.contains(w.toUniqueId())).collect(
-      Collectors.toList())
+    val workerTagsPredicate = new Predicate[WorkerInfo] {
+      override def test(w: WorkerInfo): Boolean = workersForTags.get.contains(w.toUniqueId())
+    }
+    workers.stream().filter(workerTagsPredicate).collect(Collectors.toList())
   }
 
   def addTagToWorker(tag: String, workerId: String): Unit = {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -62,10 +62,8 @@ class TagsManager extends Logging {
       return Collections.emptyList()
     }
 
-    val workerTagsPredicate = new Predicate[WorkerInfo] {
-      override def test(w: WorkerInfo): Boolean = workersForTags.get.contains(w.toUniqueId())
-    }
-    workers.stream().filter(workerTagsPredicate).collect(Collectors.toList())
+    workers.stream().filter(w => workersForTags.get.contains(w.toUniqueId())).collect(
+      Collectors.toList())
   }
 
   def addTagToWorker(tag: String, workerId: String): Unit = {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -54,9 +54,10 @@ class TagsManager extends Logging {
       if (workers != null) {
         scheme match {
           case "AND" =>
-            workersForTags.addAll(workers)
-          case "OR" =>
+
             workersForTags.retainAll(workers)
+          case "OR" =>
+            workersForTags.addAll(workers)
           case _ =>
             logWarning(s"Unknown scheme: $scheme")
         }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
@@ -123,7 +123,7 @@ class TagsManagerSuite extends AnyFunSuite
     }
   }
 
-  test("test tags expression with scheme") {
+  test("test tags expression with multiple tags") {
     tagsManager = new TagsManager()
 
     // Tag1
@@ -137,7 +137,6 @@ class TagsManagerSuite extends AnyFunSuite
     tagsManager.addTagToWorker(TAG2, WORKER3.toUniqueId())
 
     {
-      // Test AND scheme
       val taggedWorkers = tagsManager.getTaggedWorkers("tag1,tag2", workers)
       assert(taggedWorkers.size == 1)
       assert(!taggedWorkers.contains(WORKER1))
@@ -146,12 +145,8 @@ class TagsManagerSuite extends AnyFunSuite
     }
 
     {
-      // Test OR scheme
-      val taggedWorkers = tagsManager.getTaggedWorkers("tag1,tag2", workers)
-      assert(taggedWorkers.size == 3)
-      assert(taggedWorkers.contains(WORKER1))
-      assert(taggedWorkers.contains(WORKER2))
-      assert(taggedWorkers.contains(WORKER3))
+      val taggedWorkers = tagsManager.getTaggedWorkers("tag1,tag3", workers)
+      assert(taggedWorkers.size == 0)
     }
   }
 }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
@@ -122,4 +122,36 @@ class TagsManagerSuite extends AnyFunSuite
       assert(tags.contains(TAG2))
     }
   }
+
+  test("test tags expression with scheme") {
+    tagsManager = new TagsManager()
+
+    // Tag1
+    val TAG1 = "tag1"
+    tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId())
+    tagsManager.addTagToWorker(TAG1, WORKER2.toUniqueId())
+
+    // Tag2
+    val TAG2 = "tag2"
+    tagsManager.addTagToWorker(TAG2, WORKER2.toUniqueId())
+    tagsManager.addTagToWorker(TAG2, WORKER3.toUniqueId())
+
+    {
+      // Test AND scheme
+      val taggedWorkers = tagsManager.getTaggedWorkers("tag1,tag2", workers)
+      assert(taggedWorkers.size == 1)
+      assert(!taggedWorkers.contains(WORKER1))
+      assert(taggedWorkers.contains(WORKER2))
+      assert(!taggedWorkers.contains(WORKER3))
+    }
+
+    {
+      // Test OR scheme
+      val taggedWorkers = tagsManager.getTaggedWorkers("tag1,tag2", workers)
+      assert(taggedWorkers.size == 3)
+      assert(taggedWorkers.contains(WORKER1))
+      assert(taggedWorkers.contains(WORKER2))
+      assert(taggedWorkers.contains(WORKER3))
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Current TagsManager code only supported one tags for selecting tagged workers. This change will enable support of passing multiple tags to TagsManager. Multiple tags will be evaluated as "AND" expression i.e only workers tagged with all the passed tags will be selected. 

Support for more schemes will be added in follow up PRs.

### Why are the changes needed?
https://cwiki.apache.org/confluence/display/CELEBORN/CIP-11+Supporting+Tags+in+Celeborn

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UTs
