### PR TITLE
[CELEBORN-1631][FOLLOWUP] Add latest snapshot index in message of HandleResponse for /snapshot/create

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
@@ -241,7 +241,7 @@ class RatisResource extends ApiRequestContext with Logging {
     val reply = ratisServer.getServer.snapshotManagement(request)
     if (reply.isSuccess) {
       new HandleResponse().success(true).message(
-        s"Successfully create snapshot at ${ratisServer.getLocalAddress}.")
+        s"Successfully create snapshot at ${ratisServer.getLocalAddress}. The latest snapshot index is ${reply.getLogIndex}.")
     } else {
       new HandleResponse().success(false).message(
         s"Failed to create snapshot at ${ratisServer.getLocalAddress}. $reply")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add latest snapshot index in message of `HandleResponse` for `/snapshot/create`.

### Why are the changes needed?

[TakeSnapshotCommand.java#68](https://github.com/apache/ratis/blob/master/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/snapshot/TakeSnapshotCommand.java#L68) prints the latest snapshot index. Therefore,  the message of `HandleResponse` for `/snapshot/create` could also provide the latest snapshot index.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.