### PR TITLE
[CELEBORN-1720][FOLLOWUP] Fix compilation error of CelebornTezReader for ShuffleClient#readPartition

### DIFF
--- a/client-tez/tez/src/main/java/org/apache/celeborn/client/CelebornTezReader.java
+++ b/client-tez/tez/src/main/java/org/apache/celeborn/client/CelebornTezReader.java
@@ -55,7 +55,7 @@ public class CelebornTezReader {
         };
     celebornInputStream =
         shuffleClient.readPartition(
-            shuffleId, partitionId, attemptNumber, 0, Integer.MAX_VALUE, metricsCallback);
+            shuffleId, partitionId, attemptNumber, 0, 0, Integer.MAX_VALUE, metricsCallback);
   }
 
   public byte[] getShuffleBlock() throws IOException {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix compilation error of `CelebornTezReader` for `ShuffleClient#readPartition`.

### Why are the changes needed?

There is a compilation error in `CelebornTezReader` for `ShuffleClient#readPartition`, which is as follows:

```
Error:  /home/runner/work/celeborn/celeborn/client-tez/tez/src/main/java/org/apache/celeborn/client/CelebornTezReader.java:57:21:  error: no suitable method found for readPartition(int,int,int,int,int,MetricsCallback)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.