### PR TITLE
[CELEBORN-1685] ShuffleFallbackPolicy supports ShuffleFallbackCount metric

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -1472,7 +1472,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The count of shuffle fallbacks.",
+          "description": "The total count of shuffle including celeborn shuffle and spark built-in shuffle.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1531,6 +1531,94 @@
             "y": 34
           },
           "id": 218,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "metrics_ShuffleTotalCount_Value{instance=~\"${instance}\"}",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_ShuffleTotalCount_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The count of shuffle fallbacks.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 219,
           "options": {
             "legend": {
               "calcs": [],

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -118,6 +118,7 @@ public class SparkShuffleManager implements ShuffleManager {
     String appId = SparkUtils.appUniqueId(dependency.rdd().context());
     initializeLifecycleManager(appId);
 
+    lifecycleManager.shuffleCount().increment();
     if (fallbackPolicyRunner.applyFallbackPolicies(dependency, lifecycleManager)) {
       logger.warn("Fallback to SortShuffleManager!");
       sortShuffleIds.add(shuffleId);

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleFallbackPolicyRunner.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.shuffle.celeborn
 
+import java.util.function.BiFunction
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.ShuffleDependency
@@ -35,12 +37,26 @@ class CelebornShuffleFallbackPolicyRunner(conf: CelebornConf) extends Logging {
   def applyFallbackPolicies[K, V, C](
       dependency: ShuffleDependency[K, V, C],
       lifecycleManager: LifecycleManager): Boolean = {
-    val needFallback =
-      shuffleFallbackPolicies.exists(_.needFallback(dependency, conf, lifecycleManager))
-    if (needFallback && FallbackPolicy.NEVER.equals(shuffleFallbackPolicy)) {
-      throw new CelebornIOException(
-        "Fallback to spark built-in shuffle implementation is prohibited.")
+    val fallbackPolicy =
+      shuffleFallbackPolicies.find(_.needFallback(dependency, conf, lifecycleManager))
+    if (fallbackPolicy.isDefined) {
+      if (FallbackPolicy.NEVER.equals(shuffleFallbackPolicy)) {
+        throw new CelebornIOException(
+          "Fallback to spark built-in shuffle implementation is prohibited.")
+      } else {
+        lifecycleManager.shuffleFallbackCounts.compute(
+          fallbackPolicy.getClass.getName,
+          new BiFunction[String, java.lang.Long, java.lang.Long] {
+            override def apply(k: String, v: java.lang.Long): java.lang.Long = {
+              if (v == null) {
+                1L
+              } else {
+                v + 1L
+              }
+            }
+          })
+      }
     }
-    needFallback
+    fallbackPolicy.isDefined
   }
 }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -161,8 +161,8 @@ public class SparkShuffleManager implements ShuffleManager {
     String appId = SparkUtils.appUniqueId(dependency.rdd().context());
     initializeLifecycleManager(appId);
 
+    lifecycleManager.shuffleCount().increment();
     if (fallbackPolicyRunner.applyFallbackPolicies(dependency, lifecycleManager)) {
-      lifecycleManager.shuffleFallbackCount().increment();
       if (conf.getBoolean("spark.dynamicAllocation.enabled", false)
           && !conf.getBoolean("spark.shuffle.service.enabled", false)) {
         logger.error(

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -442,7 +442,8 @@ message PbHeartbeatFromApplication {
   string requestId = 4;
   repeated PbWorkerInfo needCheckedWorkerList = 5;
   bool shouldResponse = 6;
-  int64 shuffleFallbackCount = 7;
+  int64 shuffleCount = 7;
+  map<string, int64> shuffleFallbackCounts = 8;
 }
 
 message PbHeartbeatFromApplicationResponse {
@@ -675,7 +676,8 @@ message PbSnapshotMetaInfo {
   map<string, PbWorkerEventInfo> workerEventInfos = 15;
   map<string, PbApplicationMeta> applicationMetas = 16;
   repeated PbWorkerInfo decommissionWorkers = 17;
-  int64 shuffleTotalFallbackCount = 18;
+  int64 shuffleTotalCount = 18;
+  map<string, int64> shuffleFallbackCounts = 19;
 }
 
 message PbOpenStream {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -412,7 +412,8 @@ object ControlMessages extends Logging {
       appId: String,
       totalWritten: Long,
       fileCount: Long,
-      shuffleFallbackCount: Long,
+      shuffleCount: Long,
+      shuffleFallbackCounts: util.Map[String, java.lang.Long],
       needCheckedWorkerList: util.List[WorkerInfo],
       override var requestId: String = ZERO_UUID,
       shouldResponse: Boolean = false) extends MasterRequestMessage
@@ -810,7 +811,8 @@ object ControlMessages extends Logging {
           appId,
           totalWritten,
           fileCount,
-          shuffleFallbackCount,
+          shuffleCount,
+          shuffleFallbackCounts,
           needCheckedWorkerList,
           requestId,
           shouldResponse) =>
@@ -819,7 +821,8 @@ object ControlMessages extends Logging {
         .setRequestId(requestId)
         .setTotalWritten(totalWritten)
         .setFileCount(fileCount)
-        .setShuffleFallbackCount(shuffleFallbackCount)
+        .setShuffleCount(shuffleCount)
+        .putAllShuffleFallbackCounts(shuffleFallbackCounts)
         .addAllNeedCheckedWorkerList(needCheckedWorkerList.asScala.map(
           PbSerDeUtils.toPbWorkerInfo(_, true, true)).toList.asJava)
         .setShouldResponse(shouldResponse)
@@ -1212,7 +1215,8 @@ object ControlMessages extends Logging {
           pbHeartbeatFromApplication.getAppId,
           pbHeartbeatFromApplication.getTotalWritten,
           pbHeartbeatFromApplication.getFileCount,
-          pbHeartbeatFromApplication.getShuffleFallbackCount,
+          pbHeartbeatFromApplication.getShuffleCount,
+          pbHeartbeatFromApplication.getShuffleFallbackCountsMap,
           new util.ArrayList[WorkerInfo](
             pbHeartbeatFromApplication.getNeedCheckedWorkerListList.asScala
               .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava),

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -466,7 +466,8 @@ object PbSerDeUtils {
       workers: java.util.Set[WorkerInfo],
       partitionTotalWritten: java.lang.Long,
       partitionTotalFileCount: java.lang.Long,
-      shuffleTotalFallbackCount: java.lang.Long,
+      shuffleTotalCount: java.lang.Long,
+      shuffleFallbackCounts: java.util.Map[String, java.lang.Long],
       appDiskUsageMetricSnapshots: Array[AppDiskUsageSnapShot],
       currentAppDiskUsageMetricsSnapshot: AppDiskUsageSnapShot,
       lostWorkers: ConcurrentHashMap[WorkerInfo, java.lang.Long],
@@ -488,7 +489,8 @@ object PbSerDeUtils {
       .addAllWorkers(workers.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .setPartitionTotalWritten(partitionTotalWritten)
       .setPartitionTotalFileCount(partitionTotalFileCount)
-      .setShuffleTotalFallbackCount(shuffleTotalFallbackCount)
+      .setShuffleTotalCount(shuffleTotalCount)
+      .putAllShuffleFallbackCounts(shuffleFallbackCounts)
       // appDiskUsageMetricSnapshots can have null values,
       // protobuf repeated value can't support null value in list.
       .addAllAppDiskUsageMetricSnapshots(appDiskUsageMetricSnapshots.filter(_ != null)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -92,24 +92,25 @@ These metrics are exposed by Celeborn master.
 
   - namespace=master
     
-    | Metric Name              | Description                                                                     |
-    |--------------------------|---------------------------------------------------------------------------------|
-    | RegisteredShuffleCount   | The count of registered shuffle.                                                |
-    | DeviceCelebornFreeBytes  | The actual usable space of Celeborn for device.                                 |
-    | DeviceCelebornTotalBytes | The total space of Celeborn for device.                                         |
-    | RunningApplicationCount  | The count of running applications.                                              |
-    | ActiveShuffleSize        | The active shuffle size of workers.                                             |
-    | ActiveShuffleFileCount   | The active shuffle file count of workers.                                       |
-    | ShuffleFallbackCount     | The count of shuffle fallbacks.                                                 |
-    | WorkerCount              | The count of active workers.                                                    |
-    | LostWorkerCount          | The count of workers in lost list.                                              |
-    | ExcludedWorkerCount      | The count of workers in excluded list.                                          |
-    | AvailableWorkerCount     | The count of workers in available list.                                         |
-    | ShutdownWorkerCount      | The count of workers in shutdown list.                                          |
-    | DecommissionWorkerCount  | The count of workers in decommission list.                                      |
-    | IsActiveMaster           | Whether the current master is active.                                           |
-    | PartitionSize            | The size of estimated shuffle partition.                                        |
-    | OfferSlotsTime           | The time for masters to handle `RequestSlots` request when registering shuffle. |
+    | Metric Name              | Description                                                                       |
+    |--------------------------|-----------------------------------------------------------------------------------|
+    | RegisteredShuffleCount   | The count of registered shuffle.                                                  |
+    | DeviceCelebornFreeBytes  | The actual usable space of Celeborn for device.                                   |
+    | DeviceCelebornTotalBytes | The total space of Celeborn for device.                                           |
+    | RunningApplicationCount  | The count of running applications.                                                |
+    | ActiveShuffleSize        | The active shuffle size of workers.                                               |
+    | ActiveShuffleFileCount   | The active shuffle file count of workers.                                         |
+    | ShuffleTotalCount        | The total count of shuffle including celeborn shuffle and spark built-in shuffle. |
+    | ShuffleFallbackCount     | The count of shuffle fallbacks.                                                   |
+    | WorkerCount              | The count of active workers.                                                      |
+    | LostWorkerCount          | The count of workers in lost list.                                                |
+    | ExcludedWorkerCount      | The count of workers in excluded list.                                            |
+    | AvailableWorkerCount     | The count of workers in available list.                                           |
+    | ShutdownWorkerCount      | The count of workers in shutdown list.                                            |
+    | DecommissionWorkerCount  | The count of workers in decommission list.                                        |
+    | IsActiveMaster           | Whether the current master is active.                                             |
+    | PartitionSize            | The size of estimated shuffle partition.                                          |
+    | OfferSlotsTime           | The time for masters to handle `RequestSlots` request when registering shuffle.   |
 
   - namespace=CPU
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -42,7 +42,8 @@ public interface IMetadataHandler {
       String appId,
       long totalWritten,
       long fileCount,
-      long shuffleFallbackCount,
+      long shuffleCount,
+      Map<String, Long> shuffleFallbackCounts,
       long time,
       String requestId);
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -76,10 +76,12 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
       String appId,
       long totalWritten,
       long fileCount,
-      long shuffleFallbackCount,
+      long shuffleCount,
+      Map<String, Long> shuffleFallbackCounts,
       long time,
       String requestId) {
-    updateAppHeartbeatMeta(appId, time, totalWritten, fileCount, shuffleFallbackCount);
+    updateAppHeartbeatMeta(
+        appId, time, totalWritten, fileCount, shuffleCount, shuffleFallbackCounts);
   }
 
   @Override

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -133,7 +133,8 @@ public class HAMasterMetaManager extends AbstractMetaManager {
       String appId,
       long totalWritten,
       long fileCount,
-      long shuffleFallbackCount,
+      long shuffleCount,
+      Map<String, Long> shuffleFallbackCounts,
       long time,
       String requestId) {
     try {
@@ -147,7 +148,8 @@ public class HAMasterMetaManager extends AbstractMetaManager {
                       .setTime(time)
                       .setTotalWritten(totalWritten)
                       .setFileCount(fileCount)
-                      .setShuffleFallbackCount(shuffleFallbackCount)
+                      .setShuffleCount(shuffleCount)
+                      .putAllShuffleFallbackCounts(shuffleFallbackCounts)
                       .build())
               .build());
     } catch (CelebornRuntimeException e) {

--- a/master/src/main/proto/Resource.proto
+++ b/master/src/main/proto/Resource.proto
@@ -120,7 +120,8 @@ message AppHeartbeatRequest {
   required int64 time = 2;
   required int64 totalWritten = 3;
   required int64 fileCount = 4;
-  optional int64 shuffleFallbackCount = 5;
+  optional int64 shuffleCount = 5;
+  map<string, int64> shuffleFallbackCounts = 6;
 }
 
 message AppLostRequest {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -44,6 +44,9 @@ object MasterSource {
   val DECOMMISSION_WORKER_COUNT = "DecommissionWorkerCount"
 
   val REGISTERED_SHUFFLE_COUNT = "RegisteredShuffleCount"
+  val SHUFFLE_FALLBACK_COUNT = "ShuffleFallbackCount"
+  // The total count including RegisteredShuffleCount(celeborn shuffle) and ShuffleFallbackCount(spark built-in shuffle).
+  val SHUFFLE_TOTAL_COUNT = "ShuffleTotalCount"
 
   val RUNNING_APPLICATION_COUNT = "RunningApplicationCount"
 
@@ -54,8 +57,6 @@ object MasterSource {
   val ACTIVE_SHUFFLE_SIZE = "ActiveShuffleSize"
 
   val ACTIVE_SHUFFLE_FILE_COUNT = "ActiveShuffleFileCount"
-
-  val SHUFFLE_FALLBACK_COUNT = "ShuffleFallbackCount"
 
   val OFFER_SLOTS_TIME = "OfferSlotsTime"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. `ShuffleFallbackPolicy` supports `ShuffleFallbackCount` metric to provide the shuffle fallback count of each fallback policy.
2. Introduce `ShuffleTotalCount` metric to record the total count of shuffle.
3. Fix Spark 2 does not increment shuffle count via `LifecycleManager`.

### Why are the changes needed?

The implementations of `ShuffleFallbackPolicy` does not support `ShuffleFallbackCount` metric at present. Meanwhile, Bilibili production practice needs `ShuffleFallbackCount` of different `ShuffleFallbackPolicy`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Cluster test.