### PR TITLE
[CELEBORN-1770] FlushNotifier should setException for all Throwables in Flusher

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -44,6 +44,14 @@ public class ExceptionUtils {
     }
   }
 
+  public static IOException wrapThrowableToIOException(Throwable throwable) {
+    if (throwable instanceof IOException) {
+      return (IOException) throwable;
+    } else {
+      return new IOException(throwable.getMessage(), throwable);
+    }
+  }
+
   public static String stringifyException(Throwable exception) {
     if (exception == null) {
       return "(null)";

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -29,7 +29,7 @@ import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskStatus, TimeWindow}
 import org.apache.celeborn.common.metrics.source.{AbstractSource, ThreadPoolSource}
 import org.apache.celeborn.common.protocol.StorageInfo
-import org.apache.celeborn.common.util.{ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{ExceptionUtils, ThreadUtils, Utils}
 import org.apache.celeborn.service.deploy.worker.WorkerSource
 import org.apache.celeborn.service.deploy.worker.WorkerSource.FLUSH_WORKING_QUEUE_SIZE
 import org.apache.celeborn.service.deploy.worker.congestcontrol.CongestionController
@@ -77,14 +77,9 @@ abstract private[worker] class Flusher(
                   }
                 } catch {
                   case t: Throwable =>
-                    t match {
-                      case exception: IOException =>
-                        task.notifier.setException(exception)
-                        processIOException(
-                          exception,
-                          DiskStatus.READ_OR_WRITE_FAILURE)
-                      case _ =>
-                    }
+                    val e = ExceptionUtils.wrapThrowableToIOException(t)
+                    task.notifier.setException(e)
+                    processIOException(e, DiskStatus.READ_OR_WRITE_FAILURE)
                     logWarning(s"Flusher-$this-thread-$index encounter exception.", t)
                 }
                 lastBeginFlushTime.set(index, -1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Non-IOException (will throw illegalReferenceCountException If a netty's buffer reference count is incorrect) 
should also be set in FlushNotifier.
Provides Utils to convert non-IOExceptions to IOExceptions.

### Why are the changes needed?
In some test scenarios where data replication is enabled and workers are randomly terminated, it will throw illegalReferenceCountException which won't be caught.
![image](https://github.com/user-attachments/assets/6503204a-9594-4a7e-850c-c411e0b07117)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UT & cluster test.
