### PR TITLE
[CELEBORN-1861] Support celeborn.worker.storage.baseDir.diskType option to specify disk type of base directory for worker

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -3084,8 +3084,8 @@ object CelebornConf extends Logging {
       .internal
       .categories("worker")
       .version("0.6.0")
-      .doc(
-        s"The disk type of base directory for worker. Available options: ${StorageInfo.Type.HDD.name}, ${StorageInfo.Type.SSD.name}.")
+      .doc(s"The disk type of base directory for worker to write if `${WORKER_STORAGE_DIRS.key}` is not set. " +
+        s"Available options: ${StorageInfo.Type.HDD.name}, ${StorageInfo.Type.SSD.name}.")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(Set(StorageInfo.Type.HDD.name, StorageInfo.Type.SSD.name))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support `celeborn.worker.storage.baseDir.diskType` option to specify disk type of base directory for worker.

### Why are the changes needed?

The disk type of base directory for worker is `HDD` at default. We could support `celeborn.worker.storage.baseDir.diskType` option to specify disk type of base directory for worker.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.