### PR TITLE
[CELEBORN-1711][TEST] RetryReviveTest - shutdownMiniCluster after each test 

### DIFF
--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
@@ -37,6 +37,7 @@ class RetryReviveTest extends AnyFunSuite
   override def beforeEach(): Unit = {}
 
   override def afterEach(): Unit = {
+    shutdownMiniCluster()
     System.gc()
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
For RetryReviveTest, shutdownMiniCluster after each test


### Why are the changes needed?

Currently, the minicluster is not shutdown after each test.
https://github.com/apache/celeborn/blob/ca8831e55f9902b0f95dbe40659d7713e45ebaa2/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala#L43-L80

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA
