### PR TITLE
[CELEBORN-1794] Fix TestCongestionController occasional failing

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -292,8 +292,8 @@ public class CongestionController {
 
   public void close() {
     logger.info("Closing {}", this.getClass().getSimpleName());
-    this.removeUserExecutorService.shutdownNow();
-    this.checkService.shutdownNow();
+    ThreadUtils.shutdown(this.removeUserExecutorService);
+    ThreadUtils.shutdown(this.checkService);
     this.userBufferStatuses.clear();
     this.consumedBufferStatusHub.clear();
     this.producedBufferStatusHub.clear();
@@ -301,7 +301,7 @@ public class CongestionController {
 
   @VisibleForTesting
   public void shutDownCheckService() {
-    this.checkService.shutdownNow();
+    ThreadUtils.shutdown(this.checkService);
   }
 
   public static synchronized void destroy() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -296,6 +297,11 @@ public class CongestionController {
     this.userBufferStatuses.clear();
     this.consumedBufferStatusHub.clear();
     this.producedBufferStatusHub.clear();
+  }
+
+  @VisibleForTesting
+  public void shutDownCheckService() {
+    this.checkService.shutdownNow();
   }
 
   public static synchronized void destroy() {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestCongestionController.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestCongestionController.java
@@ -36,7 +36,6 @@ public class TestCongestionController {
 
   private long pendingBytes = 0L;
   private final long userInactiveTimeMills = 2000L;
-  private final long checkIntervalTimeMills = Integer.MAX_VALUE;
 
   @Before
   public void initialize() {
@@ -56,8 +55,6 @@ public class TestCongestionController {
         CelebornConf.WORKER_CONGESTION_CONTROL_WORKER_PRODUCE_SPEED_LOW_WATERMARK().key(), "10000");
     celebornConf.set(
         CelebornConf.WORKER_CONGESTION_CONTROL_USER_INACTIVE_INTERVAL(), userInactiveTimeMills);
-    celebornConf.set(
-        CelebornConf.WORKER_CONGESTION_CONTROL_CHECK_INTERVAL(), checkIntervalTimeMills);
     // Make sampleTimeWindow a bit larger in case the tests run time exceed this window.
     controller =
         new CongestionController(source, 10, celebornConf, null) {
@@ -71,6 +68,7 @@ public class TestCongestionController {
             // No op
           }
         };
+    controller.shutDownCheckService();
   }
 
   @After
@@ -176,8 +174,6 @@ public class TestCongestionController {
     celebornConf.set(
         CelebornConf.WORKER_CONGESTION_CONTROL_WORKER_PRODUCE_SPEED_LOW_WATERMARK().key(), "1000");
     celebornConf.set(CelebornConf.WORKER_CONGESTION_CONTROL_USER_INACTIVE_INTERVAL(), 120L * 1000);
-    celebornConf.set(
-        CelebornConf.WORKER_CONGESTION_CONTROL_CHECK_INTERVAL(), checkIntervalTimeMills);
     CongestionController controller1 =
         new CongestionController(source, 10, celebornConf, null) {
           @Override
@@ -190,6 +186,7 @@ public class TestCongestionController {
             // No op
           }
         };
+    controller1.shutDownCheckService();
 
     UserIdentifier user1 = new UserIdentifier("test1", "celeborn");
     UserCongestionControlContext context1 = controller1.getUserCongestionContext(user1);
@@ -252,8 +249,6 @@ public class TestCongestionController {
     celebornConf.set(
         CelebornConf.WORKER_CONGESTION_CONTROL_WORKER_PRODUCE_SPEED_LOW_WATERMARK().key(), "700");
     celebornConf.set(CelebornConf.WORKER_CONGESTION_CONTROL_USER_INACTIVE_INTERVAL(), 120L * 1000);
-    celebornConf.set(
-        CelebornConf.WORKER_CONGESTION_CONTROL_CHECK_INTERVAL(), checkIntervalTimeMills);
     CongestionController controller1 =
         new CongestionController(source, 10, celebornConf, null) {
           @Override
@@ -266,6 +261,7 @@ public class TestCongestionController {
             // No op
           }
         };
+    controller1.shutDownCheckService();
 
     UserIdentifier user1 = new UserIdentifier("test1", "celeborn");
     UserCongestionControlContext context1 = controller1.getUserCongestionContext(user1);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### Why are the changes needed?
There are a small probability of the TestCongestionController test failing.

![image](https://github.com/user-attachments/assets/bc5bfb91-0b40-4ee0-bd74-2b96715d7cd7)

That is because the `checkService` will excute once it was init, which can cause a multithreading conflict with the test code.

![image](https://github.com/user-attachments/assets/dff58b08-a340-4c29-a61d-fafaeb182c5d)

### What changes were proposed in this pull request?
Fix ut bug.
In fact, `shutDownCheckService` still wont prevent the `checkService` from excuting at once but can make the main testing thread waiting for it to shutDown.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
manual test.
