### PR TITLE
[CELEBORN-1787] Fix netty memory metrics was not registered when enable memory allocator share

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.celeborn.common.network.util;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -124,7 +124,7 @@ public class NettyUtils {
    * parameter value.
    */
   public static synchronized PooledByteBufAllocator getSharedPooledByteBufAllocator(
-      CelebornConf conf, AbstractSource source, boolean allowCache) {
+      CelebornConf conf, boolean allowCache) {
     final int index = allowCache ? 0 : 1;
     if (_sharedPooledByteBufAllocator[index] == null) {
       _sharedPooledByteBufAllocator[index] =
@@ -145,7 +145,6 @@ public class NettyUtils {
       allocator =
           getSharedPooledByteBufAllocator(
               conf.getCelebornConf(),
-              source,
               allowCache && conf.getCelebornConf().networkMemoryAllocatorAllowCache());
     } else {
       int arenas;

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -168,7 +168,7 @@ public class NettyUtils {
       String poolName;
       Map<String, String> labels = new HashMap<>();
       if (conf.getCelebornConf().networkMemoryAllocatorAllowCache()) {
-        poolName = allowCache ? "shared-pool" : "non-shared-pool";
+        poolName = allowCache ? "netty-shared-pool" : "netty-non-shared-pool";
       } else {
         poolName = conf.getModuleName();
         int index = allocatorsIndex.compute(poolName, (k, v) -> v == null ? 0 : v + 1);

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -129,14 +129,6 @@ public class NettyUtils {
     if (_sharedPooledByteBufAllocator[index] == null) {
       _sharedPooledByteBufAllocator[index] =
           createPooledByteBufAllocator(true, allowCache, conf.networkAllocatorArenas());
-      if (source != null) {
-        new NettyMemoryMetrics(
-            _sharedPooledByteBufAllocator[index],
-            "shared-pool-" + index,
-            conf.networkAllocatorVerboseMetric(),
-            source,
-            Collections.emptyMap());
-      }
     }
     return _sharedPooledByteBufAllocator[index];
   }

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -168,7 +168,7 @@ public class NettyUtils {
       String poolName;
       Map<String, String> labels = new HashMap<>();
       if (conf.getCelebornConf().networkMemoryAllocatorAllowCache()) {
-        poolName = allowCache ? "netty-shared-pool" : "netty-non-shared-pool";
+        poolName = allowCache ? "netty-shared-cache-pool" : "netty-shared-non-cache-pool";
       } else {
         poolName = conf.getModuleName();
         int index = allocatorsIndex.compute(poolName, (k, v) -> v == null ? 0 : v + 1);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -132,7 +132,10 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     DeviceMonitor.createDeviceMonitor(conf, this, deviceInfos, tmpDiskInfos, workerSource)
 
   val storageBufferAllocator: PooledByteBufAllocator =
-    NettyUtils.getPooledByteBufAllocator(new TransportConf("StorageManager", conf), null, true)
+    NettyUtils.getPooledByteBufAllocator(
+      new TransportConf("StorageManager", conf),
+      workerSource,
+      true)
 
   // (mountPoint -> LocalFlusher)
   private val (

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -59,9 +59,8 @@ public class MemoryPartitionFilesSorterSuiteJ {
     byte[] batchHeader = new byte[16];
     fileInfo = new MemoryFileInfo(userIdentifier, true, new ReduceFileMeta(8 * 1024 * 1024));
 
-    AbstractSource source = Mockito.mock(AbstractSource.class);
     PooledByteBufAllocator allocator =
-        NettyUtils.getSharedPooledByteBufAllocator(new CelebornConf(), source, false);
+        NettyUtils.getSharedPooledByteBufAllocator(new CelebornConf(), false);
     CompositeByteBuf buffer = allocator.compositeBuffer();
     fileInfo.setBuffer(buffer);
 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -36,7 +36,6 @@ import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.meta.MemoryFileInfo;
 import org.apache.celeborn.common.meta.ReduceFileMeta;
-import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix netty memory metrics was not registered when enable memory allocator share

### Why are the changes needed?
Fix netty memory metrics was not registered when enable memory allocator share


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing uts.
