### PR TITLE
[CELEBORN-1672] Bump Spark from 3.4.3 to 3.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1467,7 +1467,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.17</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.4.3</spark.version>
+        <spark.version>3.4.4</spark.version>
         <zstd-jni.version>1.5.2-5</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -762,7 +762,7 @@ object Spark34 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.12.17"
 
-  val sparkVersion = "3.4.3"
+  val sparkVersion = "3.4.4"
   val zstdJniVersion = "1.5.2-5"
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Spark from 3.4.3 to 3.4.4.

### Why are the changes needed?

Spark 3.4.4 has been announced to release: [Spark 3.4.4 released](https://spark.apache.org/news/spark-3-4-4-released.html). The profile spark-3.4 could bump Spark from 3.4.3 to 3.4.4.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.