### PR TITLE
[CELEBORN-1707] Audit all RESTful api calls and use separate restAuditFile

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -128,7 +128,7 @@ data:
                 <Appender-ref ref="stdout" level="WARN" />
                 <Appender-ref ref="file" level="WARN"/>
             </Logger>
-            <Logger name="org.apache.celeborn.server.common.http.authentication.AuthenticationAuditLogger" level="INFO" additivity="false">
+            <Logger name="org.apache.celeborn.server.common.http.RestAuditLogger" level="INFO" additivity="false">
                 <Appender-ref ref="restAuditFile" level="INFO"/>
             </Logger>
         </Loggers>

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -100,6 +100,23 @@ data:
                     </Delete>
                 </DefaultRolloverStrategy>
             </RollingRandomAccessFile>
+            <RollingRandomAccessFile name="restAuditFile" fileName="${env:CELEBORN_LOG_DIR}/audit/rest-audit.log"
+                                     filePattern="${env:CELEBORN_LOG_DIR}/audit/rest-audit.log.%d-%i">
+                <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+                <Policies>
+                    <SizeBasedTriggeringPolicy size="200 MB"/>
+                </Policies>
+                <DefaultRolloverStrategy max="7">
+                    <Delete basePath="${env:CELEBORN_LOG_DIR}/audit" maxDepth="1">
+                        <IfFileName glob="rest-audit.log*">
+                            <IfAny>
+                                <IfAccumulatedFileSize exceeds="1 GB"/>
+                                <IfAccumulatedFileCount exceeds="10"/>
+                            </IfAny>
+                        </IfFileName>
+                    </Delete>
+                </DefaultRolloverStrategy>
+            </RollingRandomAccessFile>
         </Appenders>
 
         <Loggers>
@@ -110,6 +127,9 @@ data:
             <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
                 <Appender-ref ref="stdout" level="WARN" />
                 <Appender-ref ref="file" level="WARN"/>
+            </Logger>
+            <Logger name="org.apache.celeborn.server.common.http.authentication.AuthenticationAuditLogger" level="INFO" additivity="false">
+                <Appender-ref ref="restAuditFile" level="INFO"/>
             </Logger>
         </Loggers>
     </Configuration>

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -49,6 +49,23 @@
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingRandomAccessFile>
+        <RollingRandomAccessFile name="restAuditFile" fileName="${env:CELEBORN_LOG_DIR}/audit/rest-audit.log"
+                                 filePattern="${env:CELEBORN_LOG_DIR}/audit/rest-audit.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}/audit" maxDepth="1">
+                    <IfFileName glob="rest-audit.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB"/>
+                            <IfAccumulatedFileCount exceeds="10"/>
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
     </Appenders>
 
     <Loggers>
@@ -66,6 +83,9 @@
         <Logger name="org.apache.ratis.server.RaftServerConfigKeys" level="WARN" additivity="false">
             <!-- <Appender-ref ref="stdout" level="WARN"/>-->
             <Appender-ref ref="file" level="WARN"/>
+        </Logger>
+        <Logger name="org.apache.celeborn.server.common.http.authentication.AuthenticationAuditLogger" level="INFO" additivity="false">
+            <Appender-ref ref="restAuditFile" level="INFO"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -84,7 +84,7 @@
             <!-- <Appender-ref ref="stdout" level="WARN"/>-->
             <Appender-ref ref="file" level="WARN"/>
         </Logger>
-        <Logger name="org.apache.celeborn.server.common.http.authentication.AuthenticationAuditLogger" level="INFO" additivity="false">
+        <Logger name="org.apache.celeborn.server.common.http.RestAuditLogger" level="INFO" additivity="false">
             <Appender-ref ref="restAuditFile" level="INFO"/>
         </Logger>
     </Loggers>

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/RestAuditLogger.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/RestAuditLogger.scala
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.server.common.http.authentication
+package org.apache.celeborn.server.common.http
 
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.AuthenticationFilter._
 
-object AuthenticationAuditLogger extends Logging {
+object RestAuditLogger extends Logging {
   final private val AUDIT_BUFFER = new ThreadLocal[StringBuilder]() {
     override protected def initialValue: StringBuilder = new StringBuilder()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Audit all RESTful api calls and use separate restAuditFile.

### Why are the changes needed?
Audit all the api calls and use the separate log file to easy check the audit log.

### Does this PR introduce _any_ user-facing change?

No, this feature has not been released.

### How was this patch tested?

```
build/sbt "clean;celeborn-master/testOnly *ApiV1MasterResourceSuite"
```

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/7b94fd89-005b-4f48-ab24-cc4ae7f473e5">

