### PR TITLE
CELEBORN-1689: CLI Support for Ratis APIs

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,35 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to You under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
       <list>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="ISSUE-(\d+)"/>
-          <option name="linkRegexp" value="https://github.com/apache/celeborn/issues/$1"/>
+          <option name="issueRegexp" value="[A-Z]+\-\d+" />
+          <option name="linkRegexp" value="https://go/jira $0" />
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="CELEBORN\-\d+"/>
-          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0"/>
+          <option name="issueRegexp" value="RB[\-=](\d+)" />
+          <option name="linkRegexp" value="https://go/rb $1" />
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="#(\d+)"/>
-          <option name="linkRegexp" value="https://github.com/apache/celeborn/pull/$1"/>
+          <option name="issueRegexp" value="ISSUE-(\d+)" />
+          <option name="linkRegexp" value="https://github.com/apache/celeborn/issues/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="CELEBORN\-\d+" />
+          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/apache/celeborn/pull/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\(#(\d+)\)" />
+          <option name="linkRegexp" value="https://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@github.com/akpatnam25/incubator-celeborn/issues/$1" />
         </IssueNavigationLink>
       </list>
     </option>

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -123,7 +123,8 @@ final class MasterOptions {
 
   @Option(
     names = Array("--transfer-ratis-leader"),
-    description = Array("Transfer the group leader to the specified server. Specify leader via --peerAddress."))
+    description =
+      Array("Transfer the group leader to the specified server. Specify leader via --peerAddress."))
   private[master] var transferRatisLeader: Boolean = _
 
   @Option(
@@ -153,7 +154,8 @@ final class MasterOptions {
 
   @Option(
     names = Array("--set-ratis-peers-priorities"),
-    description = Array("Set the priority of the peers in the raft group. Specify priorities via --priorities."))
+    description = Array(
+      "Set the priority of the peers in the raft group. Specify priorities via --priorities."))
   private[master] var setRatisPeersPriorities: Boolean = _
 
   @Option(
@@ -161,4 +163,3 @@ final class MasterOptions {
     description = Array("Trigger the current server to take snapshot."))
   private[master] var createSnapshot: Boolean = _
 }
-

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -120,4 +120,45 @@ final class MasterOptions {
     names = Array("--delete-apps"),
     description = Array("Delete resource of an application."))
   private[master] var deleteApps: Boolean = _
+
+  @Option(
+    names = Array("--transfer-ratis-leader"),
+    description = Array("Transfer the group leader to the specified server. Specify leader via --peerAddress."))
+  private[master] var transferRatisLeader: Boolean = _
+
+  @Option(
+    names = Array("--step-down-ratis-leader"),
+    description = Array("Step down from group leadership."))
+  private[master] var stepDownRatisLeader: Boolean = _
+
+  @Option(
+    names = Array("--pause-leader-election"),
+    description = Array("Pause leader election at the current server."))
+  private[master] var pauseLeaderElection: Boolean = _
+
+  @Option(
+    names = Array("--resume-leader-election"),
+    description = Array("Resume leader election at the current server."))
+  private[master] var resumeLeaderElection: Boolean = _
+
+  @Option(
+    names = Array("--add-ratis-peers"),
+    description = Array("Add new peers to the raft group. Specify peers list via --peers."))
+  private[master] var addRatisPeers: Boolean = _
+
+  @Option(
+    names = Array("--remove-ratis-peers"),
+    description = Array("Remove new peers from the raft group. Specify peers list via --peers."))
+  private[master] var removeRatisPeers: Boolean = _
+
+  @Option(
+    names = Array("--set-ratis-peers-priorities"),
+    description = Array("Set the priority of the peers in the raft group. Specify priorities via --priorities."))
+  private[master] var setRatisPeersPriorities: Boolean = _
+
+  @Option(
+    names = Array("--create-snapshot"),
+    description = Array("Trigger the current server to take snapshot."))
+  private[master] var createSnapshot: Boolean = _
 }
+

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
@@ -18,8 +18,10 @@
 package org.apache.celeborn.cli.master
 
 import java.util
+
 import picocli.CommandLine.{ArgGroup, Mixin, ParameterException, ParentCommand, Spec}
 import picocli.CommandLine.Model.CommandSpec
+
 import org.apache.celeborn.cli.CelebornCli
 import org.apache.celeborn.cli.common.{CliLogging, CommonOptions}
 import org.apache.celeborn.cli.config.CliConfigManager

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
@@ -18,14 +18,12 @@
 package org.apache.celeborn.cli.master
 
 import java.util
-
 import picocli.CommandLine.{ArgGroup, Mixin, ParameterException, ParentCommand, Spec}
 import picocli.CommandLine.Model.CommandSpec
-
 import org.apache.celeborn.cli.CelebornCli
 import org.apache.celeborn.cli.common.{CliLogging, CommonOptions}
 import org.apache.celeborn.cli.config.CliConfigManager
-import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, MasterApi, ShuffleApi, WorkerApi}
+import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, MasterApi, RatisApi, ShuffleApi, WorkerApi}
 import org.apache.celeborn.rest.v1.master.invoker.ApiClient
 import org.apache.celeborn.rest.v1.model._
 
