### PR TITLE
[CELEBORN-1782] Worker in congestion control should be in blacklist to avoid impact new shuffle

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -285,6 +285,10 @@ public class CongestionController {
     }
   }
 
+  public Boolean isOverHighWatermark() {
+    return overHighWatermark.get();
+  }
+
   public void close() {
     logger.info("Closing {}", this.getClass().getSimpleName());
     this.removeUserExecutorService.shutdownNow();

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -447,7 +447,8 @@ private[celeborn] class Worker(
   }
 
   private def highWorkload: Boolean = {
-    (memoryManager.currentServingState,
+    (
+      memoryManager.currentServingState,
       Option(CongestionController.instance()),
       conf.workerActiveConnectionMax) match {
       case (_, Some(instance), _) if instance.isOverHighWatermark => true

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -447,10 +447,13 @@ private[celeborn] class Worker(
   }
 
   private def highWorkload: Boolean = {
-    (memoryManager.servingState, conf.workerActiveConnectionMax) match {
-      case (ServingState.PUSH_AND_REPLICATE_PAUSED, _) => true
-      case (ServingState.PUSH_PAUSED, _) => true
-      case (_, Some(activeConnectionMax)) =>
+    (memoryManager.currentServingState,
+      Option(CongestionController.instance()),
+      conf.workerActiveConnectionMax) match {
+      case (_, Some(instance), _) if instance.isOverHighWatermark => true
+      case (ServingState.PUSH_AND_REPLICATE_PAUSED, _, _) => true
+      case (ServingState.PUSH_PAUSED, _, _) => true
+      case (_, _, Some(activeConnectionMax)) =>
         workerSource.getCounterCount(ACTIVE_CONNECTION_COUNT) >= activeConnectionMax
       case _ => false
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set highWorkload=true when worker in congestion control.

### Why are the changes needed?
Worker in congestion control should be in blacklist to avoid impact new shuffle.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UTS.
