### PR TITLE
[MINOR] Remove unused TODO comments in CelebornTierProducerAgent#processBuffer

### DIFF
--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierProducerAgent.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierProducerAgent.java
@@ -453,9 +453,9 @@ public class CelebornTierProducerAgent implements TierProducerAgent {
 
       Buffer buffer = originBuffer;
       if (originBuffer.isCompressed()) {
-        // In flink 1.20.0, it will receive a compressed buffer. However, since we need to write
-        // data to this buffer and the compressed buffer is read-only,
-        // we must create a new Buffer object to the wrap origin buffer.
+        // Flink hybrid shuffle will send a compressed buffer to tier. However, since we need to
+        // write data to this buffer and the compressed buffer is read-only, we must create a
+        // new Buffer object to the wrap origin buffer.
         NetworkBuffer networkBuffer =
             new NetworkBuffer(
                 originBuffer.getMemorySegment(),
@@ -465,9 +465,6 @@ public class CelebornTierProducerAgent implements TierProducerAgent {
         networkBuffer.writerIndex(originBuffer.asByteBuf().writerIndex());
         buffer = networkBuffer;
       }
-
-      // TODO: To enhance performance, the flink should pass an no-compressed buffer to producer
-      // agent and we compress the buffer here
 
       // set the buffer meta
       BufferUtils.setCompressedDataWithoutHeader(buffer, originBuffer);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Remove unused TODO comments in CelebornTierProducerAgent#processBuffer


### Why are the changes needed?
In order for buffers to be packed together, we are going to modify the Flink side implementation to delegate buffer compression to tiers. But after discussion, we have been able to handle the case of receiving the compressed buffer on the Celeborn side, so this TODO is no longer needed.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No need.
