### PR TITLE
[CELEBORN-1790] Improve partition location hashcode

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -290,7 +290,7 @@ public class PartitionLocation implements Serializable {
     result = 31 * result + host.hashCode();
     result = 31 * result + rpcPort;
     result = 31 * result + pushPort;
-    result = 31 * result + replicatePort;
+    result = 31 * result + fetchPort;
     return result;
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -286,7 +286,12 @@ public class PartitionLocation implements Serializable {
 
   @Override
   public int hashCode() {
-    return (id + epoch + host + rpcPort + pushPort + fetchPort).hashCode();
+    int result = (id + "-" + epoch).hashCode();
+    result = 31 * result + host.hashCode();
+    result = 31 * result + rpcPort;
+    result = 31 * result + pushPort;
+    result = 31 * result + replicatePort;
+    return result;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the partition location hashcode.


### Why are the changes needed?
Avoid potential original hashcode conflicts. e.g. `partitionId+epoch` "1+0" and "0+1".


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test.
