### PR TITLE
[CELEBORN-1839] PartitionsSorter.getSortedFileInfo should not block the handleOpenStream thread

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -829,6 +829,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerCommitThreads: Int =
     if (hasHDFSStorage) Math.max(128, get(WORKER_COMMIT_THREADS)) else get(WORKER_COMMIT_THREADS)
   def workerCommitFilesCheckInterval: Long = get(WORKER_COMMIT_FILES_CHECK_INTERVAL)
+  def workerSortFilesCheckInterval: Long = get(WORKER_SORT_FILES_CHECK_INTERVAL)
   def workerCleanThreads: Int = get(WORKER_CLEAN_THREADS)
   def workerShuffleCommitTimeout: Long = get(WORKER_SHUFFLE_COMMIT_TIMEOUT)
   def maxPartitionSizeToEstimate: Long =
@@ -3488,6 +3489,14 @@ object CelebornConf extends Logging {
       .categories("worker")
       .version("0.6.0")
       .doc("Time length for a window about checking whether commit shuffle data files finished.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("100")
+
+  val WORKER_SORT_FILES_CHECK_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.worker.sortFiles.check.interval")
+      .categories("worker")
+      .version("0.6.0")
+      .doc("Time length for a window about checking whether FileSorter task finished.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("100")
 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -165,6 +165,7 @@ license: |
 | celeborn.worker.shuffle.partitionSplit.enabled | true | false | enable the partition split on worker side | 0.3.0 | celeborn.worker.partition.split.enabled | 
 | celeborn.worker.shuffle.partitionSplit.max | 2g | false | Specify the maximum partition size for splitting, and ensure that individual partition files are always smaller than this limit. | 0.3.0 |  | 
 | celeborn.worker.shuffle.partitionSplit.min | 1m | false | Min size for a partition to split | 0.3.0 | celeborn.shuffle.partitionSplit.min | 
+| celeborn.worker.sortFiles.check.interval | 100 | false | Time length for a window about checking whether FileSorter task finished. | 0.6.0 |  | 
 | celeborn.worker.sortPartition.indexCache.expire | 180s | false | PartitionSorter's cache item expire time. | 0.4.0 |  | 
 | celeborn.worker.sortPartition.indexCache.maxWeight | 100000 | false | PartitionSorter's cache max weight for index buffer. | 0.4.0 |  | 
 | celeborn.worker.sortPartition.prefetch.enabled | true | false | When true, partition sorter will prefetch the original partition files to page cache and reserve memory configured by `celeborn.worker.sortPartition.reservedMemoryPerPartition` to allocate a block of memory for prefetching while sorting a shuffle file off-heap with page cache for non-hdfs files. Otherwise, partition sorter seeks to position of each block and does not prefetch for non-hdfs files. | 0.5.0 |  | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -195,106 +195,6 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     return sortedFilesSize.get();
   }
 
-  // return the sorted FileInfo.
-  // 1. If the sorted file is not generated, it adds the FileSorter task to the sorting queue and
-  //    synchronously waits for the sorted FileInfo.
-  // 2. If the FileSorter task is already in the sorting queue but the sorted file has not been
-  //    generated, it awaits until a timeout occurs (default 220 seconds).
-  // 3. If the sorted file is generated, it returns the sorted FileInfo.
-  // This method will generate temporary file info for this shuffle read
-  public FileInfo getSortedFileInfo(
-      String shuffleKey, String fileName, FileInfo fileInfo, int startMapIndex, int endMapIndex)
-      throws IOException {
-    if (fileInfo instanceof MemoryFileInfo) {
-      MemoryFileInfo memoryFileInfo = ((MemoryFileInfo) fileInfo);
-      Map<Integer, List<ShuffleBlockInfo>> indexesMap;
-      sortMemoryShuffleFile(memoryFileInfo);
-      indexesMap = memoryFileInfo.getSortedIndexes();
-
-      ReduceFileMeta reduceFileMeta =
-          new ReduceFileMeta(
-              ShuffleBlockInfoUtils.getChunkOffsetsFromShuffleBlockInfos(
-                  startMapIndex, endMapIndex, shuffleChunkSize, indexesMap, true),
-              shuffleChunkSize);
-      CompositeByteBuf targetBuffer =
-          MemoryManager.instance().getStorageByteBufAllocator().compositeBuffer(Integer.MAX_VALUE);
-      ShuffleBlockInfoUtils.sliceSortedBufferByMapRange(
-          startMapIndex,
-          endMapIndex,
-          indexesMap,
-          memoryFileInfo.getSortedBuffer(),
-          targetBuffer,
-          shuffleChunkSize);
-      return new MemoryFileInfo(
-          memoryFileInfo.getUserIdentifier(),
-          memoryFileInfo.isPartitionSplitEnabled(),
-          reduceFileMeta,
-          targetBuffer);
-    } else {
-      DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);
-      String fileId = shuffleKey + "-" + fileName;
-      Set<String> sorted =
-          sortedShuffleFiles.computeIfAbsent(shuffleKey, v -> ConcurrentHashMap.newKeySet());
-      Set<String> sorting =
-          sortingShuffleFiles.computeIfAbsent(shuffleKey, v -> ConcurrentHashMap.newKeySet());
-
-      boolean fileSorting = true;
-      synchronized (sorting) {
-        if (sorted.contains(fileId)) {
-          fileSorting = false;
-        } else if (!sorting.contains(fileId)) {
-          try {
-            FileSorter fileSorter = new FileSorter(diskFileInfo, fileId, shuffleKey);
-            sorting.add(fileId);
-            logger.debug(
-                "Adding sorter to sort queue shuffle key {}, file name {}", shuffleKey, fileName);
-            shuffleSortTaskDeque.put(fileSorter);
-          } catch (InterruptedException e) {
-            logger.error(
-                "Sorter scheduler thread is interrupted means worker is shutting down.", e);
-            throw new IOException(
-                "Sort scheduler thread is interrupted means worker is shutting down.", e);
-          } catch (IOException e) {
-            logger.error("File sorter access DFS failed.", e);
-            throw new IOException("File sorter access DFS failed.", e);
-          }
-        }
-      }
-
-      if (fileSorting) {
-        long sortStartTime = System.currentTimeMillis();
-        while (!sorted.contains(fileId)) {
-          if (sorting.contains(fileId)) {
-            try {
-              Thread.sleep(50);
-              if (System.currentTimeMillis() - sortStartTime > sortTimeout) {
-                logger.error("Sorting file {} timeout after {}ms", fileId, sortTimeout);
-                throw new IOException(
-                    "Sort file " + diskFileInfo.getFilePath() + " timeout after " + sortTimeout);
-              }
-            } catch (InterruptedException e) {
-              logger.error(
-                  "Sorter scheduler thread is interrupted means worker is shutting down.", e);
-              throw new IOException(
-                  "Sorter scheduler thread is interrupted means worker is shutting down.", e);
-            }
-          } else {
-            logger.debug(
-                "Sorting shuffle file for {} {} failed.", shuffleKey, diskFileInfo.getFilePath());
-            throw new IOException(
-                "Sorting shuffle file for "
-                    + shuffleKey
-                    + " "
-                    + diskFileInfo.getFilePath()
-                    + " failed.");
-          }
-        }
-      }
-
-      return getSortedDiskFileInfo(shuffleKey, fileName, fileInfo, startMapIndex, endMapIndex);
-    }
-  }
-
   // 1. If the sorted file is not generated, it adds the FileSorter task to the sorting queue and
   // return.
   //    The asynchronous thread will get the sorted fileInfo.
@@ -327,6 +227,74 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         }
       }
     }
