### PR TITLE
[CELEBORN-1854] Change receive revive request log level to debug

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -379,7 +379,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         }
         causes.add(Utils.toStatusCode(info.getStatus))
       }
-      logWarning(s"Received Revive request, number of partitions ${partitionIds.size()}")
+      logDebug(s"Received Revive request, number of partitions ${partitionIds.size()}")
       handleRevive(
         context,
         shuffleId,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Change log level of revive request to debug.

### Why are the changes needed?

This log is very spammy and fills up the driver logs 

```
25/02/06 16:02:14 WARN [celeborn-dispatcher-4] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-15] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-7] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-3] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-2] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-17] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-12] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-8] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-27] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-0] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-28] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-29] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-1] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-25] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-25] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-22] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:14 WARN [celeborn-dispatcher-18] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-client-lifecycle-manager-change-partition-executor-7] ChangePartitionManager: Batch handle change partition for [0-2-322]
25/02/06 16:02:15 INFO [celeborn-client-lifecycle-manager-change-partition-executor-7] LifecycleManager: Try reserve slots for 0 for 1 times.
25/02/06 16:02:15 INFO [celeborn-client-lifecycle-manager-change-partition-executor-7] LifecycleManager: Reserve buffer success for shuffleId 0
25/02/06 16:02:15 INFO [celeborn-client-lifecycle-manager-change-partition-executor-7] ChangePartitionManager: [Update partition] success for shuffle 0, succeed partitions: [(partition 2 epoch from 322 to 323)].
25/02/06 16:02:15 WARN [celeborn-dispatcher-13] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-5] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-21] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-19] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-24] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-9] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-23] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-20] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-6] LifecycleManager: Received Revive request, number of partitions 1
25/02/06 16:02:15 WARN [celeborn-dispatcher-14] LifecycleManager: Received Revive request, number of partitions 1
```


### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA