### PR TITLE
[CELEBORN-1710] Bump commons-io version from 2.13.0 to 2.17.0

### DIFF
--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-flink-1.16
+++ b/dev/deps/dependencies-client-flink-1.16
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-flink-1.19
+++ b/dev/deps/dependencies-client-flink-1.19
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-flink-1.20
+++ b/dev/deps/dependencies-client-flink-1.20
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -30,7 +30,7 @@ commons-compress/1.4.1//commons-compress-1.4.1.jar
 commons-configuration2/2.8.0//commons-configuration2-2.8.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-daemon/1.0.13//commons-daemon-1.0.13.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.1.1//commons-math3-3.1.1.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -17,7 +17,7 @@
 
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -22,7 +22,7 @@ ap-loader-all/3.0-8//ap-loader-all-3.0-8.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
 commons-cli/1.5.0//commons-cli-1.5.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.17.0//commons-io-2.17.0.jar
 commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     -->
     <codahale.metrics.version>4.2.25</codahale.metrics.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
-    <commons-io.version>2.13.0</commons-io.version>
+    <commons-io.version>2.17.0</commons-io.version>
     <commons-crypto.version>1.0.0</commons-crypto.version>
     <!-- last version to support compilation in java 8. See https://errorprone.info/docs/installation#:~:text=you%20are%20using.-,JDK%208,-Error%20Prone%202.10.0 -->
     <error-prone.version>2.10.0</error-prone.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -44,7 +44,7 @@ object Dependencies {
   val apLoaderVersion = "3.0-8"
   val commonsCompressVersion = "1.4.1"
   val commonsCryptoVersion = "1.0.0"
-  val commonsIoVersion = "2.13.0"
+  val commonsIoVersion = "2.17.0"
   val commonsLoggingVersion = "1.1.3"
   val commonsLang3Version = "3.17.0"
   val findbugsVersion = "1.3.9"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
 Bump commons-io from 2.13.0 to 2.17.0


### Why are the changes needed?

To fix CVE: https://github.com/advisories/GHSA-78wr-2p64-hpwj 

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA.
