### PR TITLE
[CELEBORN-1671] CelebornShuffleReader will try replica if create client failed

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -40,7 +40,6 @@ import org.apache.celeborn.common.exception.{CelebornIOException, PartitionUnRet
 import org.apache.celeborn.common.network.client.TransportClient
 import org.apache.celeborn.common.network.protocol.TransportMessage
 import org.apache.celeborn.common.protocol.{MessageType, PartitionLocation, PbOpenStreamList, PbOpenStreamListResponse, PbStreamHandler}
-import org.apache.celeborn.common.protocol.PartitionLocation.Mode
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils, Utils}
 
@@ -136,17 +135,17 @@ class CelebornShuffleReader[K, C](
                   s"Failed to create client for $shuffleKey-$partitionId from host: ${location.hostAndFetchPort}. " +
                     s"Shuffle reader will try its replica if exists.")
             }
-            workerRequestMap.get(hostPort) match {
-              case (_, locArr, pbOpenStreamListBuilder) =>
-                locArr.add(location)
-                pbOpenStreamListBuilder.addFileName(location.getFileName)
-                  .addStartIndex(startMapIndex)
-                  .addEndIndex(endMapIndex)
-                pbOpenStreamListBuilder.addReadLocalShuffle(
-                  localFetchEnabled && location.getHost.equals(localHostAddress))
-              case _ =>
-                logDebug(s"Empty client for host ${hostPort}")
-            }
+          }
+          workerRequestMap.get(hostPort) match {
+            case (_, locArr, pbOpenStreamListBuilder) =>
+              locArr.add(location)
+              pbOpenStreamListBuilder.addFileName(location.getFileName)
+                .addStartIndex(startMapIndex)
+                .addEndIndex(endMapIndex)
+              pbOpenStreamListBuilder.addReadLocalShuffle(
+                localFetchEnabled && location.getHost.equals(localHostAddress))
+            case _ =>
+              logDebug(s"Empty client for host ${hostPort}")
           }
         }
       }

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -139,6 +139,7 @@ class CelebornShuffleReader[K, C](
               }
             } catch {
               case ex: Exception =>
+                shuffleClient.excludeFailedFetchLocation(location.hostAndFetchPort, ex)
                 logWarning(
                   s"Failed to create client for $shuffleKey-$partitionId from host: ${location.hostAndFetchPort}. " +
                     s"Shuffle reader will try its replica if exists.")

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -128,21 +128,21 @@ class CelebornShuffleReader[K, C](
               workerRequestMap.put(
                 hostPort,
                 (client, new util.ArrayList[PartitionLocation], pbOpenStreamList))
-              val (_, locArr, pbOpenStreamListBuilder) = workerRequestMap.get(hostPort)
-              if (locArr != null) {
-                locArr.add(location)
-                pbOpenStreamListBuilder.addFileName(location.getFileName)
-                  .addStartIndex(startMapIndex)
-                  .addEndIndex(endMapIndex)
-                pbOpenStreamListBuilder.addReadLocalShuffle(
-                  localFetchEnabled && location.getHost.equals(localHostAddress))
-              }
             } catch {
               case ex: Exception =>
                 shuffleClient.excludeFailedFetchLocation(location.hostAndFetchPort, ex)
                 logWarning(
                   s"Failed to create client for $shuffleKey-$partitionId from host: ${location.hostAndFetchPort}. " +
                     s"Shuffle reader will try its replica if exists.")
+            }
+            val (_, locArr, pbOpenStreamListBuilder) = workerRequestMap.get(hostPort)
+            if (locArr != null) {
+              locArr.add(location)
+              pbOpenStreamListBuilder.addFileName(location.getFileName)
+                .addStartIndex(startMapIndex)
+                .addEndIndex(endMapIndex)
+              pbOpenStreamListBuilder.addReadLocalShuffle(
+                localFetchEnabled && location.getHost.equals(localHostAddress))
             }
           }
         }

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -128,20 +128,21 @@ class CelebornShuffleReader[K, C](
               workerRequestMap.put(
                 hostPort,
                 (client, new util.ArrayList[PartitionLocation], pbOpenStreamList))
+              val (_, locArr, pbOpenStreamListBuilder) = workerRequestMap.get(hostPort)
+              if (locArr != null) {
+                locArr.add(location)
+                pbOpenStreamListBuilder.addFileName(location.getFileName)
+                  .addStartIndex(startMapIndex)
+                  .addEndIndex(endMapIndex)
+                pbOpenStreamListBuilder.addReadLocalShuffle(
+                  localFetchEnabled && location.getHost.equals(localHostAddress))
+              }
             } catch {
               case ex: Exception =>
                 logWarning(
-                  s"Failed to create client for $shuffleKey-$partitionId from host: ${location.hostAndFetchPort}")
+                  s"Failed to create client for $shuffleKey-$partitionId from host: ${location.hostAndFetchPort}. " +
+                    s"Shuffle reader will try its replica if exists.")
             }
