### PR TITLE
[CELEBORN-1832] MapPartitionData should create fixed thread pool with registration of ThreadPoolSource

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -122,8 +122,15 @@ object ThreadUtils {
    * Create a thread factory that names threads with a prefix and also sets the threads to daemon.
    */
   def namedThreadFactory(threadNamePrefix: String): ThreadFactory = {
+    namedThreadFactory(threadNamePrefix, daemon = true)
+  }
+
+  /**
+   * Create a thread factory that names threads with a prefix and also sets the threads to daemon.
+   */
+  def namedThreadFactory(threadNamePrefix: String, daemon: Boolean): ThreadFactory = {
     new ThreadFactoryBuilder()
-      .setDaemon(true)
+      .setDaemon(daemon)
       .setNameFormat(s"$threadNamePrefix-%d")
       .setUncaughtExceptionHandler(new ThreadExceptionHandler(threadNamePrefix))
       .build()
@@ -176,7 +183,15 @@ object ThreadUtils {
    * unique, sequentially assigned integer.
    */
   def newDaemonFixedThreadPool(nThreads: Int, prefix: String): ThreadPoolExecutor = {
-    val threadPool = Executors.newFixedThreadPool(nThreads, namedThreadFactory(prefix))
+    newFixedThreadPool(nThreads, prefix, daemon = true)
+  }
+
+  /**
+   * Wrapper over newFixedThreadPool with daemon setting. Thread names are formatted as prefix-ID, where ID is a
+   * unique, sequentially assigned integer.
+   */
+  def newFixedThreadPool(nThreads: Int, prefix: String, daemon: Boolean): ThreadPoolExecutor = {
+    val threadPool = Executors.newFixedThreadPool(nThreads, namedThreadFactory(prefix, daemon))
       .asInstanceOf[ThreadPoolExecutor]
     ThreadPoolSource.registerSource(prefix, threadPool)
     threadPool


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MapPartitionData` creates fixed thread pool with registration of `ThreadPoolSource`.

### Why are the changes needed?

`MapPartitionData` creates fixed thread pool without registering `ThreadPoolSource` at present, which causes that map partition reader thread of worker is lack of thread pool metrics. Therefore, `MapPartitionData` should create fixed thread pool with registration of `ThreadPoolSource`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.