### PR TITLE
[CELEBORN-1779] Create reader didn't change to peer

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -414,9 +414,6 @@ public abstract class CelebornInputStream extends InputStream {
         throws IOException, InterruptedException {
       if (!location.hasPeer()) {
         logger.debug("Partition {} has only one partition replica.", location);
-      } else if (pbStreamHandler == null && attemptNumber % 2 == 1) {
-        location = location.getPeer();
-        logger.debug("Read peer {} for attempt {}.", location, attemptNumber);
       }
       logger.debug("Create reader for location {}", location);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the change peer logic when task attempt id is an odd number


### Why are the changes needed?
Create reader didn't change to peer when fetch primary location failed and task attempt id is an odd number


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing uts.
