### PR TITLE
[CELEBORN-1756] Only gauge hdfs metrics if HDFS storage enabled to reduce metrics

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1173,15 +1173,17 @@ private[celeborn] class Master(
       resourceConsumptionLabel) { () =>
       computeResourceConsumption(userIdentifier, applicationId).diskBytesWritten
     }
-    resourceConsumptionSource.addGauge(
-      ResourceConsumptionSource.HDFS_FILE_COUNT,
-      resourceConsumptionLabel) { () =>
-      computeResourceConsumption(userIdentifier, applicationId).hdfsFileCount
-    }
-    resourceConsumptionSource.addGauge(
-      ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
-      resourceConsumptionLabel) { () =>
-      computeResourceConsumption(userIdentifier, applicationId).hdfsBytesWritten
+    if (hasHDFSStorage) {
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.HDFS_FILE_COUNT,
+        resourceConsumptionLabel) { () =>
+        computeResourceConsumption(userIdentifier, applicationId).hdfsFileCount
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+        resourceConsumptionLabel) { () =>
+        computeResourceConsumption(userIdentifier, applicationId).hdfsBytesWritten
+      }
     }
   }
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
@@ -134,15 +134,31 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
       0,
       0,
       Map("app1" -> ResourceConsumption(1024, 1, 0, 0)).asJava)).asJava)
-    assert(worker.resourceConsumptionSource.gauges().size == 4)
+    assert(worker.resourceConsumptionSource.gauges().size == 2)
     worker.handleTopResourceConsumption(Map(userIdentifier -> ResourceConsumption(
       1024,
       1,
       0,
       0,
       Map("app2" -> ResourceConsumption(1024, 1, 0, 0)).asJava)).asJava)
-    assert(worker.resourceConsumptionSource.gauges().size == 4)
+    assert(worker.resourceConsumptionSource.gauges().size == 2)
     worker.handleTopResourceConsumption(Map.empty[UserIdentifier, ResourceConsumption].asJava)
     assert(worker.resourceConsumptionSource.gauges().size == 0)
+  }
+
+  test("only gauge hdfs metrics if HDFS storage enabled") {
+    conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, "/tmp")
+    conf.set(CelebornConf.ACTIVE_STORAGE_TYPES.key, "HDD,HDFS")
+    conf.set(CelebornConf.HDFS_DIR.key, "hdfs://localhost:9000/test")
+
+    worker = new Worker(conf, workerArgs)
+    val userIdentifier = new UserIdentifier("default", "celeborn")
+    worker.handleTopResourceConsumption(Map(userIdentifier -> ResourceConsumption(
+      1024,
+      1,
+      0,
+      0,
+      Map("app1" -> ResourceConsumption(1024, 1, 0, 0)).asJava)).asJava)
+    assert(worker.resourceConsumptionSource.gauges().size == 4)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

If `HDFS` is not defined in the `celeborn.storage.availableTypes`, do not gauge the HDFS metrics.

### Why are the changes needed?

To reduce the metrics number, due there is metrics capacity limitation. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.