### PR TITLE
[CELEBORN-1683] Support to get worker versions with RESTful api

### DIFF
--- a/build/celeborn-build-info
+++ b/build/celeborn-build-info
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script generates the build info for celeborn and places it into the celeborn-version-info.properties file.
+# Arguments:
+#   build_tgt_directory - The target directory where properties file would be created. [./common/target/extra-resources]
+#   celeborn_version - The current version of celeborn
+
+RESOURCE_DIR="$1"
+mkdir -p "$RESOURCE_DIR"
+CELEBORN_BUILD_INFO="${RESOURCE_DIR%/}"/celeborn-version-info.properties
+
+echo_build_properties() {
+  echo version=$1
+  echo user=$USER
+  echo revision=$(git rev-parse HEAD)
+  echo branch=$(git rev-parse --abbrev-ref HEAD)
+  echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+}
+
+echo_build_properties $2 > "$CELEBORN_BUILD_INFO"

--- a/build/celeborn-build-info.ps1
+++ b/build/celeborn-build-info.ps1
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script generates the build info for celeborn and places it into the celeborn-version-info.properties file.
+# Arguments:
+#   ResourceDir - The target directory where properties file would be created. [./core/target/extra-resources]
+#   CelebornVersion - The current version of celeborn
+
+param(
+    # The resource directory.
+    [Parameter(Position = 0)]
+    [String]
+    $ResourceDir,
+
+    # The celeborn version.
+    [Parameter(Position = 1)]
+    [String]
+    $CelebornVersion
+)
+
+$null = New-Item -Type Directory -Force $ResourceDir
+$CelebornBuildInfoPath = $ResourceDir.TrimEnd('\').TrimEnd('/') + '\celeborn-version-info.properties'
+
+$CelebornBuildInfoContent =
+"version=$CelebornVersion
+user=$($Env:USERNAME)
+revision=$(git rev-parse HEAD)
+branch=$(git rev-parse --abbrev-ref HEAD)
+date=$([DateTime]::UtcNow | Get-Date -UFormat +%Y-%m-%dT%H:%M:%SZ)"
+
+Set-Content -Path $CelebornBuildInfoPath -Value $CelebornBuildInfoContent

--- a/build/celeborn-build-info.ps1
+++ b/build/celeborn-build-info.ps1
@@ -17,7 +17,7 @@
 
 # This script generates the build info for celeborn and places it into the celeborn-version-info.properties file.
 # Arguments:
-#   ResourceDir - The target directory where properties file would be created. [./core/target/extra-resources]
+#   ResourceDir - The target directory where properties file would be created. [./common/target/extra-resources]
 #   CelebornVersion - The current version of celeborn
 
 param(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -180,6 +180,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   rpcEnv.setupEndpoint(RpcNameConstants.LIFECYCLE_MANAGER_EP, this)
 
   logInfo(s"Starting LifecycleManager on ${rpcEnv.address}")
+  Utils.printVersion()
 
   private var masterRpcEnvInUse = rpcEnv
   private var workerRpcEnvInUse = rpcEnv

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -158,10 +158,69 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <filtering>true</filtering>
+        <!-- Include the properties file to provide the build information. -->
+        <directory>${project.build.directory}/extra-resources</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven.plugin.antrun.version}</version>
+        <executions>
+          <execution>
+            <id>choose-shell-and-script</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <condition else="bash" property="shell" value="powershell.exe">
+                  <and>
+                    <os family="windows"></os>
+                  </and>
+                </condition>
+                <condition else="celeborn-build-info" property="celeborn-build-info-script" value="celeborn-build-info.ps1">
+                  <and>
+                    <os family="windows"></os>
+                  </and>
+                </condition>
+                <echo>Shell to use for generating celeborn-version-info.properties file =
+                  ${shell}</echo>
+                <echo>Script to use for generating celeborn-version-info.properties file =
+                  ${celeborn-build-info-script}</echo>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-celeborn-build-info</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <target>
+                <exec executable="${shell}">
+                  <arg value="${project.basedir}/../build/${celeborn-build-info-script}"></arg>
+                  <arg value="${project.build.directory}/extra-resources"></arg>
+                  <arg value="${project.version}"></arg>
+                </exec>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <extensions>

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -183,6 +183,7 @@ message PbWorkerInfo {
   map<string, PbResourceConsumption> userResourceConsumption = 7;
   int32 internalPort = 8;
   string networkLocation = 9;
+  string version = 10;
 }
 
 message PbFileGroup {
@@ -201,6 +202,7 @@ message PbRegisterWorker {
   map<string, PbResourceConsumption> userResourceConsumption = 8;
   int32 internalPort = 10;
   string networkLocation = 11;
+  string version = 12;
 }
 
 message PbHeartbeatFromWorker {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornBuildInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornBuildInfo.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common
+
+import java.util.Properties
+
+import org.apache.celeborn.common.exception.CelebornException
+
+private[celeborn] object CelebornBuildInfo {
+  val (
+    celeborn_version: String,
+    celeborn_branch: String,
+    celeborn_revision: String,
+    celeborn_build_user: String,
+    celeborn_build_date: String) = {
+
+    val resourceStream = Thread.currentThread().getContextClassLoader.getResourceAsStream(
+      "celeborn-version-info.properties")
+    if (resourceStream == null) {
+      throw new CelebornException("Could not find celeborn-version-info.properties")
+    }
+
+    try {
+      val unknownProp = "<unknown>"
+      val props = new Properties()
+      props.load(resourceStream)
+      (
+        props.getProperty("version", unknownProp),
+        props.getProperty("branch", unknownProp),
+        props.getProperty("revision", unknownProp),
+        props.getProperty("user", unknownProp),
+        props.getProperty("date", unknownProp))
+    } catch {
+      case e: Exception =>
+        throw new CelebornException(
+          "Error loading properties from celeborn-version-info.properties",
+          e)
+    } finally {
+      if (resourceStream != null) {
+        try {
+          resourceStream.close()
+        } catch {
+          case e: Exception =>
+            throw new CelebornException("Error closing celeborn build info resource stream", e)
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -44,7 +44,7 @@ class WorkerInfo(
     _userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption]) extends Serializable
   with Logging {
   var networkLocation = NetworkTopology.DEFAULT_RACK
-  val version = Option(_version).getOrElse(WorkerInfo.UNKNOWN_VERSION)
+  var version = Option(_version).filter(_.nonEmpty).getOrElse(WorkerInfo.UNKNOWN_VERSION)
   var lastHeartbeat: Long = 0
   var workerStatus = WorkerStatus.normalWorkerStatus()
   val diskInfos =

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -39,10 +39,12 @@ class WorkerInfo(
     val fetchPort: Int,
     val replicatePort: Int,
     val internalPort: Int,
+    _version: String,
     _diskInfos: util.Map[String, DiskInfo],
     _userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption]) extends Serializable
   with Logging {
   var networkLocation = NetworkTopology.DEFAULT_RACK
+  val version = Option(_version).getOrElse(WorkerInfo.UNKNOWN_VERSION)
   var lastHeartbeat: Long = 0
   var workerStatus = WorkerStatus.normalWorkerStatus()
   val diskInfos =
@@ -67,6 +69,7 @@ class WorkerInfo(
       fetchPort,
       replicatePort,
       -1,
+      WorkerInfo.UNKNOWN_VERSION,
       new util.HashMap[String, DiskInfo](),
       new util.HashMap[UserIdentifier, ResourceConsumption]())
   }
@@ -85,8 +88,30 @@ class WorkerInfo(
       fetchPort,
       replicatePort,
       internalPort,
+      WorkerInfo.UNKNOWN_VERSION,
       new util.HashMap[String, DiskInfo](),
       new util.HashMap[UserIdentifier, ResourceConsumption]())
+  }
+
+  def this(
+      host: String,
+      rpcPort: Int,
+      pushPort: Int,
+      fetchPort: Int,
+      replicatePort: Int,
+      internalPort: Int,
+      diskInfos: util.Map[String, DiskInfo],
+      userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption]) = {
+    this(
+      host,
+      rpcPort,
+      pushPort,
+      fetchPort,
+      replicatePort,
+      internalPort,
+      WorkerInfo.UNKNOWN_VERSION,
+      diskInfos,
+      userResourceConsumption)
   }
 
   def isActive: Boolean = {
@@ -314,4 +339,6 @@ object WorkerInfo {
       Utils.parseColonSeparatedHostPorts(id, portsNum = 4)
     new WorkerInfo(host, rpcPort.toInt, pushPort.toInt, fetchPort.toInt, replicatePort.toInt)
   }
+
+  val UNKNOWN_VERSION = "<UNKNOWN>"
 }

--- a/common/src/main/scala/org/apache/celeborn/common/package.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/package.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn
 package object common {
   val CELEBORN_VERSION: String = CelebornBuildInfo.celeborn_version
   val CELEBORN_BRANCH: String = CelebornBuildInfo.celeborn_branch
-  val CELEBORN_REVISION: String = CelebornBuildInfo.celeborn_version
+  val CELEBORN_REVISION: String = CelebornBuildInfo.celeborn_revision
   val CELEBORN_BUILD_USER: String = CelebornBuildInfo.celeborn_build_user
   val CELEBORN_BUILD_DATE: String = CelebornBuildInfo.celeborn_build_date
 }

--- a/common/src/main/scala/org/apache/celeborn/common/package.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/package.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn
+
+package object common {
+  val CELEBORN_VERSION: String = CelebornBuildInfo.celeborn_version
+  val CELEBORN_BRANCH: String = CelebornBuildInfo.celeborn_branch
+  val CELEBORN_REVISION: String = CelebornBuildInfo.celeborn_version
+  val CELEBORN_BUILD_USER: String = CelebornBuildInfo.celeborn_build_user
+  val CELEBORN_BUILD_DATE: String = CelebornBuildInfo.celeborn_build_date
+}

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -89,6 +89,7 @@ object ControlMessages extends Logging {
         replicatePort: Int,
         internalPort: Int,
         networkLocation: String,
+        version: String,
         disks: Map[String, DiskInfo],
         userResourceConsumption: Map[UserIdentifier, ResourceConsumption],
         requestId: String): PbRegisterWorker = {
@@ -103,6 +104,7 @@ object ControlMessages extends Logging {
         .setReplicatePort(replicatePort)
         .setInternalPort(internalPort)
         .setNetworkLocation(networkLocation)
+        .setVersion(version)
         .addAllDisks(pbDisks)
         .putAllUserResourceConsumption(pbUserResourceConsumption)
         .setRequestId(requestId)

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -273,6 +273,7 @@ object PbSerDeUtils {
       pbWorkerInfo.getFetchPort,
       pbWorkerInfo.getReplicatePort,
       pbWorkerInfo.getInternalPort,
+      pbWorkerInfo.getVersion,
       disks,
       userResourceConsumption)
     if (masterPersistWorkerNetworkLocation) {
@@ -292,6 +293,7 @@ object PbSerDeUtils {
       .setPushPort(workerInfo.pushPort)
       .setReplicatePort(workerInfo.replicatePort)
       .setInternalPort(workerInfo.internalPort)
+      .setVersion(workerInfo.version)
     if (masterPersistWorkerNetworkLocation) {
       builder.setNetworkLocation(workerInfo.networkLocation)
     }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -1371,4 +1371,21 @@ object Utils extends Logging {
     connectException || rpcTimeout || fetchChunkTimeout
   }
 
+  def printVersion(): Unit = {
+    logInfo("""
+      _____    __    __
+     / ___/__ / /__ / /  ___  _______
+    / /__/ -_) / -_) _ \/ _ \/ __/ _ \
+    \___/\__/_/\__/_.__/\___/_/ /_//_/  version %s
+
+    Branch %s
+    Compiled by user %s on %s
+    Revision %s
+    """.format(
+      org.apache.celeborn.common.CELEBORN_VERSION,
+      org.apache.celeborn.common.CELEBORN_BRANCH,
+      org.apache.celeborn.common.CELEBORN_BUILD_USER,
+      org.apache.celeborn.common.CELEBORN_BUILD_DATE,
+      org.apache.celeborn.common.CELEBORN_REVISION))
+  }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/CelebornBuildInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/CelebornBuildInfoSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common
+
+import org.apache.celeborn.CelebornFunSuite
+
+class CelebornBuildInfoSuite extends CelebornFunSuite {
+  test("celeborn build info") {
+    assert(CelebornBuildInfo.celeborn_version !== "<unknown>")
+    assert(CelebornBuildInfo.celeborn_branch !== "<unknown>")
+    assert(CelebornBuildInfo.celeborn_revision !== "<unknown>")
+    assert(CelebornBuildInfo.celeborn_build_user !== "<unknown>")
+    assert(CelebornBuildInfo.celeborn_build_date !== "<unknown>")
+  }
+}

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -123,6 +123,7 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
       1003,
       1004,
       1005,
+      org.apache.celeborn.common.CELEBORN_VERSION,
       diskInfos,
       userResourceConsumption)
   workerInfo1.networkLocation_$eq("/1")
@@ -134,6 +135,7 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
       2003,
       2004,
       2005,
+      org.apache.celeborn.common.CELEBORN_VERSION,
       diskInfos,
       userResourceConsumption)
 
@@ -328,6 +330,7 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
       assert(restoredWorkerInfoWithEmptyResource.userResourceConsumption.equals(new util.HashMap[
         UserIdentifier,
         ResourceConsumption]()))
+      assert(restoredWorkerInfo.version === org.apache.celeborn.common.CELEBORN_VERSION)
     }
   }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -310,6 +310,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       int replicatePort,
       int internalPort,
       String networkLocation,
+      String version,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption) {
     WorkerInfo workerInfo =
@@ -320,6 +321,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
             fetchPort,
             replicatePort,
             internalPort,
+            version,
             disks,
             userResourceConsumption);
     workerInfo.lastHeartbeat_$eq(System.currentTimeMillis());

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -334,7 +334,10 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     }
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
     synchronized (workersMap) {
-      workersMap.putIfAbsent(workerInfo.toUniqueId(), workerInfo);
+      WorkerInfo existingWorkerInfo = workersMap.putIfAbsent(workerInfo.toUniqueId(), workerInfo);
+      if (existingWorkerInfo != null) {
+        existingWorkerInfo.version_$eq(workerInfo.version());
+      }
       shutdownWorkers.remove(workerInfo);
       lostWorkers.remove(workerInfo);
       excludedWorkers.remove(workerInfo);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -80,6 +80,7 @@ public interface IMetadataHandler {
       int replicatePort,
       int internalPort,
       String networkLocation,
+      String version,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
       String requestId);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -145,6 +145,7 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
       int replicatePort,
       int internalPort,
       String networkLocation,
+      String version,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
       String requestId) {
@@ -156,6 +157,7 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
         replicatePort,
         internalPort,
         networkLocation,
+        version,
         disks,
         userResourceConsumption);
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.service.deploy.master.clustermeta.ha;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -312,6 +313,7 @@ public class HAMasterMetaManager extends AbstractMetaManager {
       int replicatePort,
       int internalPort,
       String networkLocation,
+      String version,
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
       String requestId) {
@@ -329,6 +331,7 @@ public class HAMasterMetaManager extends AbstractMetaManager {
                       .setReplicatePort(replicatePort)
                       .setInternalPort(internalPort)
                       .setNetworkLocation(networkLocation)
+                      .setVersion(Optional.ofNullable(version).orElse(WorkerInfo.UNKNOWN_VERSION()))
                       .putAllDisks(MetaUtil.toPbDiskInfos(disks))
                       .putAllUserResourceConsumption(
                           MetaUtil.toPbUserResourceConsumption(userResourceConsumption))

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -240,19 +240,21 @@ public class MetaHandler {
           fetchPort = request.getRegisterWorkerRequest().getFetchPort();
           replicatePort = request.getRegisterWorkerRequest().getReplicatePort();
           String networkLocation = request.getRegisterWorkerRequest().getNetworkLocation();
+          String version = request.getRegisterWorkerRequest().getVersion();
           int internalPort = request.getRegisterWorkerRequest().getInternalPort();
           diskInfos = MetaUtil.fromPbDiskInfos(request.getRegisterWorkerRequest().getDisksMap());
           userResourceConsumption =
               MetaUtil.fromPbUserResourceConsumption(
                   request.getRegisterWorkerRequest().getUserResourceConsumptionMap());
           LOG.debug(
-              "Handle worker register for {} {} {} {} {} {} {} {}",
+              "Handle worker register for {} {} {} {} {} {} {} {} {}",
               host,
               rpcPort,
               pushPort,
               fetchPort,
               replicatePort,
               internalPort,
+              version,
               diskInfos,
               userResourceConsumption);
           metaSystem.updateRegisterWorkerMeta(
@@ -263,6 +265,7 @@ public class MetaHandler {
               replicatePort,
               internalPort,
               networkLocation,
+              version,
               diskInfos,
               userResourceConsumption);
           break;

--- a/master/src/main/proto/Resource.proto
+++ b/master/src/main/proto/Resource.proto
@@ -188,6 +188,7 @@ message RegisterWorkerRequest {
   map<string, ResourceConsumption> userResourceConsumption = 7;
   required int32 internalPort = 8;
   optional string networkLocation = 9;
+  optional string version = 10;
 }
 
 message ReportWorkerUnavailableRequest {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -314,6 +314,7 @@ private[celeborn] class Master(
     if (!threadsStarted.compareAndSet(false, true)) {
       return
     }
+    logInfo(s"Running Celeborn version ${org.apache.celeborn.common.CELEBORN_VERSION}")
     if (authEnabled) {
       sendApplicationMetaExecutor = ThreadUtils.newDaemonFixedThreadPool(
         sendApplicationMetaThreads,
@@ -437,6 +438,7 @@ private[celeborn] class Master(
       val replicatePort = pbRegisterWorker.getReplicatePort
       val internalPort = pbRegisterWorker.getInternalPort
       val networkLocation = pbRegisterWorker.getNetworkLocation
+      val version = pbRegisterWorker.getVersion
       val disks = pbRegisterWorker.getDisksList.asScala
         .map { pbDiskInfo => pbDiskInfo.getMountPoint -> PbSerDeUtils.fromPbDiskInfo(pbDiskInfo) }
         .toMap.asJava
@@ -444,7 +446,7 @@ private[celeborn] class Master(
         PbSerDeUtils.fromPbUserResourceConsumption(pbRegisterWorker.getUserResourceConsumptionMap)
 
       logDebug(s"Received RegisterWorker request $requestId, $host:$pushPort:$replicatePort" +
-        s" $disks.")
+        s" $version $disks.")
       executeWithLeaderChecker(
         context,
         handleRegisterWorker(
@@ -456,6 +458,7 @@ private[celeborn] class Master(
           replicatePort,
           internalPort,
           networkLocation,
+          version,
           disks,
           userResourceConsumption,
           requestId))
@@ -774,6 +777,7 @@ private[celeborn] class Master(
       replicatePort: Int,
       internalPort: Int,
       networkLocation: String,
+      version: String,
       disks: util.Map[String, DiskInfo],
       userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption],
       requestId: String): Unit = {
@@ -785,6 +789,7 @@ private[celeborn] class Master(
         fetchPort,
         replicatePort,
         internalPort,
+        version,
         disks,
         userResourceConsumption)
 
@@ -809,6 +814,7 @@ private[celeborn] class Master(
         replicatePort,
         internalPort,
         networkLocation,
+        version,
         disks,
         userResourceConsumption,
         requestId)
@@ -825,6 +831,7 @@ private[celeborn] class Master(
         replicatePort,
         internalPort,
         networkLocation,
+        version,
         disks,
         userResourceConsumption,
         requestId)
@@ -838,6 +845,7 @@ private[celeborn] class Master(
         replicatePort,
         internalPort,
         networkLocation,
+        version,
         disks,
         userResourceConsumption,
         requestId)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1514,6 +1514,7 @@ private[celeborn] class Master(
   override def initialize(): Unit = {
     super.initialize()
     logInfo("Master started.")
+    Utils.printVersion()
     rpcEnv.awaitTermination()
     if (conf.internalPortEnabled) {
       internalRpcEnvInUse.awaitTermination()

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -133,6 +133,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -144,6 +145,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -155,6 +157,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -194,6 +197,7 @@ public class DefaultMetaSystemSuiteJ {
         workerInfo1.replicatePort(),
         workerInfo1.internalPort(),
         workerInfo1.networkLocation(),
+        workerInfo1.version(),
         workerInfo1.diskInfos(),
         workerInfo1.userResourceConsumption(),
         getNewReqeustId());
@@ -205,6 +209,7 @@ public class DefaultMetaSystemSuiteJ {
         workerInfo2.replicatePort(),
         workerInfo2.internalPort(),
         workerInfo2.networkLocation(),
+        workerInfo2.version(),
         workerInfo2.diskInfos(),
         workerInfo2.userResourceConsumption(),
         getNewReqeustId());
@@ -230,6 +235,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -241,6 +247,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -252,6 +259,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -276,6 +284,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -287,6 +296,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -298,6 +308,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -356,6 +367,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -367,6 +379,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -378,6 +391,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -422,6 +436,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -433,6 +448,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -444,6 +460,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -496,6 +513,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -507,6 +525,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -518,6 +537,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -568,6 +588,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -579,6 +600,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -590,6 +612,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -663,6 +686,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         new HashMap<>(),
         userResourceConsumption1,
         getNewReqeustId());
@@ -674,6 +698,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         new HashMap<>(),
         userResourceConsumption2,
         getNewReqeustId());
@@ -685,6 +710,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         new HashMap<>(),
         userResourceConsumption3,
         getNewReqeustId());
@@ -764,6 +790,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -775,6 +802,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -786,6 +814,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -866,6 +895,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -877,6 +907,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -888,6 +919,7 @@ public class DefaultMetaSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -164,6 +164,26 @@ public class DefaultMetaSystemSuiteJ {
 
     assertEquals(3, statusSystem.workersMap.size());
     assertEquals(3, statusSystem.availableWorkers.size());
+
+    WorkerInfo workerInfo3 =
+        statusSystem.workersMap.values().stream()
+            .filter(w -> w.host().equals(HOSTNAME3))
+            .findFirst()
+            .get();
+    assertEquals(WorkerInfo.UNKNOWN_VERSION(), workerInfo3.version());
+    statusSystem.handleRegisterWorker(
+        HOSTNAME3,
+        RPCPORT3,
+        PUSHPORT3,
+        FETCHPORT3,
+        REPLICATEPORT3,
+        INTERNALPORT3,
+        NETWORK_LOCATION3,
+        "v1",
+        disks3,
+        userResourceConsumption3,
+        getNewReqeustId());
+    assertEquals("v1", workerInfo3.version());
   }
 
   @Test

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -401,6 +401,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
           4000 + i,
           5000 + i,
           "networkLocation1",
+          null,
           disks1,
           userResourceConsumption1,
           getNewReqeustId());
@@ -436,6 +437,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
           4100 + i,
           5100 + i,
           "networkLocation1",
+          null,
           disks1,
           userResourceConsumption1,
           getNewReqeustId());
@@ -478,6 +480,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
           4180 + i,
           5180 + i,
           "networkLocation1",
+          null,
           disks1,
           userResourceConsumption1,
           getNewReqeustId());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.service.deploy.master.clustermeta.ha;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -364,6 +365,43 @@ public class RatisMasterStatusSystemSuiteJ {
     assertWorkers(STATUSSYSTEM1.workersMap.values());
     assertWorkers(STATUSSYSTEM2.workersMap.values());
     assertWorkers(STATUSSYSTEM3.workersMap.values());
+
+    WorkerInfo workerInfo13 =
+        STATUSSYSTEM1.workersMap.values().stream()
+            .filter(w -> w.host().equals(HOSTNAME3))
+            .findFirst()
+            .get();
+    WorkerInfo workerInfo23 =
+        STATUSSYSTEM1.workersMap.values().stream()
+            .filter(w -> w.host().equals(HOSTNAME3))
+            .findFirst()
+            .get();
+    WorkerInfo workerInfo33 =
+        STATUSSYSTEM1.workersMap.values().stream()
+            .filter(w -> w.host().equals(HOSTNAME3))
+            .findFirst()
+            .get();
+    assertEquals(WorkerInfo.UNKNOWN_VERSION(), workerInfo13.version());
+    assertEquals(WorkerInfo.UNKNOWN_VERSION(), workerInfo23.version());
+    assertEquals(WorkerInfo.UNKNOWN_VERSION(), workerInfo33.version());
+
+    statusSystem.handleRegisterWorker(
+        HOSTNAME3,
+        RPCPORT3,
+        PUSHPORT3,
+        FETCHPORT3,
+        REPLICATEPORT3,
+        INTERNALPORT3,
+        NETWORK_LOCATION3,
+        "v1",
+        disks3,
+        userResourceConsumption3,
+        getNewReqeustId());
+    Thread.sleep(3000L);
+
+    assertEquals("v1", workerInfo13.version());
+    assertEquals("v1", workerInfo23.version());
+    assertEquals("v1", workerInfo33.version());
   }
 
   private void assertWorkers(Collection<WorkerInfo> workerInfos) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -298,6 +298,7 @@ public class RatisMasterStatusSystemSuiteJ {
           REPLICATEPORT1,
           INTERNALPORT1,
           NETWORK_LOCATION1,
+          null,
           disks1,
           userResourceConsumption1,
           getNewReqeustId());
@@ -322,6 +323,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -333,6 +335,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -344,6 +347,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -410,6 +414,7 @@ public class RatisMasterStatusSystemSuiteJ {
         workerInfo1.replicatePort(),
         workerInfo1.internalPort(),
         workerInfo1.networkLocation(),
+        workerInfo1.version(),
         workerInfo1.diskInfos(),
         workerInfo1.userResourceConsumption(),
         getNewReqeustId());
@@ -421,6 +426,7 @@ public class RatisMasterStatusSystemSuiteJ {
         workerInfo2.replicatePort(),
         workerInfo2.internalPort(),
         workerInfo2.networkLocation(),
+        workerInfo2.version(),
         workerInfo2.diskInfos(),
         workerInfo2.userResourceConsumption(),
         getNewReqeustId());
@@ -463,6 +469,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -474,6 +481,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -485,6 +493,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -515,6 +524,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -526,6 +536,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -537,6 +548,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -549,6 +561,7 @@ public class RatisMasterStatusSystemSuiteJ {
             FETCHPORT1,
             REPLICATEPORT1,
             INTERNALPORT1,
+            null,
             disks1,
             userResourceConsumption1);
     WorkerInfo workerInfo2 =
@@ -623,6 +636,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -634,6 +648,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION3,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -645,6 +660,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -713,6 +729,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -724,6 +741,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -735,6 +753,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -794,6 +813,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -805,6 +825,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -816,6 +837,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -875,6 +897,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -886,6 +909,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -897,6 +921,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -996,6 +1021,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -1007,6 +1033,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -1018,6 +1045,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -1229,6 +1257,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -1240,6 +1269,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -1251,6 +1281,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -1293,6 +1324,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -1304,6 +1336,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -1315,6 +1348,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -1419,6 +1453,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -1430,6 +1465,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -1441,6 +1477,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
@@ -1530,6 +1567,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT1,
         INTERNALPORT1,
         NETWORK_LOCATION1,
+        null,
         disks1,
         userResourceConsumption1,
         getNewReqeustId());
@@ -1541,6 +1579,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT2,
         INTERNALPORT2,
         NETWORK_LOCATION2,
+        null,
         disks2,
         userResourceConsumption2,
         getNewReqeustId());
@@ -1552,6 +1591,7 @@ public class RatisMasterStatusSystemSuiteJ {
         REPLICATEPORT3,
         INTERNALPORT3,
         NETWORK_LOCATION3,
+        null,
         disks3,
         userResourceConsumption3,
         getNewReqeustId());

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
@@ -49,7 +49,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerData.JSON_PROPERTY_WORKER_REF,
   WorkerData.JSON_PROPERTY_WORKER_STATE,
   WorkerData.JSON_PROPERTY_WORKER_STATE_START_TIME,
-  WorkerData.JSON_PROPERTY_NETWORK_LOCATION
+  WorkerData.JSON_PROPERTY_NETWORK_LOCATION,
+  WorkerData.JSON_PROPERTY_VERSION
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerData {
@@ -97,6 +98,9 @@ public class WorkerData {
 
   public static final String JSON_PROPERTY_NETWORK_LOCATION = "networkLocation";
   private String networkLocation;
+
+  public static final String JSON_PROPERTY_VERSION = "version";
+  private String version;
 
   public WorkerData() {
   }
@@ -492,6 +496,31 @@ public class WorkerData {
     this.networkLocation = networkLocation;
   }
 
+  public WorkerData version(String version) {
+    
+    this.version = version;
+    return this;
+  }
+
+  /**
+   * The version of the worker.
+   * @return version
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_VERSION)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getVersion() {
+    return version;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_VERSION)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -515,12 +544,13 @@ public class WorkerData {
         Objects.equals(this.workerRef, workerData.workerRef) &&
         Objects.equals(this.workerState, workerData.workerState) &&
         Objects.equals(this.workerStateStartTime, workerData.workerStateStartTime) &&
-        Objects.equals(this.networkLocation, workerData.networkLocation);
+        Objects.equals(this.networkLocation, workerData.networkLocation) &&
+        Objects.equals(this.version, workerData.version);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumptions, workerRef, workerState, workerStateStartTime, networkLocation);
+    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumptions, workerRef, workerState, workerStateStartTime, networkLocation, version);
   }
 
   @Override
@@ -542,6 +572,7 @@ public class WorkerData {
     sb.append("    workerState: ").append(toIndentedString(workerState)).append("\n");
     sb.append("    workerStateStartTime: ").append(toIndentedString(workerStateStartTime)).append("\n");
     sb.append("    networkLocation: ").append(toIndentedString(networkLocation)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
@@ -51,7 +51,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerInfoResponse.JSON_PROPERTY_WORKER_STATE_START_TIME,
   WorkerInfoResponse.JSON_PROPERTY_IS_REGISTERED,
   WorkerInfoResponse.JSON_PROPERTY_IS_SHUTDOWN,
-  WorkerInfoResponse.JSON_PROPERTY_IS_DECOMMISSIONING
+  WorkerInfoResponse.JSON_PROPERTY_IS_DECOMMISSIONING,
+  WorkerInfoResponse.JSON_PROPERTY_VERSION
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkerInfoResponse {
@@ -105,6 +106,9 @@ public class WorkerInfoResponse {
 
   public static final String JSON_PROPERTY_IS_DECOMMISSIONING = "isDecommissioning";
   private Boolean isDecommissioning;
+
+  public static final String JSON_PROPERTY_VERSION = "version";
+  private String version;
 
   public WorkerInfoResponse() {
   }
@@ -550,6 +554,31 @@ public class WorkerInfoResponse {
     this.isDecommissioning = isDecommissioning;
   }
 
+  public WorkerInfoResponse version(String version) {
+    
+    this.version = version;
+    return this;
+  }
+
+  /**
+   * The version of the worker.
+   * @return version
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_VERSION)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getVersion() {
+    return version;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_VERSION)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -575,12 +604,13 @@ public class WorkerInfoResponse {
         Objects.equals(this.workerStateStartTime, workerInfoResponse.workerStateStartTime) &&
         Objects.equals(this.isRegistered, workerInfoResponse.isRegistered) &&
         Objects.equals(this.isShutdown, workerInfoResponse.isShutdown) &&
-        Objects.equals(this.isDecommissioning, workerInfoResponse.isDecommissioning);
+        Objects.equals(this.isDecommissioning, workerInfoResponse.isDecommissioning) &&
+        Objects.equals(this.version, workerInfoResponse.version);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumptions, workerRef, workerState, workerStateStartTime, isRegistered, isShutdown, isDecommissioning);
+    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumptions, workerRef, workerState, workerStateStartTime, isRegistered, isShutdown, isDecommissioning, version);
   }
 
   @Override
@@ -604,6 +634,7 @@ public class WorkerInfoResponse {
     sb.append("    isRegistered: ").append(toIndentedString(isRegistered)).append("\n");
     sb.append("    isShutdown: ").append(toIndentedString(isShutdown)).append("\n");
     sb.append("    isDecommissioning: ").append(toIndentedString(isDecommissioning)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -858,6 +858,9 @@ components:
         networkLocation:
           type: string
           description: The network location of the worker.
+        version:
+          type: string
+          description: The version of the worker.
       required:
         - host
         - rpcPort

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -453,6 +453,9 @@ components:
         isDecommissioning:
           type: boolean
           description: The decommission status of the worker.
+        version:
+          type: string
+          description: The version of the worker.
       required:
         - host
         - rpcPort
@@ -555,6 +558,9 @@ components:
         networkLocation:
           type: string
           description: The network location of the worker.
+        version:
+          type: string
+          description: The version of the worker.
       required:
         - host
         - rpcPort

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -581,12 +581,31 @@ object CeleborMPU {
 }
 
 object CelebornCommon {
+  import scala.sys.process.Process
+  def buildenv = Process(Seq("uname")).!!.trim.replaceFirst("[^A-Za-z0-9].*", "").toLowerCase
+  def bashpath = Process(Seq("where", "bash")).!!.split("[\r\n]+").head.replace('\\', '/')
+  lazy val buildInfoSettings = Seq(
+    (Compile / resourceGenerators) += Def.task {
+      val buildScript = baseDirectory.value + "/../build/celeborn-build-info"
+      val targetDir = baseDirectory.value + "/target/extra-resources/"
+      // support Windows build under cygwin/mingw64, etc
+      val bash = buildenv match {
+        case "cygwin" | "msys2" | "mingw64" | "clang64" => bashpath
+        case _ => "bash"
+      }
+      val command = Seq(bash, buildScript, targetDir, version.value)
+      Process(command).!!
+      val propsFile = baseDirectory.value / "target" / "extra-resources" / "celeborn-version-info.properties"
+      Seq(propsFile)
+    }.taskValue
+  )
 
 
   lazy val common = Project("celeborn-common", file("common"))
     .dependsOn(CelebornSpi.spi)
     .settings (
       commonSettings,
+      buildInfoSettings,
       protoSettings,
       libraryDependencies ++= Seq(
         Dependencies.protobufJava,

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
@@ -58,6 +58,7 @@ object ApiUtils {
       .workerState(workerInfo.workerStatus.getState.toString)
       .workerStateStartTime(workerInfo.workerStatus.getStateStartTime)
       .networkLocation(workerInfo.networkLocation)
+      .version(workerInfo.version)
   }
 
   private def workerResourceConsumptions(workerInfo: WorkerInfo)
@@ -120,6 +121,7 @@ object ApiUtils {
         isShutdown && (
           currentStatus.getState == State.InDecommission ||
             currentStatus.getState == State.InDecommissionThenIdle))
+      .version(org.apache.celeborn.common.CELEBORN_VERSION)
   }
 
   def toWorkerInfo(workerId: WorkerId): WorkerInfo = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -563,6 +563,7 @@ private[celeborn] class Worker(
     rpcEnv.setupEndpoint(RpcNameConstants.WORKER_EP, controller)
 
     logInfo("Worker started.")
+    Utils.printVersion()
     rpcEnv.awaitTermination()
     if (conf.internalPortEnabled) {
       internalRpcEnvInUse.awaitTermination()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -293,6 +293,7 @@ private[celeborn] class Worker(
       fetchPort,
       replicatePort,
       internalPort,
+      org.apache.celeborn.common.CELEBORN_VERSION,
       diskInfos,
       JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption])
 
@@ -513,6 +514,7 @@ private[celeborn] class Worker(
     super.initialize()
     logInfo(s"Starting Worker $host:$pushPort:$fetchPort:$replicatePort" +
       s" with ${workerInfo.diskInfos} slots.")
+    logInfo(s"Running Celeborn version ${org.apache.celeborn.common.CELEBORN_VERSION}")
     registerWithMaster()
 
     // start heartbeat
@@ -646,6 +648,7 @@ private[celeborn] class Worker(
               replicatePort,
               internalPort,
               networkLocation,
+              org.apache.celeborn.common.CELEBORN_VERSION,
               // Use WorkerInfo's diskInfo since re-register when heartbeat return not-registered,
               // StorageManager have update the disk info.
               workerInfo.diskInfos.asScala.toMap,

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
@@ -20,6 +20,8 @@ package org.apache.celeborn.service.deploy.worker.http.api.v1
 import java.util.Collections
 import javax.servlet.http.HttpServletResponse
 
+import scala.collection.JavaConverters._
+
 import org.apache.celeborn.rest.v1.master._
 import org.apache.celeborn.rest.v1.master.invoker._
 import org.apache.celeborn.rest.v1.model.{ExcludeWorkerRequest, RemoveWorkersUnavailableInfoRequest, SendWorkerEventRequest, WorkerId}
@@ -70,6 +72,8 @@ class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
     val api = new WorkerApi(masterApiClient)
     var workersResponse = api.getWorkers
     assert(!workersResponse.getWorkers.isEmpty)
+    assert(workersResponse.getWorkers.asScala.forall(
+      _.getVersion === org.apache.celeborn.common.CELEBORN_VERSION))
     assert(workersResponse.getLostWorkers.isEmpty)
     assert(workersResponse.getExcludedWorkers.isEmpty)
     assert(workersResponse.getManualExcludedWorkers.isEmpty)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResourceSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResourceSuite.scala
@@ -69,6 +69,7 @@ class ApiV1WorkerResourceSuite extends ApiV1BaseResourceSuite with MiniClusterFe
     assert(workerData.getIsRegistered)
     assert(!workerData.getIsShutdown)
     assert(!workerData.getIsDecommissioning)
+    assert(workerData.getVersion === org.apache.celeborn.common.CELEBORN_VERSION)
 
     response = webTarget.path("workers/unavailable_peers").request(MediaType.APPLICATION_JSON).get()
     assert(HttpServletResponse.SC_OK == response.getStatus)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. build `celeborn-version-info.properties` to get the celeborn version in code.
2. when registering the worker, transfer the worker version 
3. support to get the worker versions with master RESTful API, `/ap1/v1/workers`.

### Why are the changes needed?
It is helpful for celeborn cluster maintain and feature rollout, especially for large celeborn cluster.

### Does this PR introduce _any_ user-facing change?
No break change. Introduce a new field of WorkerInfo.

### How was this patch tested?

UT and IT.
<img width="767" alt="image" src="https://github.com/user-attachments/assets/4fa26018-d8e7-4ad6-821a-03880831502f" />
