### PR TITLE
[CELEBORN-1850] Setup worker endpoint after initalizing controller

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -194,9 +194,6 @@ private[celeborn] class Worker(
       configService)
   }
 
-  var controller = new Controller(rpcEnv, conf, metricsSystem, workerSource)
-  rpcEnv.setupEndpoint(RpcNameConstants.WORKER_EP, controller)
-
   // Visible for testing
   private[worker] var internalRpcEndpoint: RpcEndpoint = _
   private var internalRpcEndpointRef: RpcEndpointRef = _
@@ -557,8 +554,11 @@ private[celeborn] class Worker(
     pushDataHandler.init(this)
     replicateHandler.init(this)
     fetchHandler.init(this)
-    controller.init(this)
     workerStatusManager.init(this)
+
+    val controller = new Controller(rpcEnv, conf, metricsSystem, workerSource)
+    controller.init(this)
+    rpcEnv.setupEndpoint(RpcNameConstants.WORKER_EP, controller)
 
     logInfo("Worker started.")
     rpcEnv.awaitTermination()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -186,13 +186,14 @@ private[celeborn] class Worker(
   val partitionsSorter = new PartitionFilesSorter(memoryManager, conf, workerSource)
 
   if (conf.workerCongestionControlEnabled) {
-
     CongestionController.initialize(
       workerSource,
       conf.workerCongestionControlSampleTimeWindowSeconds.toInt,
       conf,
       configService)
   }
+
+  val controller = new Controller(rpcEnv, conf, metricsSystem, workerSource)
 
   // Visible for testing
   private[worker] var internalRpcEndpoint: RpcEndpoint = _
@@ -556,7 +557,6 @@ private[celeborn] class Worker(
     fetchHandler.init(this)
     workerStatusManager.init(this)
 
-    val controller = new Controller(rpcEnv, conf, metricsSystem, workerSource)
     controller.init(this)
     rpcEnv.setupEndpoint(RpcNameConstants.WORKER_EP, controller)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Setup worker endpoint after initalizing the controller.

### Why are the changes needed?

In current flow controller rpc endpoint is setup before calling the `controller.init(this)` leaving the required members to be unintialized which leading to lot of NullPointer exception in worker during restarts.

```
10:53:55.262 [celeborn-dispatcher-6] ERROR org.apache.celeborn.common.rpc.netty.Inbox - Ignoring error
java.lang.NullPointerException: null
	at org.apache.celeborn.service.deploy.worker.Controller.org$apache$celeborn$service$deploy$worker$Controller$$handleDestroy(Controller.scala:659) ~[celeborn-worker_2.12-0.5.3.jar:0.5.3]
	at org.apache.celeborn.service.deploy.worker.Controller$$anonfun$receiveAndReply$1.applyOrElse(Controller.scala:143) ~[celeborn-worker_2.12-0.5.3.jar:0.5.3]
	at org.apache.celeborn.common.rpc.netty.Inbox.processInternal(Inbox.scala:119) ~[celeborn-common_2.12-0.5.3.jar:0.5.3]
	at org.apache.celeborn.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:218) ~[celeborn-common_2.12-0.5.3.jar:0.5.3]
	at org.apache.celeborn.common.rpc.netty.Inbox.safelyCall(Inbox.scala:314) ~[celeborn-common_2.12-0.5.3.jar:0.5.3]
	at org.apache.celeborn.common.rpc.netty.Inbox.process(Inbox.scala:218) ~[celeborn-common_2.12-0.5.3.jar:0.5.3]
	at org.apache.celeborn.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:238) ~[celeborn-common_2.12-0.5.3.jar:0.5.3]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_412]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_412]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_412]
10:53:55.570 [main] INFO  org.apache.celeborn.service.deploy.worker.Worker - Register worker successfully.
10:53:55.573 [main] INFO  org.apache.celeborn.service.deploy.worker.Worker - Worker started.
```


### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Existing UTs

