### PR TITLE
[CELEBORN-1715] RemoteShuffleMaster should check celeborn.client.push.replicate.enabled in constructor

### DIFF
--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -218,6 +218,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -218,6 +218,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After

--- a/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -228,6 +228,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -240,6 +240,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -240,6 +240,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After

--- a/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -240,6 +240,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After

--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierMasterAgent.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornTierMasterAgent.java
@@ -87,11 +87,6 @@ public class CelebornTierMasterAgent implements TierMasterAgent {
         if (lifecycleManager == null) {
           celebornAppId = FlinkUtils.toCelebornAppId(lifecycleManagerTimestamp, jobID);
           LOG.info("CelebornAppId: {}", celebornAppId);
-          // The default value of this config option is false. If set to true, Celeborn will use
-          // local allocated workers as candidate being checked workers, this is more useful for
-          // map partition to regenerate the lost data. So if not set, set to true as default for
-          // flink.
-          conf.setIfMissing(CelebornConf.CLIENT_CHECKED_USE_ALLOCATED_WORKERS(), true);
           lifecycleManager = new LifecycleManager(celebornAppId, conf);
           this.shuffleResourceTracker = new ShuffleResourceTracker(executor, lifecycleManager);
         }

--- a/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -243,6 +243,14 @@ public class RemoteShuffleMasterSuiteJ {
                     .set(
                         ExecutionOptions.BATCH_SHUFFLE_MODE,
                         BatchShuffleMode.ALL_EXCHANGES_PIPELINED)));
+    Configuration configuration = new Configuration();
+    configuration.setString(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key(), "true");
+    Assert.assertThrows(
+        String.format(
+            "Flink does not support replicate shuffle data. Please check the config %s.",
+            CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED().key()),
+        IllegalArgumentException.class,
+        () -> createShuffleMaster(configuration));
   }
 
   @After


### PR DESCRIPTION
### What changes were proposed in this pull request?

`RemoteShuffleMaster` checks `celeborn.client.push.replicate.enabled` in constructor instead of `registerJob`.

### Why are the changes needed?

`RemoteShuffleMaster` checks whether `celeborn.client.push.replicate.enabled` is false in `registerJob`, which could check in constructor.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`RemoteShuffleMasterSuiteJ#testInvalidShuffleConfig `