### PR TITLE
[WIP][CELEBORN-1705] Fix abnormal disk buffer size/memory file storage size

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -528,7 +528,7 @@ public class MemoryManager {
     return memoryFileStorageCounter.sum() < memoryFileStorageThreshold;
   }
 
-  public void increaseMemoryFileStorage(int bytes) {
+  public void incrementMemoryFileStorage(int bytes) {
     memoryFileStorageCounter.add(bytes);
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -448,7 +448,9 @@ public abstract class PartitionDataWriter implements DeviceObserver {
       tryClose.run();
       waitOnNoPending(notifier.numPendingFlushes);
     } finally {
-      returnBuffer(false);
+      if (flushBuffer != null && flusher != null) {
+        flushBuffer = null;
+      }
       try {
         if (channel != null) {
           channel.close();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -317,7 +317,7 @@ public abstract class PartitionDataWriter implements DeviceObserver {
 
     final int numBytes = data.readableBytes();
     if (isMemoryShuffleFile.get()) {
-      MemoryManager.instance().increaseMemoryFileStorage(numBytes);
+      MemoryManager.instance().incrementMemoryFileStorage(numBytes);
     } else {
       MemoryManager.instance().incrementDiskBuffer(numBytes);
       if (userCongestionControlContext != null) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Try to fix the disk buffer size and memory file storage size abnormal issue.

### Why are the changes needed?


After no active running application in the celeborn cluster, I found that, it is abnormal per the celeborn worker log.
```
24/11/09 23:30:50,474 INFO [worker-memory-manager-reporter] MemoryManager: Direct memory usage: 276.0 MiB/40.0 GiB, disk buffer size: -748726.0 B, sort memory size: 0.0 B, read buffer size: 0.0 B, memory file storage size : 731.2 KiB
```

```
disk buffer size: -748726.0 B
memory file storage size : 731.2 KiB
```

Both of them are expected to be 0.

Seems in `close()`, it will create a flush task, and  `returnBuffer()` in the flush task.

https://github.com/apache/celeborn/blob/14d9cd130dd2c18cea60674406c124096800fe58/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java#L439-L444

https://github.com/apache/celeborn/blob/14d9cd130dd2c18cea60674406c124096800fe58/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala#L92

So, if we `returnBuffer()` again in the finally part, I wonder it will release the disk buffer size again.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Integration testing.
