### PR TITLE
[CELEBORN-1743] [FOLLOWUP]Introduces a configuration option to determine whether application metrics should be included

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -879,6 +879,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def metricsWorkerForceAppendPauseSpentTimeThreshold: Int =
     get(METRICS_WORKER_PAUSE_SPENT_TIME_FORCE_APPEND_THRESHOLD)
   def metricsJsonPrettyEnabled: Boolean = get(METRICS_JSON_PRETTY_ENABLED)
+  def metricsAppEnabled: Boolean = get(METRICS_APP_ENABLED)
 
   // //////////////////////////////////////////////////////
   //                      Quota                         //
@@ -5337,6 +5338,14 @@ object CelebornConf extends Logging {
       .categories("metrics")
       .doc("When true, view metrics in json pretty format")
       .version("0.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val METRICS_APP_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.metrics.application.enabled")
+      .categories("metrics")
+      .doc("When false, the metrics of application won't return to reduce the num of metrics.")
+      .version("0.6.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -21,8 +21,8 @@ import java.lang
 import java.util.{Map => JMap}
 import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 
-import scala.collection.{breakOut, mutable}
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
@@ -530,8 +530,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
         sb.append(s.toString)
     var addNum = 0
     val appCount0Metrics = ArrayBuffer[String]()
-    for (m <- metricList) {
-      if (addNum >= leftNum) breakOut
+    for (m <- metricList if addNum < leftNum) {
       var strMetrics = ""
       var isApp = false
       m match {

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -511,9 +511,9 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     if (leftNum <= 0) {
       return 0
     }
-    var addNum = 0
+    var nonAppMetricsAddNum = 0
     val appCount0Metrics = ArrayBuffer[String]()
-    for (m <- metricList if addNum < leftNum) {
+    for (m <- metricList if nonAppMetricsAddNum < leftNum) {
       var strMetrics = ""
       var isApp = false
       var isCount0 = false
@@ -546,10 +546,9 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
       }
       if (!isApp) {
         sb.append(strMetrics)
-        addNum = addNum + 1
+        nonAppMetricsAddNum = nonAppMetricsAddNum + 1
       } else {
-        val leftAppMetricsNum = leftNum - addNum - appMetricsSnapshot.size
-        if (leftAppMetricsNum > 0) {
+        if (leftNum - nonAppMetricsAddNum - appMetricsSnapshot.size > 0) {
           if (isCount0) {
             appCount0Metrics += strMetrics
           } else {
@@ -558,8 +557,11 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
         }
       }
     }
-    appMetricsSnapshot ++= appCount0Metrics
-    leftNum - addNum
+    val leftAppMetricsNum = leftNum - nonAppMetricsAddNum - appMetricsSnapshot.size
+    if (appCount0Metrics.nonEmpty && leftAppMetricsNum > 0) {
+      appMetricsSnapshot ++= appCount0Metrics.toList.take(leftAppMetricsNum)
+    }
+    leftNum - nonAppMetricsAddNum
   }
 
   override def destroy(): Unit = {

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.metrics.source
 
+import java.{lang, util}
 import java.util.{Map => JMap}
 import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -18,7 +18,7 @@
 package org.apache.celeborn.common.metrics.source
 
 import java.util.{Map => JMap}
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -105,8 +105,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     // filter out non-number type gauges
     if (gauge.getValue.isInstanceOf[Number]) {
       namedGauges.putIfAbsent(
-        metricNameWithCustomizedLabels(name, labels),
-        NamedGauge(name, gauge, labels ++ staticLabels))
+        metricNameWithCustomizedLabels(name, labels), NamedGauge(name, gauge, labels ++ staticLabels))
     } else {
       logWarning(
         s"Add gauge $name failed, the value type ${gauge.getValue.getClass} is not a number")

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.common.metrics.source
 
-import java.{lang, util}
+import java.lang
 import java.util.{Map => JMap}
 import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -49,7 +49,7 @@ class CelebornSourceSuite extends CelebornFunSuite {
     mockSource.stopTimer("Timer1", "key1")
     mockSource.stopTimer("Timer2", "key2", user3)
 
-    mockSource.timerMetricsMap.add("testTimerMetricsMap")
+    mockSource.timerMetrics.add("testTimerMetricsMap")
 
     val res = mockSource.getMetrics()
     var extraLabelsStr = extraLabels
@@ -142,5 +142,23 @@ class CelebornSourceSuite extends CelebornFunSuite {
     List[Int](3).foreach { i =>
       assert(!res3.contains(exps3(i)))
     }
+  }
+
+  test("test getAndClearTimerMetrics in timerMetrics") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "6")
+    val role = "mock"
+    val mockSource = new AbstractSource(conf, role) {
+      override def sourceName: String = "mockSource"
+    }
+    val exp1 = "testTimerMetrics1"
+    val exp2 = "testTimerMetrics2"
+    mockSource.timerMetrics.add(exp1)
+    val res1 = mockSource.getMetrics()
+    mockSource.timerMetrics.add(exp2)
+    val res2 = mockSource.getMetrics()
+
+    assert(res1.contains(exp1) && !res1.contains(exp2))
+    assert(res2.contains(exp2) && !res2.contains(exp1))
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -22,16 +22,10 @@ import org.apache.celeborn.common.CelebornConf
 
 class CelebornSourceSuite extends CelebornFunSuite {
 
-  test("test getMetrics with customized label") {
-    val conf = new CelebornConf()
-    createAbstractSourceAndCheck(conf, "", Role.MASTER)
-    createAbstractSourceAndCheck(conf, "", Role.WORKER)
-  }
-
-  def createAbstractSourceAndCheck(
+  def createAbstractSource(
       conf: CelebornConf,
       extraLabels: String,
-      role: String = "mock"): Unit = {
+      role: String = "mock"): (String, List[String]) = {
     val mockSource = new AbstractSource(conf, role) {
       override def sourceName: String = "mockSource"
     }
@@ -39,12 +33,13 @@ class CelebornSourceSuite extends CelebornFunSuite {
     val user2 = Map("user" -> "user2")
     val user3 = Map("user" -> "user3")
     mockSource.addGauge("Gauge1") { () => 1000 }
-    mockSource.addGauge("Gauge2", user1) { () => 2000 }
-    mockSource.addCounter("Counter1")
-    mockSource.addCounter("Counter2", user2)
+    mockSource.addGauge("Gauge2", user1, true) { () => 2000 }
+    mockSource.addCounter("Counter1", Map.empty[String, String], true)
+    mockSource.addCounter("Counter2", user2, true)
     // test operation with and without label
     mockSource.incCounter("Counter1", 3000)
     mockSource.incCounter("Counter2", 4000, user2)
+    mockSource.incCounter("Counter2", -4000, user2)
     mockSource.addTimer("Timer1")
     mockSource.addTimer("Timer2", user3)
     // ditto
@@ -66,37 +61,83 @@ class CelebornSourceSuite extends CelebornFunSuite {
       s"""metrics_Gauge2_Value{${extraLabelsStr}${instanceLabelStr}role="$role",user="user1"} 2000"""
     val exp3 = s"""metrics_Counter1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 3000"""
     val exp4 =
-      s"""metrics_Counter2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user2"} 4000"""
+      s"""metrics_Counter2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user2"} 0"""
     val exp5 = s"""metrics_Timer1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 1"""
     val exp6 =
       s"""metrics_Timer2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user3"} 1"""
 
-    assert(res.contains(exp1))
-    assert(res.contains(exp2))
-    assert(res.contains(exp3))
-    assert(res.contains(exp4))
-    assert(res.contains(exp5))
-    assert(res.contains(exp6))
+    val expList = List[String](exp1, exp2, exp3, exp4, exp5, exp6)
+    (res, expList)
+  }
+
+  def checkMetricsRes(res: String, labelList: List[String]): Unit = {
+    labelList.foreach { exp =>
+      assert(res.contains(exp))
+    }
   }
 
   test("test getMetrics with customized label by conf") {
     val conf = new CelebornConf()
+    val (resM, expsM) = createAbstractSource(conf, "", Role.MASTER)
+    checkMetricsRes(resM, expsM)
+    val (resW, expsW) = createAbstractSource(conf, "", Role.WORKER)
+    checkMetricsRes(resW, expsW)
+
     // label's is normal
     conf.set(CelebornConf.METRICS_EXTRA_LABELS.key, "l1=v1,l2=v2,l3=v3")
     val extraLabels = """l1="v1",l2="v2",l3="v3""""
-    createAbstractSourceAndCheck(conf, extraLabels)
+    val (res, exps) = createAbstractSource(conf, extraLabels)
+    checkMetricsRes(res, exps)
 
     // labels' kv not correct
     assertThrows[IllegalArgumentException] {
       conf.set(CelebornConf.METRICS_EXTRA_LABELS.key, "l1=v1,l2=")
       val extraLabels2 = """l1="v1",l2="v2",l3="v3""""
-      createAbstractSourceAndCheck(conf, extraLabels2)
+      val (res2, exps2) = createAbstractSource(conf, extraLabels2)
+      checkMetricsRes(res2, exps2)
     }
 
     // there are spaces in labels
     conf.set(CelebornConf.METRICS_EXTRA_LABELS.key, " l1 = v1, l2  =v2  ,l3 =v3  ")
     val extraLabels3 = """l1="v1",l2="v2",l3="v3""""
-    createAbstractSourceAndCheck(conf, extraLabels3)
+    val (res3, exps3) = createAbstractSource(conf, extraLabels3)
+    checkMetricsRes(res3, exps3)
+  }
 
+  test("test getMetrics with full capacity and isAppEnable false") {
+    val conf = new CelebornConf()
+
+    // metrics won't contain appMetrics
+    conf.set(CelebornConf.METRICS_APP_ENABLED.key, "false")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "6")
+    val (res1, exps1) = createAbstractSource(conf, "")
+    List[Int](0, 4, 5).foreach { i =>
+      assert(res1.contains(exps1(i)))
+    }
+    List[Int](1, 2, 3).foreach { i =>
+      assert(!res1.contains(exps1(i)))
+    }
+
+    // app metrics will fall behind when it reaches capacity
+    conf.set(CelebornConf.METRICS_APP_ENABLED.key, "true")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "3")
+    val (res2, exps2) = createAbstractSource(conf, "")
+    List[Int](0, 4, 5).foreach { i =>
+      assert(res2.contains(exps2(i)))
+    }
+    List[Int](1, 2, 3).foreach { i =>
+      assert(!res2.contains(exps2(i)))
+    }
+
+    // app metrics count0 will fall behind
+    conf.set(CelebornConf.METRICS_APP_ENABLED.key, "true")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "5")
+    val (res3, exps3) = createAbstractSource(conf, "")
+    List[Int](0, 4, 5, 1, 2).foreach { i =>
+      assert(res3.contains(exps3(i)))
+    }
+    List[Int](3).foreach { i =>
+      assert(!res3.contains(exps3(i)))
+    }
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -49,6 +49,8 @@ class CelebornSourceSuite extends CelebornFunSuite {
     mockSource.stopTimer("Timer1", "key1")
     mockSource.stopTimer("Timer2", "key2", user3)
 
+    mockSource.timerMetricsMap.add("testTimerMetricsMap")
+
     val res = mockSource.getMetrics()
     var extraLabelsStr = extraLabels
     if (extraLabels.nonEmpty) {
@@ -65,8 +67,9 @@ class CelebornSourceSuite extends CelebornFunSuite {
     val exp5 = s"""metrics_Timer1_Count{${extraLabelsStr}${instanceLabelStr}role="$role"} 1"""
     val exp6 =
       s"""metrics_Timer2_Count{${extraLabelsStr}${instanceLabelStr}role="$role",user="user3"} 1"""
+    val exp7 = "testTimerMetricsMap"
 
-    val expList = List[String](exp1, exp2, exp3, exp4, exp5, exp6)
+    val expList = List[String](exp1, exp2, exp3, exp4, exp5, exp6, exp7)
     (res, expList)
   }
 
@@ -111,7 +114,7 @@ class CelebornSourceSuite extends CelebornFunSuite {
     conf.set(CelebornConf.METRICS_APP_ENABLED.key, "false")
     conf.set(CelebornConf.METRICS_CAPACITY.key, "6")
     val (res1, exps1) = createAbstractSource(conf, "")
-    List[Int](0, 4, 5).foreach { i =>
+    List[Int](0, 4, 5, 6).foreach { i =>
       assert(res1.contains(exps1(i)))
     }
     List[Int](1, 2, 3).foreach { i =>
@@ -120,9 +123,9 @@ class CelebornSourceSuite extends CelebornFunSuite {
 
     // app metrics will fall behind when it reaches capacity
     conf.set(CelebornConf.METRICS_APP_ENABLED.key, "true")
-    conf.set(CelebornConf.METRICS_CAPACITY.key, "3")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "4")
     val (res2, exps2) = createAbstractSource(conf, "")
-    List[Int](0, 4, 5).foreach { i =>
+    List[Int](0, 4, 5, 6).foreach { i =>
       assert(res2.contains(exps2(i)))
     }
     List[Int](1, 2, 3).foreach { i =>
@@ -131,9 +134,9 @@ class CelebornSourceSuite extends CelebornFunSuite {
 
     // app metrics count0 will fall behind
     conf.set(CelebornConf.METRICS_APP_ENABLED.key, "true")
-    conf.set(CelebornConf.METRICS_CAPACITY.key, "5")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "6")
     val (res3, exps3) = createAbstractSource(conf, "")
-    List[Int](0, 4, 5, 1, 2).foreach { i =>
+    List[Int](0, 4, 5, 6, 1, 2).foreach { i =>
       assert(res3.contains(exps3(i)))
     }
     List[Int](3).foreach { i =>

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -112,7 +112,7 @@ class CelebornSourceSuite extends CelebornFunSuite {
 
     // metrics won't contain appMetrics
     conf.set(CelebornConf.METRICS_APP_ENABLED.key, "false")
-    conf.set(CelebornConf.METRICS_CAPACITY.key, "6")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "7")
     val (res1, exps1) = createAbstractSource(conf, "")
     List[Int](0, 4, 5, 6).foreach { i =>
       assert(res1.contains(exps1(i)))
@@ -121,27 +121,11 @@ class CelebornSourceSuite extends CelebornFunSuite {
       assert(!res1.contains(exps1(i)))
     }
 
-    // app metrics will fall behind when it reaches capacity
+    // metrics contain appMetrics
     conf.set(CelebornConf.METRICS_APP_ENABLED.key, "true")
-    conf.set(CelebornConf.METRICS_CAPACITY.key, "4")
+    conf.set(CelebornConf.METRICS_CAPACITY.key, "7")
     val (res2, exps2) = createAbstractSource(conf, "")
-    List[Int](0, 4, 5, 6).foreach { i =>
-      assert(res2.contains(exps2(i)))
-    }
-    List[Int](1, 2, 3).foreach { i =>
-      assert(!res2.contains(exps2(i)))
-    }
-
-    // app metrics count0 will fall behind
-    conf.set(CelebornConf.METRICS_APP_ENABLED.key, "true")
-    conf.set(CelebornConf.METRICS_CAPACITY.key, "6")
-    val (res3, exps3) = createAbstractSource(conf, "")
-    List[Int](0, 4, 5, 6, 1, 2).foreach { i =>
-      assert(res3.contains(exps3(i)))
-    }
-    List[Int](3).foreach { i =>
-      assert(!res3.contains(exps3(i)))
-    }
+    checkMetricsRes(res2, exps2)
   }
 
   test("test getAndClearTimerMetrics in timerMetrics") {

--- a/docs/configuration/metrics.md
+++ b/docs/configuration/metrics.md
@@ -19,6 +19,7 @@ license: |
 <!--begin-include-->
 | Key | Default | isDynamic | Description | Since | Deprecated |
 | --- | ------- | --------- | ----------- | ----- | ---------- |
+| celeborn.metrics.application.enabled | true | false | When false, the metrics of application won't return to reduce the num of metrics. | 0.6.0 |  | 
 | celeborn.metrics.capacity | 4096 | false | The maximum number of metrics which a source can use to generate output strings. | 0.2.0 |  | 
 | celeborn.metrics.collectPerfCritical.enabled | false | false | It controls whether to collect metrics which may affect performance. When enable, Celeborn collects them. | 0.2.0 |  | 
 | celeborn.metrics.conf | &lt;undefined&gt; | false | Custom metrics configuration file path. Default use `metrics.properties` in classpath. | 0.3.0 |  | 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -703,23 +703,27 @@ private[celeborn] class Worker(
       resourceConsumptionLabel += (resourceConsumptionSource.applicationLabel -> applicationId)
     resourceConsumptionSource.addGauge(
       ResourceConsumptionSource.DISK_FILE_COUNT,
-      resourceConsumptionLabel) { () =>
+      resourceConsumptionLabel,
+      true) { () =>
       computeResourceConsumption(userIdentifier, resourceConsumption).diskFileCount
     }
     resourceConsumptionSource.addGauge(
       ResourceConsumptionSource.DISK_BYTES_WRITTEN,
-      resourceConsumptionLabel) { () =>
+      resourceConsumptionLabel,
+      true) { () =>
       computeResourceConsumption(userIdentifier, resourceConsumption).diskBytesWritten
     }
     if (hasHDFSStorage) {
       resourceConsumptionSource.addGauge(
         ResourceConsumptionSource.HDFS_FILE_COUNT,
-        resourceConsumptionLabel) { () =>
+        resourceConsumptionLabel,
+        true) { () =>
         computeResourceConsumption(userIdentifier, resourceConsumption).hdfsFileCount
       }
       resourceConsumptionSource.addGauge(
         ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
-        resourceConsumptionLabel) { () =>
+        resourceConsumptionLabel,
+        true) { () =>
         computeResourceConsumption(userIdentifier, resourceConsumption).hdfsBytesWritten
       }
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -107,7 +107,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER)
     val applicationIds = appActiveConnections.get(client.getChannel.id().asLongText())
     val applicationId = Utils.splitShuffleKey(shuffleKey)._1
     if (applicationIds != null && !applicationIds.contains(applicationId)) {
-      addCounter(ACTIVE_CONNECTION_COUNT, Map(applicationLabel -> applicationId))
+      addCounter(ACTIVE_CONNECTION_COUNT, Map(applicationLabel -> applicationId), true)
       incCounter(ACTIVE_CONNECTION_COUNT, 1, Map(applicationLabel -> applicationId))
       applicationIds.add(applicationId)
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -84,7 +84,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER)
 
   def getCounterCount(metricsName: String): Long = {
     val metricNameWithLabel = metricNameWithCustomizedLabels(metricsName, Map.empty)
-    namedCounters.get(metricNameWithLabel).counter.getCount
+    namedCounters.get(metricNameWithLabel)._2.counter.getCount
   }
 
   def connectionActive(client: TransportClient): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -84,7 +84,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER)
 
   def getCounterCount(metricsName: String): Long = {
     val metricNameWithLabel = metricNameWithCustomizedLabels(metricsName, Map.empty)
-    namedCounters.get(metricNameWithLabel)._2.counter.getCount
+    namedCounters.get(metricNameWithLabel).counter.getCount
   }
 
   def connectionActive(client: TransportClient): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
On the basis of [CELEBORN-1743](https://github.com/apache/celeborn/pull/2956)
This pull request implements the following changes:

Introduces a configuration option to determine whether application metrics should be included.

### Why are the changes needed?
[Jira](https://issues.apache.org/jira/browse/CELEBORN-1743)
There are too many application metrics when it reach the metrics capacity.
`metrics_ActiveConnectionCount_Count{applicationId="1732528803184-dd11f77814d04bca2121140182ad7c0f",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732529148502-3d72447b9773d89e941bcb83059424b7",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732529499296-5facd993325e193ce54c8217066dfe26",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732530155191-19068d5eba8a23b42a1e581b20ab0e5a",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732527089786-9fc4a0bfe4c3cb49adf8a87919976a4f",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732526536555-c8f0aaacf7dd92bd00a03bbe61c7216a",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732527096128-5f416a4784a5d5b416dd4db471a51f44",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732530177724-eeecda14217d8990ae0536eae83d3e3b",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732527117022-769334f90b981c54280195da5d871351",role="Worker"} 0 1732530713886
metrics_ActiveConnectionCount_Count{applicationId="1732528325685-129d44a4392d98a830157333d9955558",role="Worker"} 0 1732530713886`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT
