### PR TITLE
[CELEBORN-1771] Bring forward PUSH_DATA_CREATE_CONNECTION_FAIL_REPLICA

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -337,28 +337,25 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
             }
 
             override def onFailure(e: Throwable): Unit = {
-              Try(Await.result(writePromise.future, Duration.Inf)) match {
-                case _ =>
-                  logError(s"PushData replication failed for partitionLocation: $location", e)
-                  // 1. Throw PUSH_DATA_WRITE_FAIL_REPLICA by replica peer worker
-                  // 2. Throw PUSH_DATA_TIMEOUT_REPLICA by TransportResponseHandler
-                  // 3. Throw IOException by channel, convert to PUSH_DATA_CONNECTION_EXCEPTION_REPLICA
-                  if (e.getMessage.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_REPLICA.name())) {
-                    workerSource.incCounter(WorkerSource.REPLICATE_DATA_WRITE_FAIL_COUNT)
-                    callbackWithTimer.onFailure(e)
-                  } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())) {
-                    workerSource.incCounter(WorkerSource.REPLICATE_DATA_TIMEOUT_COUNT)
-                    callbackWithTimer.onFailure(e)
-                  } else if (ExceptionUtils.connectFail(e.getMessage)) {
-                    workerSource.incCounter(WorkerSource.REPLICATE_DATA_CONNECTION_EXCEPTION_COUNT)
-                    callbackWithTimer.onFailure(
-                      new CelebornIOException(StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA))
-                  } else {
-                    workerSource.incCounter(
-                      WorkerSource.REPLICATE_DATA_FAIL_NON_CRITICAL_CAUSE_COUNT)
-                    callbackWithTimer.onFailure(
-                      new CelebornIOException(StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_REPLICA))
-                  }
+              logError(s"PushData replication failed for partitionLocation: $location", e)
+              // 1. Throw PUSH_DATA_WRITE_FAIL_REPLICA by replica peer worker
+              // 2. Throw PUSH_DATA_TIMEOUT_REPLICA by TransportResponseHandler
+              // 3. Throw IOException by channel, convert to PUSH_DATA_CONNECTION_EXCEPTION_REPLICA
+              if (e.getMessage.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_REPLICA.name())) {
+                workerSource.incCounter(WorkerSource.REPLICATE_DATA_WRITE_FAIL_COUNT)
+                callbackWithTimer.onFailure(e)
+              } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())) {
+                workerSource.incCounter(WorkerSource.REPLICATE_DATA_TIMEOUT_COUNT)
+                callbackWithTimer.onFailure(e)
+              } else if (ExceptionUtils.connectFail(e.getMessage)) {
+                workerSource.incCounter(WorkerSource.REPLICATE_DATA_CONNECTION_EXCEPTION_COUNT)
+                callbackWithTimer.onFailure(
+                  new CelebornIOException(StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA))
+              } else {
+                workerSource.incCounter(
+                  WorkerSource.REPLICATE_DATA_FAIL_NON_CRITICAL_CAUSE_COUNT)
+                callbackWithTimer.onFailure(
+                  new CelebornIOException(StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_REPLICA))
               }
             }
           }
