### PR TITLE
[CELEBORN-1675] User with zero quota should not be allowed to submit any shuffle to cluster.

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -5302,7 +5302,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.quota.tenant.diskBytesWritten")
       .categories("quota")
       .dynamic
-      .doc("Quota dynamic configuration for written disk bytes.")
+      .doc("Quota dynamic configuration for written disk bytes. 0 means that no shuffle submissions are allowed.")
       .version("0.5.0")
       .longConf
       .createWithDefault(Long.MaxValue)
@@ -5311,7 +5311,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.quota.tenant.diskFileCount")
       .categories("quota")
       .dynamic
-      .doc("Quota dynamic configuration for written disk file count.")
+      .doc("Quota dynamic configuration for written disk file count. 0 means that no shuffle submissions are allowed.")
       .version("0.5.0")
       .longConf
       .createWithDefault(Long.MaxValue)
@@ -5320,7 +5320,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.quota.tenant.hdfsBytesWritten")
       .categories("quota")
       .dynamic
-      .doc("Quota dynamic configuration for written hdfs bytes.")
+      .doc("Quota dynamic configuration for written hdfs bytes. 0 means that no shuffle submissions are allowed.")
       .version("0.5.0")
       .longConf
       .createWithDefault(Long.MaxValue)
@@ -5329,7 +5329,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.quota.tenant.hdfsFileCount")
       .categories("quota")
       .dynamic
-      .doc("Quota dynamic configuration for written hdfs file count.")
+      .doc("Quota dynamic configuration for written hdfs file count. 0 means that no shuffle submissions are allowed.")
       .version("0.5.0")
       .longConf
       .createWithDefault(Long.MaxValue)

--- a/docs/configuration/quota.md
+++ b/docs/configuration/quota.md
@@ -22,10 +22,10 @@ license: |
 | celeborn.quota.enabled | true | false | When Master side sets to true, the master will enable to check the quota via QuotaManager. When Client side sets to true, LifecycleManager will request Master side to check whether the current user has enough quota before registration of shuffle. Fallback to the default shuffle service of Spark when Master side checks that there is no enough quota for current user. | 0.2.0 |  | 
 | celeborn.quota.identity.provider | org.apache.celeborn.common.identity.DefaultIdentityProvider | false | IdentityProvider class name. Default class is `org.apache.celeborn.common.identity.DefaultIdentityProvider`. Optional values: org.apache.celeborn.common.identity.HadoopBasedIdentityProvider user name will be obtained by UserGroupInformation.getUserName; org.apache.celeborn.common.identity.DefaultIdentityProvider user name and tenant id are default values or user-specific values. | 0.2.0 |  | 
 | celeborn.quota.identity.user-specific.tenant | default | false | Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider. | 0.3.0 |  | 
