### PR TITLE
[CELEBORN-1785][CIP-14] Add baseConf to cppClient

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -270,6 +270,8 @@ Meta Velox
 ./cpp/celeborn/utils/Exceptions.cpp
 ./cpp/celeborn/utils/flags.cpp
 ./cpp/celeborn/utils/tests/ExceptionTest.cpp
+./cpp/celeborn/conf/BaseConf.h
+./cpp/celeborn/conf/BaseConf.cpp
 
 ------------------------------------------------------------------------------------
 This product bundles various third-party components under the CC0 license.

--- a/cpp/celeborn/conf/BaseConf.cpp
+++ b/cpp/celeborn/conf/BaseConf.cpp
@@ -26,7 +26,7 @@ namespace fs = std::experimental::filesystem;
 #endif
 
 #include "celeborn/conf/BaseConf.h"
-// #include "celeborn/utils/CelebornUtils.h"
+#include "celeborn/utils/CelebornUtils.h"
 
 namespace celeborn {
 namespace core {

--- a/cpp/celeborn/conf/BaseConf.cpp
+++ b/cpp/celeborn/conf/BaseConf.cpp
@@ -1,0 +1,227 @@
+/*
+ * Based on Config.h from Facebook Velox
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#if __has_include("filesystem")
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#include "celeborn/conf/BaseConf.h"
+#include "celeborn/utils/CelebornUtils.h"
+
+namespace celeborn {
+namespace core {
+
+folly::Optional<std::string> MemConfig::get(const std::string& key) const {
+  folly::Optional<std::string> val;
+  auto it = values_.find(key);
+  if (it != values_.end()) {
+    val = it->second;
+  }
+  return val;
+}
+
+bool MemConfig::isValueExists(const std::string& key) const {
+  return values_.find(key) != values_.end();
+}
+
+folly::Optional<std::string> MemConfigMutable::get(
+    const std::string& key) const {
+  auto lockedValues = values_.rlock();
+  folly::Optional<std::string> val;
+  auto it = lockedValues->find(key);
+  if (it != lockedValues->end()) {
+    val = it->second;
+  }
+  return val;
+}
+
+bool MemConfigMutable::isValueExists(const std::string& key) const {
+  auto lockedValues = values_.rlock();
+  return lockedValues->find(key) != lockedValues->end();
+}
+
+} // namespace core
+
+namespace util {
+
+std::unordered_map<std::string, std::string> readConfig(
+    const std::string& filePath) {
+  // https://teradata.github.io/presto/docs/141t/configuration/configuration.html
+
+  std::ifstream configFile(filePath);
+  if (!configFile.is_open()) {
+    CELEBORN_USER_FAIL("Couldn't open config file {} for reading.", filePath);
+  }
+
+  std::unordered_map<std::string, std::string> properties;
+  std::string line;
+  while (getline(configFile, line)) {
+    line.erase(std::remove_if(line.begin(), line.end(), isspace), line.end());
+    if (line[0] == '#' || line.empty()) {
+      continue;
+    }
+    auto delimiterPos = line.find('=');
+    auto name = line.substr(0, delimiterPos);
+    auto value = line.substr(delimiterPos + 1);
+    properties.emplace(name, value);
+  }
+
+  return properties;
+}
+
+std::string requiredProperty(
+    const std::unordered_map<std::string, std::string>& properties,
+    const std::string& name) {
+  auto it = properties.find(name);
+  if (it == properties.end()) {
+    CELEBORN_USER_FAIL("Missing configuration property {}", name);
+  }
+  return it->second;
+}
+
+std::string requiredProperty(
+    const Config& properties,
+    const std::string& name) {
+  auto value = properties.get(name);
+  if (!value.hasValue()) {
+    CELEBORN_USER_FAIL("Missing configuration property {}", name);
+  }
+  return value.value();
+}
+
+std::string getOptionalProperty(
+    const std::unordered_map<std::string, std::string>& properties,
+    const std::string& name,
+    const std::function<std::string()>& func) {
+  auto it = properties.find(name);
+  if (it == properties.end()) {
+    return func();
+  }
+  return it->second;
+}
+
+std::string getOptionalProperty(
+    const std::unordered_map<std::string, std::string>& properties,
+    const std::string& name,
+    const std::string& defaultValue) {
+  auto it = properties.find(name);
+  if (it == properties.end()) {
+    return defaultValue;
+  }
+  return it->second;
+}
+
+std::string getOptionalProperty(
+    const Config& properties,
+    const std::string& name,
+    const std::string& defaultValue) {
+  auto value = properties.get(name);
+  if (!value.hasValue()) {
+    return defaultValue;
+  }
+  return value.value();
+}
+
+} // namespace util
+
+BaseConf::BaseConf() : config_(std::make_unique<core::MemConfigMutable>()) {}
+
+void BaseConf::initialize(const std::string& filePath) {
+  // See if we want to create a mutable config.
+  auto values = util::readConfig(fs::path(filePath));
+  filePath_ = filePath;
+  checkRegisteredProperties(values);
+
+  bool mutableConfig{false};
+  auto it = values.find(std::string(kMutableConfig));
+  if (it != values.end()) {
+    mutableConfig = folly::to<bool>(it->second);
+  }
+
+  if (mutableConfig) {
+    config_ = std::make_unique<core::MemConfigMutable>(values);
+    CELEBORN_STARTUP_LOG(INFO) << "System Config is MemConfigMutable.";
+  } else {
+    config_ = std::make_unique<core::MemConfig>(values);
+    CELEBORN_STARTUP_LOG(INFO) << "System Config is MemConfig.";
+  }
+}
+
+bool BaseConf::registerProperty(
+    const std::string& propertyName,
+    const folly::Optional<std::string>& defaultValue) {
+  if (registeredProps_.count(propertyName) != 0) {
+    CELEBORN_STARTUP_LOG(WARNING)
+        << "Property '" << propertyName
+        << "' is already registered with default value '"
+        << registeredProps_[propertyName].value_or("<none>") << "'.";
+    return false;
+  }
+
+  registeredProps_[propertyName] = defaultValue;
+  return true;
+}
+
+folly::Optional<std::string> BaseConf::setValue(
+    const std::string& propertyName,
+    const std::string& value) {
+  CELEBORN_USER_CHECK_EQ(
+      1,
+      registeredProps_.count(propertyName),
+      "Property '{}' is not registered in the config.",
+      propertyName);
+  if (auto* memConfig = dynamic_cast<core::MemConfigMutable*>(config_.get())) {
+    auto oldValue = config_->get(propertyName);
+    memConfig->setValue(propertyName, value);
+    if (oldValue.hasValue()) {
+      return oldValue;
+    }
+    return registeredProps_[propertyName];
+  }
+  CELEBORN_USER_FAIL(
+      "Config is not mutable. Consider setting '{}' to 'true'.",
+      kMutableConfig);
+}
+
+void BaseConf::checkRegisteredProperties(
+    const std::unordered_map<std::string, std::string>& values) {
+  std::stringstream supported;
+  std::stringstream unsupported;
+  for (const auto& pair : values) {
+    ((registeredProps_.count(pair.first) != 0) ? supported : unsupported)
+        << "  " << pair.first << "=" << pair.second << "\n";
+  }
+  auto str = supported.str();
+  if (!str.empty()) {
+    CELEBORN_STARTUP_LOG(INFO)
+        << "Registered properties from '" << filePath_ << "':\n"
+        << str;
+  }
+  str = unsupported.str();
+  if (!str.empty()) {
+    CELEBORN_STARTUP_LOG(WARNING)
+        << "Unregistered properties from '" << filePath_ << "':\n"
+        << str;
+  }
+}
+} // namespace celeborn

--- a/cpp/celeborn/conf/BaseConf.cpp
+++ b/cpp/celeborn/conf/BaseConf.cpp
@@ -26,7 +26,7 @@ namespace fs = std::experimental::filesystem;
 #endif
 
 #include "celeborn/conf/BaseConf.h"
-#include "celeborn/utils/CelebornUtils.h"
+// #include "celeborn/utils/CelebornUtils.h"
 
 namespace celeborn {
 namespace core {
@@ -152,7 +152,8 @@ void BaseConf::initialize(const std::string& filePath) {
   filePath_ = filePath;
   checkRegisteredProperties(values);
 
-  bool mutableConfig{false};
+  // Use mutableConfig by default.
+  bool mutableConfig{true};
   auto it = values.find(std::string(kMutableConfig));
   if (it != values.end()) {
     mutableConfig = folly::to<bool>(it->second);

--- a/cpp/celeborn/conf/BaseConf.h
+++ b/cpp/celeborn/conf/BaseConf.h
@@ -1,0 +1,263 @@
+/*
+ * Based on Config.h from Facebook Velox
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Conv.h>
+#include <folly/Optional.h>
+#include <folly/SocketAddress.h>
+#include <folly/Synchronized.h>
+#include <set>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+
+#include "celeborn/utils/Exceptions.h"
+
+namespace celeborn {
+
+class Config {
+ public:
+  virtual ~Config() = default;
+
+  virtual folly::Optional<std::string> get(const std::string& key) const = 0;
+  // virtual const string operator[](const std::string& key) = 0;
+  // overload and disable not supported cases.
+
+  template <typename T>
+  folly::Optional<T> get(const std::string& key) const {
+    auto val = get(key);
+    if (val.hasValue()) {
+      return folly::to<T>(val.value());
+    } else {
+      return folly::none;
+    }
+  }
+
+  template <typename T>
+  T get(const std::string& key, const T& defaultValue) const {
+    auto val = get(key);
+    if (val.hasValue()) {
+      return folly::to<T>(val.value());
+    } else {
+      return defaultValue;
+    }
+  }
+
+  virtual bool isValueExists(const std::string& key) const = 0;
+
+  virtual const std::unordered_map<std::string, std::string>& values() const {
+    CELEBORN_UNSUPPORTED("method values() is not supported by this config");
+  }
+
+  virtual std::unordered_map<std::string, std::string> valuesCopy() const {
+    CELEBORN_UNSUPPORTED("method valuesCopy() is not supported by this config");
+  }
+};
+
+namespace core {
+
+class MemConfig : public Config {
+ public:
+  explicit MemConfig(const std::unordered_map<std::string, std::string>& values)
+      : values_(values) {}
+
+  explicit MemConfig() : values_{} {}
+
+  explicit MemConfig(std::unordered_map<std::string, std::string>&& values)
+      : values_(std::move(values)) {}
+
+  folly::Optional<std::string> get(const std::string& key) const override;
+
+  bool isValueExists(const std::string& key) const override;
+
+  const std::unordered_map<std::string, std::string>& values() const override {
+    return values_;
+  }
+
+  std::unordered_map<std::string, std::string> valuesCopy() const override {
+    return values_;
+  }
+
+ private:
+  std::unordered_map<std::string, std::string> values_;
+};
+
+/// In-memory config allowing changing properties at runtime.
+class MemConfigMutable : public Config {
+ public:
+  explicit MemConfigMutable(
+      const std::unordered_map<std::string, std::string>& values)
+      : values_(values) {}
+
+  explicit MemConfigMutable() : values_{} {}
+
+  explicit MemConfigMutable(
+      std::unordered_map<std::string, std::string>&& values)
+      : values_(std::move(values)) {}
+
+  folly::Optional<std::string> get(const std::string& key) const override;
+
+  bool isValueExists(const std::string& key) const override;
+
+  const std::unordered_map<std::string, std::string>& values() const override {
+    CELEBORN_UNSUPPORTED(
+        "Mutable config cannot return unprotected reference to values.");
+    return *values_.rlock();
+  }
+
+  std::unordered_map<std::string, std::string> valuesCopy() const override {
+    return *values_.rlock();
+  }
+
+  /// Adds or replaces value at the given key. Can be used by debugging or
+  /// testing code.
+  void setValue(const std::string& key, const std::string& value) {
+    (*values_.wlock())[key] = value;
+  }
+
+ private:
+  folly::Synchronized<std::unordered_map<std::string, std::string>> values_;
+};
+
+} // namespace core
+
+class BaseConf {
+ public:
+  // Setting this to 'true' makes configs modifiable via server operations.
+  static constexpr std::string_view kMutableConfig{"mutable-config"};
+
+  /// Reads configuration properties from the specified file. Must be called
+  /// before calling any of the getters below.
+  /// @param filePath Path to configuration file.
+  void initialize(const std::string& filePath);
+
+  /// Uses a config object already materialized.
+  void initialize(std::unique_ptr<Config>&& config) {
+    config_ = std::move(config);
+  }
+
+  /// Registers an extra property in the config.
+  /// Returns true if succeeded, false if failed (due to the property already
+  /// registered).
+  bool registerProperty(
+      const std::string& propertyName,
+      const folly::Optional<std::string>& defaultValue = {});
+
+  /// Adds or replaces value at the given key. Can be used by debugging or
+  /// testing code.
+  /// Returns previous value if there was any.
+  folly::Optional<std::string> setValue(
+      const std::string& propertyName,
+      const std::string& value);
+
+  /// Returns a required value of the requested type. Fails if no value found.
+  template <typename T>
+  T requiredProperty(const std::string& propertyName) const {
+    auto propertyValue = config_->get<T>(propertyName);
+    if (propertyValue.has_value()) {
+      return propertyValue.value();
+    } else {
+      CELEBORN_USER_FAIL(
+          "{} is required in the {} file.", propertyName, filePath_);
+    }
+  }
+
+  /// Returns a required value of the requested type. Fails if no value found.
+  template <typename T>
+  T requiredProperty(std::string_view propertyName) const {
+    return requiredProperty<T>(std::string{propertyName});
+  }
+
+  /// Returns a required value of the string type. Fails if no value found.
+  std::string requiredProperty(const std::string& propertyName) const {
+    auto propertyValue = config_->get(propertyName);
+    if (propertyValue.has_value()) {
+      return propertyValue.value();
+    } else {
+      CELEBORN_USER_FAIL(
+          "{} is required in the {} file.", propertyName, filePath_);
+    }
+  }
+
+  /// Returns a required value of the requested type. Fails if no value found.
+  std::string requiredProperty(std::string_view propertyName) const {
+    return requiredProperty(std::string{propertyName});
+  }
+
+  /// Returns optional value of the requested type. Can return folly::none.
+  template <typename T>
+  folly::Optional<T> optionalProperty(const std::string& propertyName) const {
+    auto val = config_->get(propertyName);
+    if (!val.hasValue()) {
+      const auto it = registeredProps_.find(propertyName);
+      if (it != registeredProps_.end()) {
+        val = it->second;
+      }
+    }
+    if (val.hasValue()) {
+      return folly::to<T>(val.value());
+    }
+    return folly::none;
+  }
+
+  /// Returns optional value of the requested type. Can return folly::none.
+  template <typename T>
+  folly::Optional<T> optionalProperty(std::string_view propertyName) const {
+    return optionalProperty<T>(std::string{propertyName});
+  }
+
+  /// Returns optional value of the string type. Can return folly::none.
+  folly::Optional<std::string> optionalProperty(
+      const std::string& propertyName) const {
+    auto val = config_->get(propertyName);
+    if (!val.hasValue()) {
+      const auto it = registeredProps_.find(propertyName);
+      if (it != registeredProps_.end()) {
+        return it->second;
+      }
+    }
+    return val;
+  }
+
+  /// Returns optional value of the string type. Can return folly::none.
+  folly::Optional<std::string> optionalProperty(
+      std::string_view propertyName) const {
+    return optionalProperty(std::string{propertyName});
+  }
+
+  /// Returns copy of the config values map.
+  std::unordered_map<std::string, std::string> values() const {
+    return config_->valuesCopy();
+  }
+
+ protected:
+  BaseConf();
+
+  // Check if all properties are registered.
+  void checkRegisteredProperties(
+      const std::unordered_map<std::string, std::string>& values);
+
+  std::unique_ptr<Config> config_;
+  std::string filePath_;
+  // Map of registered properties with their default values.
+  std::unordered_map<std::string, folly::Optional<std::string>>
+      registeredProps_;
+};
+
+} // namespace celeborn

--- a/cpp/celeborn/conf/CMakeLists.txt
+++ b/cpp/celeborn/conf/CMakeLists.txt
@@ -12,7 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(utils)
-add_subdirectory(proto)
-add_subdirectory(memory)
-add_subdirectory(conf)
+add_library(conf BaseConf.cpp)
+
+target_link_libraries(
+        conf
+        utils
+        memory
+        ${FOLLY_WITH_DEPENDENCIES}
+        ${GLOG}
+        ${GFLAGS_LIBRARIES}
+        ${RE2}
+)
+
+if(CELEBORN_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/cpp/celeborn/conf/tests/BaseConfTest.cpp
+++ b/cpp/celeborn/conf/tests/BaseConfTest.cpp
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <fstream>
+
+#include "celeborn/conf/BaseConf.h"
+
+using namespace celeborn;
+
+// As the BaseConf's construction is protected, we expose it explicitly.
+class TestedBaseConf : public BaseConf {};
+
+using ValueType = folly::Optional<std::string>;
+
+void testInsertToConf(TestedBaseConf* conf, bool isMutable = true) {
+  const std::string key1 = "key1";
+  const std::string val1 = "val1";
+  // Before insert.
+  EXPECT_THROW(conf->requiredProperty(key1), celeborn::CelebornUserError);
+  EXPECT_EQ(conf->optionalProperty(key1), ValueType());
+
+  // Insert.
+  EXPECT_THROW(conf->setValue(key1, val1), celeborn::CelebornUserError);
+  EXPECT_TRUE(conf->registerProperty(key1, ValueType(val1)));
+
+  // After insert.
+  EXPECT_FALSE(conf->registerProperty(key1, ValueType(val1)));
+  EXPECT_THROW(conf->requiredProperty(key1), celeborn::CelebornUserError);
+  EXPECT_EQ(conf->optionalProperty(key1), ValueType(val1));
+
+  // Update.
+  const std::string val1_1 = "val1_1";
+  if (isMutable) {
+    EXPECT_EQ(conf->setValue(key1, val1_1), ValueType(val1));
+  } else {
+    EXPECT_THROW(conf->setValue(key1, val1_1), celeborn::CelebornUserError);
+  }
+}
+
+void testInitedConf(
+    TestedBaseConf* conf,
+    bool isMutable,
+    const std::string& key,
+    const std::string& val) {
+  // Test init config.
+  EXPECT_EQ(conf->requiredProperty(key), val);
+  EXPECT_EQ(conf->optionalProperty(key), ValueType(val));
+
+  // Test insert to init config.
+  const std::string val_1 = "val_1_random";
+  EXPECT_THROW(conf->setValue(key, val_1), celeborn::CelebornUserError);
+  EXPECT_TRUE(conf->registerProperty(key, val_1));
+  // The init config has highest priority.
+  EXPECT_EQ(conf->optionalProperty(key), val);
+  EXPECT_FALSE(conf->registerProperty(key, val_1));
+
+  if (isMutable) {
+    // Insert with setValue() would work.
+    EXPECT_EQ(conf->setValue(key, val_1), val);
+    EXPECT_EQ(conf->requiredProperty(key), val_1);
+    EXPECT_EQ(conf->optionalProperty(key), ValueType(val_1));
+  } else {
+    // Insert with setValue() would not work!
+    EXPECT_THROW(conf->setValue(key, val_1), celeborn::CelebornUserError);
+  }
+}
+
+void writeToFile(
+    const std::string& filename,
+    const std::vector<std::string>& lines) {
+  std::ofstream file;
+  file.open(filename);
+  for (auto& line : lines) {
+    file << line << "\n";
+  }
+  file.close();
+}
+
+TEST(BaseConfTest, registerToEmptyConf) {
+  auto conf = std::make_unique<TestedBaseConf>();
+  testInsertToConf(conf.get());
+}
+
+TEST(BaseConfTest, registerToConfInitedWithMutableConfig) {
+  auto conf = std::make_unique<TestedBaseConf>();
+  const std::string key0 = "key0";
+  const std::string val0 = "val0";
+  std::unordered_map<std::string, std::string> init;
+  init[key0] = val0;
+  conf->initialize(std::make_unique<core::MemConfigMutable>(init));
+
+  // Test init.
+  testInitedConf(conf.get(), true, key0, val0);
+
+  // Test insert.
+  testInsertToConf(conf.get());
+}
+
+TEST(BaseConfTest, registerToConfInitedWithImmutableConfig) {
+  auto conf = std::make_unique<TestedBaseConf>();
+  const std::string key0 = "key0";
+  const std::string val0 = "val0";
+  std::unordered_map<std::string, std::string> init;
+  init[key0] = val0;
+  conf->initialize(std::make_unique<core::MemConfig>(init));
+
+  // Test init.
+  testInitedConf(conf.get(), false, key0, val0);
+
+  // Test insert.
+  testInsertToConf(conf.get(), false);
+}
+
+TEST(BaseConfTest, registerToConfInitedWithMutableConfigFile) {
+  auto conf = std::make_unique<TestedBaseConf>();
+  std::vector<std::string> lines;
+  // Lines start with # would be ignored.
+  const std::string annotatedKey = "annotatedKey";
+  const std::string annotatedVal = "annotatedVal";
+  const std::string annotatedKv = "# " + annotatedKey + " = " + annotatedVal;
+  lines.push_back(annotatedKv);
+  const std::string key0 = "key0";
+  const std::string val0 = "val0";
+  // Spaces are allowed and will be trimmed.
+  const std::string kv0 = key0 + " = " + val0;
+  lines.push_back(kv0);
+  // Only the first k-v declaration works. The duplicate keys inserted later
+  // wouldn't work.
+  const std::string val0_0 = "val0_0";
+  const std::string kv0_0 = key0 + " = " + val0_0;
+  lines.push_back(kv0_0);
+  lines.push_back("  ");
+
+  // Explicitly declare the config as mutable.
+  lines.push_back(std::string(BaseConf::kMutableConfig) + " = true");
+  const std::string filename = "/tmp/test.conf";
+  writeToFile(filename, lines);
+
+  conf->initialize(filename);
+
+  // The annotated kv would not be recorded.
+  EXPECT_THROW(
+      conf->requiredProperty(annotatedKey), celeborn::CelebornUserError);
+  // Test init.
+  testInitedConf(conf.get(), true, key0, val0);
+
+  // Test insert.
+  testInsertToConf(conf.get());
+}
+
+TEST(BaseConfTest, registerToConfInitedWithImmutableConfigFile) {
+  auto conf = std::make_unique<TestedBaseConf>();
+  std::vector<std::string> lines;
+  // Lines start with # would be ignored.
+  const std::string annotatedKey = "annotatedKey";
+  const std::string annotatedVal = "annotatedVal";
+  const std::string annotatedKv = "# " + annotatedKey + " = " + annotatedVal;
+  lines.push_back(annotatedKv);
+  const std::string key0 = "key0";
+  const std::string val0 = "val0";
+  // Spaces are allowed and will be trimmed.
+  const std::string kv0 = key0 + " = " + val0;
+  lines.push_back(kv0);
+  // Only the first k-v declaration works. The duplicate keys inserted later
+  // wouldn't work.
+  const std::string val0_0 = "val0_0";
+  const std::string kv0_0 = key0 + " = " + val0_0;
+  lines.push_back(kv0_0);
+  lines.push_back("  ");
+
+  // Explicitly declare the config as mutable. The default is false as well.
+  lines.push_back(std::string(BaseConf::kMutableConfig) + " = false");
+  const std::string filename = "/tmp/test.conf";
+  writeToFile(filename, lines);
+
+  conf->initialize(filename);
+
+  // The annotated kv would not be recorded.
+  EXPECT_THROW(
+      conf->requiredProperty(annotatedKey), celeborn::CelebornUserError);
+  // Test init.
+  testInitedConf(conf.get(), false, key0, val0);
+
+  // Test insert.
+  testInsertToConf(conf.get(), false);
+}

--- a/cpp/celeborn/conf/tests/BaseConfTest.cpp
+++ b/cpp/celeborn/conf/tests/BaseConfTest.cpp
@@ -145,7 +145,7 @@ TEST(BaseConfTest, registerToConfInitedWithMutableConfigFile) {
   lines.push_back(kv0_0);
   lines.push_back("  ");
 
-  // Explicitly declare the config as mutable.
+  // Explicitly declare the config as mutable. . The default is true as well.
   lines.push_back(std::string(BaseConf::kMutableConfig) + " = true");
   const std::string filename = "/tmp/test.conf";
   writeToFile(filename, lines);
@@ -182,7 +182,7 @@ TEST(BaseConfTest, registerToConfInitedWithImmutableConfigFile) {
   lines.push_back(kv0_0);
   lines.push_back("  ");
 
-  // Explicitly declare the config as mutable. The default is false as well.
+  // Explicitly declare the config as immutable.
   lines.push_back(std::string(BaseConf::kMutableConfig) + " = false");
   const std::string filename = "/tmp/test.conf";
   writeToFile(filename, lines);

--- a/cpp/celeborn/conf/tests/CMakeLists.txt
+++ b/cpp/celeborn/conf/tests/CMakeLists.txt
@@ -12,7 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(utils)
-add_subdirectory(proto)
-add_subdirectory(memory)
-add_subdirectory(conf)
+
+add_executable(celeborn_conf_test BaseConfTest.cpp)
+
+add_test(NAME celeborn_conf_test COMMAND celeborn_conf_test)
+
+target_link_libraries(
+        celeborn_conf_test
+        PRIVATE
+        conf
+        ${FOLLY_WITH_DEPENDENCIES}
+        ${GLOG}
+        ${GFLAGS_LIBRARIES}
+        GTest::gtest
+        GTest::gmock
+        GTest::gtest_main)

--- a/cpp/celeborn/utils/CelebornUtils.h
+++ b/cpp/celeborn/utils/CelebornUtils.h
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "celeborn/utils/Exceptions.h"
+
+namespace celeborn {
+#define CELEBORN_STARTUP_LOG_PREFIX "[CELEBORN_STARTUP] "
+#define CELEBORN_STARTUP_LOG(severity) \
+  LOG(severity) << CELEBORN_STARTUP_LOG_PREFIX
+
+#define CELEBORN_SHUTDOWN_LOG_PREFIX "[CELEBORN_SHUTDOWN] "
+#define CELEBORN_SHUTDOWN_LOG(severity) \
+  LOG(severity) << CELEBORN_SHUTDOWN_LOG_PREFIX
+} // namespace celeborn


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add baseConf to cppClient, which is the building block of conf module.

### Why are the changes needed?
To support CelebornCpp configuration module in cppClient.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
