### PR TITLE
[CELEBORN-1504][FOLLOWUP] Start test nodes in random ports to allow multiple builds run in the same ci server

### DIFF
--- a/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -53,17 +53,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
-public class RemoteShuffleMasterTest {
+public class RemoteShuffleMasterSuiteJ {
 
-  private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMasterTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMasterSuiteJ.class);
   private RemoteShuffleMaster remoteShuffleMaster;
   private Configuration configuration;
 
   @Before
   public void setUp() {
     configuration = new Configuration();
+    int startPort = Utils$.MODULE$.selectRandomPort(1024, 65535);
+    configuration.setInteger("celeborn.master.port", startPort);
+    configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Start test nodes in random ports to allow multiple builds run in the same ci server, which improves the test implementations so that it starts test nodes in random ports instead of using the hardcoded ones.

Follow up #2619.

### Why are the changes needed?

The test nodes are started in the hard coded ports, this prevents to run multiple builds in the same CI/CD server at present.

Bump the changes of #2237.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`RemoteShuffleMasterSuiteJ`