### PR TITLE
[CELEBORN-1685][FOLLOWUP] CelebornShuffleFallbackPolicyRunner should compute shuffleFallbackCounts via class name of ShuffleFallbackPolicy implementation

### DIFF
--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleFallbackPolicyRunner.scala
@@ -45,7 +45,7 @@ class CelebornShuffleFallbackPolicyRunner(conf: CelebornConf) extends Logging {
           "Fallback to spark built-in shuffle implementation is prohibited.")
       } else {
         lifecycleManager.shuffleFallbackCounts.compute(
-          fallbackPolicy.getClass.getName,
+          fallbackPolicy.get.getClass.getName,
           new BiFunction[String, java.lang.Long, java.lang.Long] {
             override def apply(k: String, v: java.lang.Long): java.lang.Long = {
               if (v == null) {

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleFallbackPolicyRunner.scala
@@ -43,7 +43,7 @@ class CelebornShuffleFallbackPolicyRunner(conf: CelebornConf) extends Logging {
           "Fallback to spark built-in shuffle implementation is prohibited.")
       } else {
         lifecycleManager.shuffleFallbackCounts.compute(
-          fallbackPolicy.getClass.getName,
+          fallbackPolicy.get.getClass.getName,
           (_, v) => {
             if (v == null) {
               1L


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CelebornShuffleFallbackPolicyRunner` should compute `shuffleFallbackCounts` via class name of `ShuffleFallbackPolicy` implementation.

Follow up #2891.

### Why are the changes needed?

`CelebornShuffleFallbackPolicyRunner` computes `shuffleFallbackCounts` via class name of `Option` instead of class name of `ShuffleFallbackPolicy` implementation at present.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.