+  }
+
+  public DiskFileInfo getSortedDiskFileInfo(
+      String shuffleKey, String fileName, FileInfo fileInfo, int startMapIndex, int endMapIndex)
+      throws IOException {
+    DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);
+    String fileId = shuffleKey + "-" + fileName;
+    UserIdentifier userIdentifier = diskFileInfo.getUserIdentifier();
+    String sortedFilePath = Utils.getSortedFilePath(diskFileInfo.getFilePath());
+    String indexFilePath = Utils.getIndexFilePath(diskFileInfo.getFilePath());
+    if (sortedShuffleFiles.containsKey(shuffleKey)
+        && sortedShuffleFiles.get(shuffleKey).contains(fileId)) {
+      Map<Integer, List<ShuffleBlockInfo>> indexMap;
+      try {
+        indexMap =
+            indexCache.get(
+                fileId,
+                () -> {
+                  FileChannel indexChannel = null;
+                  FSDataInputStream dfsIndexStream = null;
+                  boolean isDfs = Utils.isHdfsPath(indexFilePath) || Utils.isS3Path(indexFilePath);
+                  boolean isS3 = Utils.isS3Path(indexFilePath);
+                  int indexSize;
+                  try {
+                    if (isDfs) {
+                      StorageInfo.Type storageType =
+                          isS3 ? StorageInfo.Type.S3 : StorageInfo.Type.HDFS;
+                      FileSystem hadoopFs = StorageManager.hadoopFs().get(storageType);
+                      dfsIndexStream = hadoopFs.open(new Path(indexFilePath));
+                      indexSize = (int) hadoopFs.getFileStatus(new Path(indexFilePath)).getLen();
+                    } else {
+                      indexChannel = FileChannelUtils.openReadableFileChannel(indexFilePath);
+                      File indexFile = new File(indexFilePath);
+                      indexSize = (int) indexFile.length();
+                    }
+                    ByteBuffer indexBuf = ByteBuffer.allocate(indexSize);
+                    if (isDfs) {
+                      readStreamFully(dfsIndexStream, indexBuf, indexFilePath);
+                    } else {
+                      readChannelFully(indexChannel, indexBuf, indexFilePath);
+                    }
+                    indexBuf.rewind();
+                    Map<Integer, List<ShuffleBlockInfo>> tIndexMap =
+                        ShuffleBlockInfoUtils.parseShuffleBlockInfosFromByteBuffer(indexBuf);
+                    Set<String> indexCacheItemsSet =
+                        indexCacheNames.computeIfAbsent(shuffleKey, v -> new HashSet<>());
+                    indexCacheItemsSet.add(fileId);
+                    return tIndexMap;
+                  } catch (Exception e) {
+                    logger.error(
+                        "Read sorted shuffle file index " + indexFilePath + " error, detail: ", e);
+                    throw new IOException("Read sorted shuffle file index failed.", e);
+                  } finally {
+                    IOUtils.closeQuietly(indexChannel, null);
+                    IOUtils.closeQuietly(dfsIndexStream, null);
+                  }
+                });
+      } catch (ExecutionException e) {
+        throw new IOException("Read sorted shuffle file index failed.", e);
+      }
+      ReduceFileMeta reduceFileMeta =
+          new ReduceFileMeta(
+              ShuffleBlockInfoUtils.getChunkOffsetsFromShuffleBlockInfos(
+                  startMapIndex, endMapIndex, shuffleChunkSize, indexMap, false),
+              shuffleChunkSize);
+      return new DiskFileInfo(userIdentifier, reduceFileMeta, sortedFilePath);
+    }
+    return null;
   }
 
   public FileInfo sortAndGetMemoryFileInfo(FileInfo fileInfo, int startMapIndex, int endMapIndex) {
@@ -633,74 +601,6 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
               offset + transferredSize, length - transferredSize, targetChannel);
     }
     return transferredSize;
