### PR TITLE
[CELEBORN-1708] Bump protobuf version from 3.21.7 to 3.25.5

### DIFF
--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-flink-1.16
+++ b/dev/deps/dependencies-client-flink-1.16
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-flink-1.19
+++ b/dev/deps/dependencies-client-flink-1.19
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-flink-1.20
+++ b/dev/deps/dependencies-client-flink-1.20
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -179,7 +179,7 @@ nimbus-jose-jwt/9.8.1//nimbus-jose-jwt-9.8.1.jar
 okhttp/4.9.3//okhttp-4.9.3.jar
 okio/2.8.0//okio-2.8.0.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 re2j/1.1//re2j-1.1.jar
 reload4j/1.2.22//reload4j-1.2.22.jar
 scala-library/2.12.18//scala-library-2.12.18.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.11.12//scala-library-2.11.12.jar
 scala-reflect/2.11.12//scala-reflect-2.11.12.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.10//scala-library-2.12.10.jar
 scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.10//scala-library-2.12.10.jar
 scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.15//scala-library-2.12.15.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.15//scala-library-2.12.15.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.17//scala-library-2.12.17.jar
 scala-reflect/2.12.17//scala-reflect-2.12.17.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -72,7 +72,7 @@ netty-transport-sctp/4.1.109.Final//netty-transport-sctp-4.1.109.Final.jar
 netty-transport-udt/4.1.109.Final//netty-transport-udt-4.1.109.Final.jar
 netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -121,7 +121,7 @@ netty-transport/4.1.109.Final//netty-transport-4.1.109.Final.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
 picocli/4.7.6//picocli-4.7.6.jar
-protobuf-java/3.21.7//protobuf-java-3.21.7.jar
+protobuf-java/3.25.5//protobuf-java-3.25.5.jar
 ratis-client/3.1.1//ratis-client-3.1.1.jar
 ratis-common/3.1.1//ratis-common-3.1.1.jar
 ratis-grpc/3.1.1//ratis-grpc-3.1.1.jar

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/GrpcRatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/GrpcRatisMasterStatusSystemSuiteJ.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.clustermeta.ha;
+
+import org.junit.BeforeClass;
+
+import org.apache.celeborn.common.CelebornConf;
+
+public class GrpcRatisMasterStatusSystemSuiteJ extends RatisMasterStatusSystemSuiteJ {
+  @BeforeClass
+  public static void init() throws Exception {
+    resetRaftServer(
+        configureServerConf(
+            new CelebornConf().set(CelebornConf.HA_MASTER_RATIS_RPC_TYPE().key(), "grpc"), 1),
+        configureServerConf(
+            new CelebornConf().set(CelebornConf.HA_MASTER_RATIS_RPC_TYPE().key(), "grpc"), 2),
+        configureServerConf(
+            new CelebornConf().set(CelebornConf.HA_MASTER_RATIS_RPC_TYPE().key(), "grpc"), 3),
+        false);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <mockito-scalatest.version>1.17.14</mockito-scalatest.version>
     <netty.version>4.1.109.Final</netty.version>
     <bouncycastle.version>1.77</bouncycastle.version>
-    <protobuf.version>3.21.7</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <ratis.version>3.1.1</ratis.version>
     <scalatest.version>3.2.16</scalatest.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -88,8 +88,8 @@ object Dependencies {
   val bouncycastleVersion = "1.77"
 
   // Versions for proto
-  val protocVersion = "3.21.7"
-  val protoVersion = "3.21.7"
+  val protocVersion = "3.25.5"
+  val protoVersion = "3.25.5"
 
   val apLoader = "me.bechberger" % "ap-loader-all" % apLoaderVersion
   val commonsCompress = "org.apache.commons" % "commons-compress" % commonsCompressVersion


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Bump protobuf from 3.21.7 to 3.25.5.

### Why are the changes needed?

To fix CVE: https://github.com/advisories/GHSA-735f-pc8j-v9w8


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

GA.