### PR TITLE
[CELEBORN-1764][CIP-11] Adding support for TagsQL for filtering workers tags

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1354,6 +1354,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def tagsExpr: String = get(TAGS_EXPR)
   def preferClientTagsExpr: Boolean = get(PREFER_CLIENT_TAGS_EXPR)
 
+  def useTagsQL: Boolean = get(USE_TAGS_QL)
+
   // //////////////////////////////////////////////////////
   //                    kerberos                         //
   // //////////////////////////////////////////////////////
@@ -6021,6 +6023,14 @@ object CelebornConf extends Logging {
         "expression provided by the master.")
       .dynamic
       .version("0.6.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val USE_TAGS_QL: ConfigEntry[Boolean] =
+    buildConf("celeborn.tags.useTagsQL")
+      .categories("master")
+      .version("0.6.0")
+      .doc("Whether to use tagsQL for tags expression.")
       .booleanConf
       .createWithDefault(false)
 

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -94,4 +94,5 @@ license: |
 | celeborn.tags.enabled | true | false | Whether to enable tags for workers. | 0.6.0 |  | 
 | celeborn.tags.preferClientTagsExpr | false | true | When `true`, prefer the tags expression provided by the client over the tags expression provided by the master. | 0.6.0 |  | 
 | celeborn.tags.tagsExpr |  | true | Expression to filter workers by tags. The expression is a comma-separated list of tags. The expression is evaluated as a logical AND of all tags. For example, `prod,high-io` filters workers that have both the `prod` and `high-io` tags. | 0.6.0 |  | 
+| celeborn.tags.useTagsQL | false | false | Whether to use tagsQL for tags expression. | 0.6.0 |  | 
 <!--end-include-->

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -187,7 +187,7 @@ private[celeborn] class Master(
   private val hasS3Storage = conf.hasS3Storage
 
   private val quotaManager = new QuotaManager(conf, configService)
-  private val tagsManager = new TagsManager(Option(configService))
+  private val tagsManager = new TagsManager(conf, Option(configService))
   private val masterResourceConsumptionInterval = conf.masterResourceConsumptionInterval
   private val userResourceConsumptions =
     JavaUtils.newConcurrentHashMap[UserIdentifier, (ResourceConsumption, Long)]()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/DefaultTagsFilter.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/DefaultTagsFilter.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.tags
+
+import java.util
+import java.util.{Collections, Set => JSet}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Predicate
+import java.util.stream.Collectors
+
+import org.apache.celeborn.common.meta.WorkerInfo
+
+class DefaultTagsFilter(tagsStore: ConcurrentHashMap[String, JSet[String]])
+  extends TagsFilter {
+
+  override def filter(tagsExpr: String, workers: util.List[WorkerInfo]): util.List[WorkerInfo] = {
+    val tags: Array[String] = tagsExpr.split(",").map(_.trim)
+    var workersForTags: Option[JSet[String]] = None
+
+    tags.foreach { tag =>
+      val taggedWorkers = tagsStore.getOrDefault(tag, Collections.emptySet())
+      workersForTags match {
+        case Some(w) =>
+          w.retainAll(taggedWorkers)
+        case _ =>
+          workersForTags = Some(taggedWorkers)
+      }
+    }
+
+    val workerTagsPredicate = new Predicate[WorkerInfo] {
+      override def test(w: WorkerInfo): Boolean = {
+        workersForTags.get.contains(w.toUniqueId())
+      }
+    }
+
+    workers.stream().filter(workerTagsPredicate).collect(Collectors.toList())
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsFilter.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsFilter.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.tags
+
+import java.util
+
+import org.apache.celeborn.common.meta.WorkerInfo
+
+abstract class TagsFilter {
+
+  def filter(tagsExpr: String, workers: util.List[WorkerInfo]): util.List[WorkerInfo]
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLFilter.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLFilter.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.tags.ql
+
+import java.util
+import java.util.{Set => JSet}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Predicate
+import java.util.stream.Collectors
+
+import org.apache.celeborn.common.meta.WorkerInfo
+import org.apache.celeborn.service.deploy.master.tags.TagsFilter
+
+class TagsQLFilter(tagsStore: ConcurrentHashMap[String, JSet[String]])
+  extends TagsFilter {
+
+  private val TAGS_KV_SEPARATOR = "="
+
+  override def filter(tagsExpr: String, workers: util.List[WorkerInfo]): util.List[WorkerInfo] = {
+    val parser = new TagsQLParser()
+    val nodes = parser.parse(tagsExpr)
+
+    var positiveWorkerSet: Option[util.HashSet[String]] = None
+    val negativeWorkerSet = new util.HashSet[String]
+
+    nodes.foreach { node =>
+      val tagKey = node.key
+
+      val workerForNode = new util.HashSet[String]
+      node.values.foreach { tagValue =>
+        val tag = s"$tagKey$TAGS_KV_SEPARATOR$tagValue"
+        val taggedWorkers = tagsStore.getOrDefault(tag, util.Collections.emptySet())
+        workerForNode.addAll(taggedWorkers)
+      }
+
+      node.operator match {
+        case Equals =>
+          positiveWorkerSet match {
+            case Some(w) =>
+              w.retainAll(workerForNode)
+            case _ =>
+              positiveWorkerSet = Some(workerForNode)
+          }
+        case NotEquals =>
+          negativeWorkerSet.addAll(workerForNode)
+      }
+    }
+
+    val workerTagsPredicate = new Predicate[WorkerInfo] {
+      override def test(w: WorkerInfo): Boolean = {
+        positiveWorkerSet.get.contains(w.toUniqueId()) && !negativeWorkerSet.contains(
+          w.toUniqueId())
+      }
+    }
+
+    workers.stream().filter(workerTagsPredicate).collect(Collectors.toList())
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLParser.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLParser.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.tags.ql
+
+sealed trait Operator
+case object Equals extends Operator
+case object NotEquals extends Operator
+
+case class Node(key: String, operator: Operator, values: Set[String])
+
+/**
+ * TagsQL uses key/value pair to give your tags more context.
+ *
+ * The query language supports the following syntax:
+ *   - Match single value: `key:value`
+ *   - Negate single value: `key:!value`
+ *   - Match list of values: `key:{value1,value2}`
+ *   - Negate list of values: `key:!{value1,value2}`
+ *
+ * Example tags expression: `env:production region:{us-east,us-west} env:!sandbox`
+ * This tags expression will select all of the workers that have the following tags:
+ *  - env=production
+ *  - region=us-east or region=us-west
+ * and will ignore all of the workers that have the following tags:
+ *  - env=sandbox
+ *
+ * TagsQLParser defines the parsing logic for TagsQL.
+ */
+class TagsQLParser {
+
+  private val SEPARATOR_TOKEN = ","
+  private val NEGATION_TOKEN = "!"
+  // Only allow word characters and hyphen in the key and value
+  // (This includes underscore and numbers as well)
+  private val VALID_CHARS = "\\w\\-"
+
+  private val Pattern = (s"^([$VALID_CHARS]+):($NEGATION_TOKEN?)" +
+    s"(?:\\{([$VALID_CHARS$SEPARATOR_TOKEN]+)}|([$VALID_CHARS]+))" + "$").r
+
+  def parse(tagsExpr: String): List[Node] = {
+    tagsExpr.split("\\s+").map(parseToken).toList
+  }
+
+  private def parseToken(token: String): Node = {
+    token match {
+      case Pattern(key, condition, values, value) =>
+        val valuesStr = if (values != null) values else value
+        val operator = condition match {
+          case NEGATION_TOKEN => NotEquals
+          case _ => Equals
+        }
+        Node(key, operator, valuesStr.split(",").toSet)
+
+      case _ => throw new IllegalArgumentException(
+          s"Found invalid token: $token while parsing the tagsExpr.")
+    }
+  }
+}

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/TagsManagerSuite.scala
@@ -45,7 +45,7 @@ class TagsManagerSuite extends CelebornFunSuite {
   }
 
   test("test tags manager") {
-    tagsManager = new TagsManager(Option(null))
+    tagsManager = new TagsManager(new CelebornConf(), Option(null))
 
     tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId())
     tagsManager.addTagToWorker(TAG1, WORKER2.toUniqueId())
@@ -127,7 +127,7 @@ class TagsManagerSuite extends CelebornFunSuite {
   }
 
   test("test tags expression with multiple tags") {
-    tagsManager = new TagsManager(Option(null))
+    tagsManager = new TagsManager(new CelebornConf(), Option(null))
 
     // Tag1
     tagsManager.addTagToWorker(TAG1, WORKER1.toUniqueId())
@@ -159,7 +159,7 @@ class TagsManagerSuite extends CelebornFunSuite {
       getTestResourceFile("dynamicConfig-tags.yaml").getPath)
     val configService = DynamicConfigServiceFactory.getConfigService(conf)
 
-    tagsManager = new TagsManager(Option(configService))
+    tagsManager = new TagsManager(new CelebornConf(), Option(configService))
 
     {
       // preferClientTagsExpr: true

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLFilterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLFilterSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.tags.ql
+
+import java.util.{Set => JSet}
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, seqAsJavaListConverter, setAsJavaSetConverter}
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.meta.WorkerInfo
+
+class TagsQLFilterSuite extends CelebornFunSuite {
+
+  private val WORKER1 = new WorkerInfo("host1", 111, 112, 113, 114, 115)
+  private val WORKER2 = new WorkerInfo("host2", 211, 212, 213, 214, 215)
+  private val WORKER3 = new WorkerInfo("host3", 311, 312, 313, 314, 315)
+  private val workers = List(WORKER1, WORKER2, WORKER3).asJava
+
+  private val tagsMap = new ConcurrentHashMap[String, JSet[String]]()
+  tagsMap.putAll(Map(
+    "env=production" -> Set(WORKER1.toUniqueId(), WORKER2.toUniqueId()).asJava,
+    "env=staging" -> Set(WORKER3.toUniqueId()).asJava,
+    "region=us-east" -> Set(WORKER1.toUniqueId(), WORKER3.toUniqueId()).asJava,
+    "region=us-west" -> Set(WORKER2.toUniqueId(), WORKER3.toUniqueId()).asJava).asJava)
+
+  test("Test TagsQLFilter") {
+    val tagsFilter = new TagsQLFilter(tagsMap)
+
+    {
+      val tagsExpr = "env:production region:{us-east,us-west}"
+      val taggedWorkers = tagsFilter.filter(tagsExpr, workers)
+      assert(taggedWorkers.size() == 2)
+      assert(taggedWorkers.contains(WORKER1))
+      assert(taggedWorkers.contains(WORKER2))
+    }
+
+    {
+      val tagsExpr = "env:production region:!{us-east,us-west}"
+      val taggedWorkers = tagsFilter.filter(tagsExpr, workers)
+      assert(taggedWorkers.size() == 0)
+    }
+
+    {
+      val tagsExpr = "env:staging region:{us-east,us-west}"
+      val taggedWorkers = tagsFilter.filter(tagsExpr, workers)
+      assert(taggedWorkers.size() == 1)
+      assert(taggedWorkers.contains(WORKER3))
+    }
+
+    {
+      val tagsExpr = "env:!staging region:{us-east,us-west}"
+      val taggedWorkers = tagsFilter.filter(tagsExpr, workers)
+      assert(taggedWorkers.size() == 2)
+      assert(taggedWorkers.contains(WORKER1))
+      assert(taggedWorkers.contains(WORKER2))
+    }
+  }
+}

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLParserSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/tags/ql/TagsQLParserSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master.tags.ql
+
+import org.apache.celeborn.CelebornFunSuite
+
+class TagsQLParserSuite extends CelebornFunSuite {
+
+  private val parser = new TagsQLParser()
+
+  test("test tags ql parser") {
+
+    def assertValidNodes(nodes: List[Node], operator: Operator): Unit = {
+      assert(nodes.size == 2)
+      assert(nodes(0).key == "env")
+      assert(nodes(0).operator == operator)
+      assert(nodes(0).values == Set("production"))
+      assert(nodes(1).key == "region")
+      assert(nodes(1).operator == operator)
+      assert(nodes(1).values.contains("us-east"))
+      assert(nodes(1).values.contains("us-west"))
+    }
+
+    {
+      val tagsExpr = "env:production region:{us-east,us-west}"
+      val nodes = parser.parse(tagsExpr)
+      assertValidNodes(nodes, Equals)
+    }
+
+    {
+      val tagsExpr = "env:!production region:!{us-east,us-west}"
+      val nodes = parser.parse(tagsExpr)
+      assertValidNodes(nodes, NotEquals)
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Added support for TagsQL, which uses key/value pair to give workers tags more context.
The TagsQL supports the following syntax:
 - Match single value: `key:value`
 - Negate single value: `key:!value`
 - Match list of values: `key:{value1,value2}`
 - Negate list of values: `key:!{value1,value2}`

Example tags expression: `env:production region:{us-east,us-west} env:!sandbox`
This tags expression will select all of the workers that have the following tags:
 - env=production
 - region=us-east or region=us-west
 
and will ignore all of the workers that have the following tags:
  - env=sandbox

### Why are the changes needed?

Current/default supported tags expression is very basic which select the workers with all the mentioned tags. TagsQL will allow more flexibility and extensibility to workers tags.

### Does this PR introduce _any_ user-facing change?
NA


### How was this patch tested?
UTs
