### PR TITLE
[CELEBORN-1619][CELEBORN-474][FOLLOWUP] TagsManager uses JavaUtils#newConcurrentHashMap to speed up ConcurrentHashMap#computeIfAbsent

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -43,7 +43,7 @@ class TagsManager(configService: Option[ConfigService]) extends Logging {
     configService match {
       case Some(cs) =>
         // TODO: Make configStore.getTags return ConcurrentMap
-        new ConcurrentHashMap(cs.getSystemConfigFromCache.getTags)
+        JavaUtils.newConcurrentHashMap(cs.getSystemConfigFromCache.getTags)
       case _ =>
         defaultTagStore
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TagsManager` uses `JavaUtils#newConcurrentHashMap` to speed up `ConcurrentHashMap#computeIfAbsent`.

Follow up #2844.

### Why are the changes needed?

Celeborn supports JDK8, which could meet the bug mentioned in [JDK-8161372](https://bugs.openjdk.org/browse/JDK-8161372). Therefore, it's better to use `JavaUtils#newConcurrentHashMap` to speed up `ConcurrentHashMap#computeIfAbsent`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.