### PR TITLE
[CELEBORN-1531][FOLLOWUP] Assign the scheduled check task

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -172,7 +172,6 @@ private[celeborn] class Master(
   private var checkForApplicationTimeOutTask: ScheduledFuture[_] = _
   private var checkForUnavailableWorkerTimeOutTask: ScheduledFuture[_] = _
   private var checkForHDFSRemnantDirsTimeOutTask: ScheduledFuture[_] = _
-  private var checkForS3RemnantDirsTimeOutTask: ScheduledFuture[_] = _
   private val nonEagerHandler = ThreadUtils.newDaemonCachedThreadPool("master-noneager-handler", 64)
 
   // Config constants
@@ -312,7 +311,7 @@ private[celeborn] class Master(
       scheduleCheckTask(appHeartbeatTimeoutMs / 2, CheckForApplicationTimeOut)
 
     if (workerUnavailableInfoExpireTimeoutMs > 0) {
-      scheduleCheckTask(
+      checkForUnavailableWorkerTimeOutTask = scheduleCheckTask(
         workerUnavailableInfoExpireTimeoutMs / 2,
         CheckForWorkerUnavailableInfoTimeout)
     }
@@ -352,9 +351,6 @@ private[celeborn] class Master(
     }
     if (checkForHDFSRemnantDirsTimeOutTask != null) {
       checkForHDFSRemnantDirsTimeOutTask.cancel(true)
-    }
-    if (checkForS3RemnantDirsTimeOutTask != null) {
-      checkForS3RemnantDirsTimeOutTask.cancel(true)
     }
     forwardMessageThread.shutdownNow()
     rackResolver.stop()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -171,7 +171,7 @@ private[celeborn] class Master(
   private var checkForWorkerTimeOutTask: ScheduledFuture[_] = _
   private var checkForApplicationTimeOutTask: ScheduledFuture[_] = _
   private var checkForUnavailableWorkerTimeOutTask: ScheduledFuture[_] = _
-  private var checkForHDFSRemnantDirsTimeOutTask: ScheduledFuture[_] = _
+  private var checkForDFSRemnantDirsTimeOutTask: ScheduledFuture[_] = _
   private val nonEagerHandler = ThreadUtils.newDaemonCachedThreadPool("master-noneager-handler", 64)
 
   // Config constants
@@ -317,7 +317,7 @@ private[celeborn] class Master(
     }
 
     if (hasHDFSStorage || hasS3Storage) {
-      checkForHDFSRemnantDirsTimeOutTask =
+      checkForDFSRemnantDirsTimeOutTask =
         scheduleCheckTask(dfsExpireDirsTimeoutMS, CheckForDFSExpiredDirsTimeout)
     }
 
@@ -349,8 +349,8 @@ private[celeborn] class Master(
     if (checkForApplicationTimeOutTask != null) {
       checkForApplicationTimeOutTask.cancel(true)
     }
-    if (checkForHDFSRemnantDirsTimeOutTask != null) {
-      checkForHDFSRemnantDirsTimeOutTask.cancel(true)
+    if (checkForDFSRemnantDirsTimeOutTask != null) {
+      checkForDFSRemnantDirsTimeOutTask.cancel(true)
     }
     forwardMessageThread.shutdownNow()
     rackResolver.stop()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -323,7 +323,7 @@ private[celeborn] class Master(
 
   }
 
-  def scheduleCheckTask[T](timeoutMS: Long, message: T): ScheduledFuture[_] = {
+  private def scheduleCheckTask[T](timeoutMS: Long, message: T): ScheduledFuture[_] = {
     forwardMessageThread.scheduleWithFixedDelay(
       new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {
@@ -340,18 +340,10 @@ private[celeborn] class Master(
       return
     }
     logInfo("Stopping Celeborn Master.")
-    if (checkForWorkerTimeOutTask != null) {
-      checkForWorkerTimeOutTask.cancel(true)
-    }
-    if (checkForUnavailableWorkerTimeOutTask != null) {
-      checkForUnavailableWorkerTimeOutTask.cancel(true)
-    }
-    if (checkForApplicationTimeOutTask != null) {
-      checkForApplicationTimeOutTask.cancel(true)
-    }
-    if (checkForDFSRemnantDirsTimeOutTask != null) {
-      checkForDFSRemnantDirsTimeOutTask.cancel(true)
-    }
+    Option(checkForWorkerTimeOutTask).foreach(_.cancel(true))
+    Option(checkForUnavailableWorkerTimeOutTask).foreach(_.cancel(true))
+    Option(checkForApplicationTimeOutTask).foreach(_.cancel(true))
+    Option(checkForDFSRemnantDirsTimeOutTask).foreach(_.cancel(true))
     forwardMessageThread.shutdownNow()
     rackResolver.stop()
     if (authEnabled) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title.


### Why are the changes needed?
Followup for https://github.com/apache/celeborn/pull/2653

`checkForUnavailableWorkerTimeOutTask` and `checkForS3RemnantDirsTimeOutTask` are not assigned and always null.
<img width="834" alt="image" src="https://github.com/user-attachments/assets/747a3054-87db-458f-acf8-876926bd1883">


Combine the `checkForHDFSRemnantDirsTimeOutTask` and `checkForS3RemnantDirsTimeOutTask` with `checkForDFSRemnantDirsTimeOutTask`.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
GA.