@@ -39,6 +37,9 @@ trait MasterSubcommand extends CliLogging {
 
   @ArgGroup(exclusive = false)
   private[master] var reviseLostShuffleOptions: ReviseLostShuffleOptions = _
+
+  @ArgGroup(exclusive = false)
+  private[master] var ratisOptions: RatisOptions = _
 
   @Mixin
   private[master] var commonOptions: CommonOptions = _
@@ -70,6 +71,8 @@ trait MasterSubcommand extends CliLogging {
   private[master] def masterApi: MasterApi = new MasterApi(apiClient)
   private[master] def shuffleApi: ShuffleApi = new ShuffleApi(apiClient)
   private[master] def workerApi: WorkerApi = new WorkerApi(apiClient)
+
+  private[master] def ratisApi: RatisApi = new RatisApi(apiClient)
 
   private[master] def runShowMastersInfo: MasterInfoResponse
 
@@ -116,5 +119,21 @@ trait MasterSubcommand extends CliLogging {
   private[master] def reviseLostShuffles: HandleResponse
 
   private[master] def deleteApps: HandleResponse
+
+  private[master] def transferRatisLeader: HandleResponse
+
+  private[master] def stepDownRatisLeader: HandleResponse
+
+  private[master] def pauseLeaderElection: HandleResponse
+
+  private[master] def resumeLeaderElection: HandleResponse
+
+  private[master] def addRatisPeers: HandleResponse
+
+  private[master] def removeRatisPeers: HandleResponse
+
+  private[master] def setRatisPeersPriorities: HandleResponse
+
+  private[master] def createSnapshot: HandleResponse
 
 }

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -274,7 +274,7 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
 
   override private[master] def setRatisPeersPriorities: HandleResponse = {
     ratisApi.setRatisPeerPriority(new RatisPeerSetPriorityRequest()
-      .addressPriorities(mapAsJavaMap(getRatisPeerPrioritiesMap)))
+      .addressPriorities(getRatisPeerPrioritiesMap))
   }
 
   override private[master] def createSnapshot: HandleResponse = ratisApi.createRatisSnapshot()
@@ -285,8 +285,12 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
     }.asJava
   }
 
-  private[master] def getRatisPeerPrioritiesMap: Map[String, Int] = {
-    parseCliMapping(ratisOptions.peers).map(e => (e._1, e._2.toInt)).toMap
+  private[master] def getRatisPeerPrioritiesMap: util.Map[String, Integer] = {
+    val javaMap: util.Map[String, Integer] = new util.HashMap[String, Integer]()
+    parseCliMapping(ratisOptions.peers).map(e => (e._1, e._2.toInt)).toMap.foreach {
+      case (k, v) => javaMap.put(k, Integer.valueOf(v))
+    }
+    javaMap
   }
 
   private def parseCliMapping(cliMappingString: String): List[(String, String)] = {

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/RatisOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/RatisOptions.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.cli.master
+
+import picocli.CommandLine.Option
+
+final class RatisOptions {
+
+  @Option(
+    names = Array("--peerAddress"),
+    description = Array("The peer address in form of host:port."))
+  private[master] var peerAddress: String = _
+
+  @Option(
+    names = Array("--peers"),
+    description = Array("The comma separated list of peers in" +
+      " the format id=host:port, e.g. `a=host1:9872,b=host2:9872`."))
+  private[master] var peers: String = _
+
+  @Option(
+    names = Array("--priorities"),
+    description = Array("The comma separated list of peers in" +
+      " the format host:port=priority, e.g. `host1:9872=0,host2:9872=1`."))
+  private[master] var priorities: String = _
+
+}

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -302,8 +302,8 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
   test("master --add-ratis-peers") {
     val args = prepareMasterArgs() ++ Array(
       "--add-ratis-peers",
-    "--peers",
-    "a=host1:9872")
+      "--peers",
+      "a=host1:9872")
     captureOutputAndValidateResponse(args, "Master HA is not enabled.")
   }
 

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -273,6 +273,62 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureOutputAndValidateResponse(args, "success: true")
   }
 
