### PR TITLE
[CELEBORN-1190][FOLLOWUP] Fix WARNING of error prone

### DIFF
--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
@@ -140,17 +140,12 @@ public class TransportFrameDecoderWithBufferSupplierSuiteJ {
     int bufferSizeBytes = 10 * 1024;
     ConcurrentHashMap<Long, Supplier<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf>>
         supplier = JavaUtils.newConcurrentHashMap();
-    List<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf> buffers = new ArrayList<>();
 
     supplier.put(
         0L,
-        () -> {
-          org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf buffer =
-              org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.buffer(
-                  bufferSizeBytes, bufferSizeBytes);
-          buffers.add(buffer);
-          return buffer;
-        });
+        () ->
+            org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.buffer(
+                bufferSizeBytes, bufferSizeBytes));
 
     TransportFrameDecoderWithBufferSupplier decoder =
         new TransportFrameDecoderWithBufferSupplier(

--- a/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -140,7 +140,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
 
   private List<SupplierWithException<BufferPool, IOException>> createBufferPoolFactory() {
     NetworkBufferPool networkBufferPool =
-        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofMillis(1000));
+        new NetworkBufferPool(256 * 8, 32 * 1024, Duration.ofSeconds(1));
 
     int numBuffersPerPartition = 64 * 1024 / 32;
     int numForResultPartition = numBuffersPerPartition * 7 / 8;

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -636,6 +636,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     return pbReportShuffleFetchFailureResponse.getSuccess();
   }
 
+  @Override
   public boolean reportBarrierTaskFailure(int appShuffleId, String appShuffleIdentifier) {
     PbReportBarrierStageAttemptFailure pbReportBarrierStageAttemptFailure =
         PbReportBarrierStageAttemptFailure.newBuilder()

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1910,6 +1910,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     return dataClientFactory;
   }
 