-  }
-
-  public DiskFileInfo getSortedDiskFileInfo(
-      String shuffleKey, String fileName, FileInfo fileInfo, int startMapIndex, int endMapIndex)
-      throws IOException {
-    DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);
-    String fileId = shuffleKey + "-" + fileName;
-    UserIdentifier userIdentifier = diskFileInfo.getUserIdentifier();
-    String sortedFilePath = Utils.getSortedFilePath(diskFileInfo.getFilePath());
-    String indexFilePath = Utils.getIndexFilePath(diskFileInfo.getFilePath());
-    if (sortedShuffleFiles.containsKey(shuffleKey)
-        && sortedShuffleFiles.get(shuffleKey).contains(fileId)) {
-      Map<Integer, List<ShuffleBlockInfo>> indexMap;
-      try {
-        indexMap =
-            indexCache.get(
-                fileId,
-                () -> {
-                  FileChannel indexChannel = null;
-                  FSDataInputStream dfsIndexStream = null;
-                  boolean isDfs = Utils.isHdfsPath(indexFilePath) || Utils.isS3Path(indexFilePath);
-                  boolean isS3 = Utils.isS3Path(indexFilePath);
-                  int indexSize;
-                  try {
-                    if (isDfs) {
-                      StorageInfo.Type storageType =
-                          isS3 ? StorageInfo.Type.S3 : StorageInfo.Type.HDFS;
-                      FileSystem hadoopFs = StorageManager.hadoopFs().get(storageType);
-                      dfsIndexStream = hadoopFs.open(new Path(indexFilePath));
-                      indexSize = (int) hadoopFs.getFileStatus(new Path(indexFilePath)).getLen();
-                    } else {
-                      indexChannel = FileChannelUtils.openReadableFileChannel(indexFilePath);
-                      File indexFile = new File(indexFilePath);
-                      indexSize = (int) indexFile.length();
-                    }
-                    ByteBuffer indexBuf = ByteBuffer.allocate(indexSize);
-                    if (isDfs) {
-                      readStreamFully(dfsIndexStream, indexBuf, indexFilePath);
-                    } else {
-                      readChannelFully(indexChannel, indexBuf, indexFilePath);
-                    }
-                    indexBuf.rewind();
-                    Map<Integer, List<ShuffleBlockInfo>> tIndexMap =
-                        ShuffleBlockInfoUtils.parseShuffleBlockInfosFromByteBuffer(indexBuf);
-                    Set<String> indexCacheItemsSet =
-                        indexCacheNames.computeIfAbsent(shuffleKey, v -> new HashSet<>());
-                    indexCacheItemsSet.add(fileId);
-                    return tIndexMap;
-                  } catch (Exception e) {
-                    logger.error(
-                        "Read sorted shuffle file index " + indexFilePath + " error, detail: ", e);
-                    throw new IOException("Read sorted shuffle file index failed.", e);
-                  } finally {
-                    IOUtils.closeQuietly(indexChannel, null);
-                    IOUtils.closeQuietly(dfsIndexStream, null);
-                  }
-                });
-      } catch (ExecutionException e) {
-        throw new IOException("Read sorted shuffle file index failed.", e);
-      }
-      ReduceFileMeta reduceFileMeta =
-          new ReduceFileMeta(
-              ShuffleBlockInfoUtils.getChunkOffsetsFromShuffleBlockInfos(
-                  startMapIndex, endMapIndex, shuffleChunkSize, indexMap, false),
-              shuffleChunkSize);
-      return new DiskFileInfo(userIdentifier, reduceFileMeta, sortedFilePath);
-    }
-    return null;
   }
 
   class FileSorter {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -233,22 +233,18 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     } else {
       DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);
       String fileId = shuffleKey + "-" + fileName;
-      UserIdentifier userIdentifier = diskFileInfo.getUserIdentifier();
       Set<String> sorted =
           sortedShuffleFiles.computeIfAbsent(shuffleKey, v -> ConcurrentHashMap.newKeySet());
       Set<String> sorting =
           sortingShuffleFiles.computeIfAbsent(shuffleKey, v -> ConcurrentHashMap.newKeySet());
 
-      String sortedFilePath = Utils.getSortedFilePath(diskFileInfo.getFilePath());
-      String indexFilePath = Utils.getIndexFilePath(diskFileInfo.getFilePath());
       boolean fileSorting = true;
       synchronized (sorting) {
         if (sorted.contains(fileId)) {
           fileSorting = false;
         } else if (!sorting.contains(fileId)) {
           try {
-            PartitionFilesSorter.FileSorter fileSorter =
-                new PartitionFilesSorter.FileSorter(diskFileInfo, fileId, shuffleKey);
+            FileSorter fileSorter = new FileSorter(diskFileInfo, fileId, shuffleKey);
             sorting.add(fileId);
             logger.debug(
                 "Adding sorter to sort queue shuffle key {}, file name {}", shuffleKey, fileName);
@@ -295,7 +291,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         }
       }
 
-      return getSortedDiskFileInfo(shuffleKey, fileId, fileInfo, startMapIndex, endMapIndex);
+      return getSortedDiskFileInfo(shuffleKey, fileName, fileInfo, startMapIndex, endMapIndex);
     }
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -75,12 +75,11 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
   private File recoverFile;
   private volatile boolean shutdown = false;
 
-  // shuffleKey -> Set(shuffleKey-fileName)
+  // shuffleKey -> Set(fileId: shuffleKey-fileName)
   private final ConcurrentHashMap<String, Set<String>> sortedShuffleFiles =
       JavaUtils.newConcurrentHashMap();
   private final ConcurrentHashMap<String, Set<String>> sortingShuffleFiles =
       JavaUtils.newConcurrentHashMap();
-
   private final Cache<String, Map<Integer, List<ShuffleBlockInfo>>> indexCache;
   private final Map<String, Set<String>> indexCacheNames = JavaUtils.newConcurrentHashMap();
 
@@ -648,7 +647,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     UserIdentifier userIdentifier = diskFileInfo.getUserIdentifier();
     String sortedFilePath = Utils.getSortedFilePath(diskFileInfo.getFilePath());
     String indexFilePath = Utils.getIndexFilePath(diskFileInfo.getFilePath());
