### PR TITLE
[CELEBORN-1853] Remove idle executors when DRA enable and using Celeborn

### DIFF
--- a/assets/spark-patch/Celeborn_Dynamic_Allocation_spark3_4.patch
+++ b/assets/spark-patch/Celeborn_Dynamic_Allocation_spark3_4.patch
@@ -21,9 +21,10 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
---- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala	(revision efae5362cbeaf1594b18edf594e83b2cf72afce6)
-+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala	(date 1685946134830)
-@@ -209,7 +209,7 @@
+index f06312c15cf..3d2e8f72d42 100644
+--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
++++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+@@ -209,7 +209,7 @@ private[spark] class ExecutorAllocationManager(
        } else if (decommissionEnabled &&
            conf.get(config.STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED)) {
          logInfo("Shuffle data decommission is enabled without a shuffle service.")
@@ -32,50 +33,25 @@ diff --git a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scal
          throw new SparkException("Dynamic allocation of executors requires the external " +
            "shuffle service. You may enable this through spark.shuffle.service.enabled.")
        }
-Index: core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
---- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala	(revision efae5362cbeaf1594b18edf594e83b2cf72afce6)
-+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala	(date 1685946134830)
-@@ -2515,7 +2515,7 @@
+index 26be8c72bbc..e1cf377b533 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+@@ -2520,7 +2520,8 @@ private[spark] class DAGScheduler(
      // if the cluster manager explicitly tells us that the entire worker was lost, then
      // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
      // from a Standalone cluster, where the shuffle service lives in the Worker.)
 -    val fileLost = workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled
-+    val fileLost = !Utils.isCelebornEnabled(sc.getConf) && (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
++    val fileLost = !Utils.isCelebornEnabled(sc.getConf) &&
++      (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
      removeExecutorAndUnregisterOutputs(
        execId = execId,
        fileLost = fileLost,
-Index: core/src/main/scala/org/apache/spark/util/Utils.scala
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/core/src/main/scala/org/apache/spark/util/Utils.scala b/core/src/main/scala/org/apache/spark/util/Utils.scala
---- a/core/src/main/scala/org/apache/spark/util/Utils.scala	(revision efae5362cbeaf1594b18edf594e83b2cf72afce6)
-+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala	(date 1685946145650)
-@@ -3271,6 +3271,9 @@
-     files.toSeq
-   }
-
-+  def isCelebornEnabled(conf: SparkConf): Boolean =
-+    conf.get("spark.shuffle.manager", "sort").contains("celeborn")
-+
-   /**
-    * Return the median number of a long array
-    *
-Index: core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
---- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala	(revision efae5362cbeaf1594b18edf594e83b2cf72afce6)
-+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala	(date 1685946134830)
-@@ -1055,7 +1055,7 @@
+index 124a27502fe..9a59a08e875 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+@@ -1055,7 +1055,7 @@ private[spark] class TaskSetManager(
      // data from this dead executor so we would need to rerun these tasks on other executors.
      val maybeShuffleMapOutputLoss = isShuffleMapTasks &&
        (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
@@ -84,3 +60,39 @@ diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
        for ((tid, info) <- taskInfos if info.executorId == execId) {
          val index = info.index
          lazy val isShuffleMapOutputAvailable = reason match {
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+index 34878b8e561..169c25d05ec 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+@@ -30,7 +30,7 @@ import org.apache.spark.internal.config._
+ import org.apache.spark.resource.ResourceProfile.UNKNOWN_RESOURCE_PROFILE_ID
+ import org.apache.spark.scheduler._
+ import org.apache.spark.storage.{RDDBlockId, ShuffleDataBlockId}
+-import org.apache.spark.util.Clock
++import org.apache.spark.util.{Clock, Utils}
+ 
+ /**
+  * A monitor for executor activity, used by ExecutorAllocationManager to detect idle executors.
+@@ -552,7 +552,7 @@ private[spark] class ExecutorMonitor(
+     // This should only be used in the event thread.
+     private val shuffleIds = if (shuffleTrackingEnabled) new mutable.HashSet[Int]() else null
+ 
+-    def isIdle: Boolean = idleStart >= 0 && !hasActiveShuffle
++    def isIdle: Boolean = idleStart >= 0 && (!hasActiveShuffle || Utils.isCelebornEnabled(conf))
+ 
+     def updateRunningTasks(delta: Int): Unit = {
+       runningTasks = math.max(0, runningTasks + delta)
+diff --git a/core/src/main/scala/org/apache/spark/util/Utils.scala b/core/src/main/scala/org/apache/spark/util/Utils.scala
+index b4c9060f2e1..8ad92c20868 100644
+--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
++++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
+@@ -3271,6 +3271,9 @@ private[spark] object Utils extends Logging {
+     files.toSeq
+   }
+ 
++  def isCelebornEnabled(conf: SparkConf): Boolean =
++    conf.get("spark.shuffle.manager", "sort").contains("celeborn")
++
+   /**
+    * Return the median number of a long array
+    *

--- a/assets/spark-patch/Celeborn_Dynamic_Allocation_spark3_5.patch
+++ b/assets/spark-patch/Celeborn_Dynamic_Allocation_spark3_5.patch
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Subject: [PATCH] [CORE][SHUFFLE] Support enabling DRA with Apache Celeborn
+---
+Index: core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+index 441bf60e489..8e967825fd3 100644
+--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
++++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+@@ -210,7 +210,7 @@ private[spark] class ExecutorAllocationManager(
+       } else if (decommissionEnabled &&
+           conf.get(config.STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED)) {
+         logInfo("Shuffle data decommission is enabled without a shuffle service.")
+-      } else if (!testing) {
++      } else if (!testing && !Utils.isCelebornEnabled(conf)) {
+         throw new SparkException("Dynamic allocation of executors requires one of the " +
+           "following conditions: 1) enabling external shuffle service through " +
+           s"${config.SHUFFLE_SERVICE_ENABLED.key}. 2) enabling shuffle tracking through " +
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+index 89d16e57934..d7456d37e46 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+@@ -2585,7 +2585,8 @@ private[spark] class DAGScheduler(
+     // if the cluster manager explicitly tells us that the entire worker was lost, then
+     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
+     // from a Standalone cluster, where the shuffle service lives in the Worker.)
+-    val fileLost = !sc.shuffleDriverComponents.supportsReliableStorage() &&
++    val fileLost = !Utils.isCelebornEnabled(sc.getConf) &&
++      !sc.shuffleDriverComponents.supportsReliableStorage() &&
+       (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
+     removeExecutorAndUnregisterOutputs(
+       execId = execId,
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+index 69b626029e4..d8361b87043 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+@@ -1049,7 +1049,7 @@ private[spark] class TaskSetManager(
+     val maybeShuffleMapOutputLoss = isShuffleMapTasks &&
+       !sched.sc.shuffleDriverComponents.supportsReliableStorage() &&
+       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
+-    if (maybeShuffleMapOutputLoss && !isZombie) {
++    if (maybeShuffleMapOutputLoss && !isZombie && !Utils.isCelebornEnabled(conf)) {
+       for ((tid, info) <- taskInfos if info.executorId == execId) {
+         val index = info.index
+         lazy val isShuffleMapOutputAvailable = reason match {
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+index 34878b8e561..169c25d05ec 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+@@ -30,7 +30,7 @@ import org.apache.spark.internal.config._
+ import org.apache.spark.resource.ResourceProfile.UNKNOWN_RESOURCE_PROFILE_ID
+ import org.apache.spark.scheduler._
+ import org.apache.spark.storage.{RDDBlockId, ShuffleDataBlockId}
+-import org.apache.spark.util.Clock
++import org.apache.spark.util.{Clock, Utils}
+ 
+ /**
+  * A monitor for executor activity, used by ExecutorAllocationManager to detect idle executors.
+@@ -552,7 +552,7 @@ private[spark] class ExecutorMonitor(
+     // This should only be used in the event thread.
+     private val shuffleIds = if (shuffleTrackingEnabled) new mutable.HashSet[Int]() else null
+ 
+-    def isIdle: Boolean = idleStart >= 0 && !hasActiveShuffle
++    def isIdle: Boolean = idleStart >= 0 && (!hasActiveShuffle || Utils.isCelebornEnabled(conf))
+ 
+     def updateRunningTasks(delta: Int): Unit = {
+       runningTasks = math.max(0, runningTasks + delta)
+diff --git a/core/src/main/scala/org/apache/spark/util/Utils.scala b/core/src/main/scala/org/apache/spark/util/Utils.scala
+index 3b0efffedec..393fcad3576 100644
+--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
++++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
+@@ -3071,6 +3071,9 @@ private[spark] object Utils
+     files.toSeq
+   }
+ 
++  def isCelebornEnabled(conf: SparkConf): Boolean =
++    conf.get("spark.shuffle.manager", "sort").contains("celeborn")
++
+   /**
+    * Return the median number of a long array
+    *


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Remove idle executors when spark.dynamicAllocation.enabled is true and using Celeborn

### Why are the changes needed?
When using Celeborn as remote shuffle service,  the idle executors can be removed although `hasActiveShuffle` is true in DRA condition.


### Does this PR introduce _any_ user-facing change?
Spark patch change.


### How was this patch tested?
Cluster testing.
