### PR TITLE
[CELEBORN-1727] Correct the calculation of worker diskInfo actualUsableSpace

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/DiskUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/DiskUtils.scala
@@ -27,28 +27,28 @@ import org.apache.celeborn.common.meta.DiskInfo
 object DiskUtils {
 
   /**
-   * Gets the minimum usable size for each disk, which size is the max space between the reserved space
-   * and the space calculate via reserved ratio.
+   * Get the actual size that the disk needs to reserve. It will take the larger value between
+   * the configured fixed reserved size and the size calculated by the reserved ratio.
    *
-   * @param diskInfo The reserved disk info.
-   * @param diskReserveSize The reserved space for each disk.
-   * @param diskReserveRatio The reserved ratio for each disk.
-   * @return the minimum usable space.
+   * @param diskInfo The disk info being calculated.
+   * @param diskReserveSize The configured fixed reserved size space for the disk.
+   * @param diskReserveRatio The configured reserved ratio for the disk.
+   * @return the actual size (in bytes) that the disk needs to reserve.
    */
-  def getMinimumUsableSize(
+  def getActualReserveSize(
       diskInfo: DiskInfo,
       diskReserveSize: Long,
       diskReserveRatio: Option[Double]): Long = {
-    var minimumUsableSize = diskReserveSize
+    var actualReserveSize = diskReserveSize
     if (diskReserveRatio.isDefined) {
       try {
         val totalSpace = Files.getFileStore(Paths.get(diskInfo.mountPoint)).getTotalSpace
-        minimumUsableSize =
-          BigDecimal(totalSpace * diskReserveRatio.get).longValue.max(minimumUsableSize)
+        actualReserveSize =
+          BigDecimal(totalSpace * diskReserveRatio.get).longValue.max(actualReserveSize)
       } catch {
         case _: Exception => // Do nothing
       }
     }
-    minimumUsableSize
+    actualReserveSize
   }
 }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
@@ -60,7 +60,6 @@ class CelebornHashCheckDiskSuite extends SparkTestBase {
     val combineResult = combine(sparkSession)
     val groupByResult = groupBy(sparkSession)
     val repartitionResult = repartition(sparkSession)
-    val sqlResult = runsql(sparkSession)
     sparkSession.stop()
 
     val sparkSessionEnableCeleborn = SparkSession.builder()
@@ -69,16 +68,14 @@ class CelebornHashCheckDiskSuite extends SparkTestBase {
     val celebornCombineResult = combine(sparkSessionEnableCeleborn)
     val celebornGroupByResult = groupBy(sparkSessionEnableCeleborn)
     val celebornRepartitionResult = repartition(sparkSessionEnableCeleborn)
-    val celebornSqlResult = runsql(sparkSessionEnableCeleborn)
 
     assert(combineResult.equals(celebornCombineResult))
     assert(groupByResult.equals(celebornGroupByResult))
     assert(repartitionResult.equals(celebornRepartitionResult))
-    assert(combineResult.equals(celebornCombineResult))
-    assert(sqlResult.equals(celebornSqlResult))
 
     // shuffle key not expired, diskInfo.actualUsableSpace <= 0, no space
     workers.foreach { worker =>
+      worker.storageManager.updateDiskInfos()
       worker.storageManager.disksSnapshot().foreach { diskInfo =>
         assert(diskInfo.actualUsableSpace <= 0)
       }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -1220,7 +1220,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     val mountPoint = fileWriter.flusher.asInstanceOf[LocalFlusher].mountPoint
     val diskInfo = workerInfo.diskInfos.get(mountPoint)
     val diskFull =
-      diskInfo.status.equals(DiskStatus.HIGH_DISK_USAGE) || diskInfo.actualUsableSpace > 0
+      diskInfo.status.equals(DiskStatus.HIGH_DISK_USAGE) || diskInfo.actualUsableSpace <= 0
     diskFull
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -274,6 +274,7 @@ private[celeborn] class Worker(
   assert(replicatePort > 0, "worker replica bind port should be positive")
 
   storageManager.updateDiskInfos()
+  storageManager.startDeviceMonitor()
 
   // WorkerInfo's diskInfos is a reference to storageManager.diskInfos
   val diskInfos = JavaUtils.newConcurrentHashMap[String, DiskInfo]()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -254,18 +254,18 @@ object DeviceMonitor extends Logging {
     tryWithTimeoutAndCallback({
       val usage = getDiskUsageInfos(diskInfo)
       // assume no single device capacity exceeds 1EB in this era
-      val minimumUsableSize = DiskUtils.getMinimumUsableSize(
+      val actualReserveSize = DiskUtils.getActualReserveSize(
         diskInfo,
         conf.workerDiskReserveSize,
         conf.workerDiskReserveRatio)
       val highDiskUsage =
-        usage.freeSpace < minimumUsableSize || diskInfo.actualUsableSpace <= 0
+        usage.freeSpace < actualReserveSize || diskInfo.actualUsableSpace <= 0
       if (highDiskUsage) {
         logWarning(s"${diskInfo.mountPoint} usage is above threshold." +
-          s" Disk usage(Report by OS):{total:${Utils.bytesToString(usage.totalSpace)}," +
-          s" free:${Utils.bytesToString(usage.freeSpace)}, used_percent:${usage.usedPercent}} " +
-          s"usage(Report by Celeborn):{" +
-          s"total:${Utils.bytesToString(diskInfo.configuredUsableSpace)}" +
+          s" Disk usage(Report by OS): {total:${Utils.bytesToString(usage.totalSpace)}," +
+          s" free:${Utils.bytesToString(usage.freeSpace)}, used_percent:${usage.usedPercent}}," +
+          s" usage(Report by Celeborn): {" +
+          s" total:${Utils.bytesToString(diskInfo.configuredUsableSpace)}," +
           s" free:${Utils.bytesToString(diskInfo.actualUsableSpace)} }")
       }
       highDiskUsage

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -160,8 +160,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     (flushers, totalThread)
   }
 
-  deviceMonitor.startCheck()
-
   val hdfsDir = conf.hdfsDir
   val s3Dir = conf.s3Dir
   val hdfsPermission = new FsPermission("755")
@@ -890,15 +888,17 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           try {
             val (fileSystemReportedUsableSpace, fileSystemReportedTotalSpace) =
               getFileSystemReportedSpace(diskInfo.mountPoint)
+            val actualReserveSize =
+              DiskUtils.getActualReserveSize(diskInfo, diskReserveSize, diskReserveRatio)
             val workingDirUsableSpace =
-              Math.min(diskInfo.configuredUsableSpace - totalUsage, fileSystemReportedUsableSpace)
-            val minimumReserveSize =
-              DiskUtils.getMinimumUsableSize(diskInfo, diskReserveSize, diskReserveRatio)
-            val usableSpace = Math.max(workingDirUsableSpace - minimumReserveSize, 0)
+              Math.min(
+                diskInfo.configuredUsableSpace - totalUsage,
+                fileSystemReportedUsableSpace - actualReserveSize)
+            val usableSpace = Math.max(workingDirUsableSpace, 0)
             logDebug(
-              s"Update diskInfo:${diskInfo.mountPoint} workingDirUsableSpace:$workingDirUsableSpace fileMeta:$fileSystemReportedUsableSpace" +
-                s"conf:${diskInfo.configuredUsableSpace} totalUsage:$totalUsage totalSpace:$fileSystemReportedTotalSpace" +
-                s"minimumReserveSize:$minimumReserveSize usableSpace:$usableSpace")
+              s"Update diskInfo:${diskInfo.mountPoint} workingDirUsableSpace:$workingDirUsableSpace fileMeta:$fileSystemReportedUsableSpace " +
+                s"configuredUsableSpace:${diskInfo.configuredUsableSpace} totalUsage:$totalUsage totalSpace:$fileSystemReportedTotalSpace " +
+                s"actualReserveSize:$actualReserveSize usableSpace:$usableSpace")
             diskInfo.setUsableSpace(usableSpace)
             diskInfo.setTotalSpace(fileSystemReportedTotalSpace)
           } catch {
@@ -1170,6 +1170,11 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     }
     throw exception
   }
+
+  def startDeviceMonitor(): Unit = {
+    deviceMonitor.startCheck()
+  }
+
 }
 
 object StorageManager {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the calculation of worker diskInfo actualUsableSpace.
Make the expression of the function to get the reserve size clearer. (`getMinimumUsableSize` -> `getActualReserveSize`).
Let deviceMonitor startCheck after the first `storageManager.updateDiskInfos()` to avoid disks from being misidentified as HIGH_DISK_USAGE.
Fix PushDataHandler#checkDiskFull judge.


### Why are the changes needed?
Make sure worker disk reserve work correctly.


### Does this PR introduce _any_ user-facing change?
No.



### How was this patch tested?
Cluster test and UT.
