### PR TITLE
Add support for NodePort Service per Master replica

### DIFF
--- a/charts/celeborn/templates/master/service.yaml
+++ b/charts/celeborn/templates/master/service.yaml
@@ -15,6 +15,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
+{{ if .Values.additionalNodePortServicePerReplica.enabled }}
+{{ range  $i, $e := until (int .Values.masterReplicas) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "celeborn.masterServiceName" $ }}-{{ $i }}
+  labels:
+    {{- include "celeborn.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "celeborn.masterMetricsAnnotation" $ | nindent 4 }}
+    {{- with index $.Values.additionalNodePortServicePerReplica.annotations (printf "master-replica-%d" $i) }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  selector:
+    {{- include "celeborn.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/role: master
+    apps.kubernetes.io/pod-index: "{{ $i }}"
+  ports:
+  - port: {{ $.Values.additionalNodePortServicePerReplica.port }}
+    targetPort: {{ $.Values.additionalNodePortServicePerReplica.port }}
+    nodePort: {{ add $.Values.additionalNodePortServicePerReplica.nodePortStartRange $i }}
+    protocol: TCP
+    name: celeborn-master
+  type: NodePort
+{{ end -}}
+{{ end -}}
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/celeborn/tests/master/service_test.yaml
+++ b/charts/celeborn/tests/master/service_test.yaml
@@ -52,3 +52,29 @@ tests:
       - equal:
           path: spec.ports[0].targetPort
           value: 9097
+  - it: Should create NodePort service for each master replica
+    set:
+      masterReplicas: 3
+      additionalNodePortServicePerReplica:
+        enabled: true
+        port: 9097
+        nodePortStartRange: 30100
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: celeborn-master-svc-0
+        equal:
+          path: spec.ports[0].nodePort
+          value: 30100
+      - documentSelector:
+          path: metadata.name
+          value: celeborn-master-svc-1
+        equal:
+          path: spec.ports[0].nodePort
+          value: 30101
+      - documentSelector:
+          path: metadata.name
+          value: celeborn-master-svc-2
+        equal:
+          path: spec.ports[0].nodePort
+          value: 30102

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -49,6 +49,18 @@ service:
   type: ClusterIP
   # -- Specifies service port
   port: 9097
+  # -- Specifies service annotations
+  annotations: {}
+
+# -- Specifies whether to create additional NodePort service for each master replica
+additionalNodePortServicePerReplica:
+  enabled: false
+  # -- Specifies service port
+  port: 9097
+  # -- Specifies nodeport start range
+  nodePortStartRange: 30000
+  # -- when using NodePort service type, you can specify map of annotations for each master replica
+  annotations: {}
 
 cluster:
   # -- Specifies Kubernetes cluster name


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR add support for NodePort svc per master replica, instead of only dealing on hostnet in master's when client is outside of k8s


### Why are the changes needed?
To better support external access 


### Does this PR introduce _any_ user-facing change?
Added optional fields 


### How was this patch tested?
locally on my cluster
