### PR TITLE
[CELEBORN-1490][CIP-6] Support process large buffer in flink hybrid shuffle

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/BufferPacker.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/BufferPacker.java
@@ -166,7 +166,8 @@ public class BufferPacker {
         ByteBuf headerBuffer = compositeByteBuf.component(0).unwrap();
         ByteBuf dataBuffer = compositeByteBuf.component(1).unwrap();
         dataBuffer.retain();
-        Utils.checkState(dataBuffer instanceof Buffer, "Illegal buffer type.");
+        Utils.checkState(
+            dataBuffer instanceof Buffer, "Illegal data buffer type for CompositeByteBuf.");
         BufferHeader bufferHeader = BufferUtils.getBufferHeaderFromByteBuf(headerBuffer, 0);
         Buffer slice = ((Buffer) dataBuffer).readOnlySlice(0, bufferHeader.getSize());
         buffers.add(

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
@@ -39,11 +39,14 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
 
   private ConcurrentHashMap<Long, Supplier<ByteBuf>> bufferSuppliers;
 
+  private int bufferSizeBytes;
+
   public FlinkTransportClientFactory(
-      TransportContext context, List<TransportClientBootstrap> bootstraps) {
+      TransportContext context, List<TransportClientBootstrap> bootstraps, int bufferSizeBytes) {
     super(context, bootstraps);
     bufferSuppliers = JavaUtils.newConcurrentHashMap();
     this.pooledAllocator = new UnpooledByteBufAllocator(true);
+    this.bufferSizeBytes = bufferSizeBytes;
   }
 
   public TransportClient createClientWithRetry(String remoteHost, int remotePort)
@@ -52,7 +55,7 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
         remoteHost,
         remotePort,
         -1,
-        () -> new TransportFrameDecoderWithBufferSupplier(bufferSuppliers));
+        () -> new TransportFrameDecoderWithBufferSupplier(bufferSuppliers, bufferSizeBytes));
   }
 
   public void registerSupplier(long streamId, Supplier<ByteBuf> supplier) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
@@ -50,7 +50,7 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
   private int largeBufferHeaderRemainingBytes = -1;
   private boolean isReadingLargeBuffer = false;
   private ByteBuf largeBufferHeaderBuffer;
-  public static int DISABLE_LARGE_BUFFER_SPLIT_SIZE = -1;
+  public static final int DISABLE_LARGE_BUFFER_SPLIT_SIZE = -1;
 
   /**
    * The flink buffer size bytes. If the received buffer size large than this value, means that we

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.network.protocol.Message;
 import org.apache.celeborn.common.network.util.FrameDecoder;
 import org.apache.celeborn.plugin.flink.protocol.ReadData;
+import org.apache.celeborn.plugin.flink.utils.BufferUtils;
 
 public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandlerAdapter
     implements FrameDecoder {
@@ -44,17 +46,37 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
   private final ByteBuf msgBuf = Unpooled.buffer(8);
   private Message curMsg = null;
   private int remainingSize = -1;
+  private int totalReadBytes = 0;
+  private int largeBufferHeaderRemainingBytes = -1;
+  private boolean isReadingLargeBuffer = false;
+  private ByteBuf largeBufferHeaderBuffer;
+  public static int DISABLE_LARGE_BUFFER_SPLIT_SIZE = -1;
+
+  /**
+   * The flink buffer size bytes. If the received buffer size large than this value, means that we
+   * need to divide the received buffer into multiple smaller buffers, each small than {@link
+   * #bufferSizeBytes}. And when this value set to {@link #DISABLE_LARGE_BUFFER_SPLIT_SIZE},
+   * indicates that large buffer splitting will not be checked.
+   */
+  private final int bufferSizeBytes;
 
   private final ConcurrentHashMap<Long, Supplier<ByteBuf>> bufferSuppliers;
 
   public TransportFrameDecoderWithBufferSupplier(
       ConcurrentHashMap<Long, Supplier<ByteBuf>> bufferSuppliers) {
-    this.bufferSuppliers = bufferSuppliers;
+    this(bufferSuppliers, DISABLE_LARGE_BUFFER_SPLIT_SIZE);
   }
 
