### PR TITLE
[CELEBORN-1700][FOLLOWUP] Support ShuffleFallbackCount metric for fallback to vanilla Flink built-in shuffle implementation

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -110,7 +110,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<ShuffleDescriptor> {
     try {
       if (nettyShuffleServiceFactory != null) {
         Optional<ShuffleFallbackPolicy> shuffleFallbackPolicy =
-            ShuffleFallbackPolicyRunner.applyFallbackPolicies(context, conf, lifecycleManager);
+            ShuffleFallbackPolicyRunner.getActivatedFallbackPolicy(context, conf, lifecycleManager);
         if (shuffleFallbackPolicy.isPresent()) {
           LOG.warn("Fallback to vanilla Flink NettyShuffleMaster for job: {}.", jobID);
           jobFallbackPolicies.put(jobID, shuffleFallbackPolicy.get().getClass().getName());

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/fallback/ShuffleFallbackPolicyRunner.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/fallback/ShuffleFallbackPolicyRunner.java
@@ -32,7 +32,7 @@ public class ShuffleFallbackPolicyRunner {
   private static final List<ShuffleFallbackPolicy> FALLBACK_POLICIES =
       ShuffleFallbackPolicyFactory.getShuffleFallbackPolicies();
 
-  public static Optional<ShuffleFallbackPolicy> applyFallbackPolicies(
+  public static Optional<ShuffleFallbackPolicy> getActivatedFallbackPolicy(
       JobShuffleContext shuffleContext,
       CelebornConf celebornConf,
       LifecycleManager lifecycleManager)

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/fallback/ShuffleFallbackPolicyRunner.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/fallback/ShuffleFallbackPolicyRunner.java
@@ -32,7 +32,7 @@ public class ShuffleFallbackPolicyRunner {
   private static final List<ShuffleFallbackPolicy> FALLBACK_POLICIES =
       ShuffleFallbackPolicyFactory.getShuffleFallbackPolicies();
 
-  public static boolean applyFallbackPolicies(
+  public static Optional<ShuffleFallbackPolicy> applyFallbackPolicies(
       JobShuffleContext shuffleContext,
       CelebornConf celebornConf,
       LifecycleManager lifecycleManager)
@@ -44,11 +44,11 @@ public class ShuffleFallbackPolicyRunner {
                     shuffleFallbackPolicy.needFallback(
                         shuffleContext, celebornConf, lifecycleManager))
             .findFirst();
-    boolean needFallback = fallbackPolicy.isPresent();
-    if (needFallback && FallbackPolicy.NEVER.equals(celebornConf.flinkShuffleFallbackPolicy())) {
+    if (fallbackPolicy.isPresent()
+        && FallbackPolicy.NEVER.equals(celebornConf.flinkShuffleFallbackPolicy())) {
       throw new CelebornIOException(
           "Fallback to flink built-in shuffle implementation is prohibited.");
     }
-    return needFallback;
+    return fallbackPolicy;
   }
 }

--- a/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -42,8 +42,10 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
 import org.junit.After;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.FallbackPolicy;
 import org.apache.celeborn.common.util.Utils$;
+import org.apache.celeborn.plugin.flink.fallback.ForceFallbackPolicy;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterSuiteJ {
@@ -98,9 +101,9 @@ public class RemoteShuffleMasterSuiteJ {
     JobID jobID = JobID.generate();
     JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
     remoteShuffleMaster.registerJob(jobShuffleContext);
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().contains(jobID));
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().containsKey(jobID));
     remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().isEmpty());
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().isEmpty());
   }
 
   @Test
@@ -118,6 +121,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
     ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
         shuffleResource.getMapPartitionShuffleDescriptor();
@@ -135,6 +139,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(2, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
@@ -147,11 +152,38 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(3, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducerForForceFallbackPolicy()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    configuration.setString(
+        CelebornConf.FLINK_SHUFFLE_FALLBACK_POLICY().key(), FallbackPolicy.ALWAYS.name());
+    remoteShuffleMaster = createShuffleMaster(configuration, new NettyShuffleServiceFactory());
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    ShuffleDescriptor shuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    Assert.assertTrue(shuffleDescriptor instanceof NettyShuffleDescriptor);
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
+    Map<String, Long> shuffleFallbackCounts =
+        remoteShuffleMaster.lifecycleManager().shuffleFallbackCounts();
+    Assert.assertEquals(1, shuffleFallbackCounts.size());
+    Assert.assertEquals(
+        1L, shuffleFallbackCounts.get(ForceFallbackPolicy.class.getName()).longValue());
   }
 
   @Test

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -42,8 +42,10 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
 import org.junit.After;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.FallbackPolicy;
 import org.apache.celeborn.common.util.Utils$;
+import org.apache.celeborn.plugin.flink.fallback.ForceFallbackPolicy;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterSuiteJ {
@@ -98,9 +101,9 @@ public class RemoteShuffleMasterSuiteJ {
     JobID jobID = JobID.generate();
     JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
     remoteShuffleMaster.registerJob(jobShuffleContext);
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().contains(jobID));
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().containsKey(jobID));
     remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().isEmpty());
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().isEmpty());
   }
 
   @Test
@@ -118,6 +121,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
     ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
         shuffleResource.getMapPartitionShuffleDescriptor();
@@ -135,6 +139,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(2, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
@@ -147,11 +152,38 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(3, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducerForForceFallbackPolicy()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    configuration.setString(
+        CelebornConf.FLINK_SHUFFLE_FALLBACK_POLICY().key(), FallbackPolicy.ALWAYS.name());
+    remoteShuffleMaster = createShuffleMaster(configuration, new NettyShuffleServiceFactory());
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    ShuffleDescriptor shuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    Assert.assertTrue(shuffleDescriptor instanceof NettyShuffleDescriptor);
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
+    Map<String, Long> shuffleFallbackCounts =
+        remoteShuffleMaster.lifecycleManager().shuffleFallbackCounts();
+    Assert.assertEquals(1, shuffleFallbackCounts.size());
+    Assert.assertEquals(
+        1L, shuffleFallbackCounts.get(ForceFallbackPolicy.class.getName()).longValue());
   }
 
   @Test

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -42,8 +42,10 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
 import org.junit.After;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.FallbackPolicy;
 import org.apache.celeborn.common.util.Utils$;
+import org.apache.celeborn.plugin.flink.fallback.ForceFallbackPolicy;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterSuiteJ {
@@ -98,9 +101,9 @@ public class RemoteShuffleMasterSuiteJ {
     JobID jobID = JobID.generate();
     JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
     remoteShuffleMaster.registerJob(jobShuffleContext);
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().contains(jobID));
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().containsKey(jobID));
     remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().isEmpty());
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().isEmpty());
   }
 
   @Test
