### PR TITLE
[CELEBORN-1863][CIP-14] Add TransportClient to cppClient

### DIFF
--- a/cpp/celeborn/network/CMakeLists.txt
+++ b/cpp/celeborn/network/CMakeLists.txt
@@ -16,13 +16,15 @@ add_library(
         network
         STATIC
         Message.cpp
-        MessageDispatcher.cpp)
+        MessageDispatcher.cpp
+        TransportClient.cpp)
 
 target_include_directories(network PUBLIC ${CMAKE_BINARY_DIR})
 
 target_link_libraries(
         network
         memory
+        conf
         proto
         utils
         protocol

--- a/cpp/celeborn/network/MessageDispatcher.h
+++ b/cpp/celeborn/network/MessageDispatcher.h
@@ -52,62 +52,62 @@ class MessageDispatcher : public wangle::ClientDispatcherBase<
                               SerializePipeline,
                               std::unique_ptr<Message>,
                               std::unique_ptr<Message>> {
-public:
-    void read(Context*, std::unique_ptr<Message> toRecvMsg) override;
+ public:
+  void read(Context*, std::unique_ptr<Message> toRecvMsg) override;
 
-    virtual folly::Future<std::unique_ptr<Message>> sendRpcRequest(
-        std::unique_ptr<Message> toSendMsg) {
-        return operator()(std::move(toSendMsg));
-    }
+  virtual folly::Future<std::unique_ptr<Message>> sendRpcRequest(
+      std::unique_ptr<Message> toSendMsg) {
+    return operator()(std::move(toSendMsg));
+  }
 
-    virtual folly::Future<std::unique_ptr<Message>> sendFetchChunkRequest(
-        const protocol::StreamChunkSlice& streamChunkSlice,
-        std::unique_ptr<Message> toSendMsg);
+  virtual folly::Future<std::unique_ptr<Message>> sendFetchChunkRequest(
+      const protocol::StreamChunkSlice& streamChunkSlice,
+      std::unique_ptr<Message> toSendMsg);
 
-    virtual void sendRpcRequestWithoutResponse(
-        std::unique_ptr<Message> toSendMsg);
+  virtual void sendRpcRequestWithoutResponse(
+      std::unique_ptr<Message> toSendMsg);
 
-    folly::Future<std::unique_ptr<Message>> operator()(
-        std::unique_ptr<Message> toSendMsg) override;
+  folly::Future<std::unique_ptr<Message>> operator()(
+      std::unique_ptr<Message> toSendMsg) override;
 
-    void readEOF(Context* ctx) override;
+  void readEOF(Context* ctx) override;
 
-    void readException(Context* ctx, folly::exception_wrapper e) override;
+  void readException(Context* ctx, folly::exception_wrapper e) override;
 
-    void transportActive(Context* ctx) override;
+  void transportActive(Context* ctx) override;
 
-    void transportInactive(Context* ctx) override;
+  void transportInactive(Context* ctx) override;
 
-    folly::Future<folly::Unit> writeException(
-        Context* ctx,
-        folly::exception_wrapper e) override;
+  folly::Future<folly::Unit> writeException(
+      Context* ctx,
+      folly::exception_wrapper e) override;
 
-    folly::Future<folly::Unit> close() override;
+  folly::Future<folly::Unit> close() override;
 
-    folly::Future<folly::Unit> close(Context* ctx) override;
+  folly::Future<folly::Unit> close(Context* ctx) override;
 
-    bool isAvailable() override {
-        return !closed_;
-    }
+  bool isAvailable() override {
+    return !closed_;
+  }
 
-private:
-    void cleanup();
+ private:
+  void cleanup();
 
-    using MsgPromise = folly::Promise<std::unique_ptr<Message>>;
-    struct MsgPromiseHolder {
-        MsgPromise msgPromise;
-        std::chrono::time_point<std::chrono::system_clock> requestTime;
-    };
-    folly::Synchronized<std::unordered_map<long, MsgPromiseHolder>, std::mutex>
-        requestIdRegistry_;
-    folly::Synchronized<
-        std::unordered_map<
-            protocol::StreamChunkSlice,
-            MsgPromiseHolder,
-            protocol::StreamChunkSlice::Hasher>,
-        std::mutex>
-        streamChunkSliceRegistry_;
-    std::atomic<bool> closed_{false};
+  using MsgPromise = folly::Promise<std::unique_ptr<Message>>;
+  struct MsgPromiseHolder {
+    MsgPromise msgPromise;
+    std::chrono::time_point<std::chrono::system_clock> requestTime;
+  };
+  folly::Synchronized<std::unordered_map<long, MsgPromiseHolder>, std::mutex>
+      requestIdRegistry_;
+  folly::Synchronized<
+      std::unordered_map<
+          protocol::StreamChunkSlice,
+          MsgPromiseHolder,
+          protocol::StreamChunkSlice::Hasher>,
+      std::mutex>
+      streamChunkSliceRegistry_;
+  std::atomic<bool> closed_{false};
 };
 } // namespace network
 } // namespace celeborn

