### PR TITLE
[CELEBORN-1413][FOLLOWUP] Bump zstd-jni version to 1.5.6-5 for 4.0.0-preview2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1499,7 +1499,7 @@
         <scala.version>2.13.11</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
         <spark.version>4.0.0-preview2</spark.version>
-        <zstd-jni.version>1.5.5-6</zstd-jni.version>
+        <zstd-jni.version>1.5.6-5</zstd-jni.version>
       </properties>
     </profile>
 

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -881,7 +881,7 @@ object Spark40 extends SparkClientProjects {
   val sparkProjectScalaVersion = "2.13.11"
 
   val sparkVersion = "4.0.0-preview2"
-  val zstdJniVersion = "1.5.5-6"
+  val zstdJniVersion = "1.5.6-5"
   val scalaBinaryVersion = "2.13"
 
   override val sparkColumnarShuffleVersion: String = "4"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump `zstd-jni` version to 1.5.6-5 for 4.0.0-preview2.

### Why are the changes needed?

`zstd-jni` version is 1.5.6-5 for 4.0.0-preview2 for [<version>1.5.6-5</version>](https://github.com/apache/spark/blob/v4.0.0-preview2/pom.xml#L838C18-L838C25).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.