### PR TITLE
[CELEBORN-1749] Fix incorrect application diskBytesWritten metrics

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -785,10 +785,10 @@ private[celeborn] class Worker(
   }
 
   private def removeAppResourceConsumption(resourceConsumptionLabel: Map[String, String]): Unit = {
-    workerSource.removeGauge(ResourceConsumptionSource.DISK_FILE_COUNT, resourceConsumptionLabel)
-    workerSource.removeGauge(ResourceConsumptionSource.DISK_BYTES_WRITTEN, resourceConsumptionLabel)
-    workerSource.removeGauge(ResourceConsumptionSource.HDFS_FILE_COUNT, resourceConsumptionLabel)
-    workerSource.removeGauge(ResourceConsumptionSource.HDFS_BYTES_WRITTEN, resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.DISK_FILE_COUNT, resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.DISK_BYTES_WRITTEN, resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.HDFS_FILE_COUNT, resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.HDFS_BYTES_WRITTEN, resourceConsumptionLabel)
   }
 
   private def removeAppActiveConnection(applicationIds: JHashSet[String]): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -72,7 +72,7 @@ private[celeborn] class Worker(
   override val metricsSystem: MetricsSystem =
     MetricsSystem.createMetricsSystem(serviceName, conf)
   val workerSource = new WorkerSource(conf)
-  private val resourceConsumptionSource =
+  val resourceConsumptionSource =
     new ResourceConsumptionSource(conf, Role.WORKER)
   private val threadPoolSource = ThreadPoolSource(conf, Role.WORKER)
   metricsSystem.registerSource(workerSource)
@@ -674,7 +674,7 @@ private[celeborn] class Worker(
     userResourceConsumptions
   }
 
-  private def handleTopResourceConsumption(userResourceConsumptions: util.Map[
+  def handleTopResourceConsumption(userResourceConsumptions: util.Map[
     UserIdentifier,
     ResourceConsumption]): Unit = {
     // Remove application top resource consumption gauges to refresh top resource consumption metrics.
@@ -785,10 +785,18 @@ private[celeborn] class Worker(
   }
 
   private def removeAppResourceConsumption(resourceConsumptionLabel: Map[String, String]): Unit = {
-    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.DISK_FILE_COUNT, resourceConsumptionLabel)
-    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.DISK_BYTES_WRITTEN, resourceConsumptionLabel)
-    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.HDFS_FILE_COUNT, resourceConsumptionLabel)
-    resourceConsumptionSource.removeGauge(ResourceConsumptionSource.HDFS_BYTES_WRITTEN, resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(
+      ResourceConsumptionSource.DISK_FILE_COUNT,
+      resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(
+      ResourceConsumptionSource.DISK_BYTES_WRITTEN,
+      resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(
+      ResourceConsumptionSource.HDFS_FILE_COUNT,
+      resourceConsumptionLabel)
+    resourceConsumptionSource.removeGauge(
+      ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+      resourceConsumptionLabel)
   }
 
   private def removeAppActiveConnection(applicationIds: JHashSet[String]): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix the incorrect application diskBytesWritten metrics, also make some code refactor to easy understand the logic.

### Why are the changes needed?

There is typo, before when updating the top app usage metrics, it removes the gauge from `workerSrouce`, then the gauge in the `resourceConsumptionSource` will not be refreshed, and the old metrics would be never cleaned.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UT

Before this PR:
The application metrics is incorrect. The application resource consumption is 0 and will not update.
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/035b9590-1b31-4d58-af0f-ce2fd3e71d0e">

After this PR:
The application `diskBytesWritten` equals the user `diskBytesWritten` and update with the app consumption change, it is expected.

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/11bf6037-f696-4ab1-9685-f89f4dd1c692">