@@ -118,6 +121,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
     ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
         shuffleResource.getMapPartitionShuffleDescriptor();
@@ -135,6 +139,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(2, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
@@ -147,11 +152,38 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(3, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducerForForceFallbackPolicy()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    configuration.setString(
+        CelebornConf.FLINK_SHUFFLE_FALLBACK_POLICY().key(), FallbackPolicy.ALWAYS.name());
+    remoteShuffleMaster = createShuffleMaster(configuration, new NettyShuffleServiceFactory());
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    ShuffleDescriptor shuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    Assert.assertTrue(shuffleDescriptor instanceof NettyShuffleDescriptor);
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
+    Map<String, Long> shuffleFallbackCounts =
+        remoteShuffleMaster.lifecycleManager().shuffleFallbackCounts();
+    Assert.assertEquals(1, shuffleFallbackCounts.size());
+    Assert.assertEquals(
+        1L, shuffleFallbackCounts.get(ForceFallbackPolicy.class.getName()).longValue());
   }
 
   @Test

--- a/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -42,8 +42,10 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
 import org.junit.After;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.FallbackPolicy;
 import org.apache.celeborn.common.util.Utils$;
+import org.apache.celeborn.plugin.flink.fallback.ForceFallbackPolicy;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterSuiteJ {
@@ -98,9 +101,9 @@ public class RemoteShuffleMasterSuiteJ {
     JobID jobID = JobID.generate();
     JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
     remoteShuffleMaster.registerJob(jobShuffleContext);
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().contains(jobID));
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().containsKey(jobID));
     remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().isEmpty());
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().isEmpty());
   }
 
   @Test
