### PR TITLE
[CELEBORN-1750] Return struct worker resource consumption information with RESTful api

### DIFF
--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerData.JSON_PROPERTY_LAST_HEARTBEAT_TIMESTAMP,
   WorkerData.JSON_PROPERTY_HEARTBEAT_ELAPSED_SECONDS,
   WorkerData.JSON_PROPERTY_DISK_INFOS,
-  WorkerData.JSON_PROPERTY_RESOURCE_CONSUMPTION,
+  WorkerData.JSON_PROPERTY_RESOURCE_CONSUMPTIONS,
   WorkerData.JSON_PROPERTY_WORKER_REF,
   WorkerData.JSON_PROPERTY_WORKER_STATE,
   WorkerData.JSON_PROPERTY_WORKER_STATE_START_TIME
@@ -82,8 +82,8 @@ public class WorkerData {
   public static final String JSON_PROPERTY_DISK_INFOS = "diskInfos";
   private Map<String, String> diskInfos = new HashMap<>();
 
-  public static final String JSON_PROPERTY_RESOURCE_CONSUMPTION = "resourceConsumption";
-  private Map<String, WorkerResourceConsumption> resourceConsumption = new HashMap<>();
+  public static final String JSON_PROPERTY_RESOURCE_CONSUMPTIONS = "resourceConsumptions";
+  private Map<String, WorkerResourceConsumption> resourceConsumptions = new HashMap<>();
 
   public static final String JSON_PROPERTY_WORKER_REF = "workerRef";
   private String workerRef;
@@ -355,37 +355,37 @@ public class WorkerData {
     this.diskInfos = diskInfos;
   }
 
-  public WorkerData resourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
+  public WorkerData resourceConsumptions(Map<String, WorkerResourceConsumption> resourceConsumptions) {
     
-    this.resourceConsumption = resourceConsumption;
+    this.resourceConsumptions = resourceConsumptions;
     return this;
   }
 
-  public WorkerData putResourceConsumptionItem(String key, WorkerResourceConsumption resourceConsumptionItem) {
-    if (this.resourceConsumption == null) {
-      this.resourceConsumption = new HashMap<>();
+  public WorkerData putResourceConsumptionsItem(String key, WorkerResourceConsumption resourceConsumptionsItem) {
+    if (this.resourceConsumptions == null) {
+      this.resourceConsumptions = new HashMap<>();
     }
-    this.resourceConsumption.put(key, resourceConsumptionItem);
+    this.resourceConsumptions.put(key, resourceConsumptionsItem);
     return this;
   }
 
   /**
    * A map of user identifier and resource consumption.
-   * @return resourceConsumption
+   * @return resourceConsumptions
    */
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
+  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public Map<String, WorkerResourceConsumption> getResourceConsumption() {
-    return resourceConsumption;
+  public Map<String, WorkerResourceConsumption> getResourceConsumptions() {
+    return resourceConsumptions;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
+  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setResourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
-    this.resourceConsumption = resourceConsumption;
+  public void setResourceConsumptions(Map<String, WorkerResourceConsumption> resourceConsumptions) {
+    this.resourceConsumptions = resourceConsumptions;
   }
 
   public WorkerData workerRef(String workerRef) {
@@ -482,7 +482,7 @@ public class WorkerData {
         Objects.equals(this.lastHeartbeatTimestamp, workerData.lastHeartbeatTimestamp) &&
         Objects.equals(this.heartbeatElapsedSeconds, workerData.heartbeatElapsedSeconds) &&
         Objects.equals(this.diskInfos, workerData.diskInfos) &&
-        Objects.equals(this.resourceConsumption, workerData.resourceConsumption) &&
+        Objects.equals(this.resourceConsumptions, workerData.resourceConsumptions) &&
         Objects.equals(this.workerRef, workerData.workerRef) &&
         Objects.equals(this.workerState, workerData.workerState) &&
         Objects.equals(this.workerStateStartTime, workerData.workerStateStartTime);
@@ -490,7 +490,7 @@ public class WorkerData {
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumption, workerRef, workerState, workerStateStartTime);
+    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumptions, workerRef, workerState, workerStateStartTime);
   }
 
   @Override
@@ -507,7 +507,7 @@ public class WorkerData {
     sb.append("    lastHeartbeatTimestamp: ").append(toIndentedString(lastHeartbeatTimestamp)).append("\n");
     sb.append("    heartbeatElapsedSeconds: ").append(toIndentedString(heartbeatElapsedSeconds)).append("\n");
     sb.append("    diskInfos: ").append(toIndentedString(diskInfos)).append("\n");
-    sb.append("    resourceConsumption: ").append(toIndentedString(resourceConsumption)).append("\n");
+    sb.append("    resourceConsumptions: ").append(toIndentedString(resourceConsumptions)).append("\n");
     sb.append("    workerRef: ").append(toIndentedString(workerRef)).append("\n");
     sb.append("    workerState: ").append(toIndentedString(workerState)).append("\n");
     sb.append("    workerStateStartTime: ").append(toIndentedString(workerStateStartTime)).append("\n");

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerData.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.celeborn.rest.v1.model.WorkerResourceConsumption;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -82,7 +83,7 @@ public class WorkerData {
   private Map<String, String> diskInfos = new HashMap<>();
 
   public static final String JSON_PROPERTY_RESOURCE_CONSUMPTION = "resourceConsumption";
-  private Map<String, String> resourceConsumption = new HashMap<>();
+  private Map<String, WorkerResourceConsumption> resourceConsumption = new HashMap<>();
 
   public static final String JSON_PROPERTY_WORKER_REF = "workerRef";
   private String workerRef;
@@ -354,13 +355,13 @@ public class WorkerData {
     this.diskInfos = diskInfos;
   }
 
-  public WorkerData resourceConsumption(Map<String, String> resourceConsumption) {
+  public WorkerData resourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
     
     this.resourceConsumption = resourceConsumption;
     return this;
   }
 
-  public WorkerData putResourceConsumptionItem(String key, String resourceConsumptionItem) {
+  public WorkerData putResourceConsumptionItem(String key, WorkerResourceConsumption resourceConsumptionItem) {
     if (this.resourceConsumption == null) {
       this.resourceConsumption = new HashMap<>();
     }
@@ -369,21 +370,21 @@ public class WorkerData {
   }
 
   /**
-   * A map of identifier and resource consumption.
+   * A map of user identifier and resource consumption.
    * @return resourceConsumption
    */
   @javax.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public Map<String, String> getResourceConsumption() {
+  public Map<String, WorkerResourceConsumption> getResourceConsumption() {
     return resourceConsumption;
   }
 
 
   @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setResourceConsumption(Map<String, String> resourceConsumption) {
+  public void setResourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
     this.resourceConsumption = resourceConsumption;
   }
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
@@ -382,7 +382,7 @@ public class WorkerInfoResponse {
   }
 
   /**
-   * A map of identifier and resource consumption.
+   * A map of user identifier and resource consumption.
    * @return resourceConsumption
    */
   @javax.annotation.Nullable

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkerInfoResponse.JSON_PROPERTY_LAST_HEARTBEAT_TIMESTAMP,
   WorkerInfoResponse.JSON_PROPERTY_HEARTBEAT_ELAPSED_SECONDS,
   WorkerInfoResponse.JSON_PROPERTY_DISK_INFOS,
-  WorkerInfoResponse.JSON_PROPERTY_RESOURCE_CONSUMPTION,
+  WorkerInfoResponse.JSON_PROPERTY_RESOURCE_CONSUMPTIONS,
   WorkerInfoResponse.JSON_PROPERTY_WORKER_REF,
   WorkerInfoResponse.JSON_PROPERTY_WORKER_STATE,
   WorkerInfoResponse.JSON_PROPERTY_WORKER_STATE_START_TIME,
@@ -85,8 +85,8 @@ public class WorkerInfoResponse {
   public static final String JSON_PROPERTY_DISK_INFOS = "diskInfos";
   private Map<String, String> diskInfos = new HashMap<>();
 
-  public static final String JSON_PROPERTY_RESOURCE_CONSUMPTION = "resourceConsumption";
-  private Map<String, WorkerResourceConsumption> resourceConsumption = new HashMap<>();
+  public static final String JSON_PROPERTY_RESOURCE_CONSUMPTIONS = "resourceConsumptions";
+  private Map<String, WorkerResourceConsumption> resourceConsumptions = new HashMap<>();
 
   public static final String JSON_PROPERTY_WORKER_REF = "workerRef";
   private String workerRef;
@@ -367,37 +367,37 @@ public class WorkerInfoResponse {
     this.diskInfos = diskInfos;
   }
 
-  public WorkerInfoResponse resourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
+  public WorkerInfoResponse resourceConsumptions(Map<String, WorkerResourceConsumption> resourceConsumptions) {
     
-    this.resourceConsumption = resourceConsumption;
+    this.resourceConsumptions = resourceConsumptions;
     return this;
   }
 
-  public WorkerInfoResponse putResourceConsumptionItem(String key, WorkerResourceConsumption resourceConsumptionItem) {
-    if (this.resourceConsumption == null) {
-      this.resourceConsumption = new HashMap<>();
+  public WorkerInfoResponse putResourceConsumptionsItem(String key, WorkerResourceConsumption resourceConsumptionsItem) {
+    if (this.resourceConsumptions == null) {
+      this.resourceConsumptions = new HashMap<>();
     }
-    this.resourceConsumption.put(key, resourceConsumptionItem);
+    this.resourceConsumptions.put(key, resourceConsumptionsItem);
     return this;
   }
 
   /**
    * A map of user identifier and resource consumption.
-   * @return resourceConsumption
+   * @return resourceConsumptions
    */
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
+  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public Map<String, WorkerResourceConsumption> getResourceConsumption() {
-    return resourceConsumption;
+  public Map<String, WorkerResourceConsumption> getResourceConsumptions() {
+    return resourceConsumptions;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
+  @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setResourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
-    this.resourceConsumption = resourceConsumption;
+  public void setResourceConsumptions(Map<String, WorkerResourceConsumption> resourceConsumptions) {
+    this.resourceConsumptions = resourceConsumptions;
   }
 
   public WorkerInfoResponse workerRef(String workerRef) {
@@ -569,7 +569,7 @@ public class WorkerInfoResponse {
         Objects.equals(this.lastHeartbeatTimestamp, workerInfoResponse.lastHeartbeatTimestamp) &&
         Objects.equals(this.heartbeatElapsedSeconds, workerInfoResponse.heartbeatElapsedSeconds) &&
         Objects.equals(this.diskInfos, workerInfoResponse.diskInfos) &&
-        Objects.equals(this.resourceConsumption, workerInfoResponse.resourceConsumption) &&
+        Objects.equals(this.resourceConsumptions, workerInfoResponse.resourceConsumptions) &&
         Objects.equals(this.workerRef, workerInfoResponse.workerRef) &&
         Objects.equals(this.workerState, workerInfoResponse.workerState) &&
         Objects.equals(this.workerStateStartTime, workerInfoResponse.workerStateStartTime) &&
@@ -580,7 +580,7 @@ public class WorkerInfoResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumption, workerRef, workerState, workerStateStartTime, isRegistered, isShutdown, isDecommissioning);
+    return Objects.hash(host, rpcPort, pushPort, fetchPort, replicatePort, internalPort, slotUsed, lastHeartbeatTimestamp, heartbeatElapsedSeconds, diskInfos, resourceConsumptions, workerRef, workerState, workerStateStartTime, isRegistered, isShutdown, isDecommissioning);
   }
 
   @Override
@@ -597,7 +597,7 @@ public class WorkerInfoResponse {
     sb.append("    lastHeartbeatTimestamp: ").append(toIndentedString(lastHeartbeatTimestamp)).append("\n");
     sb.append("    heartbeatElapsedSeconds: ").append(toIndentedString(heartbeatElapsedSeconds)).append("\n");
     sb.append("    diskInfos: ").append(toIndentedString(diskInfos)).append("\n");
-    sb.append("    resourceConsumption: ").append(toIndentedString(resourceConsumption)).append("\n");
+    sb.append("    resourceConsumptions: ").append(toIndentedString(resourceConsumptions)).append("\n");
     sb.append("    workerRef: ").append(toIndentedString(workerRef)).append("\n");
     sb.append("    workerState: ").append(toIndentedString(workerState)).append("\n");
     sb.append("    workerStateStartTime: ").append(toIndentedString(workerStateStartTime)).append("\n");

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerInfoResponse.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.celeborn.rest.v1.model.WorkerResourceConsumption;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -85,7 +86,7 @@ public class WorkerInfoResponse {
   private Map<String, String> diskInfos = new HashMap<>();
 
   public static final String JSON_PROPERTY_RESOURCE_CONSUMPTION = "resourceConsumption";
-  private Map<String, String> resourceConsumption = new HashMap<>();
+  private Map<String, WorkerResourceConsumption> resourceConsumption = new HashMap<>();
 
   public static final String JSON_PROPERTY_WORKER_REF = "workerRef";
   private String workerRef;
@@ -366,13 +367,13 @@ public class WorkerInfoResponse {
     this.diskInfos = diskInfos;
   }
 
-  public WorkerInfoResponse resourceConsumption(Map<String, String> resourceConsumption) {
+  public WorkerInfoResponse resourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
     
     this.resourceConsumption = resourceConsumption;
     return this;
   }
 
-  public WorkerInfoResponse putResourceConsumptionItem(String key, String resourceConsumptionItem) {
+  public WorkerInfoResponse putResourceConsumptionItem(String key, WorkerResourceConsumption resourceConsumptionItem) {
     if (this.resourceConsumption == null) {
       this.resourceConsumption = new HashMap<>();
     }
@@ -388,14 +389,14 @@ public class WorkerInfoResponse {
   @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public Map<String, String> getResourceConsumption() {
+  public Map<String, WorkerResourceConsumption> getResourceConsumption() {
     return resourceConsumption;
   }
 
 
   @JsonProperty(JSON_PROPERTY_RESOURCE_CONSUMPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setResourceConsumption(Map<String, String> resourceConsumption) {
+  public void setResourceConsumption(Map<String, WorkerResourceConsumption> resourceConsumption) {
     this.resourceConsumption = resourceConsumption;
   }
 

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerResourceConsumption.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerResourceConsumption.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.celeborn.rest.v1.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * WorkerResourceConsumption
+ */
+@JsonPropertyOrder({
+  WorkerResourceConsumption.JSON_PROPERTY_DISK_BYTES_WRITTEN,
+  WorkerResourceConsumption.JSON_PROPERTY_DISK_FILE_COUNT,
+  WorkerResourceConsumption.JSON_PROPERTY_HDFS_BYTES_WRITTEN,
+  WorkerResourceConsumption.JSON_PROPERTY_HDFS_FILE_COUNT,
+  WorkerResourceConsumption.JSON_PROPERTY_SUB_RESOURCE_CONSUMPTION
+})
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
+public class WorkerResourceConsumption {
+  public static final String JSON_PROPERTY_DISK_BYTES_WRITTEN = "diskBytesWritten";
+  private Long diskBytesWritten;
+
+  public static final String JSON_PROPERTY_DISK_FILE_COUNT = "diskFileCount";
+  private Long diskFileCount;
+
+  public static final String JSON_PROPERTY_HDFS_BYTES_WRITTEN = "hdfsBytesWritten";
+  private Long hdfsBytesWritten;
+
+  public static final String JSON_PROPERTY_HDFS_FILE_COUNT = "hdfsFileCount";
+  private Long hdfsFileCount;
+
+  public static final String JSON_PROPERTY_SUB_RESOURCE_CONSUMPTION = "subResourceConsumption";
+  private Map<String, WorkerResourceConsumption> subResourceConsumption = new HashMap<>();
+
+  public WorkerResourceConsumption() {
+  }
+
+  public WorkerResourceConsumption diskBytesWritten(Long diskBytesWritten) {
+    
+    this.diskBytesWritten = diskBytesWritten;
+    return this;
+  }
+
+  /**
+   * Get diskBytesWritten
+   * @return diskBytesWritten
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_DISK_BYTES_WRITTEN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public Long getDiskBytesWritten() {
+    return diskBytesWritten;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_DISK_BYTES_WRITTEN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setDiskBytesWritten(Long diskBytesWritten) {
+    this.diskBytesWritten = diskBytesWritten;
+  }
+
+  public WorkerResourceConsumption diskFileCount(Long diskFileCount) {
+    
+    this.diskFileCount = diskFileCount;
+    return this;
+  }
+
+  /**
+   * Get diskFileCount
+   * @return diskFileCount
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_DISK_FILE_COUNT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public Long getDiskFileCount() {
+    return diskFileCount;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_DISK_FILE_COUNT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setDiskFileCount(Long diskFileCount) {
+    this.diskFileCount = diskFileCount;
+  }
+
+  public WorkerResourceConsumption hdfsBytesWritten(Long hdfsBytesWritten) {
+    
+    this.hdfsBytesWritten = hdfsBytesWritten;
+    return this;
+  }
+
+  /**
+   * Get hdfsBytesWritten
+   * @return hdfsBytesWritten
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_HDFS_BYTES_WRITTEN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public Long getHdfsBytesWritten() {
+    return hdfsBytesWritten;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_HDFS_BYTES_WRITTEN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setHdfsBytesWritten(Long hdfsBytesWritten) {
+    this.hdfsBytesWritten = hdfsBytesWritten;
+  }
+
+  public WorkerResourceConsumption hdfsFileCount(Long hdfsFileCount) {
+    
+    this.hdfsFileCount = hdfsFileCount;
+    return this;
+  }
+
+  /**
+   * Get hdfsFileCount
+   * @return hdfsFileCount
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_HDFS_FILE_COUNT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public Long getHdfsFileCount() {
+    return hdfsFileCount;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_HDFS_FILE_COUNT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setHdfsFileCount(Long hdfsFileCount) {
+    this.hdfsFileCount = hdfsFileCount;
+  }
+
+  public WorkerResourceConsumption subResourceConsumption(Map<String, WorkerResourceConsumption> subResourceConsumption) {
+    
+    this.subResourceConsumption = subResourceConsumption;
+    return this;
+  }
+
+  public WorkerResourceConsumption putSubResourceConsumptionItem(String key, WorkerResourceConsumption subResourceConsumptionItem) {
+    if (this.subResourceConsumption == null) {
+      this.subResourceConsumption = new HashMap<>();
+    }
+    this.subResourceConsumption.put(key, subResourceConsumptionItem);
+    return this;
+  }
+
+  /**
+   * Get subResourceConsumption
+   * @return subResourceConsumption
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_SUB_RESOURCE_CONSUMPTION)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public Map<String, WorkerResourceConsumption> getSubResourceConsumption() {
+    return subResourceConsumption;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SUB_RESOURCE_CONSUMPTION)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setSubResourceConsumption(Map<String, WorkerResourceConsumption> subResourceConsumption) {
+    this.subResourceConsumption = subResourceConsumption;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WorkerResourceConsumption workerResourceConsumption = (WorkerResourceConsumption) o;
+    return Objects.equals(this.diskBytesWritten, workerResourceConsumption.diskBytesWritten) &&
+        Objects.equals(this.diskFileCount, workerResourceConsumption.diskFileCount) &&
+        Objects.equals(this.hdfsBytesWritten, workerResourceConsumption.hdfsBytesWritten) &&
+        Objects.equals(this.hdfsFileCount, workerResourceConsumption.hdfsFileCount) &&
+        Objects.equals(this.subResourceConsumption, workerResourceConsumption.subResourceConsumption);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(diskBytesWritten, diskFileCount, hdfsBytesWritten, hdfsFileCount, subResourceConsumption);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class WorkerResourceConsumption {\n");
+    sb.append("    diskBytesWritten: ").append(toIndentedString(diskBytesWritten)).append("\n");
+    sb.append("    diskFileCount: ").append(toIndentedString(diskFileCount)).append("\n");
+    sb.append("    hdfsBytesWritten: ").append(toIndentedString(hdfsBytesWritten)).append("\n");
+    sb.append("    hdfsFileCount: ").append(toIndentedString(hdfsFileCount)).append("\n");
+    sb.append("    subResourceConsumption: ").append(toIndentedString(subResourceConsumption)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -844,9 +844,9 @@ components:
             type: string
         resourceConsumption:
           type: object
-          description: A map of identifier and resource consumption.
+          description: A map of user identifier and resource consumption.
           additionalProperties:
-            type: string
+            $ref: '#/components/schemas/WorkerResourceConsumption'
         workerRef:
           type: string
           description: The reference of the worker.
@@ -863,6 +863,26 @@ components:
         - pushPort
         - fetchPort
         - replicatePort
+
+    WorkerResourceConsumption:
+      type: object
+      properties:
+        diskBytesWritten:
+          type: integer
+          format: int64
+        diskFileCount:
+          type: integer
+          format: int64
+        hdfsBytesWritten:
+          type: integer
+          format: int64
+        hdfsFileCount:
+          type: integer
+          format: int64
+        subResourceConsumption:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/WorkerResourceConsumption'
 
     WorkerTimestampData:
       type: object

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -842,7 +842,7 @@ components:
           description: A map of disk name and disk info.
           additionalProperties:
             type: string
-        resourceConsumption:
+        resourceConsumptions:
           type: object
           description: A map of user identifier and resource consumption.
           additionalProperties:

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -427,7 +427,7 @@ components:
           description: A map of disk name and disk info.
           additionalProperties:
             type: string
-        resourceConsumption:
+        resourceConsumptions:
           type: object
           description: A map of user identifier and resource consumption.
           additionalProperties:
@@ -535,7 +535,7 @@ components:
           description: A map of disk name and disk info.
           additionalProperties:
             type: string
-        resourceConsumption:
+        resourceConsumptions:
           type: object
           description: A map of user identifier and resource consumption.
           additionalProperties:

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -431,7 +431,7 @@ components:
           type: object
           description: A map of identifier and resource consumption.
           additionalProperties:
-            type: string
+            $ref: '#/components/schemas/WorkerResourceConsumption'
         workerRef:
           type: string
           description: The reference of the worker.
@@ -537,9 +537,9 @@ components:
             type: string
         resourceConsumption:
           type: object
-          description: A map of identifier and resource consumption.
+          description: A map of user identifier and resource consumption.
           additionalProperties:
-            type: string
+            $ref: '#/components/schemas/WorkerResourceConsumption'
         workerRef:
           type: string
           description: The reference of the worker.
@@ -556,6 +556,26 @@ components:
         - pushPort
         - fetchPort
         - replicatePort
+
+    WorkerResourceConsumption:
+      type: object
+      properties:
+        diskBytesWritten:
+          type: integer
+          format: int64
+        diskFileCount:
+          type: integer
+          format: int64
+        hdfsBytesWritten:
+          type: integer
+          format: int64
+        hdfsFileCount:
+          type: integer
+          format: int64
+        subResourceConsumption:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/WorkerResourceConsumption'
 
     WorkerTimestampData:
       type: object

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -429,7 +429,7 @@ components:
             type: string
         resourceConsumption:
           type: object
-          description: A map of identifier and resource consumption.
+          description: A map of user identifier and resource consumption.
           additionalProperties:
             $ref: '#/components/schemas/WorkerResourceConsumption'
         workerRef:

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
@@ -53,7 +53,7 @@ object ApiUtils {
       .heartbeatElapsedSeconds(TimeUnit.MILLISECONDS.toSeconds(
         System.currentTimeMillis() - workerInfo.lastHeartbeat))
       .diskInfos(diskInfos.asJava)
-      .resourceConsumption(workerResourceConsumptions(workerInfo))
+      .resourceConsumptions(workerResourceConsumptions(workerInfo))
       .workerRef(Option(workerInfo.endpoint).map(_.toString).orNull)
       .workerState(workerInfo.workerStatus.getState.toString)
       .workerStateStartTime(workerInfo.workerStatus.getStateStartTime)
@@ -109,7 +109,7 @@ object ApiUtils {
       .lastHeartbeatTimestamp(workerData.getLastHeartbeatTimestamp)
       .heartbeatElapsedSeconds(workerData.getHeartbeatElapsedSeconds)
       .diskInfos(workerData.getDiskInfos)
-      .resourceConsumption(workerData.getResourceConsumption)
+      .resourceConsumptions(workerData.getResourceConsumptions)
       .workerRef(workerData.getWorkerRef)
       .workerState(currentStatus.getState.toString)
       .workerStateStartTime(currentStatus.getStateStartTime)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

This information is useful for the automation tool integration.  

For our automation tool, it query all the worker status periodically by calling master `/api/v1/worker`.

In decommission process, when the worker is in IDLE state, we need to check whether there is still unreleased shuffle data on this worker so that we can shutdown this node without user impaction.

Before, I have to call the worker `/ap1/v1/shuffles` to check that.

It is better that we can get all the information from celeborn master end, because master is HA enabled and always reachable.

So in this PR, it returns the struct resource consumption for automation tool integration. 

### Does this PR introduce _any_ user-facing change?

No, this RESTful api has not been released.

### How was this patch tested?
GA.
