### PR TITLE
[CELEBORN-1796] Using java StringBuilder instead of scala wrapped

### DIFF
--- a/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/sql/execution/columnar/CelebornColumnarBatchCodeGenBuild.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/sql/execution/columnar/CelebornColumnarBatchCodeGenBuild.scala
@@ -18,9 +18,8 @@
 package org.apache.spark.sql.execution.columnar
 
 import java.io.ByteArrayOutputStream
+import java.lang.{StringBuilder => JStringBuilder}
 import java.nio.ByteBuffer
-
-import scala.collection.mutable
 
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodeGenerator}
@@ -92,14 +91,14 @@ class CelebornColumnarBatchCodeGenBuild {
    *         code to build column bytes, code to write row to columnBuilder)
    */
   def genCode(schema: StructType, batchSize: Int): (
-      mutable.StringBuilder,
-      mutable.StringBuilder,
-      mutable.StringBuilder,
-      mutable.StringBuilder) = {
-    val initCode = new mutable.StringBuilder()
-    val buildCode = new mutable.StringBuilder()
-    val writeCode = new mutable.StringBuilder()
-    val writeRowCode = new mutable.StringBuilder()
+      JStringBuilder,
+      JStringBuilder,
+      JStringBuilder,
+      JStringBuilder) = {
+    val initCode = new JStringBuilder()
+    val buildCode = new JStringBuilder()
+    val writeCode = new JStringBuilder()
+    val writeRowCode = new JStringBuilder()
     for (index <- schema.indices) {
       schema.fields(index).dataType match {
         case ByteType =>

--- a/client-spark/spark-3.5-columnar-shuffle/src/main/scala/org/apache/spark/sql/execution/columnar/CelebornColumnarBatchCodeGenBuild.scala
+++ b/client-spark/spark-3.5-columnar-shuffle/src/main/scala/org/apache/spark/sql/execution/columnar/CelebornColumnarBatchCodeGenBuild.scala
@@ -18,9 +18,8 @@
 package org.apache.spark.sql.execution.columnar
 
 import java.io.ByteArrayOutputStream
+import java.lang.{StringBuilder => JStringBuilder}
 import java.nio.ByteBuffer
-
-import scala.collection.mutable
 
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodeGenerator}
@@ -92,14 +91,14 @@ class CelebornColumnarBatchCodeGenBuild {
    *         code to build column bytes, code to write row to columnBuilder)
    */
   def genCode(schema: StructType, batchSize: Int): (
-      mutable.StringBuilder,
-      mutable.StringBuilder,
-      mutable.StringBuilder,
-      mutable.StringBuilder) = {
-    val initCode = new mutable.StringBuilder()
-    val buildCode = new mutable.StringBuilder()
-    val writeCode = new mutable.StringBuilder()
-    val writeRowCode = new mutable.StringBuilder()
+      JStringBuilder,
+      JStringBuilder,
+      JStringBuilder,
+      JStringBuilder) = {
+    val initCode = new JStringBuilder()
+    val buildCode = new JStringBuilder()
+    val writeCode = new JStringBuilder()
+    val writeRowCode = new JStringBuilder()
     for (index <- schema.indices) {
       schema.fields(index).dataType match {
         case ByteType =>

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.meta
 
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction
@@ -181,13 +182,13 @@ class WorkerPartitionLocationInfo extends Logging {
   }
 
   def toStringSimplified: String = {
-    val primaryLocationStr = new StringBuilder
+    val primaryLocationStr = new JStringBuilder
     for ((shuffleKey, locations) <- primaryPartitionLocations.asScala) {
       if (!locations.isEmpty) {
         primaryLocationStr.append(s"($shuffleKey: ${locations.keySet()}) ")
       }
     }
-    val replicaLocationStr = new StringBuilder
+    val replicaLocationStr = new JStringBuilder
     for ((shuffleKey, locations) <- replicaPartitionLocations.asScala) {
       if (!locations.isEmpty) {
         replicaLocationStr.append(s"($shuffleKey: ${locations.keySet()}) ")

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -17,11 +17,11 @@
 
 package org.apache.celeborn.common.metrics.source
 
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util.{Map => JMap}
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, ScheduledExecutorService, TimeUnit}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
@@ -407,7 +407,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   def getGaugeMetrics(ng: NamedGauge[_]): String = {
     val timestamp = System.currentTimeMillis
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     val label = ng.labelString
     sb.append(s"${normalizeKey(ng.name)}Value$label ${ng.gauge.getValue} $timestamp\n")
     sb.toString()
@@ -415,7 +415,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   def getMeterMetrics(nm: NamedMeter): String = {
     val timestamp = System.currentTimeMillis
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     val label = nm.labelString
     sb.append(s"${normalizeKey(nm.name)}Count$label ${nm.meter.getCount} $timestamp\n")
     sb.append(s"${normalizeKey(nm.name)}MeanRate$label ${nm.meter.getMeanRate} $timestamp\n")
@@ -430,7 +430,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   def getHistogramMetrics(nh: NamedHistogram): String = {
     val timestamp = System.currentTimeMillis
-    val sb = new mutable.StringBuilder
+    val sb = new JStringBuilder
     val snapshot = nh.histogram.getSnapshot
     val prefix = normalizeKey(nh.name)
     val label = nh.labelString
@@ -455,7 +455,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   def getTimerMetrics(nt: NamedTimer): String = {
     val timestamp = System.currentTimeMillis
-    val sb = new mutable.StringBuilder
+    val sb = new JStringBuilder
     val snapshot = nt.timer.getSnapshot
     val prefix = normalizeKey(nt.name)
     val label = nt.labelString
@@ -489,7 +489,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
 
   override def getMetrics(): String = {
     var leftMetricsNum = metricsCapacity
-    val sb = new mutable.StringBuilder
+    val sb = new JStringBuilder
     leftMetricsNum = fillInnerMetricsSnapshot(getAndClearTimerMetrics(), leftMetricsNum, sb)
     leftMetricsNum = fillInnerMetricsSnapshot(timers(), leftMetricsNum, sb)
     leftMetricsNum = fillInnerMetricsSnapshot(histograms(), leftMetricsNum, sb)
@@ -506,7 +506,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
   private def fillInnerMetricsSnapshot(
       metricList: List[AnyRef],
       leftNum: Int,
-      sb: mutable.StringBuilder): Int = {
+      sb: JStringBuilder): Int = {
     if (leftNum <= 0) {
       return 0
     }

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/RpcMetricsTracker.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/RpcMetricsTracker.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.rpc
 
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -145,7 +146,7 @@ private[celeborn] class RpcMetricsTracker(
     if (!useHistogram)
       return
 
-    val builder = new StringBuilder();
+    val builder = new JStringBuilder();
     builder.append(s"RPC statistics for $name").append("\n")
     builder.append(s"current queue size = ${queueLengthFunc()}").append("\n")
     builder.append(s"max queue length = ${maxQueueLength.get()}").append("\n")

--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.util
 
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util.concurrent._
 import java.util.concurrent.{ForkJoinPool => SForkJoinPool, ForkJoinWorkerThread => SForkJoinWorkerThread}
 import java.util.concurrent.locks.ReentrantLock
@@ -444,7 +445,7 @@ case class ThreadStackTrace(
    * TODO(SPARK-44896): Also considering adding information os_prio, cpu, elapsed, tid, nid, etc., from the jstack tool
    */
   override def toString: String = {
-    val sb = new StringBuilder(
+    val sb = new JStringBuilder(
       s""""$threadName" Id=$threadId $threadState""")
     lockName.foreach(lock => sb.append(s" on $lock"))
     lockOwnerName.foreach {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -18,6 +18,7 @@
 package org.apache.celeborn.common.util
 
 import java.io._
+import java.lang.{StringBuilder => JStringBuilder}
 import java.lang.management.{LockInfo, ManagementFactory, MonitorInfo, ThreadInfo}
 import java.math.{MathContext, RoundingMode}
 import java.net._
@@ -860,7 +861,7 @@ object Utils extends Logging {
       extraEnvironment: Map[String, String] = Map.empty,
       redirectStderr: Boolean = true): String = {
     val process = executeCommand(command, workingDir, extraEnvironment, redirectStderr)
-    val output = new StringBuilder
+    val output = new JStringBuilder
     val threadName = "read stdout for " + command.head
 
     def appendToOutput(s: String): Unit = output.append(s).append("\n")

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -382,7 +382,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
   }
 
   def generateRandomIPv4Address: String = {
-    val ipAddress = new StringBuilder
+    val ipAddress = new java.lang.StringBuilder
     for (i <- 0 until 4) {
       ipAddress.append(Random.nextInt(256))
       if (i < 3) ipAddress.append(".")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -18,6 +18,7 @@
 package org.apache.celeborn.service.deploy.master
 
 import java.io.IOException
+import java.lang.{StringBuilder => JStringBuilder}
 import java.net.BindException
 import java.util
 import java.util.Collections
@@ -1273,7 +1274,7 @@ private[celeborn] class Master(
   }
 
   override def getMasterGroupInfo: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("====================== Master Group INFO ==============================\n")
     sb.append(getMasterGroupInfoInternal)
     sb.toString()
@@ -1286,7 +1287,7 @@ private[celeborn] class Master(
   override def handleWorkerEvent(
       workerEventType: WorkerEventType,
       workers: Seq[WorkerInfo]): HandleResponse = {
-    val sb = new StringBuilder()
+    val sb = new JStringBuilder()
     try {
       val workerEventResponse = self.askSync[PbWorkerEventResponse](WorkerEventRequest(
         workers.asJava,
@@ -1312,14 +1313,14 @@ private[celeborn] class Master(
   }
 
   override def getWorkerInfo: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("====================== Workers Info in Master =========================\n")
     sb.append(getWorkers)
     sb.toString()
   }
 
   override def getLostWorkers: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("======================= Lost Workers in Master ========================\n")
     statusSystem.lostWorkers.asScala.toSeq.sortBy(_._2).foreach { case (worker, time) =>
       sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
@@ -1328,7 +1329,7 @@ private[celeborn] class Master(
   }
 
   override def getShutdownWorkers: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("===================== Shutdown Workers in Master ======================\n")
     statusSystem.shutdownWorkers.asScala.foreach { worker =>
       sb.append(s"${worker.toUniqueId()}\n")
@@ -1337,7 +1338,7 @@ private[celeborn] class Master(
   }
 
   override def getDecommissionWorkers: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("===================== Decommission Workers in Master ======================\n")
     statusSystem.decommissionWorkers.asScala.foreach { worker =>
       sb.append(s"${worker.toUniqueId()}\n")
@@ -1346,7 +1347,7 @@ private[celeborn] class Master(
   }
 
   override def getExcludedWorkers: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("===================== Excluded Workers in Master ======================\n")
     (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala).foreach {
       worker => sb.append(s"${worker.toUniqueId()}\n")
@@ -1355,7 +1356,7 @@ private[celeborn] class Master(
   }
 
   override def getHostnameList: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("================= LifecycleManager Hostname List ======================\n")
     statusSystem.hostnameSet.asScala.foreach { host =>
       sb.append(s"$host\n")
@@ -1364,7 +1365,7 @@ private[celeborn] class Master(
   }
 
   override def getApplicationList: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("================= LifecycleManager Application List ======================\n")
     statusSystem.appHeartbeatTime.asScala.toSeq.sortBy(_._2).foreach { case (appId, time) =>
       sb.append(s"${appId.padTo(40, " ").mkString}${Utils.formatTimestamp(time)}\n")
@@ -1373,7 +1374,7 @@ private[celeborn] class Master(
   }
 
   override def getShuffleList: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("======================= Shuffle Key List ============================\n")
     statusSystem.registeredAppAndShuffles.asScala.foreach { shuffleKey =>
       val appId = shuffleKey._1
@@ -1387,7 +1388,7 @@ private[celeborn] class Master(
   override def exclude(
       addWorkers: Seq[WorkerInfo],
       removeWorkers: Seq[WorkerInfo]): HandleResponse = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     val workerExcludeResponse = self.askSync[PbWorkerExcludeResponse](WorkerExclude(
       addWorkers.asJava,
       removeWorkers.asJava,
@@ -1443,7 +1444,7 @@ private[celeborn] class Master(
 
   private def getMasterGroupInfoInternal: String = {
     if (conf.haEnabled) {
-      val sb = new StringBuilder
+      val sb = new JStringBuilder
       val groupInfo = statusSystem.asInstanceOf[HAMasterMetaManager].getRatisServer.getGroupInfo
       sb.append(s"group id: ${groupInfo.getGroup.getGroupId.getUuid}\n")
 
@@ -1476,7 +1477,7 @@ private[celeborn] class Master(
   }
 
   override def getWorkerEventInfo(): String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("======================= Workers Event in Master ========================\n")
     statusSystem.workerEventInfos.asScala.foreach { case (worker, workerEventInfo) =>
       sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}$workerEventInfo\n")

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/ApiMasterResource.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.service.deploy.master.http.api
 
+import java.lang.{StringBuilder => JStringBuilder}
 import javax.ws.rs.{FormParam, GET, Path, POST}
 import javax.ws.rs.core.MediaType
 
@@ -108,7 +109,7 @@ class ApiMasterResource extends ApiRequestContext {
   def exclude(
       @FormParam("add") addWorkers: String,
       @FormParam("remove") removeWorkers: String): String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("============================ Add/Remove Excluded Workers  Manually =============================\n")
     val workersToAdd =
       normalizeParam(addWorkers).split(",").filter(_.nonEmpty).map(WorkerInfo.fromUniqueId).toList
@@ -130,7 +131,7 @@ class ApiMasterResource extends ApiRequestContext {
   def sendWorkerEvent(
       @FormParam("type") eventType: String,
       @FormParam("workers") workers: String): String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     if (StringUtils.isEmpty(eventType) || StringUtils.isEmpty(workers)) {
       return sb.append(
         s"handle eventType failed as eventType: $eventType or workers: $workers has empty value").toString()

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.server.common
 
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util
 import javax.servlet.DispatcherType
 
@@ -40,7 +41,7 @@ abstract class HttpService extends Service with Logging {
   private var httpServer: HttpServer = _
 
   def getConf: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("=========================== Configuration ============================\n")
     if (conf.getAll.nonEmpty) {
       val redactedConf = Utils.redact(conf, conf.getAll)
@@ -59,7 +60,7 @@ abstract class HttpService extends Service with Logging {
     if (configService == null) {
       s"Dynamic configuration is disabled. Please check whether to config `${CelebornConf.DYNAMIC_CONFIG_STORE_BACKEND.key}`."
     } else {
-      val sb = new StringBuilder
+      val sb = new JStringBuilder
       sb.append("=========================== Dynamic Configuration ============================\n")
       if (level.isEmpty) {
         sb.append(dynamicConfigs(tenant, name))
@@ -77,7 +78,7 @@ abstract class HttpService extends Service with Logging {
   }
 
   private def dynamicConfigs(level: String, tenant: String, name: String): String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append(
       s"=========================== Level: $level ============================\n")
     if (ConfigLevel.SYSTEM.name().equalsIgnoreCase(level)) {
@@ -130,7 +131,7 @@ abstract class HttpService extends Service with Logging {
   }
 
   private def configs(configs: util.Map[String, String]): String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     val configMap = configs.asScala
     if (configMap.nonEmpty) {
       val maxKeyLength = configMap.keys.map(_.length).max
@@ -147,7 +148,7 @@ abstract class HttpService extends Service with Logging {
   def getWorkerInfo: String
 
   def getThreadDump: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append(
       s"========================= ${serviceName.capitalize} ThreadDump ==========================\n")
     sb.append(Utils.getThreadDump().mkString("\n")).append("\n")

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/RestAuditLogger.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/RestAuditLogger.scala
@@ -17,14 +17,15 @@
 
 package org.apache.celeborn.server.common.http
 
+import java.lang.{StringBuilder => JStringBuilder}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.authentication.AuthenticationFilter._
 
 object RestAuditLogger extends Logging {
-  final private val AUDIT_BUFFER = new ThreadLocal[StringBuilder]() {
-    override protected def initialValue: StringBuilder = new StringBuilder()
+  final private val AUDIT_BUFFER = new ThreadLocal[JStringBuilder]() {
+    override protected def initialValue: JStringBuilder = new JStringBuilder()
   }
 
   def audit(request: HttpServletRequest, response: HttpServletResponse): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -18,6 +18,7 @@
 package org.apache.celeborn.service.deploy.worker
 
 import java.io.File
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util
 import java.util.{HashSet => JHashSet, Locale, Map => JMap, UUID}
 import java.util.concurrent._
@@ -808,14 +809,14 @@ private[celeborn] class Worker(
   }
 
   override def getWorkerInfo: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("====================== WorkerInfo of Worker ===========================\n")
     sb.append(workerInfo.toString()).append("\n")
     sb.toString()
   }
 
   override def getApplicationList: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("================= LifecycleManager Application List ======================\n")
     workerInfo.getApplicationIdSet.asScala.foreach { appId =>
       sb.append(s"$appId\n")
@@ -824,7 +825,7 @@ private[celeborn] class Worker(
   }
 
   override def getShuffleList: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("======================= Shuffle Key List ============================\n")
     storageManager.shuffleKeySet().asScala.foreach { shuffleKey =>
       sb.append(s"$shuffleKey\n")
@@ -833,14 +834,14 @@ private[celeborn] class Worker(
   }
 
   override def isShutdown: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("========================= Worker Shutdown ==========================\n")
     sb.append(shutdown.get()).append("\n")
     sb.toString()
   }
 
   override def isDecommissioning: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("========================= Worker Decommission ==========================\n")
     sb.append(
       shutdown.get() && (workerStatusManager.currentWorkerStatus.getState == State.InDecommission ||
@@ -850,21 +851,21 @@ private[celeborn] class Worker(
   }
 
   override def isRegistered: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("========================= Worker Registered ==========================\n")
     sb.append(registered.get()).append("\n")
     sb.toString()
   }
 
   override def listPartitionLocationInfo: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("==================== Partition Location Info =========================\n")
     sb.append(partitionLocationInfo.toString).append("\n")
     sb.toString()
   }
 
   override def getUnavailablePeers: String = {
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("==================== Unavailable Peers of Worker =====================\n")
     unavailablePeers.asScala.foreach { case (peer, time) =>
       sb.append(s"${peer.toUniqueId().padTo(50, " ").mkString}${Utils.formatTimestamp(time)}\n")
@@ -886,7 +887,7 @@ private[celeborn] class Worker(
       case _ =>
         workerStatusManager.doTransition(workerStatusManager.exitEventType)
     }
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     sb.append("============================ Exit Worker =============================\n")
     sb.append(s"Exit worker by $exitType triggered: \n")
     sb.append(workerInfo.toString()).append("\n")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
The Scala `StringBuilder` is a very thin API that wraps Java's. Using java StringBuilder directly for better performance for below cases:
1. CelebornColumnarBatchCodeGenBuild
2. metrics source

Refer: https://issues.apache.org/jira/browse/SPARK-48568


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA.