--- a/cpp/celeborn/network/TransportClient.cpp
+++ b/cpp/celeborn/network/TransportClient.cpp
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "celeborn/network/TransportClient.h"
+
+#include "celeborn/network/FrameDecoder.h"
+#include "celeborn/protocol/TransportMessage.h"
+
+namespace celeborn {
+namespace network {
+void MessageSerializeHandler::read(
+    Context* ctx,
+    std::unique_ptr<folly::IOBuf> msg) {
+  auto buffer = memory::ByteBuffer::createReadOnly(std::move(msg));
+  ctx->fireRead(Message::decodeFrom(std::move(buffer)));
+}
+
+folly::Future<folly::Unit> MessageSerializeHandler::write(
+    Context* ctx,
+    std::unique_ptr<Message> msg) {
+  return ctx->fireWrite(msg->encode()->getData());
+}
+
+TransportClient::TransportClient(
+    std::unique_ptr<wangle::ClientBootstrap<SerializePipeline>> client,
+    std::unique_ptr<MessageDispatcher> dispatcher,
+    Timeout defaultTimeout)
+    : client_(std::move(client)),
+      dispatcher_(std::move(dispatcher)),
+      defaultTimeout_(defaultTimeout) {}
+
+RpcResponse TransportClient::sendRpcRequestSync(
+    const RpcRequest& request,
+    Timeout timeout) {
+  try {
+    auto requestMsg = std::make_unique<RpcRequest>(request);
+    auto future = dispatcher_->sendRpcRequest(std::move(requestMsg));
+    auto responseMsg = std::move(future).get(timeout);
+    CELEBORN_CHECK(
+        responseMsg->type() == Message::RPC_RESPONSE,
+        "responseMsg type should be RPC_RESPONSE");
+    return RpcResponse(*reinterpret_cast<RpcResponse*>(responseMsg.get()));
+  } catch (const std::exception& e) {
+    std::string errorMsg = fmt::format(
+        "sendRpc failure, requestId: {}, timeout: {}, errorMsg: {}",
+        request.requestId(),
+        timeout,
+        folly::exceptionStr(e).toStdString());
+    LOG(ERROR) << errorMsg;
+    CELEBORN_FAIL(errorMsg);
+  }
+}
+
+void TransportClient::sendRpcRequestWithoutResponse(const RpcRequest& request) {
+  try {
+    auto requestMsg = std::make_unique<RpcRequest>(request);
+    dispatcher_->sendRpcRequestWithoutResponse(std::move(requestMsg));
+  } catch (const std::exception& e) {
+    std::string errorMsg = fmt::format(
+        "sendRpc failure, requestId: {}, errorMsg: {}",
+        request.requestId(),
+        folly::exceptionStr(e).toStdString());
+    LOG(ERROR) << errorMsg;
+    CELEBORN_FAIL(errorMsg);
+  }
+}
+
+void TransportClient::fetchChunkAsync(
+    const protocol::StreamChunkSlice& streamChunkSlice,
+    const RpcRequest& request,
+    FetchChunkSuccessCallback onSuccess,
+    FetchChunkFailureCallback onFailure) {
+  try {
+    auto requestMsg = std::make_unique<RpcRequest>(request);
+    auto future = dispatcher_->sendFetchChunkRequest(
+        streamChunkSlice, std::move(requestMsg));
+    std::move(future)
+        .thenValue([=, _onSuccess = onSuccess, _onFailure = onFailure](
+                       std::unique_ptr<Message> responseMsg) {
+          if (responseMsg->type() == Message::CHUNK_FETCH_SUCCESS) {
+            auto chunkFetchSuccess =
+                reinterpret_cast<ChunkFetchSuccess*>(responseMsg.get());
+            _onSuccess(streamChunkSlice, chunkFetchSuccess->body());
+          } else {
+            _onFailure(
+                streamChunkSlice,
+                std::make_unique<std::runtime_error>(fmt::format(
+                    "chunk fetch of streamChunkSlice {} does not succeed",
+                    streamChunkSlice.toString())));
+          }
+        })
+        .thenError(
+            [=, _onFailure = onFailure](const folly::exception_wrapper& e) {
+              _onFailure(
+                  streamChunkSlice,
+                  std::make_unique<std::runtime_error>(e.what().toStdString()));
+            });
+  } catch (std::exception& e) {
+    CELEBORN_FAIL(e.what());
+  }
+}
+
+SerializePipeline::Ptr MessagePipelineFactory::newPipeline(
+    std::shared_ptr<folly::AsyncTransport> sock) {
+  auto pipeline = SerializePipeline::create();
+  pipeline->addBack(wangle::AsyncSocketHandler(sock));
+  // Ensure we can write from any thread.
+  pipeline->addBack(wangle::EventBaseHandler());
+  pipeline->addBack(FrameDecoder());
+  pipeline->addBack(MessageSerializeHandler());
+  pipeline->finalize();
+
+  return pipeline;
+}
+
+TransportClientFactory::TransportClientFactory(
+    const std::shared_ptr<conf::CelebornConf>& conf) {
+  numConnectionsPerPeer_ = conf->networkIoNumConnectionsPerPeer();
+  rpcLookupTimeout_ = conf->rpcLookupTimeout();
+  connectTimeout_ = conf->networkConnectTimeout();
+  numClientThreads_ = conf->networkIoClientThreads();
+  if (numClientThreads_ <= 0) {
+    numClientThreads_ = std::thread::hardware_concurrency() * 2;
+  }
+  clientExecutor_ =
+      std::make_shared<folly::IOThreadPoolExecutor>(numClientThreads_);
+}
+
+std::shared_ptr<TransportClient> TransportClientFactory::createClient(
+    const std::string& host,
+    uint16_t port) {
+  auto address = folly::SocketAddress(host, port);
+  auto pool = clientPools_.withLock([&](auto& registry) {
+    auto iter = registry.find(address);
+    if (iter != registry.end()) {
+      return iter->second;
+    }
+    auto createdPool = std::make_shared<ClientPool>();
+    createdPool->clients.resize(numConnectionsPerPeer_);
+    registry[address] = createdPool;
+    return createdPool;
+  });
+  auto clientId = std::rand() % numConnectionsPerPeer_;
+  {
+    std::lock_guard<std::mutex> lock(pool->mutex);
+    // TODO: auto-disconnect if the connection is idle for a long time?
+    if (pool->clients[clientId] && pool->clients[clientId]->active()) {
+      VLOG(1) << "reusing client for address host " << host << " port " << port;
+      return pool->clients[clientId];
+    }
+
+    auto bootstrap =
+        std::make_unique<wangle::ClientBootstrap<SerializePipeline>>();
+    bootstrap->group(clientExecutor_);
+    bootstrap->pipelineFactory(std::make_shared<MessagePipelineFactory>());
+    try {
+      auto pipeline = bootstrap->connect(folly::SocketAddress(host, port))
+                          .get(rpcLookupTimeout_);
+
+      auto dispatcher = std::make_unique<MessageDispatcher>();
+      dispatcher->setPipeline(pipeline);
+      pool->clients[clientId] = std::make_shared<TransportClient>(
+          std::move(bootstrap), std::move(dispatcher), connectTimeout_);
+      return pool->clients[clientId];
+    } catch (const std::exception& e) {
+      std::string errorMsg = fmt::format(
+          "connect to server failure, serverAddr: {}:{}, timeout: {}, errorMsg: {}",
+          host,
+          port,
+          connectTimeout_,
+          folly::exceptionStr(e).toStdString());
+      LOG(ERROR) << errorMsg;
+      CELEBORN_FAIL(errorMsg);
+    }
+  }
+}
+} // namespace network
+} // namespace celeborn

