### PR TITLE
[CELEBORN-1773] Revert [CELEBORN-1376] Push data failed should always release request body

### DIFF
--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -111,7 +111,7 @@ public class FlinkShuffleClientImplSuiteJ {
   @Test
   public void testPushDataByteBufFail() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    when(client.pushData(any(), anyLong(), any(), any(), any()))
+    when(client.pushData(any(), anyLong(), any(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback = t.getArgument(1, RpcResponseCallback.class);

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -216,23 +216,6 @@ public class TransportClient implements Closeable {
       long pushDataTimeout,
       RpcResponseCallback callback,
       Runnable rpcSendoutCallback) {
-    Runnable rpcFailureCallback =
-        () -> {
-          try {
-            pushData.body().release();
-          } catch (Throwable e) {
-            logger.error("Error release buffer for PUSH_DATA request {}", pushData.requestId, e);
-          }
-        };
-    return pushData(pushData, pushDataTimeout, callback, rpcSendoutCallback, rpcFailureCallback);
-  }
-
-  public ChannelFuture pushData(
-      PushData pushData,
-      long pushDataTimeout,
-      RpcResponseCallback callback,
-      Runnable rpcSendoutCallback,
-      Runnable rpcFailureCallback) {
     if (logger.isTraceEnabled()) {
       logger.trace("Pushing data to {}", NettyUtils.getRemoteAddress(channel));
     }
@@ -242,8 +225,7 @@ public class TransportClient implements Closeable {
     PushRequestInfo info = new PushRequestInfo(dueTime, callback);
     handler.addPushRequest(requestId, info);
     pushData.requestId = requestId;
-    PushChannelListener listener =
-        new PushChannelListener(requestId, rpcSendoutCallback, rpcFailureCallback);
+    PushChannelListener listener = new PushChannelListener(requestId, rpcSendoutCallback);
     ChannelFuture channelFuture = channel.writeAndFlush(pushData).addListener(listener);
     info.setChannelFuture(channelFuture);
     return channelFuture;
@@ -251,26 +233,6 @@ public class TransportClient implements Closeable {
 
   public ChannelFuture pushMergedData(
       PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
-    Runnable rpcFailureCallback =
-        () -> {
-          try {
-            pushMergedData.body().release();
-          } catch (Throwable e) {
-            logger.error(
-                "Error release buffer for PUSH_MERGED_DATA request {}",
-                pushMergedData.requestId,
-                e);
-          }
-        };
-    return pushMergedData(pushMergedData, pushDataTimeout, callback, null, rpcFailureCallback);
-  }
-
-  public ChannelFuture pushMergedData(
-      PushMergedData pushMergedData,
-      long pushDataTimeout,
-      RpcResponseCallback callback,
-      Runnable rpcSendoutCallback,
-      Runnable rpcFailureCallback) {
     if (logger.isTraceEnabled()) {
       logger.trace("Pushing merged data to {}", NettyUtils.getRemoteAddress(channel));
     }
@@ -281,8 +243,7 @@ public class TransportClient implements Closeable {
     handler.addPushRequest(requestId, info);
     pushMergedData.requestId = requestId;
 
-    PushChannelListener listener =
-        new PushChannelListener(requestId, rpcSendoutCallback, rpcFailureCallback);
+    PushChannelListener listener = new PushChannelListener(requestId);
     ChannelFuture channelFuture = channel.writeAndFlush(pushMergedData).addListener(listener);
     info.setChannelFuture(channelFuture);
     return channelFuture;
@@ -498,18 +459,14 @@ public class TransportClient implements Closeable {
     final long pushRequestId;
     Runnable rpcSendOutCallback;
 
-    Runnable rpcFailureCallback;
-
     PushChannelListener(long pushRequestId) {
-      this(pushRequestId, null, null);
+      this(pushRequestId, null);
     }
 
-    PushChannelListener(
-        long pushRequestId, Runnable rpcSendOutCallback, Runnable rpcFailureCallback) {
+    PushChannelListener(long pushRequestId, Runnable rpcSendOutCallback) {
       super("PUSH " + pushRequestId);
       this.pushRequestId = pushRequestId;
       this.rpcSendOutCallback = rpcSendOutCallback;
-      this.rpcFailureCallback = rpcFailureCallback;
     }
 
     @Override
@@ -523,9 +480,6 @@ public class TransportClient implements Closeable {
     @Override
     protected void handleFailure(String errorMsg, Throwable cause) {
       handler.handlePushFailure(pushRequestId, errorMsg, cause);
-      if (rpcFailureCallback != null) {
-        rpcFailureCallback.run();
-      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Revert CELEBORN-1376.


### Why are the changes needed?
Duplicate release data, because Encoder will release it event send replica data timeout.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing uts.