-  private void copyByteBuf(io.netty.buffer.ByteBuf source, ByteBuf target, int targetSize) {
+  public TransportFrameDecoderWithBufferSupplier(
+      ConcurrentHashMap<Long, Supplier<ByteBuf>> bufferSuppliers, int bufferSizeBytes) {
+    this.bufferSuppliers = bufferSuppliers;
+    this.bufferSizeBytes = bufferSizeBytes;
+  }
+
+  private int copyByteBuf(io.netty.buffer.ByteBuf source, ByteBuf target, int targetSize) {
     int bytes = Math.min(source.readableBytes(), targetSize - target.readableBytes());
     target.writeBytes(source.readSlice(bytes).nioBuffer());
+    return bytes;
   }
 
   private void decodeHeader(io.netty.buffer.ByteBuf buf, ChannelHandlerContext ctx) {
@@ -69,6 +91,15 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
       // type byte is read
       headerBuf.readByte();
       bodySize = headerBuf.readInt();
+      if (bufferSizeBytes != DISABLE_LARGE_BUFFER_SPLIT_SIZE && bodySize > bufferSizeBytes) {
+        // if the message body size is larger than bufferSizeBytes, we need to split it into two
+        // parts: celeborn header and data buffer
+        isReadingLargeBuffer = true;
+        // create a temporary buffer to store the celeborn header
+        largeBufferHeaderBuffer =
+            Unpooled.buffer(BufferUtils.HEADER_LENGTH, BufferUtils.HEADER_LENGTH);
+        largeBufferHeaderRemainingBytes = BufferUtils.HEADER_LENGTH;
+      }
       decodeMsg(buf, ctx);
     }
   }
@@ -138,9 +169,31 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
       }
     }
 
-    copyByteBuf(buf, externalBuf, bodySize);
-    if (externalBuf.readableBytes() == bodySize) {
-      ((ReadData) curMsg).setFlinkBuffer(externalBuf);
+    if (largeBufferHeaderRemainingBytes > 0) {
+      // if largeBufferHeaderRemainingBytes larger than zero, means that we are reading the celeborn
+      // header
+      int headerReadBytes = copyByteBuf(buf, largeBufferHeaderBuffer, BufferUtils.HEADER_LENGTH);
+      largeBufferHeaderRemainingBytes -= headerReadBytes;
+      totalReadBytes += headerReadBytes;
+    } else {
+      // if largeBufferHeaderRemainingBytes less or equal to zero, means that we are reading the
+      // data buffer
+      totalReadBytes += copyByteBuf(buf, externalBuf, getTargetDataBufferReadSize());
+    }
+
+    if (totalReadBytes == bodySize) {
+      ByteBuf resultByteBuf;
+      if (largeBufferHeaderBuffer == null) {
+        resultByteBuf = externalBuf;
+      } else {
+        // composite the celeborn header and data buffer together
+        CompositeByteBuf compositeByteBuf = Unpooled.compositeBuffer();
+        compositeByteBuf.addComponent(true, largeBufferHeaderBuffer);
+        compositeByteBuf.addComponent(true, externalBuf);
+        resultByteBuf = compositeByteBuf;
+      }
+
+      ((ReadData) curMsg).setFlinkBuffer(resultByteBuf);
       ctx.fireChannelRead(curMsg);
       clear();
     }
@@ -192,6 +245,13 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
     }
   }
 
