### PR TITLE
[CELEBORN-1716] Sleeping in CelebornShuffleReader while loop should have an upper bound time

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -21,15 +21,18 @@ import java.io.IOException
 import java.util
 import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
+
 import scala.collection.JavaConverters._
+
 import org.apache.spark.{Aggregator, InterruptibleIterator, ShuffleDependency, TaskContext}
 import org.apache.spark.celeborn.ExceptionMakerHelper
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.SerializerInstance
-import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter, ShuffleReader}
+import org.apache.spark.shuffle.{FetchFailedException, ShuffleReader, ShuffleReadMetricsReporter}
 import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
+
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.client.ShuffleClientImpl.ReduceFileGroups
 import org.apache.celeborn.client.read.{CelebornInputStream, MetricsCallback}
@@ -259,7 +262,8 @@ class CelebornShuffleReader[K, C](
           }
           logInfo(s"partitionId $partitionId inputStream is null, sleeping...")
           if (System.currentTimeMillis() - startTime > maxWaitTime) {
-            throw new CelebornRuntimeException(s"Waiting for inputStream for partitionId $partitionId timed out after $maxWaitTime milliseconds.")
+            throw new CelebornRuntimeException(
+              s"Waiting for inputStream for partitionId $partitionId timed out after $maxWaitTime milliseconds.")
           }
           Thread.sleep(50)
           inputStream = streams.get(partitionId)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
There should be a failure ceiling in development scenarios.

### Why are the changes needed?
Usually it won't get stuck in this while loop. 
I wrote some bugs and it stuck there... 🥹🥹🥹

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
![image](https://github.com/user-attachments/assets/5c4ded36-9869-4b5b-ab54-a9cbd866c80c)