-    if (sortedShuffleFiles.contains(shuffleKey)
+    if (sortedShuffleFiles.containsKey(shuffleKey)
         && sortedShuffleFiles.get(shuffleKey).contains(fileId)) {
       Map<Integer, List<ShuffleBlockInfo>> indexMap;
       try {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -202,7 +202,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
   //    generated, it awaits until a timeout occurs (default 220 seconds).
   // 3. If the sorted file is generated, it returns the sorted FileInfo.
   // This method will generate temporary file info for this shuffle read
-  public FileInfo getSortedFileInfoOri(
+  public FileInfo getSortedFileInfo(
       String shuffleKey, String fileName, FileInfo fileInfo, int startMapIndex, int endMapIndex)
       throws IOException {
     if (fileInfo instanceof MemoryFileInfo) {
@@ -247,7 +247,8 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
           fileSorting = false;
         } else if (!sorting.contains(fileId)) {
           try {
-            FileSorter fileSorter = new FileSorter(diskFileInfo, fileId, shuffleKey);
+            PartitionFilesSorter.FileSorter fileSorter =
+                new PartitionFilesSorter.FileSorter(diskFileInfo, fileId, shuffleKey);
             sorting.add(fileId);
             logger.debug(
                 "Adding sorter to sort queue shuffle key {}, file name {}", shuffleKey, fileName);
@@ -303,7 +304,6 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
   //    The asynchronous thread will get the sorted fileInfo.
   // 2. If the FileSorter task is already in the sorting queue but the sorted file has not been
   //    generated, return directly.
-
   public void submitDiskFileSortingTask(String shuffleKey, String fileName, FileInfo fileInfo)
       throws IOException {
     DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -20,6 +20,7 @@ package org.apache.celeborn.service.deploy.worker
 import java.io.{FileNotFoundException, IOException}
 import java.nio.charset.StandardCharsets
 import java.util
+import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, ScheduledExecutorService, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
 
@@ -39,7 +40,7 @@ import org.apache.celeborn.common.network.server.BaseMessageHandler
 import org.apache.celeborn.common.network.util.{NettyUtils, TransportConf}
 import org.apache.celeborn.common.protocol.{MessageType, PbBufferStreamEnd, PbChunkFetchRequest, PbNotifyRequiredSegment, PbOpenStream, PbOpenStreamList, PbOpenStreamListResponse, PbReadAddCredit, PbStreamHandler, PbStreamHandlerOpt, StreamType}
 import org.apache.celeborn.common.protocol.message.StatusCode
-import org.apache.celeborn.common.util.{ExceptionUtils, Utils}
+import org.apache.celeborn.common.util.{ExceptionUtils, JavaUtils, Utils}
 import org.apache.celeborn.service.deploy.worker.storage.{ChunkStreamManager, CreditStreamManager, PartitionFilesSorter, StorageManager}
 
 class FetchHandler(
@@ -58,7 +59,12 @@ class FetchHandler(
     conf.readBuffersToTriggerReadMin)
   var storageManager: StorageManager = _
   var partitionsSorter: PartitionFilesSorter = _
+  var sortFileChecker: ScheduledExecutorService = _
   var registered: Option[AtomicBoolean] = None
+  // shuffleKey -> (fileId -> SortFileInfo)
+  var sortFilesInfos: ConcurrentHashMap[String, ConcurrentHashMap[String, SortFileInfo]] = _
+
+  val workerSortFilesCheckInterval = conf.workerSortFilesCheckInterval
 
   def init(worker: Worker): Unit = {
     workerSource.addGauge(WorkerSource.ACTIVE_CHUNK_STREAM_COUNT) { () =>
@@ -76,6 +82,19 @@ class FetchHandler(
     this.storageManager = worker.storageManager
     this.partitionsSorter = worker.partitionsSorter
     this.registered = Some(worker.registered)
+
+    this.sortFilesInfos = worker.sortFilesInfo
+    this.sortFileChecker = worker.sortFileChecker
+    this.sortFileChecker.scheduleWithFixedDelay(
+      new Runnable {
+        override def run(): Unit = {
+          checkSortFiles(sortFilesInfos)
+        }
+      },
+      0,
+      workerSortFilesCheckInterval,
+      TimeUnit.MILLISECONDS)
+
   }
 
   def getRawFileInfo(
@@ -231,6 +250,59 @@ class FetchHandler(
 
   }
 
+  private def handleOpenStreamInternal(
+      client: TransportClient,
+      shuffleKey: String,
+      fileName: String,
+      startIndex: Int,
+      endIndex: Int,
+      initialCredit: Int,
+      rpcRequestId: Long,
+      isLegacy: Boolean,
+      readLocalShuffle: Boolean = false,
+      callback: RpcResponseCallback): Unit = {
+    checkAuth(client, Utils.splitShuffleKey(shuffleKey)._1)
+    workerSource.recordAppActiveConnection(client, shuffleKey)
+    // todo async timer might not be accurate
+    workerSource.startTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
+    val fileInfo = getRawFileInfo(shuffleKey, fileName)
+    fileInfo.getFileMeta match {
+      case _: ReduceFileMeta =>
+        asyncHandleReduceOpenStreamInternal(
+          client,
+          shuffleKey,
+          fileName,
+          startIndex,
+          endIndex,
+          rpcRequestId,
+          isLegacy,
+          callback,
+          readLocalShuffle)
+      case _: MapFileMeta =>
+        val creditStreamHandler =
+          new Consumer[java.lang.Long] {
+            override def accept(streamId: java.lang.Long): Unit = {
+              val pbStreamHandler = PbStreamHandler.newBuilder
+                .setStreamId(streamId)
+                .setNumChunks(0)
+                .build()
+              replyStreamHandler(client, rpcRequestId, pbStreamHandler, isLegacy)
+            }
+          }
+
+        creditStreamManager.registerStream(
+          creditStreamHandler,
+          client.getChannel,
+          shuffleKey,
+          initialCredit,
+          startIndex,
+          endIndex,
+          fileInfo.asInstanceOf[DiskFileInfo])
+        workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
+        workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
+    }
+  }
+
   private def handleReduceOpenStreamInternal(
       client: TransportClient,
       shuffleKey: String,
@@ -251,7 +323,7 @@ class FetchHandler(
       // 2. when the current request is a range openStream request.
       if ((endIndex != Int.MaxValue) || (endIndex == Int.MaxValue
           && !fileInfo.addStream(streamId))) {
-        fileInfo = partitionsSorter.getSortedFileInfo(
+        fileInfo = partitionsSorter.getSortedFileInfoOri(
           shuffleKey,
           fileName,
           fileInfo,
@@ -331,66 +403,258 @@ class FetchHandler(
     }
   }
 
-  private def handleOpenStreamInternal(
+  private def asyncHandleReduceOpenStreamInternal(
       client: TransportClient,
       shuffleKey: String,
       fileName: String,
       startIndex: Int,
       endIndex: Int,
-      initialCredit: Int,
       rpcRequestId: Long,
       isLegacy: Boolean,
-      readLocalShuffle: Boolean = false,
-      callback: RpcResponseCallback): Unit = {
-    checkAuth(client, Utils.splitShuffleKey(shuffleKey)._1)
-    workerSource.recordAppActiveConnection(client, shuffleKey)
-    workerSource.startTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
-    try {
-      val fileInfo = getRawFileInfo(shuffleKey, fileName)
-      fileInfo.getFileMeta match {
-        case _: ReduceFileMeta =>
-          val pbStreamHandlerOpt =
-            handleReduceOpenStreamInternal(
-              client,
-              shuffleKey,
-              fileName,
-              startIndex,
-              endIndex,
-              readLocalShuffle)
+      callback: RpcResponseCallback,
+      readLocalShuffle: Boolean = false): Unit = {
 
-          if (pbStreamHandlerOpt.getStatus != StatusCode.SUCCESS.getValue) {
-            throw new CelebornIOException(pbStreamHandlerOpt.getErrorMsg)
-          }
-          replyStreamHandler(client, rpcRequestId, pbStreamHandlerOpt.getStreamHandler, isLegacy)
-        case _: MapFileMeta =>
-          val creditStreamHandler =
-            new Consumer[java.lang.Long] {
-              override def accept(streamId: java.lang.Long): Unit = {
-                val pbStreamHandler = PbStreamHandler.newBuilder
-                  .setStreamId(streamId)
-                  .setNumChunks(0)
-                  .build()
-                replyStreamHandler(client, rpcRequestId, pbStreamHandler, isLegacy)
-              }
-            }
+    logDebug(s"Received open stream request $shuffleKey $fileName $startIndex " +
+      s"$endIndex get file name $fileName from client channel " +
+      s"${NettyUtils.getRemoteAddress(client.getChannel)}")
 
-          creditStreamManager.registerStream(
-            creditStreamHandler,
-            client.getChannel,
-            shuffleKey,
-            initialCredit,
+    val fileInfo = getRawFileInfo(shuffleKey, fileName)
+    val streamId = chunkStreamManager.nextStreamId()
+
+    val fileId = shuffleKey + "-" + fileName;
+    sortFilesInfos.putIfAbsent(shuffleKey, JavaUtils.newConcurrentHashMap[String, SortFileInfo]())
+    val fileInfoMap = sortFilesInfos.get(shuffleKey)
+    val startSortTIme = System.currentTimeMillis()
+    fileInfo match {
+      case memoryFileInfo: MemoryFileInfo =>
+        fileInfoMap.putIfAbsent(
+          fileId,
+          new SortFileInfo(
+            fileInfo,
+            SortFileInfo.SORT_NOTSTARTED,
+            client,
+            fileName,
             startIndex,
             endIndex,
-            fileInfo.asInstanceOf[DiskFileInfo])
-      }
-      workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
-    } catch {
-      case e: IOException =>
-        workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
-        handleRpcIOException(client, rpcRequestId, shuffleKey, fileName, e, callback)
-    } finally {
-      workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
+            readLocalShuffle,
+            startSortTIme,
+            rpcRequestId,
+            isLegacy,
+            callback,
+            memoryFileInfo.getUserIdentifier,
+            null,
+            null))
+      case diskFileInfo: DiskFileInfo =>
+        val sortedFilePath = Utils.getSortedFilePath(diskFileInfo.getFilePath)
+        val indexFilePath = Utils.getIndexFilePath(diskFileInfo.getFilePath)
+        fileInfoMap.putIfAbsent(
+          fileId,
+          new SortFileInfo(
+            fileInfo,
+            SortFileInfo.SORT_NOTSTARTED,
+            client,
+            fileName,
+            startIndex,
+            endIndex,
+            readLocalShuffle,
+            startSortTIme,
+            rpcRequestId,
+            isLegacy,
+            callback,
+            diskFileInfo.getUserIdentifier,
+            sortedFilePath,
+            indexFilePath))
     }
+
+    if ((endIndex != Int.MaxValue) || (endIndex == Int.MaxValue
+        && !fileInfo.addStream(streamId))) {
+      if (fileInfo.isInstanceOf[MemoryFileInfo]) {
+        val newFileInfo: FileInfo =
+          partitionsSorter.sortAndGetMemoryFileInfo(fileInfo, startIndex, endIndex)
+        val sortFileInfo = fileInfoMap.get(fileId)
+        sortFileInfo.synchronized {
+          sortFileInfo.fileInfo = newFileInfo
+          sortFileInfo.status = SortFileInfo.SORT_FINISHED
+        }
+      } else {
+        partitionsSorter.submitDiskFileSortingTask(shuffleKey, fileName, fileInfo)
+        val sortFileInfo = fileInfoMap.get(fileId)
+        sortFileInfo.synchronized {
+          sortFileInfo.status = SortFileInfo.SORTING
+        }
+      }
+    } else {
+      // mark status if do not need to sort
+      val sortFileInfo = fileInfoMap.get(fileId)
+      sortFileInfo.synchronized {
+        sortFileInfo.status = SortFileInfo.SORT_FINISHED
+      }
+    }
+  }
+
+  private def checkSortFiles(sortFilesInfos: ConcurrentHashMap[
+    String,
+    ConcurrentHashMap[String, SortFileInfo]]): Unit = {
+    val currentTime = System.currentTimeMillis()
+    val sortFileInfoIterator = sortFilesInfos.entrySet().iterator()
+    while (sortFileInfoIterator.hasNext) {
+      val sortFileInfoEntry = sortFileInfoIterator.next()
+      val shuffleKey = sortFileInfoEntry.getKey
+      val fileInfoMap = sortFileInfoEntry.getValue
+      val fileInfoIterator = fileInfoMap.entrySet().iterator()
+
+      while (fileInfoIterator.hasNext) {
+        val fileInfoEntry = fileInfoIterator.next()
+        val fileId = fileInfoEntry.getKey
+        val sortFileInfo = fileInfoEntry.getValue
+
+        try {
+          sortFileInfo.synchronized {
+            if (sortFileInfo.status == SortFileInfo.SORT_FINISHED) {
+              val pbStreamHandlerOpt = getPbStreamHandlerOpt(
+                sortFileInfo.fileInfo,
+                sortFileInfo.client,
+                shuffleKey,
+                sortFileInfo.fileName,
+                sortFileInfo.startIndex,
+                sortFileInfo.endIndex,
+                sortFileInfo.readLocalShuffle)
+              if (pbStreamHandlerOpt.getStatus == StatusCode.SUCCESS.getValue) {
+                replyStreamHandler(
+                  sortFileInfo.client,
+                  sortFileInfo.rpcRequestId,
+                  pbStreamHandlerOpt.getStreamHandler,
+                  sortFileInfo.isLegacy)
+              } else {
+                handleRpcIOException(
+                  sortFileInfo.client,
+                  sortFileInfo.rpcRequestId,
+                  shuffleKey,
+                  sortFileInfo.fileName,
+                  new CelebornIOException(pbStreamHandlerOpt.getErrorMsg),
+                  sortFileInfo.callback)
+              }
+              fileInfoIterator.remove()
+            } else if (sortFileInfo.status == SortFileInfo.SORT_FAILED) {
+              handleRpcIOException(
+                sortFileInfo.client,
+                sortFileInfo.rpcRequestId,
+                shuffleKey,
+                sortFileInfo.fileName,
+                new CelebornIOException("sort failed"),
+                sortFileInfo.callback)
+              fileInfoIterator.remove()
+            } else if (sortFileInfo.status == SortFileInfo.SORTING) {
+              // memoryFileInfos have not status of sorting
+              val sortedFileInfo = partitionsSorter.getSortedDiskFileInfo(
+                shuffleKey,
+                sortFileInfo.fileName,
+                sortFileInfo.fileInfo,
+                sortFileInfo.startIndex,
+                sortFileInfo.endIndex)
+
+              if (sortedFileInfo != null) {
+                sortFileInfo.fileInfo = sortedFileInfo
+              }
+
+              if (currentTime - sortFileInfo.startTime > conf.workerPartitionSorterSortPartitionTimeout) {
+                logError(s"Sort file $fileId timeout, remove it")
+                handleRpcIOException(
+                  sortFileInfo.client,
+                  sortFileInfo.rpcRequestId,
+                  shuffleKey,
+                  sortFileInfo.fileName,
+                  new CelebornIOException("sort failed timeout"),
+                  sortFileInfo.callback)
+                sortFileInfo.status = SortFileInfo.SORT_FAILED
+                fileInfoIterator.remove()
+              }
+            }
+          }
+        } catch {
+          case e: Exception =>
+            logError(s"Check sort files error, shuffleKey: $shuffleKey, fileId: $fileId", e)
+
+          // todo: handle sort fail
+
+        }
+      }
+    }
+  }
+
+  private def getPbStreamHandlerOpt(
+      fileInfo: FileInfo,
+      client: TransportClient,
+      shuffleKey: String,
+      fileName: String,
+      startIndex: Int,
+      endIndex: Int,
+      readLocalShuffle: Boolean = false): PbStreamHandlerOpt = {
+
+    val streamId = chunkStreamManager.nextStreamId()
+    val meta = fileInfo.getReduceFileMeta
+    val streamHandler =
+      if (readLocalShuffle && !fileInfo.isInstanceOf[MemoryFileInfo]) {
+        chunkStreamManager.registerStream(
+          streamId,
+          shuffleKey,
+          fileName)
+        makeStreamHandler(
+          streamId,
+          meta.getNumChunks,
+          meta.getChunkOffsets,
+          fileInfo.asInstanceOf[DiskFileInfo].getFilePath)
+      } else fileInfo match {
+        case info: DiskFileInfo if info.isHdfs =>
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            fileName)
+          makeStreamHandler(streamId, numChunks = 0)
+        case info: DiskFileInfo if info.isS3 =>
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            fileName)
+          makeStreamHandler(streamId, numChunks = 0)
+        case _ =>
+          val managedBuffer = fileInfo match {
+            case df: DiskFileInfo =>
+              new FileChunkBuffers(df, transportConf)
+            case mf: MemoryFileInfo =>
+              new MemoryChunkBuffers(mf)
+          }
+          val fetchTimeMetric =
+            fileInfo match {
+              case info: DiskFileInfo =>
+                storageManager.getFetchTimeMetric(info.getFile)
+              case _ =>
+                null
+            }
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            managedBuffer,
+            fileName,
+            fetchTimeMetric)
+          if (meta.getNumChunks == 0)
+            logDebug(s"StreamId $streamId, fileName $fileName, mapRange " +
+              s"[$startIndex-$endIndex] is empty. Received from client channel " +
+              s"${NettyUtils.getRemoteAddress(client.getChannel)}")
+          else logDebug(
+            s"StreamId $streamId, fileName $fileName, numChunks ${meta.getNumChunks}, " +
+              s"mapRange [$startIndex-$endIndex]. Received from client channel " +
+              s"${NettyUtils.getRemoteAddress(client.getChannel)}")
+          makeStreamHandler(
+            streamId,
+            meta.getNumChunks)
+      }
+
+    workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
+    workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
+    PbStreamHandlerOpt.newBuilder().setStreamHandler(streamHandler)
+      .setStatus(StatusCode.SUCCESS.getValue)
+      .build()
   }
 
   private def makeStreamHandler(
@@ -442,6 +706,8 @@ class FetchHandler(
     logError(
       s"Read file: $fileName with shuffleKey: $shuffleKey error from ${NettyUtils.getRemoteAddress(client.getChannel)}",
       ioe)
+    workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
+    workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
     handleRpcException(client, requestId, ioe, rpcCallback)
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -842,4 +842,24 @@ class FetchHandler(
   def setPartitionsSorter(partitionFilesSorter: PartitionFilesSorter): Unit = {
     this.partitionsSorter = partitionFilesSorter
   }
+
+  def setSortFilesInfos(sortFilesInfos: ConcurrentHashMap[
+    String,
+    ConcurrentHashMap[String, SortFileInfo]]): Unit = {
+    this.sortFilesInfos = sortFilesInfos
+  }
+
+  def setSortFileChecker(sortFileChecker: ScheduledExecutorService): Unit = {
+    this.sortFileChecker = sortFileChecker
+    this.sortFileChecker.scheduleWithFixedDelay(
+      new Runnable {
+        override def run(): Unit = {
+          getAndReplySortedFiles()
+        }
+      },
+      0,
+      workerSortFilesCheckInterval,
+      TimeUnit.MILLISECONDS)
+  }
+
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -478,7 +478,6 @@ class FetchHandler(
                 sortFileInfo.readLocalShuffle)
 
               if (sortFileInfo.fileIndex == -1) {
-                logInfo(s"reply stream handler for fileRequest: $fileRequest")
                 replyStreamHandler(
                   sortFileInfo.client,
                   sortFileInfo.rpcRequestId,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -526,6 +526,7 @@ class FetchHandler(
                   pbStreamHandlerOpt.getStreamHandler,
                   sortFileInfo.isLegacy)
               } else {
+                // pbStreamHandlerOpt has no exception
                 handleRpcIOException(
                   sortFileInfo.client,
                   sortFileInfo.rpcRequestId,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -349,6 +349,7 @@ class FetchHandler(
             SortFileInfo.SORT_NOTSTARTED,
             client,
             fileName,
+            streamId,
             startIndex,
             endIndex,
             readLocalShuffle,
@@ -371,6 +372,7 @@ class FetchHandler(
             SortFileInfo.SORT_NOTSTARTED,
             client,
             fileName,
+            streamId,
             startIndex,
             endIndex,
             readLocalShuffle,
@@ -470,11 +472,13 @@ class FetchHandler(
                 sortFileInfo.client,
                 shuffleKey,
                 sortFileInfo.fileName,
+                sortFileInfo.streamId,
                 sortFileInfo.startIndex,
                 sortFileInfo.endIndex,
                 sortFileInfo.readLocalShuffle)
 
               if (sortFileInfo.fileIndex == -1) {
+                logInfo(s"reply stream handler for fileRequest: $fileRequest")
                 replyStreamHandler(
                   sortFileInfo.client,
                   sortFileInfo.rpcRequestId,
@@ -554,11 +558,11 @@ class FetchHandler(
       client: TransportClient,
       shuffleKey: String,
       fileName: String,
+      streamId: Long,
       startIndex: Int,
       endIndex: Int,
       readLocalShuffle: Boolean = false): PbStreamHandlerOpt = {
 
-    val streamId = chunkStreamManager.nextStreamId()
     val meta = fileInfo.getReduceFileMeta
     val streamHandler =
       if (readLocalShuffle && !fileInfo.isInstanceOf[MemoryFileInfo]) {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
@@ -26,6 +26,7 @@ class SortFileInfo(
     var status: Int,
     var client: TransportClient,
     var fileName: String,
+    var streamId: Long,
     var startIndex: Int,
     var endIndex: Int,
     var readLocalShuffle: Boolean,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
@@ -36,7 +36,8 @@ class SortFileInfo(
     var userIdentifier: UserIdentifier,
     var sortedFilePath: String,
     var indexFilePath: String,
-    var error: String)
+    var error: String,
+    var fileIndex: Int)
 
 object SortFileInfo {
   val SORT_NOTSTARTED: Int = 0

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
@@ -35,7 +35,8 @@ class SortFileInfo(
     var callback: RpcResponseCallback,
     var userIdentifier: UserIdentifier,
     var sortedFilePath: String,
-    var indexFilePath: String)
+    var indexFilePath: String,
+    var error: String)
 
 object SortFileInfo {
   val SORT_NOTSTARTED: Int = 0

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/SortFileInfo.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker
+
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.meta.FileInfo
+import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient}
+
+class SortFileInfo(
+    var fileInfo: FileInfo,
+    var status: Int,
+    var client: TransportClient,
+    var fileName: String,
+    var startIndex: Int,
+    var endIndex: Int,
+    var readLocalShuffle: Boolean,
+    var startTime: Long,
+    var rpcRequestId: Long,
+    var isLegacy: Boolean,
+    var callback: RpcResponseCallback,
+    var userIdentifier: UserIdentifier,
+    var sortedFilePath: String,
+    var indexFilePath: String)
+
+object SortFileInfo {
+  val SORT_NOTSTARTED: Int = 0
+  val SORTING: Int = 1
+  val SORT_FINISHED: Int = 2
+  val SORT_FAILED: Int = 3
+}

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskPartitionFilesSorterSuiteJ.java
@@ -144,13 +144,24 @@ public class DiskPartitionFilesSorterSuiteJ {
       conf.set(CelebornConf.SHUFFLE_CHUNK_SIZE().key(), "8m");
       PartitionFilesSorter partitionFilesSorter =
           new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
+
+      FileInfo fileInfo = partitionDataWriter.getDiskFileInfo();
+
+      partitionFilesSorter.submitDiskFileSortingTask("application-1", originFileName, fileInfo);
+
+      while (partitionFilesSorter.getSortedDiskFileInfo(
+              "application-1", originFileName, fileInfo, startMapIndex, endMapIndex)
+          == null) {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          logger.warn("waiting for sorted DiskFileInfo error");
+        }
+      }
+
       FileInfo info =
-          partitionFilesSorter.getSortedFileInfo(
-              "application-1",
-              originFileName,
-              partitionDataWriter.getDiskFileInfo(),
-              startMapIndex,
-              endMapIndex);
+          partitionFilesSorter.getSortedDiskFileInfo(
+              "application-1", originFileName, fileInfo, startMapIndex, endMapIndex);
       long totalSizeToFetch = 0;
       for (int i = startMapIndex; i < endMapIndex; i++) {
         totalSizeToFetch += partitionSize[i];

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskPartitionFilesSorterSuiteJ.java
@@ -145,7 +145,7 @@ public class DiskPartitionFilesSorterSuiteJ {
       PartitionFilesSorter partitionFilesSorter =
           new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
       FileInfo info =
-          partitionFilesSorter.getSortedFileInfoOri(
+          partitionFilesSorter.getSortedFileInfo(
               "application-1",
               originFileName,
               partitionDataWriter.getDiskFileInfo(),

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskPartitionFilesSorterSuiteJ.java
@@ -145,7 +145,7 @@ public class DiskPartitionFilesSorterSuiteJ {
       PartitionFilesSorter partitionFilesSorter =
           new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
       FileInfo info =
-          partitionFilesSorter.getSortedFileInfo(
+          partitionFilesSorter.getSortedFileInfoOri(
               "application-1",
               originFileName,
               partitionDataWriter.getDiskFileInfo(),

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
@@ -164,7 +164,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
     Mockito.doReturn(info)
         .when(sorter)
-        .getSortedFileInfoOri(anyString(), anyString(), eq(info), anyInt(), anyInt());
+        .getSortedFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
     handler.setPartitionsSorter(sorter);
     transportContext = new TransportContext(transConf, handler);
     server = transportContext.createServer();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
@@ -164,7 +164,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
     Mockito.doReturn(info)
         .when(sorter)
-        .getSortedFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
+        .getSortedDiskFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
     handler.setPartitionsSorter(sorter);
     transportContext = new TransportContext(transConf, handler);
     server = transportContext.createServer();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
@@ -164,7 +164,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
     Mockito.doReturn(info)
         .when(sorter)
-        .getSortedFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
+        .getSortedFileInfoOri(anyString(), anyString(), eq(info), anyInt(), anyInt());
     handler.setPartitionsSorter(sorter);
     transportContext = new TransportContext(transConf, handler);
     server = transportContext.createServer();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -129,12 +129,8 @@ public class MemoryPartitionFilesSorterSuiteJ {
     PartitionFilesSorter partitionFilesSorter =
         new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     FileInfo info =
-        partitionFilesSorter.getSortedFileInfo(
-            "application-1",
-            "",
-            partitionDataWriter.getMemoryFileInfo(),
-            startMapIndex,
-            endMapIndex);
+        partitionFilesSorter.sortAndGetMemoryFileInfo(
+            partitionDataWriter.getMemoryFileInfo(), startMapIndex, endMapIndex);
     long totalSizeToFetch = 0;
     for (int i = startMapIndex; i < endMapIndex; i++) {
       totalSizeToFetch += partitionSize[i];

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -129,7 +129,7 @@ public class MemoryPartitionFilesSorterSuiteJ {
     PartitionFilesSorter partitionFilesSorter =
         new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     FileInfo info =
-        partitionFilesSorter.getSortedFileInfo(
+        partitionFilesSorter.getSortedFileInfoOri(
             "application-1",
             "",
             partitionDataWriter.getMemoryFileInfo(),

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -129,7 +129,7 @@ public class MemoryPartitionFilesSorterSuiteJ {
     PartitionFilesSorter partitionFilesSorter =
         new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     FileInfo info =
-        partitionFilesSorter.getSortedFileInfoOri(
+        partitionFilesSorter.getSortedFileInfo(
             "application-1",
             "",
             partitionDataWriter.getMemoryFileInfo(),

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -137,7 +137,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
     Mockito.doReturn(info)
         .when(sorter)
-        .getSortedFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
+        .getSortedFileInfoOri(anyString(), anyString(), eq(info), anyInt(), anyInt());
     handler.setPartitionsSorter(sorter);
     TransportContext context = new TransportContext(transConf, handler);
     server = context.createServer();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -135,9 +135,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
           }
         };
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
-    Mockito.doReturn(info)
-        .when(sorter)
-        .getSortedFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
+    Mockito.doReturn(info).when(sorter).sortAndGetMemoryFileInfo(eq(info), anyInt(), anyInt());
     handler.setPartitionsSorter(sorter);
     TransportContext context = new TransportContext(transConf, handler);
     server = context.createServer();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -137,7 +137,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
     Mockito.doReturn(info)
         .when(sorter)
-        .getSortedFileInfoOri(anyString(), anyString(), eq(info), anyInt(), anyInt());
+        .getSortedFileInfo(anyString(), anyString(), eq(info), anyInt(), anyInt());
     handler.setPartitionsSorter(sorter);
     TransportContext context = new TransportContext(transConf, handler);
     server = context.createServer();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -54,6 +54,7 @@ import org.apache.celeborn.common.protocol.*;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.ThreadUtils;
 import org.apache.celeborn.service.deploy.worker.FetchHandler;
+import org.apache.celeborn.service.deploy.worker.SortFileInfo;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
 import org.apache.celeborn.service.deploy.worker.storage.*;
@@ -136,7 +137,13 @@ public class MemoryReducePartitionDataWriterSuiteJ {
         };
     PartitionFilesSorter sorter = mock(PartitionFilesSorter.class);
     Mockito.doReturn(info).when(sorter).sortAndGetMemoryFileInfo(eq(info), anyInt(), anyInt());
+    ScheduledExecutorService sortFileChecker =
+        ThreadUtils.newDaemonSingleThreadScheduledExecutor("worker-sortFile-checker");
+    ConcurrentHashMap<String, ConcurrentHashMap<String, SortFileInfo>> sortFilesInfo =
+        new ConcurrentHashMap<>();
     handler.setPartitionsSorter(sorter);
+    handler.setSortFileChecker(sortFileChecker);
+    handler.setSortFilesInfos(sortFilesInfo);
     TransportContext context = new TransportContext(transConf, handler);
     server = context.createServer();
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Change fileInfo's sort flow from synchronous to asynchronous.


### Why are the changes needed?
Avoid sorting processes blocking other handleReduceOpenStream processes.


### Does this PR introduce _any_ user-facing change?
Introduce a config change.


### How was this patch tested?
UT and cluster testing.
