### PR TITLE
[CELEBORN-1660] Using map for workers to find worker fast

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -318,10 +318,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     }
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
     synchronized (workersMap) {
-      String workerId = workerInfo.toUniqueId();
-      if (!workersMap.containsKey(workerId)) {
-        workersMap.put(workerId, workerInfo);
-      }
+      workersMap.putIfAbsent(workerInfo.toUniqueId(), workerInfo);
       shutdownWorkers.remove(workerInfo);
       lostWorkers.remove(workerInfo);
       excludedWorkers.remove(workerInfo);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -27,13 +27,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import scala.Option;
 import scala.Tuple2;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 import org.slf4j.Logger;
@@ -66,7 +64,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public final Map<String, Set<Integer>> registeredAppAndShuffles =
       JavaUtils.newConcurrentHashMap();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
-  private final Map<String, WorkerInfo> workersMap = JavaUtils.newConcurrentHashMap();
+  public final Map<String, WorkerInfo> workersMap = JavaUtils.newConcurrentHashMap();
 
   public final ConcurrentHashMap<WorkerInfo, Long> lostWorkers = JavaUtils.newConcurrentHashMap();
   public final ConcurrentHashMap<WorkerInfo, WorkerEventInfo> workerEventInfos =
@@ -91,34 +89,6 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
 
   public final ConcurrentHashMap<String, ApplicationMeta> applicationMetas =
       JavaUtils.newConcurrentHashMap();
-
-  public Collection<WorkerInfo> getWorkers() {
-    return Collections.unmodifiableCollection(workersMap.values());
-  }
-
-  public <T> T synchronizedWorkers(Supplier<T> s) {
-    synchronized (workersMap) {
-      return s.get();
-    }
-  }
-
-  public boolean containsWorker(WorkerInfo worker) {
-    return workersMap.containsKey(worker.toUniqueId());
-  }
-
-  public WorkerInfo getWorker(WorkerInfo worker) {
-    return workersMap.get(worker.toUniqueId());
-  }
-
-  @VisibleForTesting
-  public void updateWorker(WorkerInfo worker) {
-    workersMap.put(worker.toUniqueId(), worker);
-  }
-
-  @VisibleForTesting
-  public void clearWorkers() {
-    workersMap.clear();
-  }
 
   public void updateRequestSlotsMeta(
       String shuffleKey, String hostName, Map<String, Map<String, Integer>> workerWithAllocations) {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import scala.Option;
 import scala.Tuple2;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 import org.slf4j.Logger;
@@ -64,7 +66,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public final Map<String, Set<Integer>> registeredAppAndShuffles =
       JavaUtils.newConcurrentHashMap();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
-  public final Set<WorkerInfo> workers = ConcurrentHashMap.newKeySet();
+  private final Map<String, WorkerInfo> workersMap = JavaUtils.newConcurrentHashMap();
 
   public final ConcurrentHashMap<WorkerInfo, Long> lostWorkers = JavaUtils.newConcurrentHashMap();
   public final ConcurrentHashMap<WorkerInfo, WorkerEventInfo> workerEventInfos =
@@ -89,6 +91,34 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
 
   public final ConcurrentHashMap<String, ApplicationMeta> applicationMetas =
       JavaUtils.newConcurrentHashMap();
+
+  public Collection<WorkerInfo> getWorkers() {
+    return Collections.unmodifiableCollection(workersMap.values());
+  }
+
+  public <T> T synchronizedWorkers(Supplier<T> s) {
+    synchronized (workersMap) {
+      return s.get();
+    }
+  }
+
+  public boolean containsWorker(WorkerInfo worker) {
+    return workersMap.containsKey(worker.toUniqueId());
+  }
+
+  public WorkerInfo getWorker(WorkerInfo worker) {
+    return workersMap.get(worker.toUniqueId());
+  }
+
+  @VisibleForTesting
+  public void updateWorker(WorkerInfo worker) {
+    workersMap.put(worker.toUniqueId(), worker);
+  }
+
+  @VisibleForTesting
+  public void clearWorkers() {
+    workersMap.clear();
+  }
 
   public void updateRequestSlotsMeta(
       String shuffleKey, String hostName, Map<String, Map<String, Integer>> workerWithAllocations) {
@@ -170,8 +200,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     WorkerInfo worker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
     workerLostEvents.add(worker);
     // remove worker from workers
-    synchronized (workers) {
-      workers.remove(worker);
+    synchronized (workersMap) {
+      workersMap.remove(worker.toUniqueId());
       lostWorkers.put(worker, System.currentTimeMillis());
     }
     excludedWorkers.remove(worker);
@@ -182,15 +212,15 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       String host, int rpcPort, int pushPort, int fetchPort, int replicatePort) {
     WorkerInfo worker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
     // remove worker from workers
-    synchronized (workers) {
-      workers.remove(worker);
+    synchronized (workersMap) {
+      workersMap.remove(worker.toUniqueId());
       lostWorkers.put(worker, System.currentTimeMillis());
     }
     excludedWorkers.remove(worker);
   }
 
   public void removeWorkersUnavailableInfoMeta(List<WorkerInfo> unavailableWorkers) {
-    synchronized (workers) {
+    synchronized (workersMap) {
       for (WorkerInfo workerInfo : unavailableWorkers) {
         if (lostWorkers.containsKey(workerInfo)) {
           lostWorkers.remove(workerInfo);
@@ -219,8 +249,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
             host, rpcPort, pushPort, fetchPort, replicatePort, -1, disks, userResourceConsumption);
     AtomicLong availableSlots = new AtomicLong();
     LOG.debug("update worker {}:{} heartbeat {}", host, rpcPort, disks);
-    synchronized (workers) {
-      Optional<WorkerInfo> workerInfo = workers.stream().filter(w -> w.equals(worker)).findFirst();
+    synchronized (workersMap) {
+      Optional<WorkerInfo> workerInfo = Optional.ofNullable(workersMap.get(worker.toUniqueId()));
       workerInfo.ifPresent(
           info -> {
             info.updateThenGetDiskInfos(disks, Option.apply(estimatedPartitionSize));
@@ -287,9 +317,10 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       workerInfo.networkLocation_$eq(rackResolver.resolve(host).getNetworkLocation());
     }
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
-    synchronized (workers) {
-      if (!workers.contains(workerInfo)) {
-        workers.add(workerInfo);
+    synchronized (workersMap) {
+      String workerId = workerInfo.toUniqueId();
+      if (!workersMap.containsKey(workerId)) {
+        workersMap.put(workerId, workerInfo);
       }
       shutdownWorkers.remove(workerInfo);
       lostWorkers.remove(workerInfo);
@@ -315,7 +346,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                 manuallyExcludedWorkers,
                 workerLostEvents,
                 appHeartbeatTime,
-                workers,
+                new HashSet(workersMap.values()),
                 partitionTotalWritten.sum(),
                 partitionTotalFileCount.sum(),
                 appDiskUsageMetric.snapShots(),
@@ -381,7 +412,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
               .collect(Collectors.toList());
       scala.collection.immutable.Map<String, Node> resolveMap =
           rackResolver.resolveToMap(workerHostList);
-      workers.addAll(
+      workersMap.putAll(
           workerInfoSet.stream()
               .peek(
                   workerInfo -> {
@@ -391,7 +422,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                           resolveMap.get(workerInfo.host()).get().getNetworkLocation());
                     }
                   })
-              .collect(Collectors.toSet()));
+              .collect(Collectors.toMap(WorkerInfo::toUniqueId, w -> w)));
 
       snapshotMetaInfo
           .getLostWorkersMap()
@@ -437,11 +468,11 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     LOG.info("Successfully restore meta info from snapshot {}", file.getAbsolutePath());
     LOG.info(
         "Worker size: {}, Registered shuffle size: {}. Worker excluded list size: {}. Manually Excluded list size: {}",
-        workers.size(),
+        workersMap.size(),
         registeredAppAndShuffles.size(),
         excludedWorkers.size(),
         manuallyExcludedWorkers.size());
-    workers.forEach(workerInfo -> LOG.info(workerInfo.toString()));
+    workersMap.values().forEach(workerInfo -> LOG.info(workerInfo.toString()));
     registeredAppAndShuffles.forEach(
         (appId, shuffleId) -> LOG.info("RegisteredShuffle {}-{}", appId, shuffleId));
   }
@@ -449,7 +480,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   private void cleanUpState() {
     registeredAppAndShuffles.clear();
     hostnameSet.clear();
-    workers.clear();
+    workersMap.clear();
     lostWorkers.clear();
     appHeartbeatTime.clear();
     excludedWorkers.clear();
@@ -464,7 +495,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   public void updateMetaByReportWorkerUnavailable(List<WorkerInfo> failedWorkers) {
-    synchronized (this.workers) {
+    synchronized (this.workersMap) {
       shutdownWorkers.addAll(failedWorkers);
     }
   }
@@ -473,7 +504,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     long eventTime = System.currentTimeMillis();
     ResourceProtos.WorkerEventType eventType =
         ResourceProtos.WorkerEventType.forNumber(workerEventTypeValue);
-    synchronized (this.workers) {
+    synchronized (this.workersMap) {
       for (WorkerInfo workerInfo : workerInfoList) {
         WorkerEventInfo workerEventInfo = workerEventInfos.get(workerInfo);
         LOG.info("Received worker event: {} for worker: {}", eventType, workerInfo.toUniqueId());
@@ -489,7 +520,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   public void updateMetaByReportWorkerDecommission(List<WorkerInfo> workers) {
-    synchronized (this.workers) {
+    synchronized (this.workersMap) {
       decommissionWorkers.addAll(workers);
     }
   }
@@ -520,19 +551,19 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
         "Celeborn cluster estimated partition size changed from {} to {}",
         Utils.bytesToString(oldEstimatedPartitionSize),
         Utils.bytesToString(estimatedPartitionSize));
-    workers.stream()
-        .filter(
-            worker ->
-                !excludedWorkers.contains(worker) && !manuallyExcludedWorkers.contains(worker))
-        .forEach(workerInfo -> workerInfo.updateDiskMaxSlots(estimatedPartitionSize));
+
+    HashSet<WorkerInfo> workers = new HashSet(workersMap.values());
+    excludedWorkers.forEach(workers::remove);
+    manuallyExcludedWorkers.forEach(workers::remove);
+    workers.forEach(workerInfo -> workerInfo.updateDiskMaxSlots(estimatedPartitionSize));
   }
 
   public boolean isWorkerAvailable(WorkerInfo workerInfo) {
-    return !excludedWorkers.contains(workerInfo)
+    return (workerInfo.getWorkerStatus().getState() == PbWorkerStatus.State.Normal
+            && !workerEventInfos.containsKey(workerInfo))
+        && !excludedWorkers.contains(workerInfo)
         && !shutdownWorkers.contains(workerInfo)
-        && !manuallyExcludedWorkers.contains(workerInfo)
-        && (!workerEventInfos.containsKey(workerInfo)
-            && workerInfo.getWorkerStatus().getState() == PbWorkerStatus.State.Normal);
+        && !manuallyExcludedWorkers.contains(workerInfo);
   }
 
   public void updateApplicationMeta(ApplicationMeta applicationMeta) {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1127,9 +1127,7 @@ private[celeborn] class Master(
       fileCount,
       System.currentTimeMillis(),
       requestId)
-    val unknownWorkers = needCheckedWorkerList.stream()
-      .filter(w => !statusSystem.containsWorker(w))
-      .collect(Collectors.toList[WorkerInfo]())
+    val unknownWorkers = needCheckedWorkerList.asScala.filterNot(statusSystem.containsWorker).asJava
     if (shouldResponse) {
       // UserResourceConsumption and DiskInfo are eliminated from WorkerInfo
       // during serialization of HeartbeatFromApplicationResponse
@@ -1418,7 +1416,7 @@ private[celeborn] class Master(
           ",")} and remove ${removeWorkers.map(_.readableAddress).mkString(",")}.\n")
     }
     val unknownExcludedWorkers =
-      (addWorkers ++ removeWorkers).filter(!statusSystem.containsWorker(_))
+      (addWorkers ++ removeWorkers).filterNot(statusSystem.containsWorker)
     if (unknownExcludedWorkers.nonEmpty) {
       sb.append(
         s"Unknown workers ${unknownExcludedWorkers.map(_.readableAddress).mkString(",")}." +

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1129,7 +1129,7 @@ private[celeborn] class Master(
       requestId)
     val unknownWorkers = needCheckedWorkerList.stream()
       .filter(w => !statusSystem.containsWorker(w))
-      .collect(Collectors.toList[WorkerInfo])
+      .collect(Collectors.toList[WorkerInfo]())
     if (shouldResponse) {
       // UserResourceConsumption and DiskInfo are eliminated from WorkerInfo
       // during serialization of HeartbeatFromApplicationResponse
@@ -1139,7 +1139,7 @@ private[celeborn] class Master(
           statusSystem.getWorkers.asScala.filter(worker =>
             statusSystem.isWorkerAvailable(worker)).toList.asJava)
       }
-      var appRelatedShuffles =
+      val appRelatedShuffles =
         statusSystem.registeredAppAndShuffles.getOrDefault(appId, Collections.emptySet())
       context.reply(HeartbeatFromApplicationResponse(
         StatusCode.SUCCESS,

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -24,7 +24,6 @@ import java.util.{Collections, List => JList, Map => JMap}
 import java.util.concurrent.{ExecutorService, ScheduledFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.{Supplier, ToLongFunction}
-import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 import scala.util.Random

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -20,10 +20,10 @@ package org.apache.celeborn.service.deploy.master
 import java.io.IOException
 import java.net.BindException
 import java.util
-import java.util.{Collections, List => JList, Map => JMap}
+import java.util.Collections
 import java.util.concurrent.{ExecutorService, ScheduledFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.function.{Supplier, ToLongFunction}
+import java.util.function.ToLongFunction
 
 import scala.collection.JavaConverters._
 import scala.util.Random
@@ -227,13 +227,13 @@ private[celeborn] class Master(
   masterSource.addGauge(MasterSource.REGISTERED_SHUFFLE_COUNT) { () =>
     statusSystem.registeredShuffleCount
   }
-  masterSource.addGauge(MasterSource.WORKER_COUNT) { () => statusSystem.getWorkers.size }
+  masterSource.addGauge(MasterSource.WORKER_COUNT) { () => statusSystem.workersMap.size }
   masterSource.addGauge(MasterSource.LOST_WORKER_COUNT) { () => statusSystem.lostWorkers.size }
   masterSource.addGauge(MasterSource.EXCLUDED_WORKER_COUNT) { () =>
     statusSystem.excludedWorkers.size + statusSystem.manuallyExcludedWorkers.size
   }
   masterSource.addGauge(MasterSource.AVAILABLE_WORKER_COUNT) { () =>
-    statusSystem.getWorkers.asScala.count { w =>
+    statusSystem.workersMap.values().asScala.count { w =>
       statusSystem.isWorkerAvailable(w)
     }
   }
@@ -245,7 +245,7 @@ private[celeborn] class Master(
   }
   masterSource.addGauge(MasterSource.PARTITION_SIZE) { () => statusSystem.estimatedPartitionSize }
   masterSource.addGauge(MasterSource.ACTIVE_SHUFFLE_SIZE) { () =>
-    statusSystem.getWorkers.parallelStream()
+    statusSystem.workersMap.values().parallelStream()
       .mapToLong(new ToLongFunction[WorkerInfo]() {
         override def applyAsLong(value: WorkerInfo): Long =
           value.userResourceConsumption.values().parallelStream()
@@ -255,7 +255,7 @@ private[celeborn] class Master(
       }).sum()
   }
   masterSource.addGauge(MasterSource.ACTIVE_SHUFFLE_FILE_COUNT) { () =>
-    statusSystem.getWorkers.parallelStream()
+    statusSystem.workersMap.values().parallelStream()
       .mapToLong(new ToLongFunction[WorkerInfo]() {
         override def applyAsLong(value: WorkerInfo): Long =
           value.userResourceConsumption.values().parallelStream()
@@ -266,11 +266,11 @@ private[celeborn] class Master(
   }
 
   masterSource.addGauge(MasterSource.DEVICE_CELEBORN_TOTAL_CAPACITY) { () =>
-    statusSystem.getWorkers.asScala.toList.map(_.totalSpace()).sum
+    statusSystem.workersMap.values().asScala.toList.map(_.totalSpace()).sum
   }
 
   masterSource.addGauge(MasterSource.DEVICE_CELEBORN_FREE_CAPACITY) { () =>
-    statusSystem.getWorkers.asScala.toList.map(_.totalActualUsableSpace()).sum
+    statusSystem.workersMap.values().asScala.toList.map(_.totalActualUsableSpace()).sum
   }
 
   masterSource.addGauge(MasterSource.IS_ACTIVE_MASTER) { () => isMasterActive }
@@ -599,7 +599,7 @@ private[celeborn] class Master(
       return
     }
 
-    statusSystem.getWorkers.asScala.foreach { worker =>
+    statusSystem.workersMap.values().asScala.foreach { worker =>
       if (worker.lastHeartbeat < currentTime - workerHeartbeatTimeoutMs
         && !statusSystem.workerLostEvents.contains(worker)) {
         logWarning(s"Worker ${worker.readableAddress()} timeout! Trigger WorkerLost event.")
@@ -670,7 +670,7 @@ private[celeborn] class Master(
       workerStatus: WorkerStatus,
       requestId: String): Unit = {
     val targetWorker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
-    val registered = statusSystem.containsWorker(targetWorker)
+    val registered = statusSystem.workersMap.containsKey(targetWorker.toUniqueId())
     if (!registered) {
       logWarning(s"Received heartbeat from unknown worker " +
         s"$host:$rpcPort:$pushPort:$fetchPort:$replicatePort.")
@@ -761,7 +761,7 @@ private[celeborn] class Master(
       -1,
       new util.HashMap[String, DiskInfo](),
       JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption]())
-    val worker: WorkerInfo = statusSystem.getWorker(targetWorker)
+    val worker: WorkerInfo = statusSystem.workersMap.get(targetWorker.toUniqueId())
     if (worker == null) {
       logWarning(s"Unknown worker $host:$rpcPort:$pushPort:$fetchPort:$replicatePort" +
         s" for WorkerLost handler!")
@@ -806,7 +806,7 @@ private[celeborn] class Master(
       return
     }
 
-    if (statusSystem.containsWorker(workerToRegister)) {
+    if (statusSystem.workersMap.containsKey(workerToRegister.toUniqueId())) {
       logWarning(s"Receive RegisterWorker while worker" +
         s" ${workerToRegister.toString()} already exists, re-register.")
       statusSystem.handleRegisterWorker(
@@ -908,32 +908,27 @@ private[celeborn] class Master(
     // offer slots
     val slots =
       masterSource.sample(MasterSource.OFFER_SLOTS_TIME, s"offerSlots-${Random.nextInt()}") {
-        statusSystem.synchronizedWorkers(new Supplier[JMap[
-          WorkerInfo,
-          Tuple2[JList[PartitionLocation], JList[PartitionLocation]]]] {
-          override def get()
-              : JMap[WorkerInfo, (JList[PartitionLocation], JList[PartitionLocation])] = {
-            if (slotsAssignPolicy == SlotsAssignPolicy.LOADAWARE) {
-              SlotsAllocator.offerSlotsLoadAware(
-                selectedWorkers,
-                requestSlots.partitionIdList,
-                requestSlots.shouldReplicate,
-                requestSlots.shouldRackAware,
-                slotsAssignLoadAwareDiskGroupNum,
-                slotsAssignLoadAwareDiskGroupGradient,
-                loadAwareFlushTimeWeight,
-                loadAwareFetchTimeWeight,
-                requestSlots.availableStorageTypes)
-            } else {
-              SlotsAllocator.offerSlotsRoundRobin(
-                selectedWorkers,
-                requestSlots.partitionIdList,
-                requestSlots.shouldReplicate,
-                requestSlots.shouldRackAware,
-                requestSlots.availableStorageTypes)
-            }
+        statusSystem.workersMap.synchronized {
+          if (slotsAssignPolicy == SlotsAssignPolicy.LOADAWARE) {
+            SlotsAllocator.offerSlotsLoadAware(
+              selectedWorkers,
+              requestSlots.partitionIdList,
+              requestSlots.shouldReplicate,
+              requestSlots.shouldRackAware,
+              slotsAssignLoadAwareDiskGroupNum,
+              slotsAssignLoadAwareDiskGroupGradient,
+              loadAwareFlushTimeWeight,
+              loadAwareFetchTimeWeight,
+              requestSlots.availableStorageTypes)
+          } else {
+            SlotsAllocator.offerSlotsRoundRobin(
+              selectedWorkers,
+              requestSlots.partitionIdList,
+              requestSlots.shouldReplicate,
+              requestSlots.shouldRackAware,
+              requestSlots.availableStorageTypes)
           }
-        })
+        }
       }
 
     if (log.isDebugEnabled()) {
@@ -1126,14 +1121,15 @@ private[celeborn] class Master(
       fileCount,
       System.currentTimeMillis(),
       requestId)
-    val unknownWorkers = needCheckedWorkerList.asScala.filterNot(statusSystem.containsWorker).asJava
+    val unknownWorkers = needCheckedWorkerList.asScala.filterNot(w =>
+      statusSystem.workersMap.containsKey(w.toUniqueId())).asJava
     if (shouldResponse) {
       // UserResourceConsumption and DiskInfo are eliminated from WorkerInfo
       // during serialization of HeartbeatFromApplicationResponse
       var availableWorksSentToClient = new util.ArrayList[WorkerInfo]()
       if (needAvailableWorkers) {
         availableWorksSentToClient = new util.ArrayList[WorkerInfo](
-          statusSystem.getWorkers.asScala.filter(worker =>
+          statusSystem.workersMap.values().asScala.filter(worker =>
             statusSystem.isWorkerAvailable(worker)).toList.asJava)
       }
       val appRelatedShuffles =
@@ -1219,7 +1215,7 @@ private[celeborn] class Master(
   // TODO: Support calculate topN app resource consumption.
   private def computeUserResourceConsumption(
       userIdentifier: UserIdentifier): ResourceConsumption = {
-    val resourceConsumption = statusSystem.getWorkers.asScala.flatMap {
+    val resourceConsumption = statusSystem.workersMap.values().asScala.flatMap {
       workerInfo => workerInfo.userResourceConsumption.asScala.get(userIdentifier)
     }.foldRight(ResourceConsumption(0, 0, 0, 0))(_ add _)
     resourceConsumption
@@ -1253,7 +1249,7 @@ private[celeborn] class Master(
 
   private def workersAvailable(
       tmpExcludedWorkerList: Set[WorkerInfo] = Set.empty): util.List[WorkerInfo] = {
-    statusSystem.getWorkers.asScala.filter { w =>
+    statusSystem.workersMap.values().asScala.filter { w =>
       statusSystem.isWorkerAvailable(w) && !tmpExcludedWorkerList.contains(w)
     }.toList.asJava
   }
@@ -1286,7 +1282,7 @@ private[celeborn] class Master(
   }
 
   private def getWorkers: String = {
-    statusSystem.getWorkers.asScala.mkString("\n")
+    statusSystem.workersMap.values().asScala.mkString("\n")
   }
 
   override def handleWorkerEvent(
@@ -1415,7 +1411,8 @@ private[celeborn] class Master(
           ",")} and remove ${removeWorkers.map(_.readableAddress).mkString(",")}.\n")
     }
     val unknownExcludedWorkers =
-      (addWorkers ++ removeWorkers).filterNot(statusSystem.containsWorker)
+      (addWorkers ++ removeWorkers).filterNot(w =>
+        statusSystem.workersMap.containsKey(w.toUniqueId()))
     if (unknownExcludedWorkers.nonEmpty) {
       sb.append(
         s"Unknown workers ${unknownExcludedWorkers.map(_.readableAddress).mkString(",")}." +

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -51,7 +51,7 @@ class WorkerResource extends ApiRequestContext {
   @GET
   def workers: WorkersResponse = {
     new WorkersResponse()
-      .workers(statusSystem.workers.asScala.map(ApiUtils.workerData).toSeq.asJava)
+      .workers(statusSystem.getWorkers.asScala.map(ApiUtils.workerData).toSeq.asJava)
       .lostWorkers(statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)
@@ -134,7 +134,7 @@ class WorkerResource extends ApiRequestContext {
           s"eventType(${request.getEventType}) and workers(${request.getWorkers}) are required")
       }
       val workers = request.getWorkers.asScala.map(ApiUtils.toWorkerInfo).toSeq
-      val (filteredWorkers, unknownWorkers) = workers.partition(statusSystem.workers.contains)
+      val (filteredWorkers, unknownWorkers) = workers.partition(statusSystem.containsWorker)
       if (filteredWorkers.isEmpty) {
         throw new BadRequestException(
           s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -51,7 +51,7 @@ class WorkerResource extends ApiRequestContext {
   @GET
   def workers: WorkersResponse = {
     new WorkersResponse()
-      .workers(statusSystem.getWorkers.asScala.map(ApiUtils.workerData).toSeq.asJava)
+      .workers(statusSystem.workersMap.values().asScala.map(ApiUtils.workerData).toSeq.asJava)
       .lostWorkers(statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2)
         .map(kv =>
           new WorkerTimestampData().worker(ApiUtils.workerData(kv._1)).timestamp(kv._2)).asJava)
@@ -134,7 +134,8 @@ class WorkerResource extends ApiRequestContext {
           s"eventType(${request.getEventType}) and workers(${request.getWorkers}) are required")
       }
       val workers = request.getWorkers.asScala.map(ApiUtils.toWorkerInfo).toSeq
-      val (filteredWorkers, unknownWorkers) = workers.partition(statusSystem.containsWorker)
+      val (filteredWorkers, unknownWorkers) =
+        workers.partition(w => statusSystem.workersMap.containsKey(w.toUniqueId()))
       if (filteredWorkers.isEmpty) {
         throw new BadRequestException(
           s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -157,7 +157,7 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.workers.size());
+    assertEquals(3, statusSystem.getWorkers().size());
   }
 
   @Test
@@ -253,7 +253,7 @@ public class DefaultMetaSystemSuiteJ {
 
     statusSystem.handleWorkerLost(
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
-    assertEquals(2, statusSystem.workers.size());
+    assertEquals(2, statusSystem.getWorkers().size());
   }
 
   private static final String APPID1 = "appId1";
@@ -376,20 +376,20 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.workers.size());
+    assertEquals(3, statusSystem.getWorkers().size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
     allocation.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocation);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -399,7 +399,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
     assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -157,7 +157,7 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.getWorkers().size());
+    assertEquals(3, statusSystem.workersMap.size());
   }
 
   @Test
@@ -253,7 +253,7 @@ public class DefaultMetaSystemSuiteJ {
 
     statusSystem.handleWorkerLost(
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
-    assertEquals(2, statusSystem.getWorkers().size());
+    assertEquals(2, statusSystem.workersMap.size());
   }
 
   private static final String APPID1 = "appId1";
@@ -376,20 +376,20 @@ public class DefaultMetaSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    assertEquals(3, statusSystem.getWorkers().size());
+    assertEquals(3, statusSystem.workersMap.size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
     allocation.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocation);
     workersToAllocate.put(
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -399,7 +399,7 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
     assertEquals(
         0,
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -232,20 +232,20 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     AppDiskUsageSnapShot originCurrentSnapshot =
         masterStatusSystem.appDiskUsageMetric.currentSnapShot().get();
 
-    masterStatusSystem.workers.add(new WorkerInfo(host1, 9095, 9094, 9093, 9092, 9091));
-    masterStatusSystem.workers.add(new WorkerInfo(host2, 9095, 9094, 9093, 9092, 9091));
-    masterStatusSystem.workers.add(new WorkerInfo(host3, 9095, 9094, 9093, 9092, 9091));
+    masterStatusSystem.updateWorker(new WorkerInfo(host1, 9095, 9094, 9093, 9092, 9091));
+    masterStatusSystem.updateWorker(new WorkerInfo(host2, 9095, 9094, 9093, 9092, 9091));
+    masterStatusSystem.updateWorker(new WorkerInfo(host3, 9095, 9094, 9093, 9092, 9091));
 
     masterStatusSystem.writeMetaInfoToFile(tmpFile);
 
     masterStatusSystem.hostnameSet.clear();
     masterStatusSystem.excludedWorkers.clear();
     masterStatusSystem.manuallyExcludedWorkers.clear();
-    masterStatusSystem.workers.clear();
+    masterStatusSystem.clearWorkers();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
-    Assert.assertEquals(3, masterStatusSystem.workers.size());
+    Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
     Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
     Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
@@ -260,7 +260,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     Assert.assertArrayEquals(originSnapshots, masterStatusSystem.appDiskUsageMetric.snapShots());
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
-    Assert.assertEquals(3, masterStatusSystem.workers.size());
+    Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
   }
 
   private String getNewReqeustId() {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -232,20 +232,23 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     AppDiskUsageSnapShot originCurrentSnapshot =
         masterStatusSystem.appDiskUsageMetric.currentSnapShot().get();
 
-    masterStatusSystem.updateWorker(new WorkerInfo(host1, 9095, 9094, 9093, 9092, 9091));
-    masterStatusSystem.updateWorker(new WorkerInfo(host2, 9095, 9094, 9093, 9092, 9091));
-    masterStatusSystem.updateWorker(new WorkerInfo(host3, 9095, 9094, 9093, 9092, 9091));
+    WorkerInfo workerInfo1 = new WorkerInfo(host1, 9095, 9094, 9093, 9092, 9091);
+    WorkerInfo workerInfo2 = new WorkerInfo(host2, 9095, 9094, 9093, 9092, 9091);
+    WorkerInfo workerInfo3 = new WorkerInfo(host3, 9095, 9094, 9093, 9092, 9091);
+    masterStatusSystem.workersMap.put(workerInfo1.toUniqueId(), workerInfo1);
+    masterStatusSystem.workersMap.put(workerInfo2.toUniqueId(), workerInfo2);
+    masterStatusSystem.workersMap.put(workerInfo3.toUniqueId(), workerInfo3);
 
     masterStatusSystem.writeMetaInfoToFile(tmpFile);
 
     masterStatusSystem.hostnameSet.clear();
     masterStatusSystem.excludedWorkers.clear();
     masterStatusSystem.manuallyExcludedWorkers.clear();
-    masterStatusSystem.clearWorkers();
+    masterStatusSystem.workersMap.clear();
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
 
-    Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
+    Assert.assertEquals(3, masterStatusSystem.workersMap.size());
     Assert.assertEquals(3, masterStatusSystem.excludedWorkers.size());
     Assert.assertEquals(2, masterStatusSystem.manuallyExcludedWorkers.size());
     Assert.assertEquals(3, masterStatusSystem.hostnameSet.size());
@@ -260,7 +263,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     Assert.assertArrayEquals(originSnapshots, masterStatusSystem.appDiskUsageMetric.snapShots());
 
     masterStatusSystem.restoreMetaFromFile(tmpFile);
-    Assert.assertEquals(3, masterStatusSystem.getWorkers().size());
+    Assert.assertEquals(3, masterStatusSystem.workersMap.size());
   }
 
   private String getNewReqeustId() {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -347,13 +347,13 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.getWorkers().size());
-    Assert.assertEquals(3, STATUSSYSTEM2.getWorkers().size());
-    Assert.assertEquals(3, STATUSSYSTEM3.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
 
-    assertWorkers(STATUSSYSTEM1.getWorkers());
-    assertWorkers(STATUSSYSTEM2.getWorkers());
-    assertWorkers(STATUSSYSTEM3.getWorkers());
+    assertWorkers(STATUSSYSTEM1.workersMap.values());
+    assertWorkers(STATUSSYSTEM2.workersMap.values());
+    assertWorkers(STATUSSYSTEM3.workersMap.values());
   }
 
   private void assertWorkers(Collection<WorkerInfo> workerInfos) {
@@ -479,9 +479,9 @@ public class RatisMasterStatusSystemSuiteJ {
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
-    Assert.assertEquals(2, STATUSSYSTEM2.getWorkers().size());
-    Assert.assertEquals(2, STATUSSYSTEM3.getWorkers().size());
+    Assert.assertEquals(2, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(2, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(2, STATUSSYSTEM3.workersMap.size());
   }
 
   @Test
@@ -571,21 +571,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME3))
             .findFirst()
             .get()
@@ -632,22 +632,22 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.getWorkers().size());
-    Assert.assertEquals(3, STATUSSYSTEM2.getWorkers().size());
-    Assert.assertEquals(3, STATUSSYSTEM3.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
+    Assert.assertEquals(3, STATUSSYSTEM3.workersMap.size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
     allocations.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocations);
     workersToAllocate.put(
-        statusSystem.getWorkers().stream()
+        statusSystem.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -661,21 +661,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        STATUSSYSTEM1.getWorkers().stream()
+        STATUSSYSTEM1.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM2.getWorkers().stream()
+        STATUSSYSTEM2.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM3.getWorkers().stream()
+        STATUSSYSTEM3.workersMap.values().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
@@ -1087,21 +1087,21 @@ public class RatisMasterStatusSystemSuiteJ {
   public void resetStatus() {
     STATUSSYSTEM1.registeredAppAndShuffles.clear();
     STATUSSYSTEM1.hostnameSet.clear();
-    STATUSSYSTEM1.clearWorkers();
+    STATUSSYSTEM1.workersMap.clear();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.excludedWorkers.clear();
     STATUSSYSTEM1.workerLostEvents.clear();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
-    STATUSSYSTEM2.clearWorkers();
+    STATUSSYSTEM2.workersMap.clear();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.excludedWorkers.clear();
     STATUSSYSTEM2.workerLostEvents.clear();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
-    STATUSSYSTEM3.clearWorkers();
+    STATUSSYSTEM3.workersMap.clear();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.excludedWorkers.clear();
     STATUSSYSTEM3.workerLostEvents.clear();
@@ -1280,7 +1280,7 @@ public class RatisMasterStatusSystemSuiteJ {
     statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
 
     Thread.sleep(3000L);
-    Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(2, STATUSSYSTEM1.workersMap.size());
 
     Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -347,16 +347,16 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM2.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM3.workers.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM2.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM3.getWorkers().size());
 
-    assertWorkers(STATUSSYSTEM1.workers);
-    assertWorkers(STATUSSYSTEM2.workers);
-    assertWorkers(STATUSSYSTEM3.workers);
+    assertWorkers(STATUSSYSTEM1.getWorkers());
+    assertWorkers(STATUSSYSTEM2.getWorkers());
+    assertWorkers(STATUSSYSTEM3.getWorkers());
   }
 
-  private void assertWorkers(Set<WorkerInfo> workerInfos) {
+  private void assertWorkers(Collection<WorkerInfo> workerInfos) {
     for (WorkerInfo workerInfo : workerInfos) {
       assertWorker(workerInfo);
     }
@@ -479,9 +479,9 @@ public class RatisMasterStatusSystemSuiteJ {
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
-    Assert.assertEquals(2, STATUSSYSTEM2.workers.size());
-    Assert.assertEquals(2, STATUSSYSTEM3.workers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(2, STATUSSYSTEM2.getWorkers().size());
+    Assert.assertEquals(2, STATUSSYSTEM3.getWorkers().size());
   }
 
   @Test
@@ -571,21 +571,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME3))
             .findFirst()
             .get()
@@ -632,22 +632,22 @@ public class RatisMasterStatusSystemSuiteJ {
         getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM2.workers.size());
-    Assert.assertEquals(3, STATUSSYSTEM3.workers.size());
+    Assert.assertEquals(3, STATUSSYSTEM1.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM2.getWorkers().size());
+    Assert.assertEquals(3, STATUSSYSTEM3.getWorkers().size());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
     allocations.put("disk1", 5);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .toUniqueId(),
         allocations);
     workersToAllocate.put(
-        statusSystem.workers.stream()
+        statusSystem.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME2))
             .findFirst()
             .get()
@@ -661,21 +661,21 @@ public class RatisMasterStatusSystemSuiteJ {
 
     Assert.assertEquals(
         0,
-        STATUSSYSTEM1.workers.stream()
+        STATUSSYSTEM1.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM2.workers.stream()
+        STATUSSYSTEM2.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
             .usedSlots());
     Assert.assertEquals(
         0,
-        STATUSSYSTEM3.workers.stream()
+        STATUSSYSTEM3.getWorkers().stream()
             .filter(w -> w.host().equals(HOSTNAME1))
             .findFirst()
             .get()
@@ -1087,21 +1087,21 @@ public class RatisMasterStatusSystemSuiteJ {
   public void resetStatus() {
     STATUSSYSTEM1.registeredAppAndShuffles.clear();
     STATUSSYSTEM1.hostnameSet.clear();
-    STATUSSYSTEM1.workers.clear();
+    STATUSSYSTEM1.clearWorkers();
     STATUSSYSTEM1.appHeartbeatTime.clear();
     STATUSSYSTEM1.excludedWorkers.clear();
     STATUSSYSTEM1.workerLostEvents.clear();
 
     STATUSSYSTEM2.registeredAppAndShuffles.clear();
     STATUSSYSTEM2.hostnameSet.clear();
-    STATUSSYSTEM2.workers.clear();
+    STATUSSYSTEM2.clearWorkers();
     STATUSSYSTEM2.appHeartbeatTime.clear();
     STATUSSYSTEM2.excludedWorkers.clear();
     STATUSSYSTEM2.workerLostEvents.clear();
 
     STATUSSYSTEM3.registeredAppAndShuffles.clear();
     STATUSSYSTEM3.hostnameSet.clear();
-    STATUSSYSTEM3.workers.clear();
+    STATUSSYSTEM3.clearWorkers();
     STATUSSYSTEM3.appHeartbeatTime.clear();
     STATUSSYSTEM3.excludedWorkers.clear();
     STATUSSYSTEM3.workerLostEvents.clear();
@@ -1280,7 +1280,7 @@ public class RatisMasterStatusSystemSuiteJ {
     statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
 
     Thread.sleep(3000L);
-    Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
+    Assert.assertEquals(2, STATUSSYSTEM1.getWorkers().size());
 
     Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Using map for workers so that we can find a worker by uniqueId fast.

### Why are the changes needed?

For large celeborn cluster, it might be slow.

- updateWorkerHeartbeatMeta
https://github.com/apache/celeborn/blob/1e77f01cd317b1dc885965d6053b391db1d42bc7/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java#L222

- handleWorkerLost
https://github.com/apache/celeborn/blob/1e77f01cd317b1dc885965d6053b391db1d42bc7/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala#L762-L765
### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UT.