--- a/cpp/celeborn/network/TransportClient.h
+++ b/cpp/celeborn/network/TransportClient.h
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fmt/chrono.h>
+#include <folly/io/IOBuf.h>
+#include <wangle/bootstrap/ClientBootstrap.h>
+#include <wangle/channel/EventBaseHandler.h>
+#include <wangle/service/ClientDispatcher.h>
+
+#include "celeborn/conf/CelebornConf.h"
+#include "celeborn/network/Message.h"
+#include "celeborn/network/MessageDispatcher.h"
+#include "celeborn/protocol/ControlMessages.h"
+#include "celeborn/utils/CelebornUtils.h"
+
+namespace celeborn {
+namespace network {
+/**
+ * MessageSerializeHandler serializes Message into folly::IOBuf when write(),
+ * and deserializes folly::IOBuf into Message when read().
+ */
+class MessageSerializeHandler : public wangle::Handler<
+                                   std::unique_ptr<folly::IOBuf>,
+                                   std::unique_ptr<Message>,
+                                   std::unique_ptr<Message>,
+                                   std::unique_ptr<folly::IOBuf>> {
+public:
+  void read(Context* ctx, std::unique_ptr<folly::IOBuf> msg) override;
+
+  folly::Future<folly::Unit> write(Context* ctx, std::unique_ptr<Message> msg)
+      override;
+};
+
+using FetchChunkSuccessCallback = std::function<void(
+    protocol::StreamChunkSlice,
+    std::unique_ptr<memory::ReadOnlyByteBuffer>)>;
+
+using FetchChunkFailureCallback = std::function<void(
+    protocol::StreamChunkSlice,
+    std::unique_ptr<std::exception>)>;
+
+/**
+ * TransportClient sends the messages to the network layer, and handles
+ * the message callback, timeout, error handling, etc.
+ */
+class TransportClient {
+public:
+  TransportClient(
+      std::unique_ptr<wangle::ClientBootstrap<SerializePipeline>> client,
+      std::unique_ptr<MessageDispatcher> dispatcher,
+      Timeout defaultTimeout);
+
+  RpcResponse sendRpcRequestSync(const RpcRequest& request) {
+    return sendRpcRequestSync(request, defaultTimeout_);
+  }
+
+  RpcResponse sendRpcRequestSync(const RpcRequest& request, Timeout timeout);
+
+  // Ignore the response, return immediately.
+  void sendRpcRequestWithoutResponse(const RpcRequest& request);
+
+  void fetchChunkAsync(
+      const protocol::StreamChunkSlice& streamChunkSlice,
+      const RpcRequest& request,
+      FetchChunkSuccessCallback onSuccess,
+      FetchChunkFailureCallback onFailure);
+
+  bool active() const {
+    return dispatcher_->isAvailable();
+  }
+
+  ~TransportClient() = default;
+
+private:
+  std::unique_ptr<wangle::ClientBootstrap<SerializePipeline>> client_;
+  std::unique_ptr<MessageDispatcher> dispatcher_;
+  Timeout defaultTimeout_;
+};
+
+class MessagePipelineFactory
+    : public wangle::PipelineFactory<SerializePipeline> {
+public:
+  SerializePipeline::Ptr newPipeline(
+      std::shared_ptr<folly::AsyncTransport> sock) override;
+};
+
+class TransportClientFactory {
+public:
+  TransportClientFactory(const std::shared_ptr<conf::CelebornConf>& conf);
+
+  std::shared_ptr<TransportClient> createClient(
+      const std::string& host,
+      uint16_t port);
+
+private:
+  struct ClientPool {
+    std::mutex mutex;
+    std::vector<std::shared_ptr<TransportClient>> clients;
+  };
+
+  struct Hasher {
+    size_t operator()(const folly::SocketAddress& lhs) const {
+      return lhs.hash();
+    }
+  };
+
+  int numConnectionsPerPeer_;
+  folly::Synchronized<
+      std::unordered_map<
+          folly::SocketAddress,
+          std::shared_ptr<ClientPool>,
+          Hasher>,
+      std::mutex>
+      clientPools_;
+  Timeout rpcLookupTimeout_;
+  Timeout connectTimeout_;
+  int numClientThreads_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> clientExecutor_;
+};
+} // namespace network
+} // namespace celeborn

