### PR TITLE
[CELEBORN-1743] Resolve the metrics data interruption and the job failure caused by locked resources.

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -439,6 +439,15 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     sb.toString()
   }
 
+  def getAllMetricsNum: Int = {
+    val sum = timerMetricsMap.size() +
+      namedTimers.size() +
+      namedMeters.size() +
+      namedGauges.size() +
+      namedCounters.size()
+    sum
+  }
+
   override def getMetrics(): String = {
     var leftMetricsNum = metricsCapacity
     val metricsSnapshot = ArrayBuffer[String]()
@@ -451,7 +460,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     val sb = new mutable.StringBuilder
     metricsSnapshot.foreach(metric => sb.append(metric))
     if (leftMetricsNum <= 0) {
-      logWarning("The number of metrics exceed the output metrics strings capacity!")
+      logWarning(s"The number of metrics exceed the output metrics strings capacity! All metrics Num: $getAllMetricsNum")
     }
     sb.toString()
   }

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -460,7 +460,8 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     val sb = new mutable.StringBuilder
     metricsSnapshot.foreach(metric => sb.append(metric))
     if (leftMetricsNum <= 0) {
-      logWarning(s"The number of metrics exceed the output metrics strings capacity! All metrics Num: $getAllMetricsNum")
+      logWarning(
+        s"The number of metrics exceed the output metrics strings capacity! All metrics Num: $getAllMetricsNum")
     }
     sb.toString()
   }

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.common.metrics.source
 
-import java.{lang, util}
+import java.lang
 import java.util.{Map => JMap}
 import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, Scheduled
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 import com.codahale.metrics._
@@ -204,9 +205,13 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   def getAndClearTimerMetrics(): List[String] = {
     timerMetrics.synchronized {
-      val timerList = timerMetrics.asScala.toList
-      timerMetrics.clear()
-      timerList
+      var timerMetricsSize = timerMetrics.size()
+      val timerMetricsList = ArrayBuffer[String]()
+      while (timerMetricsSize > 0) {
+        timerMetricsList.append(timerMetrics.poll())
+        timerMetricsSize = timerMetricsSize - 1
+      }
+      timerMetricsList.toList
     }
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -84,7 +84,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER)
 
   def getCounterCount(metricsName: String): Long = {
     val metricNameWithLabel = metricNameWithCustomizedLabels(metricsName, Map.empty)
-    namedCounters.get(metricNameWithLabel).counter.getCount
+    namedCounters.get(metricNameWithLabel)._2.counter.getCount
   }
 
   def connectionActive(client: TransportClient): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -84,7 +84,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER)
 
   def getCounterCount(metricsName: String): Long = {
     val metricNameWithLabel = metricNameWithCustomizedLabels(metricsName, Map.empty)
-    namedCounters.get(metricNameWithLabel)._2.counter.getCount
+    namedCounters.get(metricNameWithLabel).counter.getCount
   }
 
   def connectionActive(client: TransportClient): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Remove the  ConcurrentLinkedQueue and lock in AbstractSource which might cause the metrics data interruption and job fail.

### Why are the changes needed?
Current problems：[jira CELEBORN-1743](https://issues.apache.org/jira/browse/CELEBORN-1743)
the lock in [[CELEBORN-1453]](https://github.com/apache/celeborn/pull/2548) might block the thread.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test
same result with CELEBORN-1453
![image](https://github.com/user-attachments/assets/3e3a4c53-1cf6-48f6-8c37-67d875d675af)
 
