### PR TITLE
[CELEBORN-1778] Fix commitInfo NPE and add assert in LifecycleManagerCommitFilesSuite

### DIFF
--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -93,7 +93,8 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
         worker.controller.shuffleCommitInfos.get(Utils.makeShuffleKey(APP, shuffleId))
       if (commitInfoList != null) {
         commitInfoList.values().asScala.foreach { commitInfo =>
-          commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
+          assert(
+            commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED)
         }
       }
     }
@@ -148,7 +149,8 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
         worker.controller.shuffleCommitInfos.get(Utils.makeShuffleKey(APP, shuffleId))
       if (commitInfoList != null) {
         commitInfoList.values().asScala.foreach { commitInfo =>
-          commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
+          assert(
+            commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED)
         }
       }
     }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -89,12 +89,14 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
       new ShuffleFailedWorkers)
 
     workerInfos.keySet.foreach { worker =>
-      worker.controller.shuffleCommitInfos.get(
-        Utils.makeShuffleKey(APP, shuffleId)).values().asScala.foreach { commitInfo =>
-        commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
+      val commitInfoList =
+        worker.controller.shuffleCommitInfos.get(Utils.makeShuffleKey(APP, shuffleId))
+      if (commitInfoList != null) {
+        commitInfoList.values().asScala.foreach { commitInfo =>
+          commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
+        }
       }
     }
-
     lifecycleManager.stop()
   }
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -144,9 +144,12 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
       new ShuffleFailedWorkers)
 
     workerInfos.keySet.foreach { worker =>
-      worker.controller.shuffleCommitInfos.get(
-        Utils.makeShuffleKey(APP, shuffleId)).values().asScala.foreach { commitInfo =>
-        commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
+      val commitInfoList =
+        worker.controller.shuffleCommitInfos.get(Utils.makeShuffleKey(APP, shuffleId))
+      if (commitInfoList != null) {
+        commitInfoList.values().asScala.foreach { commitInfo =>
+          commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
+        }
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Fix commitInfo NPE in LifecycleManagerCommitFilesSuite. Not all the workers are assigned slots.
2. Add `assert` in the logic of judgement.

### Why are the changes needed?
Errors in CI.
![image](https://github.com/user-attachments/assets/d4335c65-7a10-4db9-8446-694093bbde31)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing CI.
