### PR TITLE
[CELEBORN-1823] Remove unused remote-shuffle.job.min.memory-per-partition and remote-shuffle.job.min.memory-per-gate

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -32,8 +32,6 @@ public class FlinkUtils {
   private static final JobID ZERO_JOB_ID = new JobID(0, 0);
   public static final Set<String> pluginConfNames =
       ImmutableSet.of(
-          "remote-shuffle.job.min.memory-per-partition",
-          "remote-shuffle.job.min.memory-per-gate",
           "remote-shuffle.job.concurrent-readings-per-gate",
           "remote-shuffle.job.memory-per-partition",
           "remote-shuffle.job.memory-per-gate",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove unused plugin config `remote-shuffle.job.min.memory-per-partition` and `remote-shuffle.job.min.memory-per-gate`.

### Why are the changes needed?

`remote-shuffle.job.min.memory-per-partition` and `remote-shuffle.job.min.memory-per-gate` are not alternative for `CelebornConf`. Therefore, `remote-shuffle.job.min.memory-per-partition` and `remote-shuffle.job.min.memory-per-gate` could be removed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.