+  private int getTargetDataBufferReadSize() {
+    if (isReadingLargeBuffer) {
+      return bodySize - BufferUtils.HEADER_LENGTH;
+    }
+    return bodySize;
+  }
+
   private void clear() {
     externalBuf = null;
     curMsg = null;
@@ -200,6 +260,10 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
     bodyBuf = null;
     bodySize = -1;
     remainingSize = -1;
+    totalReadBytes = 0;
+    largeBufferHeaderRemainingBytes = -1;
+    largeBufferHeaderBuffer = null;
+    isReadingLargeBuffer = false;
   }
 
   @Override

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -68,6 +68,7 @@ import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.common.write.PushState;
 import org.apache.celeborn.plugin.flink.network.FlinkTransportClientFactory;
 import org.apache.celeborn.plugin.flink.network.ReadClientHandler;
+import org.apache.celeborn.plugin.flink.network.TransportFrameDecoderWithBufferSupplier;
 
 public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   public static final Logger logger = LoggerFactory.getLogger(FlinkShuffleClientImpl.class);
@@ -81,6 +82,9 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
 
   private final TransportContext context;
 
+  /** The buffer size bytes in flink, default value is 32KB. */
+  private final int bufferSizeBytes;
+
   public static FlinkShuffleClientImpl get(
       String appUniqueId,
       String driverHost,
@@ -89,18 +93,49 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
       CelebornConf conf,
       UserIdentifier userIdentifier)
       throws DriverChangedException {
+    return get(
+        appUniqueId,
+        driverHost,
+        port,
+        driverTimestamp,
+        conf,
+        userIdentifier,
+        TransportFrameDecoderWithBufferSupplier.DISABLE_LARGE_BUFFER_SPLIT_SIZE);
+  }
+
+  public static FlinkShuffleClientImpl get(
+      String appUniqueId,
+      String driverHost,
+      int port,
+      long driverTimestamp,
+      CelebornConf conf,
+      UserIdentifier userIdentifier,
+      int bufferSizeBytes)
+      throws DriverChangedException {
     if (null == _instance || !initialized || _instance.driverTimestamp < driverTimestamp) {
       synchronized (FlinkShuffleClientImpl.class) {
         if (null == _instance) {
           _instance =
               new FlinkShuffleClientImpl(
-                  appUniqueId, driverHost, port, driverTimestamp, conf, userIdentifier);
+                  appUniqueId,
+                  driverHost,
+                  port,
+                  driverTimestamp,
+                  conf,
+                  userIdentifier,
+                  bufferSizeBytes);
           initialized = true;
         } else if (!initialized || _instance.driverTimestamp < driverTimestamp) {
           _instance.shutdown();
           _instance =
               new FlinkShuffleClientImpl(
-                  appUniqueId, driverHost, port, driverTimestamp, conf, userIdentifier);
+                  appUniqueId,
+                  driverHost,
+                  port,
+                  driverTimestamp,
+                  conf,
+                  userIdentifier,
+                  bufferSizeBytes);
           initialized = true;
         }
       }
@@ -133,8 +168,10 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
       int port,
       long driverTimestamp,
       CelebornConf conf,
-      UserIdentifier userIdentifier) {
+      UserIdentifier userIdentifier,
+      int bufferSizeBytes) {
     super(appUniqueId, conf, userIdentifier);
+    this.bufferSizeBytes = bufferSizeBytes;
     String module = TransportModuleConstants.DATA_MODULE;
     TransportConf dataTransportConf =
         Utils.fromCelebornConf(conf, module, conf.getInt("celeborn." + module + ".io.threads", 8));
@@ -147,7 +184,8 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
 
   private void initializeTransportClientFactory() {
     if (null == flinkTransportClientFactory) {
-      flinkTransportClientFactory = new FlinkTransportClientFactory(context, createBootstraps());
+      flinkTransportClientFactory =
+          new FlinkTransportClientFactory(context, createBootstraps(), bufferSizeBytes);
     }
   }
 

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/BufferUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/BufferUtils.java
@@ -113,6 +113,18 @@ public class BufferUtils {
     }
   }
 
