### PR TITLE
[CELEBORN-1686] Avoid return the same pushTaskQueue

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SendBufferPool.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SendBufferPool.java
@@ -17,7 +17,9 @@
 
 package org.apache.spark.shuffle.celeborn;
 
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -45,7 +47,7 @@ public class SendBufferPool {
   // numPartitions -> buffers
   private final LinkedList<byte[][]> buffers;
   private long lastAquireTime;
-  private final LinkedList<LinkedBlockingQueue<PushTask>> pushTaskQueues;
+  private final LinkedHashSet<LinkedBlockingQueue<PushTask>> pushTaskQueues;
 
   private ScheduledExecutorService cleaner =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor("celeborn-client-sendBufferPool-cleaner");
@@ -54,7 +56,7 @@ public class SendBufferPool {
     assert capacity > 0;
     this.capacity = capacity;
     buffers = new LinkedList<>();
-    pushTaskQueues = new LinkedList<>();
+    pushTaskQueues = new LinkedHashSet<>();
 
     lastAquireTime = System.currentTimeMillis();
     cleaner.scheduleWithFixedDelay(
@@ -90,7 +92,7 @@ public class SendBufferPool {
   public synchronized LinkedBlockingQueue<PushTask> acquirePushTaskQueue() {
     lastAquireTime = System.currentTimeMillis();
     if (!pushTaskQueues.isEmpty()) {
-      return pushTaskQueues.removeFirst();
+      return removeFirst(pushTaskQueues);
     }
     return null;
   }
@@ -104,8 +106,18 @@ public class SendBufferPool {
 
   public synchronized void returnPushTaskQueue(LinkedBlockingQueue<PushTask> pushTaskQueue) {
     if (pushTaskQueues.size() == capacity) {
-      pushTaskQueues.removeFirst();
+      removeFirst(pushTaskQueues);
     }
-    pushTaskQueues.addLast(pushTaskQueue);
+    pushTaskQueues.add(pushTaskQueue);
+  }
+
+  private static <T> T removeFirst(Collection<? extends T> c) {
+    Iterator<? extends T> it = c.iterator();
+    if (!it.hasNext()) {
+      return null;
+    }
+    T removed = it.next();
+    it.remove();
+    return removed;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
@@ -505,7 +505,7 @@ public class SortBasedPusher extends MemoryConsumer {
     cleanupResources();
     try {
       dataPusher.waitOnTermination();
-      sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());
+      sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
     } catch (InterruptedException e) {
       if (throwTaskKilledOnInterruption) {
         TaskInterruptedHelper.throwTaskKillException();

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -325,7 +325,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private void cleanupPusher() throws IOException {
     try {
       dataPusher.waitOnTermination();
-      sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());
+      sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
     } catch (InterruptedException e) {
       TaskInterruptedHelper.throwTaskKillException();
     }
@@ -334,7 +334,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private void close() throws IOException, InterruptedException {
     // here we wait for all the in-flight batches to return which sent by dataPusher thread
     dataPusher.waitOnTermination();
-    sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());
+    sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
     shuffleClient.prepareForMergeData(shuffleId, mapId, encodedAttemptId);
 
     // merge and push residual data to reduce network traffic

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -359,7 +359,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private void cleanupPusher() throws IOException {
     try {
       dataPusher.waitOnTermination();
-      sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());
+      sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
     } catch (InterruptedException e) {
       TaskInterruptedHelper.throwTaskKillException();
     }
@@ -369,7 +369,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     // here we wait for all the in-flight batches to return which sent by dataPusher thread
     long pushMergedDataTime = System.nanoTime();
     dataPusher.waitOnTermination();
-    sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());
+    sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
     shuffleClient.prepareForMergeData(shuffleId, mapId, encodedAttemptId);
     closeWrite();
     shuffleClient.pushMergedData(shuffleId, mapId, encodedAttemptId);

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -41,7 +41,7 @@ public class DataPusher {
 
   private final long WAIT_TIME_NANOS = TimeUnit.MILLISECONDS.toNanos(500);
 
-  private final LinkedBlockingQueue<PushTask> idleQueue;
+  private LinkedBlockingQueue<PushTask> idleQueue;
   // partition -> PushTask Queue
   private final DataPushQueue dataPushQueue;
   private final ReentrantLock idleLock = new ReentrantLock();
@@ -235,7 +235,9 @@ public class DataPusher {
     return dataPushQueue;
   }
 
-  public LinkedBlockingQueue<PushTask> getIdleQueue() {
-    return idleQueue;
+  public LinkedBlockingQueue<PushTask> getAndResetIdleQueue() {
+    LinkedBlockingQueue<PushTask> queue = idleQueue;
+    idleQueue = null;
+    return queue;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
The close method of `SortBasedShuffleWriter#write` will call `sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());`, but the close method may be interrupted.

After the interruption, `SortBasedShuffleWriter#cleanupPusher` will be called, and `sendBufferPool.returnPushTaskQueue(dataPusher.getIdleQueue());` will also be called.

Since `SendBufferPool#pushTaskQueues` is a `LinkedList`, repeated add will store two identical `idleQueue`, which may cause multiple tasks running in parallel to share the same `idleQueue`, resulting in inaccurate data.


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
Production environment verification
