### PR TITLE
[CELEBORN-1825] The map task ended too early, which caused problems with data consistency

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1058,8 +1058,8 @@ public class ShuffleClientImpl extends ShuffleClient {
 
             @Override
             public void updateLatestPartition(PartitionLocation newloc) {
-              pushState.addBatch(nextBatchId, newloc.hostAndPushPort());
               if (!newloc.hostAndPushPort().equals(this.latest.hostAndPushPort())) {
+                pushState.addBatch(nextBatchId, newloc.hostAndPushPort());
                 pushState.removeBatch(nextBatchId, this.latest.hostAndPushPort());
               }
               this.latest = newloc;

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1059,7 +1059,9 @@ public class ShuffleClientImpl extends ShuffleClient {
             @Override
             public void updateLatestPartition(PartitionLocation newloc) {
               pushState.addBatch(nextBatchId, newloc.hostAndPushPort());
-              pushState.removeBatch(nextBatchId, this.latest.hostAndPushPort());
+              if (!newloc.hostAndPushPort().equals(this.latest.hostAndPushPort())) {
+                pushState.removeBatch(nextBatchId, this.latest.hostAndPushPort());
+              }
               this.latest = newloc;
             }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
fix map task ended too early


### Why are the changes needed?
During the process of PushDataRpcResponseCallback.updateLatestPartition, it is possible that newloc.hostAndPushPort and latest.hostAndPushPort are equal. If these two keys are equal, it will cause the inFlightRequestTracker to be reset to zero, and eventually lead to the task ending prematurely. The specific trigger scenarios are as follows:
1. replicate.enabled=true
2. The revive request carries the information of (*_REPLICA).
3. The new primary host is the same as the previous primary host

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
GA