-          }
-          val (_, locArr, pbOpenStreamListBuilder) = workerRequestMap.get(hostPort)
-          if (locArr != null) {
-            locArr.add(location)
-            pbOpenStreamListBuilder.addFileName(location.getFileName)
-              .addStartIndex(startMapIndex)
-              .addEndIndex(endMapIndex)
-            pbOpenStreamListBuilder.addReadLocalShuffle(
-              localFetchEnabled && location.getHost.equals(localHostAddress))
           }
         }
       }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -285,4 +285,6 @@ public abstract class ShuffleClient {
   public abstract boolean reportBarrierTaskFailure(int appShuffleId, String appShuffleIdentifier);
 
   public abstract TransportClientFactory getDataClientFactory();
+
+  public abstract void excludeFailedFetchLocation(String hostAndFetchPort, Exception e);
 }

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -159,8 +159,6 @@ public abstract class CelebornInputStream extends InputStream {
     private final boolean enabledReadLocalShuffle;
     private final String localHostAddress;
 
-    private boolean pushReplicateEnabled;
-    private boolean fetchExcludeWorkerOnFailureEnabled;
     private boolean shuffleCompressionEnabled;
     private long fetchExcludedWorkerExpireTimeout;
     private ConcurrentHashMap<String, Long> fetchExcludedWorkers;
@@ -205,8 +203,6 @@ public abstract class CelebornInputStream extends InputStream {
       this.rangeReadFilter = conf.shuffleRangeReadFilterEnabled();
       this.enabledReadLocalShuffle = conf.enableReadLocalShuffleFile();
       this.localHostAddress = Utils.localHostName(conf);
-      this.pushReplicateEnabled = conf.clientPushReplicateEnabled();
-      this.fetchExcludeWorkerOnFailureEnabled = conf.clientFetchExcludeWorkerOnFailureEnabled();
       this.shuffleCompressionEnabled =
           !conf.shuffleCompressionCodec().equals(CompressionCodec.NONE);
       this.fetchExcludedWorkerExpireTimeout = conf.clientFetchExcludedWorkerExpireTimeout();

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -192,6 +192,9 @@ public class DummyShuffleClient extends ShuffleClient {
     return null;
   }
 
+  @Override
+  public void excludeFailedFetchLocation(String hostAndFetchPort, Exception e) {}
+
   public void initReducePartitionMap(int shuffleId, int numPartitions, int workerNum) {
     ConcurrentHashMap<Integer, PartitionLocation> map = JavaUtils.newConcurrentHashMap();
     String host = "host";


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. To bypass exceptions when creating clients failed in CelebornShuffleReader in spark 3.
2. Client will try the location's replicas in reading locations.


### Why are the changes needed?
Allow clients to retry locations when creating clients failed.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
Pass GA.
