### PR TITLE
[CELEBORN-1765] Fix NPE when removeFileInfo in StorageManager

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -531,7 +531,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     if (diskShuffleMap != null) {
       if (workerGracefulShutdown) {
         val committedFileInfoMap = committedFileInfos.get(shuffleKey)
-        committedFileInfoMap.remove(fileName)
+        if (committedFileInfoMap != null) {
+          committedFileInfoMap.remove(fileName)
+        }
       }
       return diskShuffleMap.remove(fileName)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
The file may not have been committed when removeFileInfo in gracefulshutdown condition.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing ut.