+  public static BufferHeader getBufferHeaderFromByteBuf(ByteBuf byteBuf, int position) {
+    byteBuf.readerIndex(position);
+    return new BufferHeader(
+        byteBuf.readInt(),
+        byteBuf.readInt(),
+        byteBuf.readInt(),
+        byteBuf.readInt(),
+        Buffer.DataType.values()[byteBuf.readByte()],
+        byteBuf.readBoolean(),
+        byteBuf.readInt());
+  }
+
   public static void reserveNumRequiredBuffers(BufferPool bufferPool, int numRequiredBuffers)
       throws IOException {
     long startTime = System.nanoTime();

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -55,7 +55,7 @@ public class FlinkShuffleClientImplSuiteJ {
     conf = new CelebornConf();
     shuffleClient =
         new FlinkShuffleClientImpl(
-            "APP", "localhost", 1232, System.currentTimeMillis(), conf, null) {
+            "APP", "localhost", 1232, System.currentTimeMillis(), conf, null, -1) {
           @Override
           public void setupLifecycleManagerRef(String host, int port) {}
         };

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
@@ -18,6 +18,8 @@
 package org.apache.celeborn.plugin.flink.network;
 
 import static org.apache.celeborn.common.network.client.TransportClient.requestId;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,6 +33,7 @@ import java.util.function.Supplier;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,6 +49,7 @@ import org.apache.celeborn.common.network.protocol.TransportMessage;
 import org.apache.celeborn.common.protocol.MessageType;
 import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
 import org.apache.celeborn.common.util.JavaUtils;
+import org.apache.celeborn.plugin.flink.utils.BufferUtils;
 
 @RunWith(Parameterized.class)
 public class TransportFrameDecoderWithBufferSupplierSuiteJ {
@@ -129,6 +133,125 @@ public class TransportFrameDecoderWithBufferSupplierSuiteJ {
     Assert.assertEquals(buffers.get(4).nioBuffer(), readData.body().nioByteBuffer());
     Assert.assertEquals(buffers.get(5).nioBuffer(), readData1.body().nioByteBuffer());
     Assert.assertEquals(buffers.size(), 6);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testFailProcessFullBufferIfDisableLargeBufferSplit() throws IOException {
+    int bufferSizeBytes = 10 * 1024;
+    ConcurrentHashMap<Long, Supplier<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf>>
+        supplier = JavaUtils.newConcurrentHashMap();
+    List<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf> buffers = new ArrayList<>();
+
+    supplier.put(
+        0L,
+        () -> {
+          org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf buffer =
+              org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.buffer(
+                  bufferSizeBytes, bufferSizeBytes);
+          buffers.add(buffer);
+          return buffer;
+        });
+
+    TransportFrameDecoderWithBufferSupplier decoder =
+        new TransportFrameDecoderWithBufferSupplier(
+            supplier, TransportFrameDecoderWithBufferSupplier.DISABLE_LARGE_BUFFER_SPLIT_SIZE);
+    ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+
+    SubPartitionReadData readData =
+        new SubPartitionReadData(0, 0, generateData(bufferSizeBytes + BufferUtils.HEADER_LENGTH));
+
+    ByteBuf buffer = Unpooled.buffer(bufferSizeBytes * 4);
+    encodeMessage(readData, buffer);
+
+    // simulate
+    buffer.retain();
+    decoder.channelRead(context, buffer);
+  }
+
+  @Test
+  public void testProcessFullBufferIfEnableLargeBufferSplit() throws IOException {
+    int bufferSizeBytes = 10 * 1024;
+    ConcurrentHashMap<Long, Supplier<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf>>
+        supplier = JavaUtils.newConcurrentHashMap();
+    List<Message> parsedMessages = new ArrayList<>();
+
+    supplier.put(
+        0L,
+        () ->
+            org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.buffer(
+                bufferSizeBytes, bufferSizeBytes));
+
+    TransportFrameDecoderWithBufferSupplier decoder =
+        new TransportFrameDecoderWithBufferSupplier(supplier, bufferSizeBytes);
+    ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+    when(context.fireChannelRead(any()))
+        .thenAnswer(
+            m -> {
+              Assert.assertEquals(1, m.getArguments().length);
+              parsedMessages.add(m.getArgument(0));
+              return null;
+            });
+
+    ReadData readData1 = new ReadData(0, generateData(1024));
+    // simulate the client received a large buffer which body size large than size of given buffer
+    // in this case, the flinkBuffer of parsed message will contain two parts: celeborn header and
+    // data buffer
+    SubPartitionReadData readData2 =
+        new SubPartitionReadData(0, 0, generateData(BufferUtils.HEADER_LENGTH + bufferSizeBytes));
+    SubPartitionReadData readData3 = new SubPartitionReadData(0, 0, generateData(1024));
+
+    ByteBuf buffer = Unpooled.buffer(bufferSizeBytes * 4);
+    encodeMessage(readData1, buffer);
+    encodeMessage(readData2, buffer);
+    encodeMessage(readData3, buffer);
+
+    // simulate
+    buffer.retain();
+    decoder.channelRead(context, buffer);
+    Assert.assertEquals(parsedMessages.size(), 3);
+
+    // the parsed first message contains the readData1
+    Assert.assertTrue(
+        parsedMessages.get(0) instanceof org.apache.celeborn.plugin.flink.protocol.ReadData);
+    Assert.assertEquals(
+        ((org.apache.celeborn.plugin.flink.protocol.ReadData) parsedMessages.get(0))
+            .getFlinkBuffer()
+            .nioBuffer(),
+        readData1.body().nioByteBuffer());
+
+    // the parsed second message contains the readData2
+    Assert.assertTrue(
+        parsedMessages.get(1)
+            instanceof org.apache.celeborn.plugin.flink.protocol.SubPartitionReadData);
+    org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf byteBuf2 =
+        ((org.apache.celeborn.plugin.flink.protocol.SubPartitionReadData) parsedMessages.get(1))
+            .getFlinkBuffer();
+    // verify the flinkBuffer of parsed message contains two parts: celeborn header and data buffer
+    Assert.assertTrue(
+        byteBuf2 instanceof org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf);
+    CompositeByteBuf compositeByteBuf2 = (CompositeByteBuf) byteBuf2;
+    Assert.assertEquals(compositeByteBuf2.numComponents(), 2);
+    org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf inputByteBuf2 =
+        org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.wrappedBuffer(
+            readData2.body().nioByteBuffer());
+    // the first part is celeborn header
+    Assert.assertEquals(
+        compositeByteBuf2.component(0).nioBuffer(),
+        inputByteBuf2.slice(0, BufferUtils.HEADER_LENGTH).nioBuffer());
+    // the second part is data buffer
+    Assert.assertEquals(
+        compositeByteBuf2.component(1).nioBuffer(),
+        inputByteBuf2.slice(BufferUtils.HEADER_LENGTH, bufferSizeBytes).nioBuffer());
+
+    // the parsed third message contains the readData3
+    Assert.assertTrue(
+        parsedMessages.get(2)
+            instanceof org.apache.celeborn.plugin.flink.protocol.SubPartitionReadData);
+    Assert.assertEquals(
+        ((org.apache.celeborn.plugin.flink.protocol.SubPartitionReadData) parsedMessages.get(2))
+            .getFlinkBuffer()
+            .nioBuffer(),
+        readData3.body().nioByteBuffer());
   }
 
   public RpcRequest createBacklogAnnouncement(long streamId, int backlog) {

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierConsumerAgent.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierConsumerAgent.java
@@ -117,10 +117,13 @@ public class CelebornTierConsumerAgent implements TierConsumerAgent {
 
   private TieredStorageMemoryManager memoryManager;
 
+  private final int bufferSizeBytes;
+
   public CelebornTierConsumerAgent(
       CelebornConf conf,
       List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
-      List<TierShuffleDescriptor> shuffleDescriptors) {
+      List<TierShuffleDescriptor> shuffleDescriptors,
+      int bufferSizeBytes) {
     checkArgument(!shuffleDescriptors.isEmpty(), "Wrong shuffle descriptors size.");
     checkArgument(
         tieredStorageConsumerSpecs.size() == shuffleDescriptors.size(),
@@ -132,6 +135,7 @@ public class CelebornTierConsumerAgent implements TierConsumerAgent {
     this.bufferReaders = new HashMap<>();
     this.receivedBuffers = new HashMap<>();
     this.subPartitionsNeedNotifyAvailable = new HashSet<>();
+    this.bufferSizeBytes = bufferSizeBytes;
     for (TierShuffleDescriptor shuffleDescriptor : shuffleDescriptors) {
       if (shuffleDescriptor instanceof TierShuffleDescriptorImpl) {
         initShuffleClient((TierShuffleDescriptorImpl) shuffleDescriptor);
@@ -326,7 +330,8 @@ public class CelebornTierConsumerAgent implements TierConsumerAgent {
               shuffleResource.getLifecycleManagerPort(),
               shuffleResource.getLifecycleManagerTimestamp(),
               conf,
-              new UserIdentifier("default", "default"));
+              new UserIdentifier("default", "default"),
+              bufferSizeBytes);
     } catch (DriverChangedException e) {
       throw new RuntimeException(e.getMessage());
     }

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierFactory.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierFactory.java
@@ -118,7 +118,8 @@ public class CelebornTierFactory implements TierFactory {
       List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
       List<TierShuffleDescriptor> shuffleDescriptors,
       TieredStorageNettyService nettyService) {
-    return new CelebornTierConsumerAgent(conf, tieredStorageConsumerSpecs, shuffleDescriptors);
+    return new CelebornTierConsumerAgent(
+        conf, tieredStorageConsumerSpecs, shuffleDescriptors, bufferSizeBytes);
   }
 
   public static String getCelebornTierName() {

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierProducerAgent.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierProducerAgent.java
@@ -329,7 +329,7 @@ public class CelebornTierProducerAgent implements TierProducerAgent {
         // In the Flink hybrid shuffle integration strategy, the data buffer sent to the Celeborn
         // workers consists of two components: the Celeborn header and the data buffers.
         // In this scenario, the maximum byte size of the buffer received by the Celeborn worker is
-        // equal to the Flink buffer size plus the size of the Celeborn header.
+        // equal to the sum of the Flink buffer size and the Celeborn header size.
         Optional<PartitionLocation> revivePartition =
             flinkShuffleClient.pushDataHandShake(
                 shuffleId,

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
@@ -37,7 +37,8 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
         0,
         System.currentTimeMillis(),
         clientConf,
-        new UserIdentifier("1", "1")) {
+        new UserIdentifier("1", "1"),
+        -1) {
         override def setupLifecycleManagerRef(host: String, port: Int): Unit = {}
       }
     testHeartbeatFromWorker2Client(flinkShuffleClientImpl.getDataClientFactory)
@@ -52,7 +53,8 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
         0,
         System.currentTimeMillis(),
         clientConf,
-        new UserIdentifier("1", "1")) {
+        new UserIdentifier("1", "1"),
+        -1) {
         override def setupLifecycleManagerRef(host: String, port: Int): Unit = {}
       }
     testHeartbeatFromWorker2ClientWithNoHeartbeat(flinkShuffleClientImpl.getDataClientFactory)
@@ -67,7 +69,8 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
         0,
         System.currentTimeMillis(),
         clientConf,
-        new UserIdentifier("1", "1")) {
+        new UserIdentifier("1", "1"),
+        -1) {
         override def setupLifecycleManagerRef(host: String, port: Int): Unit = {}
       }
     testHeartbeatFromWorker2ClientWithCloseChannel(flinkShuffleClientImpl.getDataClientFactory)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This is the last PR in the CIP-6 series.

Fix the bug when hybrid shuffle face the buffer which large then 32K.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
