### PR TITLE
[CELEBORN-1742] Fix bounded driver Inbox deadlock

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Inbox.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Inbox.scala
@@ -278,11 +278,9 @@ private[celeborn] class Inbox(
         // We should disable concurrent here. Then when RpcEndpoint.onStop is called, it's the only
         // thread that is processing messages. So `RpcEndpoint.onStop` can release its resources
         // safely.
-        // we need to have this check in case that inbox has been full and we have no way to
-        // put OnStop leading the deadlock when shutting down
-        if (capacity > 0 && messageCount.get() >= capacity) {
-          messages.clear()
-        }
+        // we need to clear the message in case that inbox (with capacity bounded) has been full
+        // and we have no way to put OnStop leading the deadlock when shutting down
+        messages.clear()
         enableConcurrent = false
         stopped = true
         addMessage(OnStop)

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Inbox.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Inbox.scala
@@ -278,6 +278,11 @@ private[celeborn] class Inbox(
         // We should disable concurrent here. Then when RpcEndpoint.onStop is called, it's the only
         // thread that is processing messages. So `RpcEndpoint.onStop` can release its resources
         // safely.
+        // we need to have this check in case that inbox has been full and we have no way to
+        // put OnStop leading the deadlock when shutting down
+        if (capacity > 0 && messageCount.get() >= capacity) {
+          messages.clear()
+        }
         enableConcurrent = false
         stopped = true
         addMessage(OnStop)

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Inbox.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Inbox.scala
@@ -278,9 +278,11 @@ private[celeborn] class Inbox(
         // We should disable concurrent here. Then when RpcEndpoint.onStop is called, it's the only
         // thread that is processing messages. So `RpcEndpoint.onStop` can release its resources
         // safely.
-        // we need to clear the message in case that inbox (with capacity bounded) has been full
-        // and we have no way to put OnStop leading the deadlock when shutting down
-        messages.clear()
+        // we need to have this check in case that inbox has been full and we have no way to
+        // put OnStop leading the deadlock when shutting down
+        if (capacity > 0 && messageCount.get() >= capacity) {
+          messages.clear()
+        }
         enableConcurrent = false
         stopped = true
         addMessage(OnStop)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?


fix the deadlock by clear the message queue if it has been full before we put OnStop message

### Why are the changes needed?

it is possible that the message queue has been full when we want to insert OnStop, and unfortunately, we have to hold the inbox as the lock when doing this....

this creates the scenario of deadlock, main thread is waiting for more capacity holding inbox lock, message processors are stuck because it needs inbox lock

(the screenshots are based on 0.4 client tho)

main thread:

![image](https://github.com/user-attachments/assets/d07b519f-dd4f-4c9c-b57f-b15505a41fdf)

processor thread:

![image](https://github.com/user-attachments/assets/c8f06144-01de-4b5f-8c43-180e30684260)

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

in prod