@@ -118,6 +121,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
     ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
         shuffleResource.getMapPartitionShuffleDescriptor();
@@ -135,6 +139,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(2, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
@@ -147,11 +152,38 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(3, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducerForForceFallbackPolicy()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    configuration.setString(
+        CelebornConf.FLINK_SHUFFLE_FALLBACK_POLICY().key(), FallbackPolicy.ALWAYS.name());
+    remoteShuffleMaster = createShuffleMaster(configuration, new NettyShuffleServiceFactory());
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    ShuffleDescriptor shuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    Assert.assertTrue(shuffleDescriptor instanceof NettyShuffleDescriptor);
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
+    Map<String, Long> shuffleFallbackCounts =
+        remoteShuffleMaster.lifecycleManager().shuffleFallbackCounts();
+    Assert.assertEquals(1, shuffleFallbackCounts.size());
+    Assert.assertEquals(
+        1L, shuffleFallbackCounts.get(ForceFallbackPolicy.class.getName()).longValue());
   }
 
   @Test

--- a/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -44,9 +44,11 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionWithMetrics;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
 import org.junit.After;
@@ -59,6 +61,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.FallbackPolicy;
 import org.apache.celeborn.common.util.Utils$;
+import org.apache.celeborn.plugin.flink.fallback.ForceFallbackPolicy;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterSuiteJ {
@@ -101,9 +104,9 @@ public class RemoteShuffleMasterSuiteJ {
     JobID jobID = JobID.generate();
     JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
     remoteShuffleMaster.registerJob(jobShuffleContext);
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().contains(jobID));
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().containsKey(jobID));
     remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
-    Assert.assertTrue(remoteShuffleMaster.nettyJobIds().isEmpty());
+    Assert.assertTrue(remoteShuffleMaster.jobFallbackPolicies().isEmpty());
   }
 
   @Test
@@ -121,6 +124,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
     ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
         shuffleResource.getMapPartitionShuffleDescriptor();
@@ -138,6 +142,7 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(2, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
@@ -150,11 +155,38 @@ public class RemoteShuffleMasterSuiteJ {
             remoteShuffleMaster
                 .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
                 .get();
+    Assert.assertEquals(3, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
     mapPartitionShuffleDescriptor =
         remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
     Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
     Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducerForForceFallbackPolicy()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    configuration.setString(
+        CelebornConf.FLINK_SHUFFLE_FALLBACK_POLICY().key(), FallbackPolicy.ALWAYS.name());
+    remoteShuffleMaster = createShuffleMaster(configuration, new NettyShuffleServiceFactory());
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    ShuffleDescriptor shuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    Assert.assertTrue(shuffleDescriptor instanceof NettyShuffleDescriptor);
+    Assert.assertEquals(1, remoteShuffleMaster.lifecycleManager().shuffleCount().sum());
+    Map<String, Long> shuffleFallbackCounts =
+        remoteShuffleMaster.lifecycleManager().shuffleFallbackCounts();
+    Assert.assertEquals(1, shuffleFallbackCounts.size());
+    Assert.assertEquals(
+        1L, shuffleFallbackCounts.get(ForceFallbackPolicy.class.getName()).longValue());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

 Support `ShuffleFallbackCount` metric for fallback to vanilla Flink built-in shuffle implementation.

### Why are the changes needed?

#2932 has already supported fallback to vanilla Flink built-in shuffle implementation, which is lack of `ShuffleFallbackCount` metric to feedback the situation of fallback.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`RemoteShuffleMasterSuiteJ#testRegisterPartitionWithProducerForForceFallbackPolicy`