### PR TITLE
[CELEBORN-1543][FOLLOWUP] License check adds flink-1.20 profile

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -49,6 +49,7 @@ jobs:
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.17
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.18
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.19
+          build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,flink-1.20
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,spark-2.4
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,spark-3.3
           build/mvn org.apache.rat:apache-rat-plugin:check -Pgoogle-mirror,mr


### PR DESCRIPTION
### What changes were proposed in this pull request?

License check adds `flink-1.20` profile.

### Why are the changes needed?

`license.yml` does not check `flink-1.20` profile, which should add the check for Flink 1.20 integration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`License check` of CI.