### PR TITLE
[CELEBORN-1761][CIP-14] Add cppProto to cppClient

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -141,6 +141,23 @@ include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 include_directories(SYSTEM celeborn)
 include_directories(.)
 
+## TODO: to avoid the file location dependency problem caused by protobuf_cpp_generate,
+## we hardcode the protoc procedure here. Maybe we could find a more elegant way to fix
+## this later...
+set(ProtoFile "${CMAKE_CURRENT_SOURCE_DIR}/celeborn/proto/TransportMessagesCpp.proto")
+set(ProtoGenHeader "${CMAKE_BINARY_DIR}/celeborn/proto/TransportMessagesCpp.pb.h")
+set(ProtoGenSource "${CMAKE_BINARY_DIR}/celeborn/proto/TransportMessagesCpp.pb.cc")
+add_custom_command(
+        OUTPUT ${ProtoGenSource} ${ProtoGenHeader}
+        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/celeborn/proto
+        COMMAND protoc --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/celeborn/proto --cpp_out=${CMAKE_BINARY_DIR}/celeborn/proto ${ProtoFile}
+        DEPENDS ${ProtoFile}
+        VERBATIM)
+add_custom_target(
+        generate_proto_source
+        DEPENDS
+        ${ProtoGenSource} ${ProtoGenHeader})
+
 option(CELEBORN_BUILD_TESTS "CELEBORN_BUILD_TESTS" ON)
 if(CELEBORN_BUILD_TESTS)
     ### TODO: we use prebuilt gtest prebuilt package here. A better way is

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -5,6 +5,13 @@ We provide several methods to setup dev environment for CelebornCpp.
 Note that currently the scripts only take care of the cpp-related dependencies, 
 and java dependencies are not included.
 
+### Clone the project
+We should clone the project as:
+```
+# the option `--config core.symlinks=true` is to make sure that the softlink works
+git clone git@github.com:apache/celeborn.git --config core.symlinks=true
+```
+
 ### Use container with prebuilt image
 We provide a pre-built image ready to be pulled and used so you could launch a container directly:
 ```

--- a/cpp/celeborn/proto/CMakeLists.txt
+++ b/cpp/celeborn/proto/CMakeLists.txt
@@ -12,5 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(utils)
-add_subdirectory(proto)
+add_library(proto STATIC ${ProtoGenSource} ${ProtoGenHeader})
+add_dependencies(proto generate_proto_source)
+target_link_libraries(proto ${Boost_LIBRARIES} ${PROTOBUF_LIBRARY})

--- a/cpp/celeborn/proto/TransportMessagesCpp.proto
+++ b/cpp/celeborn/proto/TransportMessagesCpp.proto
@@ -1,0 +1,1 @@
+../../../common/src/main/proto/TransportMessages.proto


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add cppProto (TransportMessages.proto, softlinked as TransportMessagesCpp.proto) to cppClient


### Why are the changes needed?
To support proto in cppClient and align with java's definition.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Compilation.
