### PR TITLE
[CELEBORN-1824] FlinkShuffleClientImpl should close TransportClient of currentClient

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/client/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/client/FlinkShuffleClientImpl.java
@@ -160,6 +160,10 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     if (readClientHandler != null) {
       readClientHandler.close();
     }
+    for (TransportClient client : currentClient.values()) {
+      client.close();
+    }
+    currentClient.clear();
   }
 
   public FlinkShuffleClientImpl(
@@ -685,8 +689,9 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   public void cleanup(int shuffleId, int mapId, int attemptId) {
     final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
     super.cleanup(shuffleId, mapId, attemptId);
-    if (currentClient != null) {
-      currentClient.remove(mapKey);
+    TransportClient client = currentClient.remove(mapKey);
+    if (client != null) {
+      client.close();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`FlinkShuffleClientImpl` closes `TransportClient` of `currentClient`.

### Why are the changes needed?

`FlinkShuffleClientImpl` does not close `TransportClient` of `currentClient` for `cleanup` and `shutdown`. Therefore, `FlinkShuffleClientImpl` should close `TransportClient` of `currentClient`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.