### PR TITLE
[CELEBORN-1732]Support unordered kv input for Tez

### DIFF
--- a/client-tez/tez/src/main/java/org/apache/celeborn/tez/plugin/util/ChecksumUtils.java
+++ b/client-tez/tez/src/main/java/org/apache/celeborn/tez/plugin/util/ChecksumUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.tez.plugin.util;
+
+import java.util.zip.CRC32;
+
+public class ChecksumUtils {
+
+  private static final int LENGTH_PER_CRC = 4 * 1024;
+
+  public static long getCrc32(byte[] buf) {
+    return getCrc32(buf, 0, buf.length);
+  }
+
+  public static long getCrc32(byte[] buf, int offset, int length) {
+    CRC32 crc32 = new CRC32();
+
+    for (int i = 0; i < length; ) {
+      int len = Math.min(LENGTH_PER_CRC, length - i);
+      crc32.update(buf, i + offset, len);
+      i += len;
+    }
+
+    return crc32.getValue();
+  }
+}

--- a/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/CelebornFetcher.java
+++ b/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/CelebornFetcher.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.runtime.library.common.shuffle.impl;
+
+import java.io.IOException;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.tez.common.CallableWithNdc;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.FetchResult;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInputAllocator;
+import org.apache.tez.runtime.library.common.shuffle.FetcherCallback;
+import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.CelebornTezBypassWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.CelebornTezReader;
+import org.apache.celeborn.common.exception.CelebornIOException;
+
+public class CelebornFetcher extends CallableWithNdc<FetchResult> {
+  private static final Logger LOG = LoggerFactory.getLogger(CelebornFetcher.class);
+  private final FetcherCallback fetcherCallback;
+
+  private final FetchedInputAllocator inputManager;
+
+  private long copyBlockCount = 0;
+
+  private volatile boolean stopped = false;
+
+  private final CelebornTezReader celebornTezReader;
+  private long readTime = 0;
+  private long decompressTime = 0;
+  private long serializeTime = 0;
+  private long waitTime = 0;
+  private long copyTime = 0; // the sum of readTime + decompressTime + serializeTime + waitTime
+  private static int uniqueMapId = 0;
+
+  private boolean hasPendingData = false;
+  private long startWait;
+  private int waitCount = 0;
+  private byte[] shuffleData = null;
+
+  CelebornFetcher(
+      FetcherCallback fetcherCallback,
+      FetchedInputAllocator inputManager,
+      CelebornTezReader celebornTezReader) {
+    this.fetcherCallback = fetcherCallback;
+    this.inputManager = inputManager;
+    this.celebornTezReader = celebornTezReader;
+  }
+
+  public void fetchAllRssBlocks() throws IOException {
+    while (!stopped) {
+      try {
+        copyFromRssServer();
+      } catch (Exception e) {
+        LOG.error("Failed to fetchAllRssBlocks.", e);
+        throw e;
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public void copyFromRssServer() throws IOException {
+    long blockStartFetch = 0;
+    // fetch a block
+    if (!hasPendingData) {
+      final long startFetch = System.currentTimeMillis();
+      blockStartFetch = System.currentTimeMillis();
+      shuffleData = celebornTezReader.getShuffleBlock();
+      long fetchDuration = System.currentTimeMillis() - startFetch;
+      readTime += fetchDuration;
+    }
+
+    if (shuffleData != null) {
+      // start to merge
+      final long startSerialization = System.currentTimeMillis();
+      if (issueMapOutputMerge(blockStartFetch)) {
+        long serializationDuration = System.currentTimeMillis() - startSerialization;
+        serializeTime += serializationDuration;
+        // if reserve successes, reset status for next fetch
+        if (hasPendingData) {
+          waitTime += System.currentTimeMillis() - startWait;
+        }
+        hasPendingData = false;
+        shuffleData = null;
+      } else {
+        LOG.info("UncompressedData is null");
+        // if reserve fail, return and wait
+        waitCount++;
+        startWait = System.currentTimeMillis();
+        return;
+      }
+
+      // update some status
+      copyBlockCount++;
+      copyTime = readTime + decompressTime + serializeTime + waitTime;
+    } else {
+      LOG.info("UncompressedData is null");
+      // finish reading data, close related reader and check data consistent
+      celebornTezReader.close();
+      LOG.info(
+          "Reduce task partition:"
+              + celebornTezReader.getPartitionId()
+              + " read block cnt: "
+              + copyBlockCount
+              + " cost "
+              + readTime
+              + " ms to fetch and "
+              + serializeTime
+              + " ms to serialize and "
+              + waitTime
+              + " ms to wait resource, total copy time: "
+              + copyTime);
+      LOG.info("Stop fetcher");
+      stopFetch();
+    }
+  }
+
+  private boolean issueMapOutputMerge(long blockStartFetch) throws IOException {
+    // Allocate a MapOutput (either in-memory or on-disk) to put uncompressed block
+    // In Rss, a MapOutput is sent as multiple blocks, so the reducer needs to
+    // treat each "block" as a faked "mapout".
+    // To avoid name conflicts, we use getNextUniqueTaskAttemptID instead.
+    // It will generate a unique TaskAttemptID(increased_seq++, 0).
+    InputAttemptIdentifier uniqueInputAttemptIdentifier = getNextUniqueInputAttemptIdentifier();
+    FetchedInput fetchedInput = null;
+
+    try {
+      fetchedInput =
+          inputManager.allocate(
+              shuffleData.length, shuffleData.length, uniqueInputAttemptIdentifier);
+    } catch (IOException ioe) {
+      // kill this reduce attempt
+      throw ioe;
+    }
+
+    // Allocated space and then write data to mapOutput
+    try {
+      CelebornTezBypassWriter.write(fetchedInput, shuffleData);
+      // let the merger knows this block is ready for merging
+      fetcherCallback.fetchSucceeded(
+          null,
+          uniqueInputAttemptIdentifier,
+          fetchedInput,
+          shuffleData.length,
+          shuffleData.length,
+          System.currentTimeMillis() - blockStartFetch);
+    } catch (Throwable t) {
+      LOG.error("Failed to write fetchedInput.", t);
+      throw new CelebornIOException(
+          "Partition: "
+              + celebornTezReader.getPartitionId()
+              + " cannot write block to "
+              + fetchedInput.getClass().getSimpleName()
+              + " due to: "
+              + t.getClass().getName());
+    }
+    return true;
+  }
+
+  private InputAttemptIdentifier getNextUniqueInputAttemptIdentifier() {
+    return new InputAttemptIdentifier(uniqueMapId++, 0);
+  }
+
+  private void stopFetch() {
+    stopped = true;
+  }
+
+  @VisibleForTesting
+  public int getRetryCount() {
+    return waitCount;
+  }
+
+  @Override
+  protected FetchResult callInternal() throws Exception {
+    celebornTezReader.init();
+    fetchAllRssBlocks();
+    return null;
+  }
+
+  public void shutdown() {}
+
+  public Integer getPartitionId() {
+    return celebornTezReader.getPartitionId();
+  }
+}

--- a/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/CelebornShuffleManager.java
+++ b/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/CelebornShuffleManager.java
@@ -1,0 +1,496 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.shuffle.impl;
+
+import static org.apache.celeborn.tez.plugin.util.CelebornTezUtils.getParentPrivateField;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.tez.common.CallableWithNdc;
+import org.apache.tez.common.GuavaShim;
+import org.apache.tez.common.Preconditions;
+import org.apache.tez.common.counters.TezCounter;
+import org.apache.tez.dag.records.TezTaskAttemptID;
+import org.apache.tez.runtime.api.InputContext;
+import org.apache.tez.runtime.api.TaskFailureType;
+import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.CelebornTezReader;
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.tez.plugin.util.CelebornTezUtils;
+
+public class CelebornShuffleManager extends ShuffleManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CelebornShuffleManager.class);
+
+  private final InputContext inputContext;
+  private final int numInputs;
+  private final ListeningExecutorService schedulerExecutor;
+  private final int shuffleId;
+  private final ApplicationAttemptId applicationAttemptId;
+  private final ShuffleClient shuffleClient;
+  private final FetchedInputAllocator inputManager;
+
+  private final Set<CelebornFetcher> celebornRunningFetchers;
+  private final BlockingQueue<FetchedInput> completedInputs;
+  private final BlockingQueue<InputHost> pendingHosts;
+
+  private final AtomicInteger numCompletedInputs = new AtomicInteger(0);
+  // Required to be held when manipulating pendingHosts
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Condition wakeLoop = lock.newCondition();
+
+  private final int numFetchers;
+  private final int maxTimeToWaitForReportMillis;
+  private final String sourceDestNameTrimmed;
+  private final TezCounter shufflePhaseTime;
+
+  private final AtomicBoolean isShutdown;
+  private final long startTime;
+
+  private volatile Throwable shuffleError;
+  private final Set<Integer> successRssPartitionSet = new HashSet<>();
+  private final Set<Integer> runningRssPartitionMap = new HashSet<>();
+  private final Set<Integer> allRssPartition = Sets.newConcurrentHashSet();
+  private final BlockingQueue<Integer> pendingPartition = new LinkedBlockingQueue<>();
+  Map<Integer, List<InputAttemptIdentifier>> partitionToInput = new HashMap<>();
+  private final AtomicInteger numNoDataInput = new AtomicInteger(0);
+  private final AtomicInteger numWithDataInput = new AtomicInteger(0);
+  private final boolean broadcastOrOneToOne;
+
+  public CelebornShuffleManager(
+      InputContext inputContext,
+      Configuration conf,
+      int numInputs,
+      ShuffleClient shuffleClient,
+      int bufferSize,
+      boolean ifileReadAheadEnabled,
+      int ifileReadAheadLength,
+      CompressionCodec codec,
+      FetchedInputAllocator inputAllocator,
+      int shuffleId,
+      ApplicationAttemptId applicationAttemptId,
+      boolean broadcastOrOneToOne)
+      throws IOException {
+    super(
+        inputContext,
+        conf,
+        numInputs,
+        bufferSize,
+        ifileReadAheadEnabled,
+        ifileReadAheadLength,
+        codec,
+        inputAllocator);
+    this.inputContext = inputContext;
+    this.shuffleId = shuffleId;
+    this.applicationAttemptId = applicationAttemptId;
+    this.shuffleClient = shuffleClient;
+    this.broadcastOrOneToOne = broadcastOrOneToOne;
+    this.inputManager = inputAllocator;
+    this.celebornRunningFetchers =
+        Collections.newSetFromMap(new ConcurrentHashMap<CelebornFetcher, Boolean>());
+    this.numInputs = numInputs;
+    this.numFetchers = (int) getParentPrivateField(this, "numFetchers");
+    this.schedulerExecutor =
+        (ListeningExecutorService) getParentPrivateField(this, "schedulerExecutor");
+    this.maxTimeToWaitForReportMillis =
+        (int) getParentPrivateField(this, "maxTimeToWaitForReportMillis");
+    this.isShutdown = (AtomicBoolean) getParentPrivateField(this, "isShutdown");
+    this.sourceDestNameTrimmed = (String) getParentPrivateField(this, "sourceDestNameTrimmed");
+    this.completedInputs =
+        (BlockingQueue<FetchedInput>) getParentPrivateField(this, "completedInputs");
+    this.pendingHosts = (BlockingQueue<InputHost>) getParentPrivateField(this, "pendingHosts");
+    this.shufflePhaseTime = (TezCounter) getParentPrivateField(this, "shufflePhaseTime");
+    this.startTime = (long) getParentPrivateField(this, "startTime");
+  }
+
+  @Override
+  public void run() throws IOException {
+    Preconditions.checkState(inputManager != null, "InputManager must be configured");
+    // todo maxTimeToWaitForReportMillis
+    ListenableFuture<Void> runShuffleFuture =
+        schedulerExecutor.submit(new CelebornRunShuffleCallable());
+    Futures.addCallback(
+        runShuffleFuture, new SchedulerFutureCallback(), GuavaShim.directExecutor());
+    // Shutdown this executor once this task, and the callback complete.
+    schedulerExecutor.shutdown();
+  }
+
+  private boolean isAllInputFetched() {
+    LOG.info(
+        "Check isAllInputFetched, numNoDataInput:{}, numWithDataInput:{},numInputs:{},  "
+            + "successRssPartitionSet:{},  allRssPartition:{}.",
+        numNoDataInput,
+        numWithDataInput,
+        numInputs,
+        successRssPartitionSet,
+        allRssPartition);
+    return (numNoDataInput.get() + numWithDataInput.get() >= numInputs)
+        && (successRssPartitionSet.size() >= allRssPartition.size());
+  }
+
+  private boolean isAllInputAdded() {
+    LOG.info(
+        "Check isAllInputAdded, numNoDataInput:{}, numWithDataInput:{},numInputs:{},  "
+            + "successRssPartitionSet:{}, allRssPartition:{}.",
+        numNoDataInput,
+        numWithDataInput,
+        numInputs,
+        successRssPartitionSet,
+        allRssPartition);
+    return numNoDataInput.get() + numWithDataInput.get() >= numInputs;
+  }
+
+  private class CelebornRunShuffleCallable extends CallableWithNdc<Void> {
+
+    public CelebornRunShuffleCallable() {}
+
+    @Override
+    protected Void callInternal() throws Exception {
+      while (!isShutdown.get() && !isAllInputFetched()) {
+        lock.lock();
+        try {
+          while (((celebornRunningFetchers.size() >= numFetchers || pendingPartition.isEmpty())
+                  && !isAllInputFetched())
+              || !isAllInputAdded()) {
+            inputContext.notifyProgress();
+            boolean ret = wakeLoop.await(1000, TimeUnit.MILLISECONDS);
+            if (isShutdown.get()) {
+              break;
+            }
+          }
+        } finally {
+          lock.unlock();
+        }
+
+        if (shuffleError != null) {
+          // InputContext has already been informed of a fatal error. Relying on
+          // tez to kill the task.
+          break;
+        }
+
+        LOG.debug("{}: NumCompletedInputs: {}", sourceDestNameTrimmed, numCompletedInputs);
+        if (!isAllInputFetched() && !isShutdown.get()) {
+          lock.lock();
+          try {
+            int maxFetchersToRun = numFetchers - celebornRunningFetchers.size();
+            int count = 0;
+            while (pendingPartition.peek() != null && !isShutdown.get()) {
+              Integer partition = null;
+              try {
+                partition = pendingPartition.take();
+              } catch (InterruptedException e) {
+                if (isShutdown.get()) {
+                  LOG.info(
+                      sourceDestNameTrimmed
+                          + ": "
+                          + "Interrupted and hasBeenShutdown, Breaking out of ShuffleScheduler Loop");
+                  Thread.currentThread().interrupt();
+                  break;
+                } else {
+                  throw e;
+                }
+              }
+              if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                    sourceDestNameTrimmed + ": " + "Processing pending partition: " + partition);
+              }
+              if (!isShutdown.get()
+                  && (!successRssPartitionSet.contains(partition)
+                      && !runningRssPartitionMap.contains(partition))) {
+
+                runningRssPartitionMap.add(partition);
+
+                CelebornFetcher fetcher = constructFetcherForCeleborn(partition);
+                celebornRunningFetchers.add(fetcher);
+                if (isShutdown.get()) {
+                  LOG.info(
+                      sourceDestNameTrimmed
+                          + ": "
+                          + "hasBeenShutdown,"
+                          + "Breaking out of ShuffleScheduler Loop");
+                  break;
+                }
+                ListenableFuture<FetchResult> future = fetcherExecutor.submit(fetcher);
+                Futures.addCallback(
+                    future, new FetchFutureCallback(fetcher), GuavaShim.directExecutor());
+                if (++count >= maxFetchersToRun) {
+                  break;
+                }
+              } else {
+                if (LOG.isDebugEnabled()) {
+                  LOG.debug(
+                      sourceDestNameTrimmed
+                          + ": "
+                          + "Skipping partition: "
+                          + partition
+                          + " since is shutdown");
+                }
+              }
+            }
+          } finally {
+            lock.unlock();
+          }
+        }
+      }
+      shufflePhaseTime.setValue(System.currentTimeMillis() - startTime);
+      LOG.info(
+          sourceDestNameTrimmed
+              + ": "
+              + "Shutting down FetchScheduler, Was Interrupted: "
+              + Thread.currentThread().isInterrupted());
+      if (!fetcherExecutor.isShutdown()) {
+        fetcherExecutor.shutdownNow();
+      }
+      return null;
+    }
+  }
+
+  CelebornFetcher constructFetcherForCeleborn(int partition) {
+    CelebornTezReader reader =
+        new CelebornTezReader(
+            shuffleClient, shuffleId, partition, applicationAttemptId.getAttemptId());
+    CelebornFetcher celebornFetcher = new CelebornFetcher(this, inputManager, reader);
+    return celebornFetcher;
+  }
+
+  /////////////////// Methods for InputEventHandler
+
+  public void addKnownInput(
+      String hostName,
+      int port,
+      CompositeInputAttemptIdentifier srcAttemptIdentifier,
+      int srcPhysicalIndex) {
+    HostPort identifier = new HostPort(hostName, port);
+    super.addKnownInput(hostName, port, srcAttemptIdentifier, srcPhysicalIndex);
+    lock.lock();
+    try {
+      // pendingHosts is useless in celeborn
+      pendingHosts.remove(identifier);
+      if (broadcastOrOneToOne) {
+        String pathComponent = srcAttemptIdentifier.getPathComponent();
+        TezTaskAttemptID taskAttemptId =
+            TezTaskAttemptID.fromString(
+                CelebornTezUtils.uniqueIdentifierToAttemptId(pathComponent));
+        int partitionId = taskAttemptId.getTaskID().getId();
+        LOG.info("Read partition, shuffleId {} partitionId {}", shuffleId, partitionId);
+        if (!allRssPartition.contains(partitionId)) {
+          pendingPartition.add(partitionId);
+        }
+        allRssPartition.add(partitionId);
+        partitionToInput.putIfAbsent(partitionId, new ArrayList<>());
+        partitionToInput.get(partitionId).add(srcAttemptIdentifier);
+      } else {
+        for (int i = 0; i < srcAttemptIdentifier.getInputIdentifierCount(); i++) {
+          int p = srcPhysicalIndex + i;
+          LOG.info(
+              "PartitionToInput, original:{}, add:{},  now:{}",
+              srcAttemptIdentifier,
+              srcAttemptIdentifier.expand(i),
+              partitionToInput.get(p));
+          if (!allRssPartition.contains(srcPhysicalIndex + i)) {
+            pendingPartition.add(p);
+          }
+          allRssPartition.add(p);
+          partitionToInput.putIfAbsent(p, new ArrayList<>());
+          partitionToInput.get(p).add(srcAttemptIdentifier);
+          LOG.info("Add partition:{}, after add, now partition:{}", p, allRssPartition);
+        }
+      }
+
+      numWithDataInput.incrementAndGet();
+      LOG.info("numWithDataInput:{}.", numWithDataInput.get());
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void addCompletedInputWithNoData(InputAttemptIdentifier srcAttemptIdentifier) {
+    super.addCompletedInputWithNoData(srcAttemptIdentifier);
+    numNoDataInput.incrementAndGet();
+    LOG.info(
+        "AddCompletedInputWithNoData, numNoDataInput:{}, numWithDataInput:{},numInputs:{},  "
+            + "successRssPartitionSet:{}, allRssPartition:{}.",
+        numNoDataInput,
+        numWithDataInput,
+        numInputs,
+        successRssPartitionSet,
+        allRssPartition);
+  }
+
+  public void shutdown() throws InterruptedException {
+
+    if (!isShutdown.get()) {
+      super.shutdown();
+      lock.lock();
+      try {
+        wakeLoop.signal(); // signal the fetch-scheduler
+        for (CelebornFetcher fetcher : celebornRunningFetchers) {
+          try {
+            fetcher.shutdown(); // This could be parallelized.
+          } catch (Exception e) {
+            LOG.warn(
+                "Error while stopping fetcher during shutdown. Ignoring and continuing. Message={}",
+                e.getMessage());
+          }
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  public boolean isAllPartitionFetched() {
+    lock.lock();
+    try {
+      if (!allRssPartition.containsAll(successRssPartitionSet)) {
+        LOG.error(
+            "Failed to check partition, all partition:{}, success partiton:{}",
+            allRssPartition,
+            successRssPartitionSet);
+      }
+      return isAllInputFetched();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * @return the next available input, or null if there are no available inputs. This method will
+   *     block if there are currently no available inputs, but more may become available.
+   */
+  public FetchedInput getNextInput() throws InterruptedException {
+    // Check for no additional inputs
+    FetchedInput fetchedInput = null;
+    if (completedInputs.peek() == null) {
+      while (true) {
+        fetchedInput = completedInputs.poll(2000, TimeUnit.MICROSECONDS);
+        if (fetchedInput != null) {
+          break;
+        } else if (isAllPartitionFetched()) {
+          fetchedInput = completedInputs.poll(100, TimeUnit.MICROSECONDS);
+          LOG.info("GetNextInput, enter isAllPartitionFetched");
+          break;
+        }
+        LOG.info("GetNextInput, out loop");
+        Thread.sleep(1000);
+      }
+    } else {
+      fetchedInput = completedInputs.take();
+    }
+
+    if (fetchedInput instanceof NullFetchedInput) {
+      LOG.info("getNextInput, NullFetchedInput is null:{}", fetchedInput);
+      fetchedInput = null;
+    }
+    LOG.info("getNextInput, fetchedInput:{}", fetchedInput);
+    return fetchedInput;
+  }
+
+  private class SchedulerFutureCallback implements FutureCallback<Void> {
+
+    @Override
+    public void onSuccess(Void result) {
+      LOG.info(sourceDestNameTrimmed + ": " + "Scheduler thread completed");
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+      if (isShutdown.get()) {
+        LOG.debug("{}: Already shutdown. Ignoring error.", sourceDestNameTrimmed, t);
+      } else {
+        LOG.error(sourceDestNameTrimmed + ": " + "Scheduler failed with error: ", t);
+        inputContext.reportFailure(TaskFailureType.NON_FATAL, t, "Shuffle Scheduler Failed");
+      }
+    }
+  }
+
+  private class FetchFutureCallback implements FutureCallback<FetchResult> {
+
+    private final CelebornFetcher fetcher;
+
+    public FetchFutureCallback(CelebornFetcher fetcher) {
+      this.fetcher = fetcher;
+    }
+
+    private void doBookKeepingForFetcherComplete() {
+      lock.lock();
+      try {
+        celebornRunningFetchers.remove(fetcher);
+        wakeLoop.signal();
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public void onSuccess(FetchResult result) {
+      fetcher.shutdown();
+      if (isShutdown.get()) {
+        LOG.debug("{}: Already shutdown. Ignoring event from fetcher", sourceDestNameTrimmed);
+      } else {
+        lock.lock();
+        try {
+          successRssPartitionSet.add(fetcher.getPartitionId());
+          runningRssPartitionMap.remove(fetcher.getPartitionId());
+          LOG.info(
+              "FetchFutureCallback allRssPartition:{}, successRssPartitionSet:{}, runningRssPartitionMap:{}.",
+              allRssPartition,
+              successRssPartitionSet,
+              runningRssPartitionMap);
+          doBookKeepingForFetcherComplete();
+        } finally {
+          lock.unlock();
+        }
+      }
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+      // Unsuccessful - the fetcher may not have shutdown correctly. Try shutting it down.
+      fetcher.shutdown();
+      if (isShutdown.get()) {
+        LOG.debug("{}: Already shutdown. Ignoring error from fetcher.", sourceDestNameTrimmed, t);
+      } else {
+        LOG.error(sourceDestNameTrimmed + ": " + "Fetcher failed with error: ", t);
+        shuffleError = t;
+        inputContext.reportFailure(TaskFailureType.NON_FATAL, t, "Fetch failed");
+        doBookKeepingForFetcherComplete();
+      }
+    }
+  }
+}

--- a/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/CelebornTezBypassWriter.java
+++ b/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/CelebornTezBypassWriter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import com.google.common.primitives.Ints;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
+import org.apache.tez.runtime.library.common.shuffle.MemoryFetchedInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.tez.plugin.util.ChecksumUtils;
+
+// In Tez shuffle, MapOutput encapsulates the logic to fetch map task's output data via http.
+// So, in Celeborn, we should bypass this logic, and directly write data to MapOutput.
+public class CelebornTezBypassWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CelebornTezBypassWriter.class);
+  private static final byte[] HEADER = new byte[] {(byte) 'T', (byte) 'I', (byte) 'F', (byte) 0};
+
+  public static void write(MapOutput mapOutput, byte[] buffer) {
+    LOG.debug(
+        "CelebornTezBypassWriter write mapOutput, type:{}, buffer length:{}",
+        mapOutput.getType(),
+        buffer.length);
+    // Write and commit uncompressed data to MapOutput.
+    // In the majority of cases, merger allocates memory to accept data,
+    // but when data size exceeds the threshold, merger can also allocate disk.
+    // So, we should consider the two situations, respectively.
+    if (mapOutput.getType() == MapOutput.Type.MEMORY) {
+      byte[] memory = mapOutput.getMemory();
+      System.arraycopy(buffer, 0, memory, 0, buffer.length);
+    } else if (mapOutput.getType() == MapOutput.Type.DISK) {
+      throw new IllegalStateException(
+          "Celeborn map reduce client do not support OnDiskMapOutput. Try to increase mapreduce.reduce.shuffle.memory.limit.percent");
+    } else {
+      throw new IllegalStateException(
+          "Merger reserve unknown type of MapOutput: " + mapOutput.getClass().getCanonicalName());
+    }
+  }
+
+  public static void write(final FetchedInput fetchedInput, byte[] buffer) throws IOException {
+    LOG.info(
+        "CelebornTezBypassWriter write mapOutput, type:{}, buffer length:{}",
+        fetchedInput.getType(),
+        buffer.length);
+    // Write and commit uncompressed data to MapOutput.
+    // In the majority of cases, merger allocates memory to accept data,
+    // but when data size exceeds the threshold, merger can also allocate disk.
+    // So, we should consider the two situations, respectively.
+    if (fetchedInput.getType() == FetchedInput.Type.MEMORY) {
+      byte[] memory = ((MemoryFetchedInput) fetchedInput).getBytes();
+      System.arraycopy(buffer, 0, memory, 0, buffer.length);
+    } else if (fetchedInput.getType() == FetchedInput.Type.DISK) {
+      OutputStream output = fetchedInput.getOutputStream();
+      output.write(HEADER);
+      output.write(buffer);
+      output.write(Ints.toByteArray((int) ChecksumUtils.getCrc32(buffer)));
+      output.flush();
+      output.close();
+    } else {
+      throw new CelebornIOException(
+          "Merger reserve unknown type of MapOutput: "
+              + fetchedInput.getClass().getCanonicalName());
+    }
+  }
+}

--- a/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/CelebornTezBypassWriter.java
+++ b/client-tez/tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/CelebornTezBypassWriter.java
@@ -58,7 +58,7 @@ public class CelebornTezBypassWriter {
   }
 
   public static void write(final FetchedInput fetchedInput, byte[] buffer) throws IOException {
-    LOG.info(
+    LOG.debug(
         "CelebornTezBypassWriter write mapOutput, type:{}, buffer length:{}",
         fetchedInput.getType(),
         buffer.length);

--- a/client-tez/tez/src/main/java/org/apache/tez/runtime/library/input/CelebornUnorderedKVInput.java
+++ b/client-tez/tez/src/main/java/org/apache/tez/runtime/library/input/CelebornUnorderedKVInput.java
@@ -1,0 +1,317 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.input;
+
+import static org.apache.celeborn.tez.plugin.util.CelebornTezUtils.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.tez.common.Preconditions;
+import org.apache.tez.common.TezRuntimeFrameworkConfigs;
+import org.apache.tez.common.TezUtils;
+import org.apache.tez.common.TezUtilsInternal;
+import org.apache.tez.common.counters.TaskCounter;
+import org.apache.tez.common.counters.TezCounter;
+import org.apache.tez.runtime.api.AbstractLogicalInput;
+import org.apache.tez.runtime.api.Event;
+import org.apache.tez.runtime.api.InputContext;
+import org.apache.tez.runtime.api.ProgressFailedException;
+import org.apache.tez.runtime.library.api.KeyValueReader;
+import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
+import org.apache.tez.runtime.library.common.MemoryUpdateCallbackHandler;
+import org.apache.tez.runtime.library.common.readers.UnorderedKVReader;
+import org.apache.tez.runtime.library.common.shuffle.ShuffleEventHandler;
+import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
+import org.apache.tez.runtime.library.common.shuffle.impl.CelebornShuffleManager;
+import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleInputEventHandlerImpl;
+import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleManager;
+import org.apache.tez.runtime.library.common.shuffle.impl.SimpleFetchedInputAllocator;
+import org.apache.tez.runtime.library.utils.CodecUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornException;
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.tez.plugin.util.CelebornTezUtils;
+
+/**
+ * {@link CelebornUnorderedKVInput} provides unordered key value input by bringing together
+ * (shuffling) a set of distributed data and providing a unified view to that data. There are no
+ * ordering constraints applied by this input.
+ */
+@Public
+public class CelebornUnorderedKVInput extends AbstractLogicalInput {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CelebornUnorderedKVInput.class);
+
+  private Configuration conf;
+  private ShuffleManager shuffleManager;
+  private final BlockingQueue<Event> pendingEvents = new LinkedBlockingQueue<Event>();
+  private long firstEventReceivedTime = -1;
+  private MemoryUpdateCallbackHandler memoryUpdateCallbackHandler;
+
+  @SuppressWarnings("rawtypes")
+  private UnorderedKVReader kvReader;
+
+  private final AtomicBoolean isStarted = new AtomicBoolean(false);
+  private TezCounter inputRecordCounter;
+
+  private SimpleFetchedInputAllocator inputManager;
+  private ShuffleEventHandler inputEventHandler;
+  private ApplicationAttemptId applicationAttemptId;
+
+  public CelebornUnorderedKVInput(InputContext inputContext, int numPhysicalInputs) {
+    super(inputContext, numPhysicalInputs);
+  }
+
+  @Override
+  public synchronized List<Event> initialize() throws Exception {
+    Preconditions.checkArgument(getNumPhysicalInputs() != -1, "Number of Inputs has not been set");
+    this.conf = TezUtils.createConfFromBaseConfAndPayload(getContext());
+
+    if (getNumPhysicalInputs() == 0) {
+      getContext().requestInitialMemory(0l, null);
+      isStarted.set(true);
+      getContext().inputIsReady();
+      LOG.info(
+          "input fetch not required since there are 0 physical inputs for input vertex: "
+              + getContext().getInputOutputVertexNames());
+      return Collections.emptyList();
+    } else {
+      long initialMemReq = getInitialMemoryReq();
+      memoryUpdateCallbackHandler = new MemoryUpdateCallbackHandler();
+      this.getContext().requestInitialMemory(initialMemReq, memoryUpdateCallbackHandler);
+    }
+
+    this.conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, getContext().getWorkDirs());
+    this.inputRecordCounter =
+        getContext().getCounters().findCounter(TaskCounter.INPUT_RECORDS_PROCESSED);
+    this.applicationAttemptId =
+        ApplicationAttemptId.newInstance(
+            getContext().getApplicationId(), getContext().getDAGAttemptNumber());
+    return Collections.emptyList();
+  }
+
+  @Override
+  public synchronized void start() throws IOException {
+    if (!isStarted.get()) {
+      ////// Initial configuration
+      memoryUpdateCallbackHandler.validateUpdateReceived();
+      CompressionCodec codec = CodecUtils.getCodec(conf);
+
+      boolean compositeFetch = ShuffleUtils.isTezShuffleHandler(conf);
+      boolean ifileReadAhead =
+          conf.getBoolean(
+              TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+              TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT);
+      int ifileReadAheadLength = 0;
+      int ifileBufferSize = 0;
+
+      if (ifileReadAhead) {
+        ifileReadAheadLength =
+            conf.getInt(
+                TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
+                TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT);
+      }
+      ifileBufferSize =
+          conf.getInt(
+              "io.file.buffer.size", TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_BUFFER_SIZE_DEFAULT);
+
+      this.inputManager =
+          new SimpleFetchedInputAllocator(
+              TezUtilsInternal.cleanVertexName(getContext().getSourceVertexName()),
+              getContext().getUniqueIdentifier(),
+              getContext().getDagIdentifier(),
+              conf,
+              getContext().getTotalMemoryAvailableToTask(),
+              memoryUpdateCallbackHandler.getMemoryAssigned());
+
+      String host = conf.get(TEZ_CELEBORN_LM_HOST);
+      int port = conf.getInt(TEZ_CELEBORN_LM_PORT, -1);
+      int shuffleId = conf.getInt(TEZ_SHUFFLE_ID, -1);
+      String appId = conf.get(TEZ_CELEBORN_APPLICATION_ID);
+      boolean broadcastOrOneToOne = conf.getBoolean(TEZ_BROADCAST_OR_ONETOONE, false);
+      CelebornConf celebornConf = CelebornTezUtils.fromTezConfiguration(conf);
+      ShuffleClient shuffleClient =
+          ShuffleClient.get(
+              appId,
+              host,
+              port,
+              celebornConf,
+              new UserIdentifier(
+                  celebornConf.quotaUserSpecificTenant(), celebornConf.quotaUserSpecificUserName()),
+              null);
+
+      this.shuffleManager =
+          new CelebornShuffleManager(
+              getContext(),
+              conf,
+              getNumPhysicalInputs(),
+              shuffleClient,
+              ifileBufferSize,
+              ifileReadAhead,
+              ifileReadAheadLength,
+              codec,
+              inputManager,
+              shuffleId,
+              applicationAttemptId,
+              broadcastOrOneToOne);
+
+      this.inputEventHandler =
+          new ShuffleInputEventHandlerImpl(
+              getContext(),
+              shuffleManager,
+              inputManager,
+              codec,
+              ifileReadAhead,
+              ifileReadAheadLength,
+              compositeFetch);
+
+      ////// End of Initial configuration
+
+      this.shuffleManager.run();
+      this.kvReader =
+          createReader(
+              inputRecordCounter, codec, ifileBufferSize, ifileReadAhead, ifileReadAheadLength);
+      List<Event> pending = new LinkedList<Event>();
+      pendingEvents.drainTo(pending);
+      if (pending.size() > 0) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              getContext().getInputOutputVertexNames()
+                  + ": "
+                  + "NoAutoStart delay in processing first event: "
+                  + (System.currentTimeMillis() - firstEventReceivedTime));
+        }
+        inputEventHandler.handleEvents(pending);
+      }
+      isStarted.set(true);
+    }
+  }
+
+  @Override
+  public synchronized KeyValueReader getReader() throws Exception {
+    Preconditions.checkState(isStarted.get(), "Must start input before invoking this method");
+    if (getNumPhysicalInputs() == 0) {
+      return new KeyValueReader() {
+        @Override
+        public boolean next() throws IOException {
+          getContext().notifyProgress();
+          hasCompletedProcessing();
+          completedProcessing = true;
+          return false;
+        }
+
+        @Override
+        public Object getCurrentKey() throws IOException {
+          throw new RuntimeException("No data available in Input");
+        }
+
+        @Override
+        public Object getCurrentValue() throws IOException {
+          throw new RuntimeException("No data available in Input");
+        }
+      };
+    }
+    return this.kvReader;
+  }
+
+  @Override
+  public void handleEvents(List<Event> inputEvents) throws Exception {
+    ShuffleEventHandler inputEventHandlerLocalRef;
+    synchronized (this) {
+      if (getNumPhysicalInputs() == 0) {
+        throw new CelebornException("No input events expected as numInputs is 0");
+      }
+      if (!isStarted.get()) {
+        if (firstEventReceivedTime == -1) {
+          firstEventReceivedTime = System.currentTimeMillis();
+        }
+        // This queue will keep growing if the Processor decides never to
+        // start the event. The Input, however has no idea, on whether start
+        // will be invoked or not.
+        pendingEvents.addAll(inputEvents);
+        return;
+      }
+      inputEventHandlerLocalRef = inputEventHandler;
+    }
+    inputEventHandlerLocalRef.handleEvents(inputEvents);
+  }
+
+  @Override
+  public synchronized List<Event> close() throws Exception {
+    if (this.inputEventHandler != null) {
+      this.inputEventHandler.logProgress(true);
+    }
+
+    if (this.shuffleManager != null) {
+      this.shuffleManager.shutdown();
+    }
+
+    long dataSize =
+        getContext().getCounters().findCounter(TaskCounter.SHUFFLE_BYTES_DECOMPRESSED).getValue();
+    getContext().getStatisticsReporter().reportDataSize(dataSize);
+    long inputRecords =
+        getContext().getCounters().findCounter(TaskCounter.INPUT_RECORDS_PROCESSED).getValue();
+    getContext().getStatisticsReporter().reportItemsProcessed(inputRecords);
+
+    return null;
+  }
+
+  private long getInitialMemoryReq() {
+    return SimpleFetchedInputAllocator.getInitialMemoryReq(
+        conf, getContext().getTotalMemoryAvailableToTask());
+  }
+
+  @SuppressWarnings("rawtypes")
+  private UnorderedKVReader createReader(
+      TezCounter inputRecordCounter,
+      CompressionCodec codec,
+      int ifileBufferSize,
+      boolean ifileReadAheadEnabled,
+      int ifileReadAheadLength)
+      throws IOException {
+    return new UnorderedKVReader(
+        shuffleManager,
+        conf,
+        codec,
+        ifileReadAheadEnabled,
+        ifileReadAheadLength,
+        ifileBufferSize,
+        inputRecordCounter,
+        getContext());
+  }
+
+  @Override
+  public float getProgress() throws ProgressFailedException, InterruptedException {
+    try {
+      return kvReader.getProgress();
+    } catch (IOException e) {
+      throw new ProgressFailedException("getProgress encountered IOException ", e);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add CelebornUnorderedKVInput
2. CelebornShuffleManager extends ShuffleManager to reduce redundant code


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