--- a/cpp/celeborn/network/tests/CMakeLists.txt
+++ b/cpp/celeborn/network/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ add_executable(
         celeborn_network_test
         FrameDecoderTest.cpp
         MessageTest.cpp
-        MessageDispatcherTest.cpp)
+        MessageDispatcherTest.cpp
+        TransportClientTest.cpp)
 
 add_test(NAME celeborn_network_test COMMAND celeborn_network_test)
 
@@ -25,6 +26,7 @@ target_link_libraries(
         celeborn_network_test
         PRIVATE
         memory
+        conf
         proto
         protocol
         network

--- a/cpp/celeborn/network/tests/MessageDispatcherTest.cpp
+++ b/cpp/celeborn/network/tests/MessageDispatcherTest.cpp
@@ -64,8 +64,8 @@ std::unique_ptr<memory::ReadOnlyByteBuffer> toReadOnlyByteBuffer(
 } // namespace
 
 TEST(MessageDispatcherTest, sendRpcRequestAndReceiveResponse) {
-  std::unique_ptr<Message> sendedMsg;
-  MockHandler mockHandler(sendedMsg);
+  std::unique_ptr<Message> sentMsg;
+  MockHandler mockHandler(sentMsg);
   auto mockPipeline = createMockedPipeline(std::move(mockHandler));
   auto dispatcher = std::make_unique<MessageDispatcher>();
   dispatcher->setPipeline(mockPipeline.get());
@@ -77,11 +77,11 @@ TEST(MessageDispatcherTest, sendRpcRequestAndReceiveResponse) {
   auto future = dispatcher->sendRpcRequest(std::move(rpcRequest));
 
   EXPECT_FALSE(future.isReady());
-  EXPECT_EQ(sendedMsg->type(), Message::RPC_REQUEST);
-  auto sendedRpcRequest = dynamic_cast<RpcRequest*>(sendedMsg.get());
-  EXPECT_EQ(sendedRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
   EXPECT_EQ(
-      sendedRpcRequest->body()->readToString(requestBody.size()), requestBody);
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
 
   const std::string responseBody = "test-response-body";
   auto rpcResponse = std::make_unique<RpcResponse>(
@@ -99,8 +99,8 @@ TEST(MessageDispatcherTest, sendRpcRequestAndReceiveResponse) {
 }
 
 TEST(MessageDispatcherTest, sendRpcRequestAndReceiveFailure) {
-  std::unique_ptr<Message> sendedMsg;
-  MockHandler mockHandler(sendedMsg);
+  std::unique_ptr<Message> sentMsg;
+  MockHandler mockHandler(sentMsg);
   auto mockPipeline = createMockedPipeline(std::move(mockHandler));
   auto dispatcher = std::make_unique<MessageDispatcher>();
   dispatcher->setPipeline(mockPipeline.get());
@@ -112,11 +112,11 @@ TEST(MessageDispatcherTest, sendRpcRequestAndReceiveFailure) {
   auto future = dispatcher->sendRpcRequest(std::move(rpcRequest));
 
   EXPECT_FALSE(future.isReady());
-  EXPECT_EQ(sendedMsg->type(), Message::RPC_REQUEST);
-  auto sendedRpcRequest = dynamic_cast<RpcRequest*>(sendedMsg.get());
-  EXPECT_EQ(sendedRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
   EXPECT_EQ(
-      sendedRpcRequest->body()->readToString(requestBody.size()), requestBody);
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
 
   const std::string errorMsg = "test-error-msg";
   auto copiedErrorMsg = errorMsg;
@@ -128,8 +128,8 @@ TEST(MessageDispatcherTest, sendRpcRequestAndReceiveFailure) {
 }
 
 TEST(MessageDispatcherTest, sendFetchChunkRequestAndReceiveSuccess) {
-  std::unique_ptr<Message> sendedMsg;
-  MockHandler mockHandler(sendedMsg);
+  std::unique_ptr<Message> sentMsg;
+  MockHandler mockHandler(sentMsg);
   auto mockPipeline = createMockedPipeline(std::move(mockHandler));
   auto dispatcher = std::make_unique<MessageDispatcher>();
   dispatcher->setPipeline(mockPipeline.get());
@@ -143,11 +143,11 @@ TEST(MessageDispatcherTest, sendFetchChunkRequestAndReceiveSuccess) {
       streamChunkSlice, std::move(rpcRequest));
 
   EXPECT_FALSE(future.isReady());
-  EXPECT_EQ(sendedMsg->type(), Message::RPC_REQUEST);
-  auto sendedRpcRequest = dynamic_cast<RpcRequest*>(sendedMsg.get());
-  EXPECT_EQ(sendedRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
   EXPECT_EQ(
-      sendedRpcRequest->body()->readToString(requestBody.size()), requestBody);
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
 
   const std::string chunkFetchSuccessBody = "test-chunk-fetch-success-body";
   auto chunkFetchSuccess = std::make_unique<ChunkFetchSuccess>(
@@ -169,8 +169,8 @@ TEST(MessageDispatcherTest, sendFetchChunkRequestAndReceiveSuccess) {
 }
 
 TEST(MessageDispatcherTest, sendFetchChunkRequestAndReceiveFailure) {
-  std::unique_ptr<Message> sendedMsg;
-  MockHandler mockHandler(sendedMsg);
+  std::unique_ptr<Message> sentMsg;
+  MockHandler mockHandler(sentMsg);
   auto mockPipeline = createMockedPipeline(std::move(mockHandler));
   auto dispatcher = std::make_unique<MessageDispatcher>();
   dispatcher->setPipeline(mockPipeline.get());
@@ -184,11 +184,11 @@ TEST(MessageDispatcherTest, sendFetchChunkRequestAndReceiveFailure) {
       streamChunkSlice, std::move(rpcRequest));
 
   EXPECT_FALSE(future.isReady());
-  EXPECT_EQ(sendedMsg->type(), Message::RPC_REQUEST);
-  auto sendedRpcRequest = dynamic_cast<RpcRequest*>(sendedMsg.get());
-  EXPECT_EQ(sendedRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
   EXPECT_EQ(
-      sendedRpcRequest->body()->readToString(requestBody.size()), requestBody);
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
 
   const std::string errorMsg = "test-error-msg";
   auto copiedErrorMsg = errorMsg;

--- a/cpp/celeborn/network/tests/TransportClientTest.cpp
+++ b/cpp/celeborn/network/tests/TransportClientTest.cpp
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celeborn/network/TransportClient.h"
+
+using namespace celeborn;
+using namespace celeborn::network;
+
+namespace {
+using MS = std::chrono::milliseconds;
+class MockDispatcher : public MessageDispatcher {
+ public:
+  folly::Future<std::unique_ptr<Message>> sendRpcRequest(
+      std::unique_ptr<Message> toSendMsg) override {
+    sentMsg_ = std::move(toSendMsg);
+    msgPromise_ = MsgPromise();
+    return msgPromise_.getFuture();
+  }
+
+  void sendRpcRequestWithoutResponse(
+      std::unique_ptr<Message> toSendMsg) override {
+    sentMsg_ = std::move(toSendMsg);
+  }
+
+  folly::Future<std::unique_ptr<Message>> sendFetchChunkRequest(
+      const protocol::StreamChunkSlice& streamChunkSlice,
+      std::unique_ptr<Message> toSendMsg) override {
+    sentMsg_ = std::move(toSendMsg);
+    msgPromise_ = MsgPromise();
+    return msgPromise_.getFuture();
+  }
+
+  std::unique_ptr<Message> getSentMsg() {
+    return std::move(sentMsg_);
+  }
+
+  void receiveMsg(std::unique_ptr<Message> msg) {
+    msgPromise_.setValue(std::move(msg));
+  }
+
+ private:
+  using MsgPromise = folly::Promise<std::unique_ptr<Message>>;
+  std::unique_ptr<Message> sentMsg_;
+  MsgPromise msgPromise_;
+};
+
+std::unique_ptr<memory::ReadOnlyByteBuffer> toReadOnlyByteBuffer(
+    const std::string& content) {
+  auto buffer = memory::ByteBuffer::createWriteOnly(content.size());
+  buffer->writeFromString(content);
+  return memory::ByteBuffer::toReadOnly(std::move(buffer));
+}
+} // namespace
+
+TEST(TransportClientTest, sendRpcRequestSync) {
+  auto mockDispatcher = std::make_unique<MockDispatcher>();
+  auto rawMockDispatcher = mockDispatcher.get();
+  const auto timeoutInterval = MS(10000);
+  const auto sleepInterval = MS(100);
+  TransportClient client(nullptr, std::move(mockDispatcher), timeoutInterval);
+
+  const long requestId = 1001;
+  const std::string requestBody = "test-request-body";
+  auto rpcRequest = std::make_unique<RpcRequest>(
+      requestId, toReadOnlyByteBuffer(requestBody));
+  std::unique_ptr<RpcResponse> receivedRpcResponse;
+  std::thread syncThread([&]() {
+    auto responseMsg = client.sendRpcRequestSync(*rpcRequest, timeoutInterval);
+    receivedRpcResponse = std::make_unique<RpcResponse>(responseMsg);
+  });
+  std::this_thread::sleep_for(sleepInterval);
+
+  auto sentMsg = rawMockDispatcher->getSentMsg();
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
+
+  // The response is not received yet.
+  EXPECT_FALSE(receivedRpcResponse);
+  const std::string responseBody = "test-response-body";
+  auto rpcResponse = std::make_unique<RpcResponse>(
+      requestId, toReadOnlyByteBuffer(responseBody));
+  rawMockDispatcher->receiveMsg(std::move(rpcResponse));
+
+  syncThread.join();
+  // The response is received.
+  EXPECT_TRUE(receivedRpcResponse);
+  EXPECT_EQ(receivedRpcResponse->body()->remainingSize(), responseBody.size());
+  EXPECT_EQ(
+      receivedRpcResponse->body()->readToString(responseBody.size()),
+      responseBody);
+}
+
+TEST(TransportClientTest, sendRpcRequestSyncTimeout) {
+  auto mockDispatcher = std::make_unique<MockDispatcher>();
+  auto rawMockDispatcher = mockDispatcher.get();
+  const auto timeoutInterval = MS(200);
+  const auto sleepInterval = MS(100);
+  TransportClient client(nullptr, std::move(mockDispatcher), timeoutInterval);
+
+  const long requestId = 1001;
+  const std::string requestBody = "test-request-body";
+  auto rpcRequest = std::make_unique<RpcRequest>(
+      requestId, toReadOnlyByteBuffer(requestBody));
+  std::unique_ptr<RpcResponse> receivedRpcResponse;
+  bool timeoutHappened = false;
+  std::thread syncThread([&]() {
+    try {
+      auto responseMsg =
+          client.sendRpcRequestSync(*rpcRequest, timeoutInterval);
+      receivedRpcResponse = std::make_unique<RpcResponse>(responseMsg);
+    } catch (std::exception e) {
+      timeoutHappened = true;
+    }
+  });
+  std::this_thread::sleep_for(sleepInterval);
+
+  auto sentMsg = rawMockDispatcher->getSentMsg();
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
+
+  // The response is not received yet.
+  EXPECT_FALSE(receivedRpcResponse);
+
+  syncThread.join();
+  // Not response received, should be timeout.
+  EXPECT_FALSE(receivedRpcResponse);
+  EXPECT_TRUE(timeoutHappened);
+}
+
+TEST(TransportClientTest, sendRpcRequestWithoutResponse) {
+  auto mockDispatcher = std::make_unique<MockDispatcher>();
+  auto rawMockDispatcher = mockDispatcher.get();
+  const auto timeoutInterval = MS(10000);
+  TransportClient client(nullptr, std::move(mockDispatcher), timeoutInterval);
+
+  const long requestId = 1001;
+  const std::string requestBody = "test-request-body";
+  auto rpcRequest = std::make_unique<RpcRequest>(
+      requestId, toReadOnlyByteBuffer(requestBody));
+  client.sendRpcRequestWithoutResponse(*rpcRequest);
+
+  auto sentMsg = rawMockDispatcher->getSentMsg();
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
+}
+
+TEST(TransportClientTest, fetchChunkAsyncSuccess) {
+  auto mockDispatcher = std::make_unique<MockDispatcher>();
+  auto rawMockDispatcher = mockDispatcher.get();
+  TransportClient client(nullptr, std::move(mockDispatcher), MS(10000));
+
+  const protocol::StreamChunkSlice streamChunkSlice{1, 2, 3, 4};
+  const long requestId = 1001;
+  const std::string requestBody = "test-request-body";
+  auto rpcRequest = std::make_unique<RpcRequest>(
+      requestId, toReadOnlyByteBuffer(requestBody));
+  protocol::StreamChunkSlice onSuccessStreamChunkSlice;
+  std::unique_ptr<memory::ReadOnlyByteBuffer> onSuccessBuffer;
+  FetchChunkSuccessCallback onSuccess =
+      [&](protocol::StreamChunkSlice slice, std::unique_ptr<memory::ReadOnlyByteBuffer> buffer) {
+        onSuccessStreamChunkSlice = slice;
+        onSuccessBuffer = std::move(buffer);
+      };
+  protocol::StreamChunkSlice onFailureStreamChunkSlice;
+  std::unique_ptr<std::exception> onFailureException;
+  FetchChunkFailureCallback onFailure =
+      [&](protocol::StreamChunkSlice slice, std::unique_ptr<std::exception> exception) {
+        onFailureStreamChunkSlice = slice;
+        onFailureException = std::move(exception);
+      };
+
+  client.fetchChunkAsync(streamChunkSlice, *rpcRequest, onSuccess, onFailure);
+  auto sentMsg = rawMockDispatcher->getSentMsg();
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
+  // The response is not received yet.
+  EXPECT_FALSE(onSuccessBuffer);
+
+  const std::string responseBody = "test-response-body";
+  auto chunkFetchSuccess = std::make_unique<ChunkFetchSuccess>(
+      streamChunkSlice, toReadOnlyByteBuffer(responseBody));
+  rawMockDispatcher->receiveMsg(std::move(chunkFetchSuccess));
+
+  // The response is received.
+  EXPECT_TRUE(onSuccessBuffer);
+  EXPECT_FALSE(onFailureException);
+  EXPECT_EQ(onSuccessBuffer->remainingSize(), responseBody.size());
+  EXPECT_EQ(onSuccessBuffer->readToString(responseBody.size()), responseBody);
+}
+
+TEST(TransportClientTest, fetchChunkAsyncFailure) {
+  auto mockDispatcher = std::make_unique<MockDispatcher>();
+  auto rawMockDispatcher = mockDispatcher.get();
+  TransportClient client(nullptr, std::move(mockDispatcher), MS(10000));
+
+  const protocol::StreamChunkSlice streamChunkSlice{1, 2, 3, 4};
+  const long requestId = 1001;
+  const std::string requestBody = "test-request-body";
+  auto rpcRequest = std::make_unique<RpcRequest>(
+      requestId, toReadOnlyByteBuffer(requestBody));
+  protocol::StreamChunkSlice onSuccessStreamChunkSlice;
+  std::unique_ptr<memory::ReadOnlyByteBuffer> onSuccessBuffer;
+  FetchChunkSuccessCallback onSuccess =
+      [&](protocol::StreamChunkSlice slice, std::unique_ptr<memory::ReadOnlyByteBuffer> buffer) {
+        onSuccessStreamChunkSlice = slice;
+        onSuccessBuffer = std::move(buffer);
+      };
+  protocol::StreamChunkSlice onFailureStreamChunkSlice;
+  std::unique_ptr<std::exception> onFailureException;
+  FetchChunkFailureCallback onFailure =
+      [&](protocol::StreamChunkSlice slice, std::unique_ptr<std::exception> exception) {
+        onFailureStreamChunkSlice = slice;
+        onFailureException = std::move(exception);
+      };
+
+  client.fetchChunkAsync(streamChunkSlice, *rpcRequest, onSuccess, onFailure);
+  auto sentMsg = rawMockDispatcher->getSentMsg();
+  EXPECT_EQ(sentMsg->type(), Message::RPC_REQUEST);
+  auto sentRpcRequest = dynamic_cast<RpcRequest*>(sentMsg.get());
+  EXPECT_EQ(sentRpcRequest->body()->remainingSize(), requestBody.size());
+  EXPECT_EQ(
+      sentRpcRequest->body()->readToString(requestBody.size()), requestBody);
+  // The response is not received yet.
+  EXPECT_FALSE(onSuccessBuffer);
+
+  auto chunkFetchFailure = std::make_unique<ChunkFetchFailure>(
+      streamChunkSlice, "test-error-string");
+  rawMockDispatcher->receiveMsg(std::move(chunkFetchFailure));
+
+  // The failure is received.
+  EXPECT_TRUE(onFailureException);
+  EXPECT_FALSE(onSuccessBuffer);
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds TransportClient to cppClient.

### Why are the changes needed?
The TransportClient is responsible for sending/receiving the message to/from network.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