@@ -680,28 +677,25 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
             }
 
             override def onFailure(e: Throwable): Unit = {
-              Try(Await.result(writePromise.future, Duration.Inf)) match {
-                case _ =>
-                  logError(s"PushMergedData replicate failed for partitionLocation: $location", e)
-                  // 1. Throw PUSH_DATA_WRITE_FAIL_REPLICA by replica peer worker
-                  // 2. Throw PUSH_DATA_TIMEOUT_REPLICA by TransportResponseHandler
-                  // 3. Throw IOException by channel, convert to PUSH_DATA_CONNECTION_EXCEPTION_REPLICA
-                  if (e.getMessage.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_REPLICA.name())) {
-                    workerSource.incCounter(WorkerSource.REPLICATE_DATA_WRITE_FAIL_COUNT)
-                    pushMergedDataCallback.onFailure(e)
-                  } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())) {
-                    workerSource.incCounter(WorkerSource.REPLICATE_DATA_TIMEOUT_COUNT)
-                    pushMergedDataCallback.onFailure(e)
-                  } else if (ExceptionUtils.connectFail(e.getMessage)) {
-                    workerSource.incCounter(WorkerSource.REPLICATE_DATA_CONNECTION_EXCEPTION_COUNT)
-                    pushMergedDataCallback.onFailure(
-                      new CelebornIOException(StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA))
-                  } else {
-                    workerSource.incCounter(
-                      WorkerSource.REPLICATE_DATA_FAIL_NON_CRITICAL_CAUSE_COUNT)
-                    pushMergedDataCallback.onFailure(
-                      new CelebornIOException(StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_REPLICA))
-                  }
+              logError(s"PushMergedData replicate failed for partitionLocation: $location", e)
+              // 1. Throw PUSH_DATA_WRITE_FAIL_REPLICA by replica peer worker
+              // 2. Throw PUSH_DATA_TIMEOUT_REPLICA by TransportResponseHandler
+              // 3. Throw IOException by channel, convert to PUSH_DATA_CONNECTION_EXCEPTION_REPLICA
+              if (e.getMessage.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_REPLICA.name())) {
+                workerSource.incCounter(WorkerSource.REPLICATE_DATA_WRITE_FAIL_COUNT)
+                pushMergedDataCallback.onFailure(e)
+              } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())) {
+                workerSource.incCounter(WorkerSource.REPLICATE_DATA_TIMEOUT_COUNT)
+                pushMergedDataCallback.onFailure(e)
+              } else if (ExceptionUtils.connectFail(e.getMessage)) {
+                workerSource.incCounter(WorkerSource.REPLICATE_DATA_CONNECTION_EXCEPTION_COUNT)
+                pushMergedDataCallback.onFailure(
+                  new CelebornIOException(StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA))
+              } else {
+                workerSource.incCounter(
+                  WorkerSource.REPLICATE_DATA_FAIL_NON_CRITICAL_CAUSE_COUNT)
+                pushMergedDataCallback.onFailure(
+                  new CelebornIOException(StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_REPLICA))
               }
             }
           }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -281,7 +281,6 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
         peer.getFetchPort,
         peer.getReplicatePort)
       if (unavailablePeers.containsKey(peerWorker)) {
-        // pushData.body().release()
         fileWriter.decrementPendingWrites()
         workerSource.incCounter(WorkerSource.REPLICATE_DATA_CREATE_CONNECTION_FAIL_COUNT)
         logError(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -613,9 +613,9 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
         peer.getReplicatePort)
       if (unavailablePeers.containsKey(peerWorker)) {
         for (fileWriterIndex <- 0 until totalFileWriters) {
-          if (fileWriters(fileWriterIndex) != null &&
-            !pushMergedDataCallback.isHardSplitPartition(fileWriterIndex)) {
-            fileWriters(fileWriterIndex).decrementPendingWrites()
+          val fileWriter = fileWriters(fileWriterIndex)
+          if (fileWriter != null && !pushMergedDataCallback.isHardSplitPartition(fileWriterIndex)) {
+            fileWriter.decrementPendingWrites()
           }
         }
         handlePushMergedDataConnectionFail(pushMergedDataCallback, location)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -619,7 +619,6 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           }
         }
         handlePushMergedDataConnectionFail(pushMergedDataCallback, location)
-        callbackWithTimer.onFailure(new CelebornIOException(StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_REPLICA))
         return
       }
       pushMergedData.body().retain()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1.Move the peerWorker available judgement out of ThreadPool.
2.Move `retain` after the available worker judgment Which means we don't have to release if peerWorker is unavailable.
2. Add `fileWriter.decrementPendingWrites()` if peerWorker is unavailable since it will return and won't decrementPendingWreites in `writeLocalData`.

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UT & cluster testing.