-| celeborn.quota.identity.user-specific.userName | default | false | User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider. | 0.3.0 |  | 
-| celeborn.quota.interruptShuffle.enabled | false | false | Whether to enable interrupt shuffle when quota exceeds. | 0.6.0 |  | 
-| celeborn.quota.tenant.diskBytesWritten | 9223372036854775807 | true | Quota dynamic configuration for written disk bytes. | 0.5.0 |  | 
-| celeborn.quota.tenant.diskFileCount | 9223372036854775807 | true | Quota dynamic configuration for written disk file count. | 0.5.0 |  | 
-| celeborn.quota.tenant.hdfsBytesWritten | 9223372036854775807 | true | Quota dynamic configuration for written hdfs bytes. | 0.5.0 |  | 
-| celeborn.quota.tenant.hdfsFileCount | 9223372036854775807 | true | Quota dynamic configuration for written hdfs file count. | 0.5.0 |  | 
+| celeborn.quota.identity.user-specific.userName | default | false | User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider. | 0.3.0 |  |
+| celeborn.quota.interruptShuffle.enabled | false | false | Whether to enable interrupt shuffle when quota exceeds. | 0.6.0 |  |
+| celeborn.quota.tenant.diskBytesWritten | 9223372036854775807 | true | Quota dynamic configuration for written disk bytes. 0 means that no shuffle submissions are allowed. | 0.5.0 |  |
+| celeborn.quota.tenant.diskFileCount | 9223372036854775807 | true | Quota dynamic configuration for written disk file count. 0 means that no shuffle submissions are allowed. | 0.5.0 |  |
+| celeborn.quota.tenant.hdfsBytesWritten | 9223372036854775807 | true | Quota dynamic configuration for written hdfs bytes. 0 means that no shuffle submissions are allowed. | 0.5.0 |  |
+| celeborn.quota.tenant.hdfsFileCount | 9223372036854775807 | true | Quota dynamic configuration for written hdfs file count. 0 means that no shuffle submissions are allowed. | 0.5.0 |  |
 <!--end-include-->

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManager.scala
@@ -57,7 +57,7 @@ class QuotaManager(celebornConf: CelebornConf, configService: ConfigService) ext
       userIdentifier: UserIdentifier,
       value: Long,
       quota: Quota): (Boolean, String) = {
-    val exceed = (quota.diskBytesWritten > 0 && value >= quota.diskBytesWritten)
+    val exceed = (quota.diskBytesWritten >= 0 && value >= quota.diskBytesWritten)
     var reason = ""
     if (exceed) {
       reason = s"User $userIdentifier used diskBytesWritten (${Utils.bytesToString(value)}) " +
@@ -71,11 +71,11 @@ class QuotaManager(celebornConf: CelebornConf, configService: ConfigService) ext
       userIdentifier: UserIdentifier,
       value: Long,
       quota: Quota): (Boolean, String) = {
-    val exceed = (quota.diskFileCount > 0 && value >= quota.diskFileCount)
+    val exceed = (quota.diskFileCount >= 0 && value >= quota.diskFileCount)
     var reason = ""
     if (exceed) {
       reason =
-        s"User $userIdentifier used diskFileCount($value) exceeds quota(${quota.diskFileCount}). "
+        s"User $userIdentifier used diskFileCount ($value) exceeds quota (${quota.diskFileCount}). "
       logWarning(reason)
     }
     (exceed, reason)
@@ -85,11 +85,11 @@ class QuotaManager(celebornConf: CelebornConf, configService: ConfigService) ext
       userIdentifier: UserIdentifier,
       value: Long,
       quota: Quota): (Boolean, String) = {
-    val exceed = (quota.hdfsBytesWritten > 0 && value >= quota.hdfsBytesWritten)
+    val exceed = (quota.hdfsBytesWritten >= 0 && value >= quota.hdfsBytesWritten)
     var reason = ""
     if (exceed) {
-      reason = s"User $userIdentifier used hdfsBytesWritten(${Utils.bytesToString(value)}) " +
-        s"exceeds quota(${Utils.bytesToString(quota.hdfsBytesWritten)}). "
+      reason = s"User $userIdentifier used hdfsBytesWritten (${Utils.bytesToString(value)}) " +
+        s"exceeds quota (${Utils.bytesToString(quota.hdfsBytesWritten)}). "
       logWarning(reason)
     }
     (exceed, reason)
@@ -99,11 +99,11 @@ class QuotaManager(celebornConf: CelebornConf, configService: ConfigService) ext
       userIdentifier: UserIdentifier,
       value: Long,
       quota: Quota): (Boolean, String) = {
-    val exceed = (quota.hdfsFileCount > 0 && value >= quota.hdfsFileCount)
+    val exceed = (quota.hdfsFileCount >= 0 && value >= quota.hdfsFileCount)
     var reason = ""
     if (exceed) {
       reason =
-        s"User $userIdentifier used hdfsFileCount($value) exceeds quota(${quota.hdfsFileCount}). "
+        s"User $userIdentifier used hdfsFileCount ($value) exceeds quota (${quota.hdfsFileCount}). "
       logWarning(reason)
     }
     (exceed, reason)

--- a/master/src/test/resources/dynamicConfig-quota.yaml
+++ b/master/src/test/resources/dynamicConfig-quota.yaml
@@ -32,4 +32,9 @@
          celeborn.quota.tenant.diskBytesWritten: 100G
          celeborn.quota.tenant.diskFileCount: 10000
 
+     - name: Tom
+       config:
+         celeborn.quota.tenant.diskBytesWritten: 0G
+         celeborn.quota.tenant.diskFileCount: 0
+
 

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
@@ -75,15 +75,29 @@ class QuotaManagerSuite extends CelebornFunSuite {
     val exp1 = (true, "")
     val exp2 = (
       false,
-      s"User $user used hdfsBytesWritten(30.0 GiB) exceeds quota(10.0 GiB). ")
+      s"User $user used hdfsBytesWritten (30.0 GiB) exceeds quota (10.0 GiB). ")
     val exp3 = (
       false,
       s"User $user used diskBytesWritten (200.0 GiB) exceeds quota (100.0 GiB). " +
-        s"User $user used diskFileCount(20000) exceeds quota(10000). " +
-        s"User $user used hdfsBytesWritten(30.0 GiB) exceeds quota(10.0 GiB). ")
+        s"User $user used diskFileCount (20000) exceeds quota (10000). " +
+        s"User $user used hdfsBytesWritten (30.0 GiB) exceeds quota (10.0 GiB). ")
 
     assert(res1 == exp1)
     assert(res2 == exp2)
     assert(res3 == exp3)
+  }
+
+  test("User with zero quota should not be allowed to submit any shuffle to cluster") {
+    val user = UserIdentifier("tenant_01", "Tom")
+    val rc1 =
+      ResourceConsumption(Utils.byteStringAsBytes("0"), 0, Utils.byteStringAsBytes("0"), 0)
+
+    val res1 = quotaManager.checkQuotaSpaceAvailable(user, rc1)
+
+    val exp1 = (
+      false,
+      s"User $user used diskBytesWritten (0.0 B) exceeds quota (0.0 B). ")
+
+    assert(res1 == exp1)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

In current implementation, user with zero quota still can submit one shuffle to rss cluster. 
It might be more reasonable to disallow users with a quota of 0 from submitting a shuffle to the RSS cluster.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?

No 

### How was this patch tested?

unit-test