+  @Override
   public void excludeFailedFetchLocation(String hostAndFetchPort, Exception e) {
     if (pushReplicateEnabled
         && fetchExcludeWorkerOnFailureEnabled

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
 
 import scala.Tuple2;
@@ -314,23 +313,6 @@ public abstract class CelebornInputStream extends InputStream {
       } else {
         return true;
       }
-    }
-
-    private boolean isCriticalCause(Exception e) {
-      boolean rpcTimeout =
-          e instanceof IOException
-              && e.getCause() != null
-              && e.getCause() instanceof TimeoutException;
-      boolean connectException =
-          e instanceof CelebornIOException
-              && e.getMessage() != null
-              && (e.getMessage().startsWith("Connecting to")
-                  || e.getMessage().startsWith("Failed to"));
-      boolean fetchChunkTimeout =
-          e instanceof CelebornIOException
-              && e.getCause() != null
-              && e.getCause() instanceof IOException;
-      return connectException || rpcTimeout || fetchChunkTimeout;
     }
 
     private PartitionReader createReaderWithRetry(

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -183,6 +183,7 @@ public class DummyShuffleClient extends ShuffleClient {
     return true;
   }
 
+  @Override
   public boolean reportBarrierTaskFailure(int appShuffleId, String appShuffleIdentifier) {
     return true;
   }

--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.common.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -202,13 +203,11 @@ public class MasterClientSuiteJ {
     MasterClient client = new MasterClient(rpcEnv, conf, false);
     HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
 
-    try {
-      client.askSync(message, HeartbeatFromWorkerResponse.class);
-      fail("It should be exceptions when sending one-way message.");
-    } catch (Throwable t) {
-      assertTrue(t.getCause() instanceof IOException);
-      assertEquals(1, client.getMaxRetries());
-    }
+    Throwable throwable =
+        assertThrows(
+            Throwable.class, () -> client.askSync(message, HeartbeatFromWorkerResponse.class));
+    assertTrue(throwable.getCause() instanceof IOException);
+    assertEquals(1, client.getMaxRetries());
   }
 
   @Test

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
@@ -58,6 +58,7 @@ public class SaslTestBase {
   static final String TEST_USER = "appId";
   static final String TEST_SECRET = "secret";
 
+  @SuppressWarnings("Finally")
   void authHelper(
       TransportConf conf,
       TransportServerBootstrap serverBootstrap,

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/RecyclableSegmentIdBuffer.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/RecyclableSegmentIdBuffer.java
@@ -34,6 +34,7 @@ public class RecyclableSegmentIdBuffer extends RecyclableBuffer {
     return segmentId;
   }
 
+  @Override
   public boolean isDataBuffer() {
     return false;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/segment/SegmentMapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/segment/SegmentMapPartitionDataReader.java
@@ -276,9 +276,10 @@ public class SegmentMapPartitionDataReader extends MapPartitionDataReader {
       }
       if (segmentId != -1) {
         // For the continuous segments, we use the same backlog
+        Integer subPartitionLastSegmentId = subPartitionLastSegmentIds.get(subPartitionId);
         if (segmentId == 0
-            || !segmentId.equals(subPartitionLastSegmentIds.get(subPartitionId))
-                && segmentId != (subPartitionLastSegmentIds.get(subPartitionId) + 1)) {
+            || (!segmentId.equals(subPartitionLastSegmentId)
+                && !segmentId.equals(subPartitionLastSegmentId + 1))) {
           addNewBacklog();
         }
         subPartitionLastSegmentIds.put(subPartitionId, segmentId);
@@ -296,6 +297,7 @@ public class SegmentMapPartitionDataReader extends MapPartitionDataReader {
     }
   }
 
+  @Override
   public RequestMessage generateReadDataMessage(
       long streamId, int subPartitionId, ByteBuf byteBuf) {
     return new SubPartitionReadData(streamId, subPartitionId, byteBuf);

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/segment/SegmentMapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/segment/SegmentMapPartitionDataReader.java
@@ -276,7 +276,7 @@ public class SegmentMapPartitionDataReader extends MapPartitionDataReader {
       }
       if (segmentId != -1) {
         // For the continuous segments, we use the same backlog
-        Integer subPartitionLastSegmentId = subPartitionLastSegmentIds.get(subPartitionId);
+        int subPartitionLastSegmentId = subPartitionLastSegmentIds.get(subPartitionId);
         if (segmentId == 0
             || (!segmentId.equals(subPartitionLastSegmentId)
                 && !segmentId.equals(subPartitionLastSegmentId + 1))) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `WARNING` of error prone.

### Why are the changes needed?

There are many `WARNING` generated by error prone. We should follow the suggestion of error prone to fix `WARNING`.

```
$ mvn clean install -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep "[WARNING]"|grep java
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java:[100,8] [Finally] If you return or throw from a finally, then values returned or thrown from the try-catch block will be ignored. Consider using try-with-resources instead.
[WARNING] /Users/nicholas/Github/celeborn/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java:[207,10] [AssertionFailureIgnored] This assertion throws an AssertionError if it fails, which will be caught by an enclosing try block.
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java:[319,20] [UnusedMethod] Private method 'isCriticalCause' is never used.
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[635,17] [MissingOverride] reportBarrierTaskFailure implements method in ShuffleClient; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java:[1913,14] [MissingOverride] excludeFailedFetchLocation implements method in ShuffleClient; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java:[186,17] [MissingOverride] reportBarrierTaskFailure implements method in ShuffleClient; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/RecyclableSegmentIdBuffer.java:[37,17] [MissingOverride] isDataBuffer overrides method in RecyclableBuffer; expected @Override
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/segment/SegmentMapPartitionDataReader.java:[281,16] [OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
[WARNING] /Users/nicholas/Github/celeborn/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/segment/SegmentMapPartitionDataReader.java:[299,24] [MissingOverride] generateReadDataMessage overrides method in MapPartitionDataReader; expected @Override
```

```
$ mvn clean install -Pflink-1.20 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep "[WARNING]"|grep java
[WARNING] /Users/nicholas/Github/celeborn/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java:[143,75] [ModifiedButNotUsed] A collection or proto builder was created, but its values were never accessed.
[WARNING] /Users/nicholas/Github/celeborn/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java:[143,67] [CanonicalDuration] Duration can be expressed more clearly with different units
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

```
$ mvn clean install -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pspark-2.4 -pl client-spark/common,client-spark/spark-2 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pspark-3.5 -pl client-spark/spark-3 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.14 -pl client-flink/common,client-flink/flink-1.14 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.15 -pl client-flink/flink-1.15 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.16 -pl client-flink/flink-1.16 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.17 -pl client-flink/flink-1.17 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.18 -pl client-flink/flink-1.18 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.19 -pl client-flink/flink-1.19 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pflink-1.20 -pl client-flink/flink-1.20 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
$ mvn clean install -Pmr -pl client-mr/mr -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.check.skip=true|grep WARNING|grep java
```