### PR TITLE
[CELEBORN-1753] Optimize the code for `exists` and `find` method

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceTracker.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceTracker.java
@@ -92,12 +92,12 @@ public class ShuffleResourceTracker implements WorkerStatusListener {
             int shuffleId = mapEntry.getKey();
             if (!mapEntry.getValue().isEmpty()) {
               for (WorkerInfo unknownWorker : unknownWorkers) {
-                Map<WorkerInfo, ShufflePartitionLocationInfo> shuffleAllocateInfo =
+                Map<String, ShufflePartitionLocationInfo> shuffleAllocateInfo =
                     lifecycleManager.workerSnapshots(shuffleId);
                 // shuffleResourceListener may release when the shuffle is ended
                 if (shuffleAllocateInfo != null) {
                   ShufflePartitionLocationInfo shufflePartitionLocationInfo =
-                      shuffleAllocateInfo.get(unknownWorker);
+                      shuffleAllocateInfo.get(unknownWorker.toUniqueId());
                   if (shufflePartitionLocationInfo != null) {
                     // TODO if we support partition replica for map partition we need refactor this
                     //  Currently we only untrack primary partitions for map partition

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,15 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -102,8 +102,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -46,18 +46,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,15 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -102,8 +102,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -46,18 +46,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,15 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -102,8 +102,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -46,18 +46,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,15 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -102,8 +102,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -46,18 +46,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,15 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -102,8 +102,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -46,18 +46,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,15 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -102,8 +102,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -46,18 +46,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -52,15 +52,15 @@ public class ShuffleResourceTrackerSuiteJ {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
         JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo());
+    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
         JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo());
+    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
         JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo());
+    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
@@ -105,8 +105,9 @@ public class ShuffleResourceTrackerSuiteJ {
             .isEmpty());
   }
 
-  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo() {
-    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+  public ShufflePartitionLocationInfo mockShufflePartitionLocationInfo(WorkerInfo workerInfo) {
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+        new ShufflePartitionLocationInfo(workerInfo);
 
     List<PartitionLocation> primaryLocations = new ArrayList<>();
     primaryLocations.add(mockShufflePartitionLocationInfo(1));

--- a/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
+++ b/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerSuiteJ.java
@@ -49,18 +49,15 @@ public class ShuffleResourceTrackerSuiteJ {
     LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
     ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map =
-        JavaUtils.newConcurrentHashMap();
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map = JavaUtils.newConcurrentHashMap();
     WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
-    map.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    map.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map2 =
-        JavaUtils.newConcurrentHashMap();
-    map2.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map2 = JavaUtils.newConcurrentHashMap();
+    map2.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
-    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 =
-        JavaUtils.newConcurrentHashMap();
-    map3.put(workerInfo, mockShufflePartitionLocationInfo(workerInfo));
+    ConcurrentHashMap<String, ShufflePartitionLocationInfo> map3 = JavaUtils.newConcurrentHashMap();
+    map3.put(workerInfo.toUniqueId(), mockShufflePartitionLocationInfo(workerInfo));
 
     Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -382,7 +382,11 @@ class ChangePartitionManager(
         // Add all re-allocated slots to worker snapshots.
         val partitionLocationInfo = lifecycleManager.workerSnapshots(shuffleId).computeIfAbsent(
           workInfo.toUniqueId(),
-          _ => new ShufflePartitionLocationInfo(workInfo))
+          new util.function.Function[String, ShufflePartitionLocationInfo] {
+            override def apply(workerId: String): ShufflePartitionLocationInfo = {
+              new ShufflePartitionLocationInfo(workInfo)
+            }
+          })
         partitionLocationInfo.addPrimaryPartitions(primaryLocations)
         partitionLocationInfo.addReplicaPartitions(replicaLocations)
         lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -154,13 +154,6 @@ class ChangePartitionManager(
     }
   }
 
-  private val updateWorkerSnapshotsFunc =
-    new util.function.Function[WorkerInfo, ShufflePartitionLocationInfo] {
-      override def apply(w: WorkerInfo): ShufflePartitionLocationInfo = {
-        new ShufflePartitionLocationInfo(w)
-      }
-    }
-
   def handleRequestPartitionLocation(
       context: RequestLocationCallContext,
       shuffleId: Int,
@@ -297,9 +290,11 @@ class ChangePartitionManager(
     val snapshotCandidates =
       lifecycleManager
         .workerSnapshots(shuffleId)
-        .keySet()
         .asScala
+        .values
+        .map(_.workerInfo)
         .filter(lifecycleManager.workerStatusTracker.workerAvailable)
+        .toSet
         .asJava
     candidates.addAll(snapshotCandidates)
 
@@ -386,8 +381,8 @@ class ChangePartitionManager(
       case (workInfo, (primaryLocations, replicaLocations)) =>
         // Add all re-allocated slots to worker snapshots.
         val partitionLocationInfo = lifecycleManager.workerSnapshots(shuffleId).computeIfAbsent(
-          workInfo,
-          updateWorkerSnapshotsFunc)
+          workInfo.toUniqueId(),
+          _ => new ShufflePartitionLocationInfo(workInfo))
         partitionLocationInfo.addPrimaryPartitions(primaryLocations)
         partitionLocationInfo.addReplicaPartitions(replicaLocations)
         lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -381,7 +381,7 @@ class ChangePartitionManager(
       case (workInfo, (primaryLocations, replicaLocations)) =>
         // Add all re-allocated slots to worker snapshots.
         val partitionLocationInfo = lifecycleManager.workerSnapshots(shuffleId).computeIfAbsent(
-          workInfo.toUniqueId(),
+          workInfo.toUniqueId,
           new util.function.Function[String, ShufflePartitionLocationInfo] {
             override def apply(workerId: String): ShufflePartitionLocationInfo = {
               new ShufflePartitionLocationInfo(workInfo)

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -157,7 +157,7 @@ class ChangePartitionManager(
   private val updateWorkerSnapshotsFunc =
     new util.function.Function[WorkerInfo, ShufflePartitionLocationInfo] {
       override def apply(w: WorkerInfo): ShufflePartitionLocationInfo = {
-        new ShufflePartitionLocationInfo()
+        new ShufflePartitionLocationInfo(w)
       }
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -122,7 +122,7 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
                               lifecycleManager.shuffleAllocatedWorkers
                                 .get(shuffleId)
                                 .asScala
-                                .get(worker)
+                                .get(worker.toUniqueId())
                                 .get
                                 .workerInfo
                             val primaryIds =

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -114,23 +114,17 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
 
                     if (workerToRequests.nonEmpty) {
                       val commitFilesFailedWorkers = new ShuffleFailedWorkers()
-                      val workerInfoSnapshots =
-                        lifecycleManager.shuffleAllocatedWorkers.get(shuffleId).keySet().asScala
-                          .map(worker => worker.toUniqueId() -> worker).toMap
-                      def getWorkerInfo(worker: WorkerInfo): WorkerInfo = {
-                        workerInfoSnapshots.get(worker.toUniqueId()).getOrElse(
-                          lifecycleManager.shuffleAllocatedWorkers
-                            .get(shuffleId)
-                            .asScala
-                            .find(_._1.equals(worker))
-                            .get
-                            ._1)
-                      }
                       try {
                         val params = new ArrayBuffer[CommitFilesParam](workerToRequests.size)
                         workerToRequests.foreach {
                           case (worker, requests) =>
-                            val workerInfo = getWorkerInfo(worker)
+                            val workerInfo =
+                              lifecycleManager.shuffleAllocatedWorkers
+                                .get(shuffleId)
+                                .asScala
+                                .get(worker)
+                                .get
+                                .workerInfo
                             val primaryIds =
                               requests
                                 .filter(_.getMode == PartitionLocation.Mode.PRIMARY)

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -121,9 +121,7 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
                             val workerInfo =
                               lifecycleManager.shuffleAllocatedWorkers
                                 .get(shuffleId)
-                                .asScala
                                 .get(worker.toUniqueId())
-                                .get
                                 .workerInfo
                             val primaryIds =
                               requests

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -314,13 +314,14 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
     override def notifyChangedWorkersStatus(workersStatus: WorkersStatus): Unit = {
       if (workersStatus.shutdownWorkers != null) {
         lifecycleManager.shuffleAllocatedWorkers.asScala.foreach {
-          case (shuffleId, workerToPartitionLocationInfos) =>
+          case (shuffleId, workerIdToPartitionLocationInfos) =>
             if (!isStageEndOrInProcess(shuffleId)) {
               val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
               val needCommitPartitionLocations = new util.HashSet[PartitionLocation]()
 
               workersStatus.shutdownWorkers.asScala.foreach { worker =>
-                val partitionLocationInfos = workerToPartitionLocationInfos.get(worker)
+                val partitionLocationInfos =
+                  workerIdToPartitionLocationInfos.get(worker.toUniqueId())
                 if (partitionLocationInfos != null) {
                   logWarning(s"Worker ${worker.toUniqueId()} shutdown, " +
                     s"commit all it's partition locations for shuffle $shuffleId.")

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -121,7 +121,7 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
                             val workerInfo =
                               lifecycleManager.shuffleAllocatedWorkers
                                 .get(shuffleId)
-                                .get(worker.toUniqueId())
+                                .get(worker.toUniqueId)
                                 .workerInfo
                             val primaryIds =
                               requests
@@ -319,9 +319,9 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
 
               workersStatus.shutdownWorkers.asScala.foreach { worker =>
                 val partitionLocationInfos =
-                  workerIdToPartitionLocationInfos.get(worker.toUniqueId())
+                  workerIdToPartitionLocationInfos.get(worker.toUniqueId)
                 if (partitionLocationInfos != null) {
-                  logWarning(s"Worker ${worker.toUniqueId()} shutdown, " +
+                  logWarning(s"Worker ${worker.toUniqueId} shutdown, " +
                     s"commit all it's partition locations for shuffle $shuffleId.")
                   needCommitPartitionLocations.addAll(partitionLocationInfos.getPrimaryPartitions())
                   needCommitPartitionLocations.addAll(partitionLocationInfos.getReplicaPartitions())

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -63,7 +63,7 @@ object LifecycleManager {
   type ShuffleFileGroups =
     ConcurrentHashMap[Int, ConcurrentHashMap[Integer, util.Set[PartitionLocation]]]
   type ShuffleAllocatedWorkers =
-    ConcurrentHashMap[Int, ConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]]
+    ConcurrentHashMap[Int, ConcurrentHashMap[String, ShufflePartitionLocationInfo]]
   type ShuffleFailedWorkers = ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]
 }
 
@@ -121,7 +121,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   private val authEnabled = conf.authEnabledOnClient
   private var applicationMeta: ApplicationMeta = _
   @VisibleForTesting
-  def workerSnapshots(shuffleId: Int): util.Map[WorkerInfo, ShufflePartitionLocationInfo] =
+  def workerSnapshots(shuffleId: Int): util.Map[String, ShufflePartitionLocationInfo] =
     shuffleAllocatedWorkers.get(shuffleId)
 
   @VisibleForTesting
@@ -716,13 +716,13 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       }
       // Forth, register shuffle success, update status
       val allocatedWorkers =
-        JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
+        JavaUtils.newConcurrentHashMap[String, ShufflePartitionLocationInfo]()
       slots.asScala.foreach { case (workerInfo, (primaryLocations, replicaLocations)) =>
         val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
         partitionLocationInfo.addPrimaryPartitions(primaryLocations)
         updateLatestPartitionLocations(shuffleId, primaryLocations)
         partitionLocationInfo.addReplicaPartitions(replicaLocations)
-        allocatedWorkers.put(workerInfo, partitionLocationInfo)
+        allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
       }
       shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
       registeredShuffle.add(shuffleId)
@@ -1758,7 +1758,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   }
 
   def getAllocatedWorkers(): Set[WorkerInfo] = {
-    shuffleAllocatedWorkers.asScala.values.flatMap(_.keys().asScala).toSet
+    shuffleAllocatedWorkers.asScala.values.flatMap(_.values().asScala.map(_.workerInfo)).toSet
   }
 
   // delegate workerStatusTracker to register listener

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -722,7 +722,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         partitionLocationInfo.addPrimaryPartitions(primaryLocations)
         updateLatestPartitionLocations(shuffleId, primaryLocations)
         partitionLocationInfo.addReplicaPartitions(replicaLocations)
-        allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
+        allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
       }
       shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
       registeredShuffle.add(shuffleId)
@@ -1246,7 +1246,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
                   WORKER_EP)
               } else {
                 logInfo(
-                  s"${destroyWorkerInfo.toUniqueId()} is unavailable, set destroyWorkerInfo to null")
+                  s"${destroyWorkerInfo.toUniqueId} is unavailable, set destroyWorkerInfo to null")
                 destroyWorkerInfo = null
               }
             } catch {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -718,7 +718,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       val allocatedWorkers =
         JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
       slots.asScala.foreach { case (workerInfo, (primaryLocations, replicaLocations)) =>
-        val partitionLocationInfo = new ShufflePartitionLocationInfo()
+        val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
         partitionLocationInfo.addPrimaryPartitions(primaryLocations)
         updateLatestPartitionLocations(shuffleId, primaryLocations)
         partitionLocationInfo.addReplicaPartitions(replicaLocations)

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -78,7 +78,7 @@ class WorkerStatusTracker(
     def excludeWorker(partition: PartitionLocation, statusCode: StatusCode): Unit = {
       val tmpWorker = partition.getWorker
       val worker = lifecycleManager.workerSnapshots(shuffleId).asScala.get(
-        tmpWorker.toUniqueId()).map(_.workerInfo)
+        tmpWorker.toUniqueId).map(_.workerInfo)
       if (worker.isDefined) {
         failedWorker.put(worker.get, (statusCode, System.currentTimeMillis()))
       }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -77,8 +77,8 @@ class WorkerStatusTracker(
 
     def excludeWorker(partition: PartitionLocation, statusCode: StatusCode): Unit = {
       val tmpWorker = partition.getWorker
-      val worker =
-        lifecycleManager.workerSnapshots(shuffleId).keySet().asScala.find(_.equals(tmpWorker))
+      val worker = lifecycleManager.workerSnapshots(shuffleId).asScala.get(
+        tmpWorker.toUniqueId()).map(_.workerInfo)
       if (worker.isDefined) {
         failedWorker.put(worker.get, (statusCode, System.currentTimeMillis()))
       }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -391,7 +391,7 @@ abstract class CommitHandler(
 
   def parallelCommitFiles(
       shuffleId: Int,
-      allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo],
+      allocatedWorkers: util.Map[String, ShufflePartitionLocationInfo],
       partitionIdOpt: Option[Int] = None): CommitResult = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
     val primaryPartMap = JavaUtils.newConcurrentHashMap[String, PartitionLocation]
@@ -406,7 +406,8 @@ abstract class CommitHandler(
     val workerPartitionLocations = allocatedWorkers.asScala.filter(!_._2.isEmpty)
 
     val params = new ArrayBuffer[CommitFilesParam](workerPartitionLocations.size)
-    workerPartitionLocations.foreach { case (worker, partitionLocationInfo) =>
+    workerPartitionLocations.foreach { case (_, partitionLocationInfo) =>
+      val worker = partitionLocationInfo.workerInfo
       val primaryParts =
         partitionLocationInfo.getPrimaryPartitions(partitionIdOpt)
       val replicaParts = partitionLocationInfo.getReplicaPartitions(partitionIdOpt)

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -122,7 +122,7 @@ class MapPartitionCommitHandler(
 
   private def handleFinalPartitionCommitFiles(
       shuffleId: Int,
-      allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo],
+      allocatedWorkers: util.Map[String, ShufflePartitionLocationInfo],
       partitionId: Int): (Boolean, ShuffleFailedWorkers) = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
     // commit files

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -31,7 +31,7 @@ import org.apache.celeborn.client.CommitManager.CommittedPartitionInfo
 import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.ShufflePartitionLocationInfo
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
 import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -167,7 +167,7 @@ class ReducePartitionCommitHandler(
 
   private def handleFinalCommitFiles(
       shuffleId: Int,
-      allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo])
+      allocatedWorkers: util.Map[String, ShufflePartitionLocationInfo])
       : (Boolean, ShuffleFailedWorkers) = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.celeborn.common.protocol.PartitionLocation
 
-class ShufflePartitionLocationInfo {
+class ShufflePartitionLocationInfo(val workerInfo: WorkerInfo) {
   type PartitionInfo = ConcurrentHashMap[Int, util.Set[PartitionLocation]]
 
   private val primaryPartitionLocations = new PartitionInfo

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -160,9 +160,7 @@ class WorkerInfo(
       (if (internalPort > 0) s":InternalPort:$internalPort" else "")
   }
 
-  def toUniqueId(): String = {
-    s"$host:$rpcPort:$pushPort:$fetchPort:$replicatePort"
-  }
+  lazy val toUniqueId = s"$host:$rpcPort:$pushPort:$fetchPort:$replicatePort"
 
   def slotAvailable(): Boolean = this.synchronized {
     diskInfos.asScala.exists { case (_, disk) => (disk.maxSlots - disk.activeSlots) > 0 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -411,7 +411,7 @@ object PbSerDeUtils {
         .addAllReplicaPartitions(replicaPartitions)
         .setNetworkLocation(workerInfo.networkLocation)
         .build()
-      workerInfo.toUniqueId() -> pbWorkerResource
+      workerInfo.toUniqueId -> pbWorkerResource
     }.asJava
   }
 
@@ -450,12 +450,12 @@ object PbSerDeUtils {
       .setShuffleTotalCount(shuffleTotalCount)
       .putAllShuffleFallbackCounts(shuffleFallbackCounts)
       .putAllLostWorkers(lostWorkers.asScala.map {
-        case (worker: WorkerInfo, time: java.lang.Long) => (worker.toUniqueId(), time)
+        case (worker: WorkerInfo, time: java.lang.Long) => (worker.toUniqueId, time)
       }.asJava)
       .addAllShutdownWorkers(shutdownWorkers.asScala.map(toPbWorkerInfo(_, true, false)).asJava)
       .putAllWorkerEventInfos(workerEventInfos.asScala.map {
         case (worker, workerEventInfo) =>
-          (worker.toUniqueId(), PbSerDeUtils.toPbWorkerEventInfo(workerEventInfo))
+          (worker.toUniqueId, PbSerDeUtils.toPbWorkerEventInfo(workerEventInfo))
       }.asJava)
       .addAllDecommissionWorkers(decommissionWorkers.asScala.map(
         toPbWorkerInfo(_, true, false)).asJava)
@@ -510,7 +510,7 @@ object PbSerDeUtils {
       location: PartitionLocation): PbPackedPartitionLocations.Builder = {
     pbPackedLocationsBuilder.addIds(location.getId)
     pbPackedLocationsBuilder.addEpoches(location.getEpoch)
-    pbPackedLocationsBuilder.addWorkerIds(workerIdIndex(location.getWorker.toUniqueId()))
+    pbPackedLocationsBuilder.addWorkerIds(workerIdIndex(location.getWorker.toUniqueId))
     pbPackedLocationsBuilder.addMapIdBitMap(
       Utils.roaringBitmapToByteString(location.getMapIdBitMap))
     pbPackedLocationsBuilder.addTypes(location.getStorageInfo.getType.getValue)
@@ -536,7 +536,7 @@ object PbSerDeUtils {
 
     val allLocations = (inputLocations ++ implicateLocations)
     val workerIdList = new util.ArrayList[String](
-      allLocations.map(_.getWorker.toUniqueId()).toSet.asJava)
+      allLocations.map(_.getWorker.toUniqueId).toSet.asJava)
     val workerIdIndex = workerIdList.asScala.zipWithIndex.toMap
     val mountPointsList = new util.ArrayList[String](
       allLocations.map(
@@ -666,7 +666,7 @@ object PbSerDeUtils {
           primaryLocations.asScala.toList ++ replicaLocations.asScala.toList))
         .setNetworkLocation(workerInfo.networkLocation)
         .build()
-      workerInfo.toUniqueId() -> pbWorkerResource
+      workerInfo.toUniqueId -> pbWorkerResource
     }.asJava
   }
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
@@ -46,7 +46,8 @@ class ShufflePartitionLocationInfoSuite extends CelebornFunSuite {
     replicaLocations.add(partitionLocationReplica00)
     replicaLocations.add(partitionLocationReplica10)
 
-    val shufflePartitionLocationInfo = new ShufflePartitionLocationInfo
+    val workerInfo = new WorkerInfo("localhost", 1, 2, 3, 4)
+    val shufflePartitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
     shufflePartitionLocationInfo.addPrimaryPartitions(primaryLocations)
     shufflePartitionLocationInfo.addReplicaPartitions(replicaLocations)
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -653,7 +653,7 @@ private[celeborn] class Master(
       workerStatus: WorkerStatus,
       requestId: String): Unit = {
     val targetWorker = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
-    val registered = statusSystem.workersMap.containsKey(targetWorker.toUniqueId())
+    val registered = statusSystem.workersMap.containsKey(targetWorker.toUniqueId)
     if (!registered) {
       logWarning(s"Received heartbeat from unknown worker " +
         s"$host:$rpcPort:$pushPort:$fetchPort:$replicatePort.")
@@ -683,7 +683,7 @@ private[celeborn] class Master(
       }
     }
     logDebug(
-      s"Shuffle ${expiredShuffleKeys.asScala.mkString("[", " ,", "]")} expired on ${targetWorker.toUniqueId()}.")
+      s"Shuffle ${expiredShuffleKeys.asScala.mkString("[", " ,", "]")} expired on ${targetWorker.toUniqueId}.")
 
     val workerEventInfo = statusSystem.workerEventInfos.get(targetWorker)
     if (workerEventInfo == null) {
@@ -743,7 +743,7 @@ private[celeborn] class Master(
       -1,
       new util.HashMap[String, DiskInfo](),
       JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption]())
-    val worker: WorkerInfo = statusSystem.workersMap.get(targetWorker.toUniqueId())
+    val worker: WorkerInfo = statusSystem.workersMap.get(targetWorker.toUniqueId)
     if (worker == null) {
       logWarning(s"Unknown worker $host:$rpcPort:$pushPort:$fetchPort:$replicatePort" +
         s" for WorkerLost handler!")
@@ -788,7 +788,7 @@ private[celeborn] class Master(
       return
     }
 
-    if (statusSystem.workersMap.containsKey(workerToRegister.toUniqueId())) {
+    if (statusSystem.workersMap.containsKey(workerToRegister.toUniqueId)) {
       logWarning(s"Receive RegisterWorker while worker" +
         s" ${workerToRegister.toString()} already exists, re-register.")
       statusSystem.handleRegisterWorker(
@@ -917,8 +917,8 @@ private[celeborn] class Master(
     if (log.isDebugEnabled()) {
       val distributions = SlotsAllocator.slotsToDiskAllocations(slots)
       logDebug(
-        s"allocate slots for shuffle $shuffleKey ${slots.asScala.map(m => m._1.toUniqueId() -> m._2)}" +
-          s" distributions: ${distributions.asScala.map(m => m._1.toUniqueId() -> m._2)}")
+        s"allocate slots for shuffle $shuffleKey ${slots.asScala.map(m => m._1.toUniqueId -> m._2)}" +
+          s" distributions: ${distributions.asScala.map(m => m._1.toUniqueId -> m._2)}")
     }
 
     // reply false if offer slots failed
@@ -936,7 +936,7 @@ private[celeborn] class Master(
       shuffleKey,
       requestSlots.hostname,
       Utils.getSlotsPerDisk(slots.asInstanceOf[WorkerResource])
-        .asScala.map { case (worker, slots) => worker.toUniqueId() -> slots }.asJava,
+        .asScala.map { case (worker, slots) => worker.toUniqueId -> slots }.asJava,
       requestSlots.requestId)
 
     logInfo(s"Offer slots successfully for $numReducers reducers of $shuffleKey" +
@@ -1121,7 +1121,7 @@ private[celeborn] class Master(
       requestId)
     gaugeShuffleFallbackCounts()
     val unknownWorkers = needCheckedWorkerList.asScala.filterNot(w =>
-      statusSystem.workersMap.containsKey(w.toUniqueId())).asJava
+      statusSystem.workersMap.containsKey(w.toUniqueId)).asJava
     if (shouldResponse) {
       // UserResourceConsumption and DiskInfo are eliminated from WorkerInfo
       // during serialization of HeartbeatFromApplicationResponse
@@ -1320,7 +1320,7 @@ private[celeborn] class Master(
     val sb = new StringBuilder
     sb.append("======================= Lost Workers in Master ========================\n")
     statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2).foreach { case (worker, time) =>
-      sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
+      sb.append(s"${worker.toUniqueId.padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
     }
     sb.toString()
   }
@@ -1329,7 +1329,7 @@ private[celeborn] class Master(
     val sb = new StringBuilder
     sb.append("===================== Shutdown Workers in Master ======================\n")
     statusSystem.shutdownWorkers.asScala.foreach { worker =>
-      sb.append(s"${worker.toUniqueId()}\n")
+      sb.append(s"${worker.toUniqueId}\n")
     }
     sb.toString()
   }
@@ -1338,7 +1338,7 @@ private[celeborn] class Master(
     val sb = new StringBuilder
     sb.append("===================== Decommission Workers in Master ======================\n")
     statusSystem.decommissionWorkers.asScala.foreach { worker =>
-      sb.append(s"${worker.toUniqueId()}\n")
+      sb.append(s"${worker.toUniqueId}\n")
     }
     sb.toString()
   }
@@ -1347,7 +1347,7 @@ private[celeborn] class Master(
     val sb = new StringBuilder
     sb.append("===================== Excluded Workers in Master ======================\n")
     (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala).foreach {
-      worker => sb.append(s"${worker.toUniqueId()}\n")
+      worker => sb.append(s"${worker.toUniqueId}\n")
     }
     sb.toString()
   }
@@ -1401,7 +1401,7 @@ private[celeborn] class Master(
     }
     val unknownExcludedWorkers =
       (addWorkers ++ removeWorkers).filterNot(w =>
-        statusSystem.workersMap.containsKey(w.toUniqueId()))
+        statusSystem.workersMap.containsKey(w.toUniqueId))
     if (unknownExcludedWorkers.nonEmpty) {
       sb.append(
         s"Unknown workers ${unknownExcludedWorkers.map(_.readableAddress).mkString(",")}." +
@@ -1477,7 +1477,7 @@ private[celeborn] class Master(
     val sb = new StringBuilder
     sb.append("======================= Workers Event in Master ========================\n")
     statusSystem.workerEventInfos.asScala.foreach { case (worker, workerEventInfo) =>
-      sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}$workerEventInfo\n")
+      sb.append(s"${worker.toUniqueId.padTo(50, " ").mkString}$workerEventInfo\n")
     }
     sb.toString()
   }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/WorkerResource.scala
@@ -135,7 +135,7 @@ class WorkerResource extends ApiRequestContext {
       }
       val workers = request.getWorkers.asScala.map(ApiUtils.toWorkerInfo).toSeq
       val (filteredWorkers, unknownWorkers) =
-        workers.partition(w => statusSystem.workersMap.containsKey(w.toUniqueId()))
+        workers.partition(w => statusSystem.workersMap.containsKey(w.toUniqueId))
       if (filteredWorkers.isEmpty) {
         throw new BadRequestException(
           s"None of the workers are known: ${unknownWorkers.map(_.readableAddress).mkString(", ")}")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -89,7 +89,7 @@ class TagsManager(configService: Option[ConfigService]) extends Logging {
     }
 
     val workerTagsPredicate = new Predicate[WorkerInfo] {
-      override def test(w: WorkerInfo): Boolean = workersForTags.get.contains(w.toUniqueId())
+      override def test(w: WorkerInfo): Boolean = workersForTags.get.contains(w.toUniqueId)
     }
     workers.stream().filter(workerTagsPredicate).collect(Collectors.toList())
   }
@@ -112,7 +112,7 @@ class TagsManager(configService: Option[ConfigService]) extends Logging {
   }
 
   def getTagsForWorker(worker: WorkerInfo): Set[String] = {
-    defaultTagStore.asScala.filter(_._2.contains(worker.toUniqueId())).keySet.toSet
+    defaultTagStore.asScala.filter(_._2.contains(worker.toUniqueId)).keySet.toSet
   }
 
   def removeTagFromCluster(tag: String): Unit = {

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
@@ -47,11 +47,11 @@ class TagsManagerSuite extends CelebornFunSuite {
   test("test tags manager") {
     tagsManager = new TagsManager(Option(null))
 
-    tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId())
-    tagsManager.addTagToWorker(TAG1, WORKER2.toUniqueId())
+    tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId)
+    tagsManager.addTagToWorker(TAG1, WORKER2.toUniqueId)
 
-    tagsManager.addTagToWorker(TAG2, WORKER2.toUniqueId())
-    tagsManager.addTagToWorker(TAG2, WORKER3.toUniqueId())
+    tagsManager.addTagToWorker(TAG2, WORKER2.toUniqueId)
+    tagsManager.addTagToWorker(TAG2, WORKER3.toUniqueId)
 
     {
       val taggedWorkers = tagsManager.getTaggedWorkers(user, TAG1, workers)
@@ -106,7 +106,7 @@ class TagsManagerSuite extends CelebornFunSuite {
 
     {
       // Remove tag from worker
-      tagsManager.removeTagFromWorker(TAG1, WORKER2.toUniqueId())
+      tagsManager.removeTagFromWorker(TAG1, WORKER2.toUniqueId)
       val taggedWorkers = tagsManager.getTaggedWorkers(user, TAG1, workers)
       assert(taggedWorkers.size == 1)
       assert(taggedWorkers.contains(WORKER1))
@@ -130,12 +130,12 @@ class TagsManagerSuite extends CelebornFunSuite {
     tagsManager = new TagsManager(Option(null))
 
     // Tag1
-    tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId())
-    tagsManager.addTagToWorker(TAG1, WORKER2.toUniqueId())
+    tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId)
+    tagsManager.addTagToWorker(TAG1, WORKER2.toUniqueId)
 
     // Tag2
-    tagsManager.addTagToWorker(TAG2, WORKER2.toUniqueId())
-    tagsManager.addTagToWorker(TAG2, WORKER3.toUniqueId())
+    tagsManager.addTagToWorker(TAG2, WORKER2.toUniqueId)
+    tagsManager.addTagToWorker(TAG2, WORKER3.toUniqueId)
 
     {
       val taggedWorkers = tagsManager.getTaggedWorkers(user, "tag1,tag2", workers)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -81,13 +81,13 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
-        JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
+        JavaUtils.newConcurrentHashMap[String, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo, partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
           lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
@@ -156,13 +156,13 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
-        JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
+        JavaUtils.newConcurrentHashMap[String, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo, partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
           lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
@@ -190,8 +190,9 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     val tmpSnapshotWorkers =
       lifecycleManager
         .workerSnapshots(shuffleId)
-        .keySet()
         .asScala
+        .values
+        .map(_.workerInfo)
         .filter(lifecycleManager.workerStatusTracker.workerAvailable)
     assert(tmpSnapshotWorkers.size == 1)
 
@@ -219,8 +220,9 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     val snapshotCandidates =
       lifecycleManager
         .workerSnapshots(shuffleId)
-        .keySet()
         .asScala
+        .values
+        .map(_.workerInfo)
         .filter(lifecycleManager.workerStatusTracker.workerAvailable)
 
     assert(snapshotCandidates.size == 2)
@@ -262,13 +264,13 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
-        JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
+        JavaUtils.newConcurrentHashMap[String, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo, partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
     }
@@ -333,13 +335,13 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
-        JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
+        JavaUtils.newConcurrentHashMap[String, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo, partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
     }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -20,12 +20,12 @@ package org.apache.celeborn.tests.client
 import java.util
 import java.util.Collections
 
-import scala.collection.JavaConverters.{asScalaSetConverter, mapAsScalaMapConverter}
+import scala.collection.JavaConverters.mapAsScalaMapConverter
 
 import org.apache.celeborn.client.{ChangePartitionManager, ChangePartitionRequest, LifecycleManager, WithShuffleClientSuite}
 import org.apache.celeborn.client.LifecycleManager.ShuffleFailedWorkers
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.ShufflePartitionLocationInfo
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.util.JavaUtils
 import org.apache.celeborn.service.deploy.MiniClusterFeature

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -84,7 +84,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
-          val partitionLocationInfo = new ShufflePartitionLocationInfo()
+          val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
           allocatedWorkers.put(workerInfo, partitionLocationInfo)
@@ -159,7 +159,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
-          val partitionLocationInfo = new ShufflePartitionLocationInfo()
+          val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
           allocatedWorkers.put(workerInfo, partitionLocationInfo)
@@ -265,7 +265,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
-          val partitionLocationInfo = new ShufflePartitionLocationInfo()
+          val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
           allocatedWorkers.put(workerInfo, partitionLocationInfo)
@@ -336,7 +336,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         JavaUtils.newConcurrentHashMap[WorkerInfo, ShufflePartitionLocationInfo]()
       res.workerResource.asScala.foreach {
         case (workerInfo, (primaryLocations, replicaLocations)) =>
-          val partitionLocationInfo = new ShufflePartitionLocationInfo()
+          val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
           allocatedWorkers.put(workerInfo, partitionLocationInfo)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -87,7 +87,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
           lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
@@ -162,7 +162,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
           lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
@@ -270,7 +270,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
     }
@@ -341,7 +341,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
           val partitionLocationInfo = new ShufflePartitionLocationInfo(workerInfo)
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
-          allocatedWorkers.put(workerInfo.toUniqueId(), partitionLocationInfo)
+          allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -731,11 +731,13 @@ private[deploy] class Controller(
     while (mapIdx < mapAttempts.length) {
       if (mapAttempts(mapIdx) != -1) {
         shuffleMapperAttempts.synchronized {
-          mapIdx until shuffleMapperAttempts.length() foreach (idx => {
+          var idx = mapIdx
+          while (idx < shuffleMapperAttempts.length()) {
             if (mapAttempts(idx) != -1 && shuffleMapperAttempts.get(idx) == -1) {
               shuffleMapperAttempts.set(idx, mapAttempts(idx))
             }
-          })
+            idx += 1
+          }
         }
         return
       }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -728,11 +728,13 @@ private[deploy] class Controller(
       mapAttempts: Array[Int],
       shuffleMapperAttempts: AtomicIntegerArray): Unit = {
     var mapIdx = 0
-    while (mapIdx < mapAttempts.length) {
+    val mapAttemptsLen = mapAttempts.length
+    while (mapIdx < mapAttemptsLen) {
       if (mapAttempts(mapIdx) != -1) {
         shuffleMapperAttempts.synchronized {
           var idx = mapIdx
-          while (idx < shuffleMapperAttempts.length()) {
+          val len = shuffleMapperAttempts.length()
+          while (idx < len) {
             if (mapAttempts(idx) != -1 && shuffleMapperAttempts.get(idx) == -1) {
               shuffleMapperAttempts.set(idx, mapAttempts(idx))
             }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -453,12 +453,8 @@ private[deploy] class Controller(
     }
 
     // Update shuffleMapperAttempts
-    val shuffleMapAttempts = shuffleMapperAttempts.get(shuffleKey)
-    if (shuffleMapAttempts == null) {
-      shuffleMapperAttempts.putIfAbsent(shuffleKey, new AtomicIntegerArray(mapAttempts))
-    } else {
-      updateShuffleMapperAttempts(mapAttempts, shuffleMapAttempts)
-    }
+    shuffleMapperAttempts.putIfAbsent(shuffleKey, new AtomicIntegerArray(mapAttempts))
+    updateShuffleMapperAttempts(mapAttempts, shuffleMapperAttempts.get(shuffleKey))
 
     // Use ConcurrentSet to avoid excessive lock contention.
     val committedPrimaryIds = ConcurrentHashMap.newKeySet[String]()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -351,7 +351,7 @@ private[celeborn] class Worker(
 
   private var jvmQuake: JVMQuake = _
   if (conf.workerJvmQuakeEnabled) {
-    jvmQuake = JVMQuake.create(conf, workerInfo.toUniqueId().replace(":", "-"))
+    jvmQuake = JVMQuake.create(conf, workerInfo.toUniqueId.replace(":", "-"))
     jvmQuake.start()
   }
 
@@ -857,7 +857,7 @@ private[celeborn] class Worker(
     val sb = new StringBuilder
     sb.append("==================== Unavailable Peers of Worker =====================\n")
     unavailablePeers.asScala.foreach { case (peer, time) =>
-      sb.append(s"${peer.toUniqueId().padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
+      sb.append(s"${peer.toUniqueId.padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
     }
     sb.toString()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Optimize the code for `exists` and `find`.

1.  Enhance the performance to lookup workerInfo by workerUniqueId instead of looping the collection:
 https://github.com/apache/celeborn/blob/74c1ec0a7fcc4d9efb26d9b96901234eb76e22cd/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala#L65-L66 

Change the type to:
```
 type ShuffleAllocatedWorkers =
    ConcurrentHashMap[Int, ConcurrentHashMap[String, ShufflePartitionLocationInfo]]
```
And save the `WorkerInfo` into `ShufflePartitionLocationInfo`.
```
class ShufflePartitionLocationInfo(val workerInfo: WorkerInfo) {
...
}
```

So that, we can get the `WorkerInfo` by worker uniqueId fast.

2. Reduce the loop cost for below code: https://github.com/apache/celeborn/blob/33ba0e02f56bfa032c02d1e41c52573c79661b1b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala#L455-L466


### Why are the changes needed?

Enhance the performance.
Address comments:
https://github.com/apache/celeborn/pull/2959#pullrequestreview-2466200199
https://github.com/apache/celeborn/pull/2959#issuecomment-2505137166


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

GA