+  test("master --transfer-ratis-leader") {
+    val args = prepareMasterArgs() ++ Array(
+      "--transfer-ratis-leader",
+      "--peerAddress",
+      s"${master.masterArgs.host}:9872")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --step-down-ratis-leader") {
+    val args = prepareMasterArgs() ++ Array(
+      "--step-down-ratis-leader")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --pause-leader-election") {
+    val args = prepareMasterArgs() ++ Array(
+      "--pause-leader-election")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --resume-leader-election") {
+    val args = prepareMasterArgs() ++ Array(
+      "--resume-leader-election")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --add-ratis-peers") {
+    val args = prepareMasterArgs() ++ Array(
+      "--add-ratis-peers",
+    "--peers",
+    "a=host1:9872")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --remove-ratis-peers") {
+    val args = prepareMasterArgs() ++ Array(
+      "--remove-ratis-peers",
+      "--peers",
+      "a=host1:9872")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --set-ratis-peers-priorities") {
+    val args = prepareMasterArgs() ++ Array(
+      "--set-ratis-peers-priorities",
+      "--priorities",
+      "host1:9872-0")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
+  test("master --create-snapshot") {
+    val args = prepareMasterArgs() ++ Array(
+      "--create-snapshot")
+    captureOutputAndValidateResponse(args, "Master HA is not enabled.")
+  }
+
   private def prepareMasterArgs(): Array[String] = {
     Array(
       "master",

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -19,6 +19,7 @@ package org.apache.celeborn.cli
 
 import java.io.{ByteArrayOutputStream, File, PrintStream}
 import java.nio.file.{Files, Paths}
+
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.cli.config.CliConfigManager
 import org.apache.celeborn.common.CelebornConf
@@ -279,16 +280,22 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
       "--peerAddress",
       s"${master.masterArgs.host}:9872")
     // This test just makes sure the right API response is received since HA is not enabled for unit tests.
-    captureOutputAndValidateResponse(args, "", "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
-      " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
+    captureOutputAndValidateResponse(
+      args,
+      "",
+      "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
+        " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
   }
 
   test("master --step-down-ratis-leader") {
     val args = prepareMasterArgs() ++ Array(
       "--step-down-ratis-leader")
     // This test just makes sure the right API response is received since HA is not enabled for unit tests.
-    captureOutputAndValidateResponse(args, "", "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
-      " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
+    captureOutputAndValidateResponse(
+      args,
+      "",
+      "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
+        " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
   }
 
   test("master --pause-leader-election") {
@@ -311,8 +318,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
       "--peers",
       "a=host1:9872")
     // This test just makes sure the right API response is received since HA is not enabled for unit tests.
-    captureOutputAndValidateResponse(args, "", "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
-      " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
+    captureOutputAndValidateResponse(
+      args,
+      "",
+      "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
+        " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
   }
 
   test("master --remove-ratis-peers") {
@@ -321,8 +331,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
       "--peers",
       "a=host1:9872")
     // This test just makes sure the right API response is received since HA is not enabled for unit tests.
-    captureOutputAndValidateResponse(args, "", "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
-      " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
+    captureOutputAndValidateResponse(
+      args,
+      "",
+      "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
+        " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
   }
 
   test("master --set-ratis-peers-priorities") {
@@ -331,8 +344,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
       "--priorities",
       "host1:9872=0")
     // This test just makes sure the right API response is received since HA is not enabled for unit tests.
-    captureOutputAndValidateResponse(args, "", "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
-      " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
+    captureOutputAndValidateResponse(
+      args,
+      "",
+      "org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager" +
+        " cannot be cast to org.apache.celeborn.service.deploy.master.clustermeta.ha.HAMasterMetaManager")
   }
 
   test("master --create-snapshot") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add CLI support for Ratis REST APIs that were recently added in https://issues.apache.org/jira/browse/CELEBORN-1628
Leaving out local raft meta conf APIs for no since those are not as straightforward.  Will update those in another PR. 


### Why are the changes needed?
better ops since with REST API and CLI there is no need to log onto production hosts to manage ratis operations. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added unit tests
