### PR TITLE
[CELEBORN-1830]Chart statefulset resources key duplicate

### DIFF
--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -82,8 +82,6 @@ spec:
             echo "waiting for master"; 
             sleep 2;
           done && exec /opt/celeborn/sbin/start-master.sh
-        resources:
-          {{- toYaml .Values.resources.master | nindent 10 }}
         ports:
         - containerPort: {{ .Values.service.port }}
         - containerPort: {{ get .Values.celeborn "celeborn.master.http.port" | default 9098 }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -86,8 +86,6 @@ spec:
             echo "waiting for master";
             sleep 2;
           done && exec /opt/celeborn/sbin/start-worker.sh
-        resources:
-          {{- toYaml .Values.resources.worker | nindent 10 }}
         ports:
         - containerPort: {{ get .Values.celeborn "celeborn.worker.http.port" | default 9096 }}
           name: metrics


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
update chart, remove resources key duplicate


### Why are the changes needed?
<img width="622" alt="Screenshot 2025-01-10 at 11 14 47" src="https://github.com/user-attachments/assets/03d7a13b-0a4b-4708-9b12-873625a9825f" />


### Does this PR introduce _any_ user-facing change?
No any user-facing change

### How was this patch tested?
helm template --debug ../celeborn
