### PR TITLE
[CELEBORN-1859] DfsPartitionReader and LocalPartitionReader should reuse pbStreamHandlers get from BatchOpenStream request

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -435,7 +435,7 @@ public abstract class CelebornInputStream extends InputStream {
             logger.debug("Read local shuffle file {}", localHostAddress);
             containLocalRead = true;
             return new LocalPartitionReader(
-                conf, shuffleKey, location, clientFactory, startMapIndex, endMapIndex, callback);
+                conf, shuffleKey, location, pbStreamHandler, clientFactory, startMapIndex, endMapIndex, callback);
           } else {
             return new WorkerPartitionReader(
                 conf,
@@ -452,7 +452,7 @@ public abstract class CelebornInputStream extends InputStream {
         case S3:
         case HDFS:
           return new DfsPartitionReader(
-              conf, shuffleKey, location, clientFactory, startMapIndex, endMapIndex, callback);
+              conf, shuffleKey, location, pbStreamHandler, clientFactory, startMapIndex, endMapIndex, callback);
         default:
           throw new CelebornIOException(
               String.format("Unknown storage info %s to read location %s", storageInfo, location));

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -435,7 +435,14 @@ public abstract class CelebornInputStream extends InputStream {
             logger.debug("Read local shuffle file {}", localHostAddress);
             containLocalRead = true;
             return new LocalPartitionReader(
-                conf, shuffleKey, location, pbStreamHandler, clientFactory, startMapIndex, endMapIndex, callback);
+                conf,
+                shuffleKey,
+                location,
+                pbStreamHandler,
+                clientFactory,
+                startMapIndex,
+                endMapIndex,
+                callback);
           } else {
             return new WorkerPartitionReader(
                 conf,
@@ -452,7 +459,14 @@ public abstract class CelebornInputStream extends InputStream {
         case S3:
         case HDFS:
           return new DfsPartitionReader(
-              conf, shuffleKey, location, pbStreamHandler, clientFactory, startMapIndex, endMapIndex, callback);
+              conf,
+              shuffleKey,
+              location,
+              pbStreamHandler,
+              clientFactory,
+              startMapIndex,
+              endMapIndex,
+              callback);
         default:
           throw new CelebornIOException(
               String.format("Unknown storage info %s to read location %s", storageInfo, location));

--- a/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
@@ -102,23 +102,23 @@ public class DfsPartitionReader implements PartitionReader {
         try {
           client = clientFactory.createClient(location.getHost(), location.getFetchPort());
           TransportMessage openStream =
-                  new TransportMessage(
-                          MessageType.OPEN_STREAM,
-                          PbOpenStream.newBuilder()
-                                  .setShuffleKey(shuffleKey)
-                                  .setFileName(location.getFileName())
-                                  .setStartIndex(startMapIndex)
-                                  .setEndIndex(endMapIndex)
-                                  .build()
-                                  .toByteArray());
+              new TransportMessage(
+                  MessageType.OPEN_STREAM,
+                  PbOpenStream.newBuilder()
+                      .setShuffleKey(shuffleKey)
+                      .setFileName(location.getFileName())
+                      .setStartIndex(startMapIndex)
+                      .setEndIndex(endMapIndex)
+                      .build()
+                      .toByteArray());
           ByteBuffer response = client.sendRpcSync(openStream.toByteBuffer(), fetchTimeoutMs);
           streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
           // Parse this message to ensure sort is done.
         } catch (IOException | InterruptedException e) {
           throw new IOException(
-                  "read shuffle file from DFS failed, filePath: "
-                          + location.getStorageInfo().getFilePath(),
-                  e);
+              "read shuffle file from DFS failed, filePath: "
+                  + location.getStorageInfo().getFilePath(),
+              e);
         }
       }
 

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -74,6 +74,7 @@ public class LocalPartitionReader implements PartitionReader {
       CelebornConf conf,
       String shuffleKey,
       PartitionLocation location,
+      PbStreamHandler pbStreamHandler,
       TransportClientFactory clientFactory,
       int startMapIndex,
       int endMapIndex,
@@ -95,19 +96,23 @@ public class LocalPartitionReader implements PartitionReader {
     long fetchTimeoutMs = conf.clientFetchTimeoutMs();
     try {
       client = clientFactory.createClient(location.getHost(), location.getFetchPort(), 0);
-      TransportMessage openStreamMsg =
-          new TransportMessage(
-              MessageType.OPEN_STREAM,
-              PbOpenStream.newBuilder()
-                  .setShuffleKey(shuffleKey)
-                  .setFileName(location.getFileName())
-                  .setStartIndex(startMapIndex)
-                  .setEndIndex(endMapIndex)
-                  .setReadLocalShuffle(true)
-                  .build()
-                  .toByteArray());
-      ByteBuffer response = client.sendRpcSync(openStreamMsg.toByteBuffer(), fetchTimeoutMs);
-      streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
+      if (pbStreamHandler == null) {
+        TransportMessage openStreamMsg =
+                new TransportMessage(
+                        MessageType.OPEN_STREAM,
+                        PbOpenStream.newBuilder()
+                                .setShuffleKey(shuffleKey)
+                                .setFileName(location.getFileName())
+                                .setStartIndex(startMapIndex)
+                                .setEndIndex(endMapIndex)
+                                .setReadLocalShuffle(true)
+                                .build()
+                                .toByteArray());
+        ByteBuffer response = client.sendRpcSync(openStreamMsg.toByteBuffer(), fetchTimeoutMs);
+        streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
+      } else {
+        this.streamHandler = pbStreamHandler;
+      }
     } catch (IOException | InterruptedException e) {
       throw new IOException(
           "Read shuffle file from local file failed, partition location: "

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -98,16 +98,16 @@ public class LocalPartitionReader implements PartitionReader {
       client = clientFactory.createClient(location.getHost(), location.getFetchPort(), 0);
       if (pbStreamHandler == null) {
         TransportMessage openStreamMsg =
-                new TransportMessage(
-                        MessageType.OPEN_STREAM,
-                        PbOpenStream.newBuilder()
-                                .setShuffleKey(shuffleKey)
-                                .setFileName(location.getFileName())
-                                .setStartIndex(startMapIndex)
-                                .setEndIndex(endMapIndex)
-                                .setReadLocalShuffle(true)
-                                .build()
-                                .toByteArray());
+            new TransportMessage(
+                MessageType.OPEN_STREAM,
+                PbOpenStream.newBuilder()
+                    .setShuffleKey(shuffleKey)
+                    .setFileName(location.getFileName())
+                    .setStartIndex(startMapIndex)
+                    .setEndIndex(endMapIndex)
+                    .setReadLocalShuffle(true)
+                    .build()
+                    .toByteArray());
         ByteBuffer response = client.sendRpcSync(openStreamMsg.toByteBuffer(), fetchTimeoutMs);
         streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

DfsPartitionReader and LocalPartitionReader should reuse pbStreamHandlers get from BatchOpenStream request like WorkerPartitionReader instead of sending another OpenStream Request.

### Why are the changes needed?

Reduce unnecessary rpc requests

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Test manually in test cluster 