### PR TITLE
[CELEBORN-1556][0.4] Update Github actions to v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
@@ -42,7 +42,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh benchmark
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/benchmark_manual.yml
+++ b/.github/workflows/benchmark_manual.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -42,7 +42,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh benchmark
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -54,9 +54,9 @@ jobs:
           - 'flink-1.18'
           - 'mr'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: 8
@@ -85,9 +85,9 @@ jobs:
           - 'flink-1.18'
           - 'mr'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: 8

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -34,9 +34,9 @@ jobs:
     name: License
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 8
@@ -53,7 +53,7 @@ jobs:
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,mr
       - name: Upload rat report
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: rat-report
           path: "**/target/rat*.txt"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,9 +24,9 @@ jobs:
           - 11
           - 17
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -36,7 +36,7 @@ jobs:
       run: build/mvn -Pgoogle-mirror test
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: service-unit-test-log
         path: |
@@ -55,9 +55,9 @@ jobs:
         spark:
           - '2.4'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -73,7 +73,7 @@ jobs:
           build/mvn $PROFILES -pl $TEST_MODULES test
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spark-${{ matrix.spark }}-unit-test-log
           path: |
@@ -118,9 +118,9 @@ jobs:
           - shuffle-plugin-class: 'org.apache.spark.shuffle.celeborn.CelebornShuffleDataIO'
             spark: '3.4'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -136,7 +136,7 @@ jobs:
         build/mvn $PROFILES -pl $TEST_MODULES -Dspark.shuffle.sort.io.plugin.class=${{ matrix.shuffle-plugin-class }} test
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: spark-${{ matrix.spark }}-unit-test-log
         path: |
@@ -156,9 +156,9 @@ jobs:
           - '1.17'
           - '1.18'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -172,7 +172,7 @@ jobs:
           build/mvn $PROFILES -pl $TEST_MODULES test
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flink-${{ matrix.flink }}-unit-test-log
           path: |
@@ -187,9 +187,9 @@ jobs:
           - 8
           - 11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -203,7 +203,7 @@ jobs:
           build/mvn $PROFILES -pl $TEST_MODULES test
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mr-unit-test-log
           path: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
@@ -42,7 +42,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh regression
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: regression result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/regression_manual.yml
+++ b/.github/workflows/regression_manual.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -43,7 +43,7 @@ jobs:
         run: /home/hadoop/celeborn-toolkit/reg.sh regression
 
       - name: Upload Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: regression result
           path: /home/hadoop/celeborn-toolkit/result/

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -42,9 +42,9 @@ jobs:
           - '2.12.15'
           - '2.13.5'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -54,7 +54,7 @@ jobs:
         build/sbt ++${{ matrix.scala }} "clean; test"
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: service-java-${{ matrix.java }}-scala-${{ matrix.scala }}-unit-test-log
           path: |
@@ -73,9 +73,9 @@ jobs:
           - '2.11.12'
           - '2.12.10'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -85,7 +85,7 @@ jobs:
           build/sbt -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: spark-${{ matrix.spark }}-unit-test-log
             path: |
@@ -176,9 +176,9 @@ jobs:
             scala-binary: '2.13'
             scala: '2.13.5'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -188,7 +188,7 @@ jobs:
         build/sbt -Dspark.shuffle.plugin.class=${{ matrix.shuffle-plugin-class }} -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: spark-${{ matrix.spark }}-scala-${{ matrix.scala }}-unit-test-log
           path: |
@@ -208,9 +208,9 @@ jobs:
           - '1.17'
           - '1.18'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -220,7 +220,7 @@ jobs:
           build/sbt -Pflink-${{ matrix.flink }} "clean; celeborn-flink-group/test"
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: flink-${{ matrix.flink }}-unit-test-log
             path: |
@@ -235,9 +235,9 @@ jobs:
           - 8
           - 11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
@@ -247,7 +247,7 @@ jobs:
           build/sbt -Pmr "clean; celeborn-mr-group/test"
       - name: Upload test log
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mr-unit-test-log
           path: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -38,9 +38,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 8


### PR DESCRIPTION
backport https://github.com/apache/celeborn/pull/2676 to branch-0.4

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- update actions/setup-java to v4
- update actions/upload-artifact to v4
- update actions/checkout to v4
- update pnpm/action-setup to v4

### Why are the changes needed?

Mordernize the github actions used, bumping the runtime in actions to NodeJS 20.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Passing the CI jobs.

Closes #2676 from bowenliang123/update-actions.

Lead-authored-by: Bowen Liang <liangbowen@gf.com.cn>









