### PR TITLE
[CELEBORN-1792][FOLLOWUP] Suppress noisy logs when there is no memory pressure

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -330,12 +330,10 @@ public class MemoryManager {
   public void switchServingState() {
     ServingState lastState = servingState;
     servingState = currentServingState();
-    if (servingState == lastState && servingState == ServingState.NONE_PAUSED) {
-      // this means that there is no memory pressure here
-      // skip the rest check logic of memory checker
-      return;
+
+    if (servingState != lastState) {
+      logger.info("Serving state transformed from {} to {}", lastState, servingState);
     }
-    logger.info("Serving state transformed from {} to {}", lastState, servingState);
     switch (servingState) {
       case PUSH_PAUSED:
         if (canResumeByPinnedMemory()) {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -330,6 +330,11 @@ public class MemoryManager {
   public void switchServingState() {
     ServingState lastState = servingState;
     servingState = currentServingState();
+    if (servingState == lastState && servingState == ServingState.NONE_PAUSED) {
+      // this means that there is no memory pressure here
+      // skip the rest check logic of memory checker
+      return;
+    }
     logger.info("Serving state transformed from {} to {}", lastState, servingState);
     switch (servingState) {
       case PUSH_PAUSED:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unnecessary logs.
<img width="921" alt="截屏2025-02-05 14 29 43" src="https://github.com/user-attachments/assets/ab05f96b-abc0-4d68-a416-82655cd7cd13" />




### Why are the changes needed?
Do not need to log the memory state when there is no memory pressure.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA and cluster tests.
