### PR TITLE
[CELEBORN-1677][BUILD] Update SCM information for SBT build configuration

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -334,12 +334,12 @@ object CelebornCommonSettings {
       }
     },
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")),
-      pomExtra :=
-        <url>https://celeborn.apache.org/</url>
-        <scm>
-          <url>git@github.com:apache/celeborn.git</url>
-          <connection>scm:git:git@github.com:apache/celeborn.git</connection>
-        </scm>
+    scmInfo := Some(
+      ScmInfo(
+        url("https://celeborn.apache.org/"),
+          "scm:git:https://github.com/apache/celeborn.git",
+          "scm:git:git@github.com:apache/celeborn.git"))
+
   )
 
   lazy val protoSettings = Seq(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

This PR addresses a conflict in the sbt generated POM by replacing `pomExtra` with `scmInfo`

```diff
         <name>org.apache.celeborn</name>
     </organization>
     <scm>
-        <url>https://github.com/cfmcgrady/incubator-celeborn</url>
-        <connection>scm:git:https://github.com/cfmcgrady/incubator-celeborn.git</connection>
-        <developerConnection>scm:git:git@github.com:cfmcgrady/incubator-celeborn.git</developerConnection>
-    </scm>
-    <url>https://celeborn.apache.org/</url>
-    <scm>
-        <url>git@github.com:apache/celeborn.git</url>
-        <connection>scm:git:git@github.com:apache/celeborn.git</connection>
+        <url>https://celeborn.apache.org/</url>
+        <connection>scm:git:https://github.com/apache/celeborn.git</connection>
+        <developerConnection>scm:git:git@github.com:apache/celeborn.git</developerConnection>
     </scm>

```

The conflicting POM might block publishing to a private Maven repository.

```
[error] Caused by: java.io.IOException: Server returned HTTP response code: 409 for URL: https://artifactory.devops.xxx.com/artifactory/maven-snapshots/org/apache/celeborn/celeborn-client-spark-3-shaded_2.12/0.6.0-SNAPSHOT/celeborn-client-spark-3-shaded_2.12-0.6.0-SNAPSHOT.pom
[error]         at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:2000)
[error]         at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1589)
[error]         at java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:529)
[error]         at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:308)
[error]         at org.apache.ivy.util.url.BasicURLHandler.upload(BasicURLHandler.java:284)
[error]         at org.apache.ivy.util.url.URLHandlerDispatcher.upload(URLHandlerDispatcher.java:82)
[error]         at org.apache.ivy.util.FileUtil.copy(FileUtil.java:150)
[error]         at org.apache.ivy.plugins.repository.url.URLRepository.put(URLRepository.java:84)
[error]         at sbt.internal.librarymanagement.ConvertResolver$LocalIfFileRepo.put(ConvertResolver.scala:407)
[error]         at org.apache.ivy.plugins.repository.AbstractRepository.put(AbstractRepository.java:130)
[error]         at sbt.internal.librarymanagement.ConvertResolver$ChecksumFriendlyURLResolver.put(ConvertResolver.scala:124)
[error]         at sbt.internal.librarymanagement.ConvertResolver$ChecksumFriendlyURLResolver.put$(ConvertResolver.scala:111)
[error]         at sbt.internal.librarymanagement.ConvertResolver$$anonfun$defaultConvert$lzycompute$1$PluginCapableResolver$1.put(ConvertResolver.scala:170)
[error]         at org.apache.ivy.plugins.resolver.RepositoryResolver.publish(RepositoryResolver.java:216)
[error]         at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$5(IvyActions.scala:501)
```


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

local