### PR TITLE
[CELEBORN-1792][FOLLOWUP] Keep resume for a while after resumeByPinnedMemory

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1285,6 +1285,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerDirectMemoryPressureCheckIntervalMs: Long = get(WORKER_DIRECT_MEMORY_CHECK_INTERVAL)
   def workerPinnedMemoryCheckEnabled: Boolean = get(WORKER_PINNED_MEMORY_CHECK_ENABLED)
   def workerPinnedMemoryCheckIntervalMs: Long = get(WORKER_PINNED_MEMORY_CHECK_INTERVAL)
+  def workerResumeByPinnedMemoryKeepTime: Long = get(WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME)
   def workerDirectMemoryReportIntervalSecond: Long = get(WORKER_DIRECT_MEMORY_REPORT_INTERVAL)
   def workerDirectMemoryTrimChannelWaitInterval: Long =
     get(WORKER_DIRECT_MEMORY_TRIM_CHANNEL_WAIT_INTERVAL)
@@ -3739,6 +3740,14 @@ object CelebornConf extends Logging {
       .version("0.6.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
+
+  val WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME: ConfigEntry[Long] =
+    buildConf("celeborn.worker.monitor.resumeByPinnedMemory.keepTime")
+      .categories("worker")
+      .doc("Time of worker to stay in resume state after resumeByPinnedMemory")
+      .version("0.6.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("1s")
 
   val WORKER_DIRECT_MEMORY_REPORT_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.monitor.memory.report.interval")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1285,7 +1285,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerDirectMemoryPressureCheckIntervalMs: Long = get(WORKER_DIRECT_MEMORY_CHECK_INTERVAL)
   def workerPinnedMemoryCheckEnabled: Boolean = get(WORKER_PINNED_MEMORY_CHECK_ENABLED)
   def workerPinnedMemoryCheckIntervalMs: Long = get(WORKER_PINNED_MEMORY_CHECK_INTERVAL)
-  def workerResumeByPinnedMemoryKeepTime: Long = get(WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME)
+  def workerPinnedMemoryResumeKeepTime: Long = get(WORKER_PINNED_MEMORY_RESUME_KEEP_TIME)
   def workerDirectMemoryReportIntervalSecond: Long = get(WORKER_DIRECT_MEMORY_REPORT_INTERVAL)
   def workerDirectMemoryTrimChannelWaitInterval: Long =
     get(WORKER_DIRECT_MEMORY_TRIM_CHANNEL_WAIT_INTERVAL)
@@ -3741,8 +3741,8 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
 
-  val WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME: ConfigEntry[Long] =
-    buildConf("celeborn.worker.monitor.resumeByPinnedMemory.keepTime")
+  val WORKER_PINNED_MEMORY_RESUME_KEEP_TIME: ConfigEntry[Long] =
+    buildConf("celeborn.worker.monitor.pinnedMemory.resumeKeepTime")
       .categories("worker")
       .doc("Time of worker to stay in resume state after resumeByPinnedMemory")
       .version("0.6.0")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1285,6 +1285,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerDirectMemoryPressureCheckIntervalMs: Long = get(WORKER_DIRECT_MEMORY_CHECK_INTERVAL)
   def workerPinnedMemoryCheckEnabled: Boolean = get(WORKER_PINNED_MEMORY_CHECK_ENABLED)
   def workerPinnedMemoryCheckIntervalMs: Long = get(WORKER_PINNED_MEMORY_CHECK_INTERVAL)
+  def workerResumeByPinnedMemoryKeepTime: Long = get(WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME)
   def workerDirectMemoryReportIntervalSecond: Long = get(WORKER_DIRECT_MEMORY_REPORT_INTERVAL)
   def workerDirectMemoryTrimChannelWaitInterval: Long =
     get(WORKER_DIRECT_MEMORY_TRIM_CHANNEL_WAIT_INTERVAL)
@@ -3739,6 +3740,15 @@ object CelebornConf extends Logging {
       .version("0.6.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
+
+  val WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME: ConfigEntry[Long] =
+    buildConf("celeborn.worker.monitor.resumeByPinnedMemory.keepTime")
+      .categories("worker")
+      .doc("Time of worker to stay in resume state after resumeByPinnedMemory, " +
+        "prevent workers from repeatedly switching between resume and pause states")
+      .version("0.6.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("1s")
 
   val WORKER_DIRECT_MEMORY_REPORT_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.monitor.memory.report.interval")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1285,7 +1285,6 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerDirectMemoryPressureCheckIntervalMs: Long = get(WORKER_DIRECT_MEMORY_CHECK_INTERVAL)
   def workerPinnedMemoryCheckEnabled: Boolean = get(WORKER_PINNED_MEMORY_CHECK_ENABLED)
   def workerPinnedMemoryCheckIntervalMs: Long = get(WORKER_PINNED_MEMORY_CHECK_INTERVAL)
-  def workerResumeByPinnedMemoryKeepTime: Long = get(WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME)
   def workerDirectMemoryReportIntervalSecond: Long = get(WORKER_DIRECT_MEMORY_REPORT_INTERVAL)
   def workerDirectMemoryTrimChannelWaitInterval: Long =
     get(WORKER_DIRECT_MEMORY_TRIM_CHANNEL_WAIT_INTERVAL)
@@ -3740,15 +3739,6 @@ object CelebornConf extends Logging {
       .version("0.6.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10s")
-
-  val WORKER_RESUME_BY_PINNED_MEMORY_KEEP_TIME: ConfigEntry[Long] =
-    buildConf("celeborn.worker.monitor.resumeByPinnedMemory.keepTime")
-      .categories("worker")
-      .doc("Time of worker to stay in resume state after resumeByPinnedMemory, " +
-        "prevent workers from repeatedly switching between resume and pause states")
-      .version("0.6.0")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("1s")
 
   val WORKER_DIRECT_MEMORY_REPORT_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.monitor.memory.report.interval")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -146,6 +146,7 @@ license: |
 | celeborn.worker.monitor.memory.trimFlushWaitInterval | 1s | false | Wait time after worker trigger StorageManger to flush data. | 0.3.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.enabled | true | false | If true, MemoryManager will check worker should resume by pinned memory used. | 0.6.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.interval | 10s | false | Interval of worker direct pinned memory checking, only takes effect when celeborn.network.memory.allocator.pooled and celeborn.worker.monitor.pinnedMemory.check.enabled are enabled. | 0.6.0 |  | 
+| celeborn.worker.monitor.resumeByPinnedMemory.keepTime | 1s | false | Time of worker to stay in resume state after resumeByPinnedMemory | 0.6.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMax | 1024 | false | Max number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMin | 1 | false | Min number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partitionSorter.directMemoryRatioThreshold | 0.1 | false | Max ratio of partition sorter's memory for sorting, when reserved memory is higher than max partition sorter memory, partition sorter will stop sorting. If this value is set to 0, partition files sorter will skip memory check and ServingState check. | 0.2.0 |  | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -146,7 +146,7 @@ license: |
 | celeborn.worker.monitor.memory.trimFlushWaitInterval | 1s | false | Wait time after worker trigger StorageManger to flush data. | 0.3.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.enabled | true | false | If true, MemoryManager will check worker should resume by pinned memory used. | 0.6.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.interval | 10s | false | Interval of worker direct pinned memory checking, only takes effect when celeborn.network.memory.allocator.pooled and celeborn.worker.monitor.pinnedMemory.check.enabled are enabled. | 0.6.0 |  | 
-| celeborn.worker.monitor.resumeByPinnedMemory.keepTime | 1s | false | Time of worker to stay in resume state after resumeByPinnedMemory | 0.6.0 |  | 
+| celeborn.worker.monitor.pinnedMemory.resumeKeepTime | 1s | false | Time of worker to stay in resume state after resumeByPinnedMemory | 0.6.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMax | 1024 | false | Max number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMin | 1 | false | Min number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partitionSorter.directMemoryRatioThreshold | 0.1 | false | Max ratio of partition sorter's memory for sorting, when reserved memory is higher than max partition sorter memory, partition sorter will stop sorting. If this value is set to 0, partition files sorter will skip memory check and ServingState check. | 0.2.0 |  | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -146,7 +146,6 @@ license: |
 | celeborn.worker.monitor.memory.trimFlushWaitInterval | 1s | false | Wait time after worker trigger StorageManger to flush data. | 0.3.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.enabled | true | false | If true, MemoryManager will check worker should resume by pinned memory used. | 0.6.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.interval | 10s | false | Interval of worker direct pinned memory checking, only takes effect when celeborn.network.memory.allocator.pooled and celeborn.worker.monitor.pinnedMemory.check.enabled are enabled. | 0.6.0 |  | 
-| celeborn.worker.monitor.resumeByPinnedMemory.keepTime | 1s | false | Time of worker to stay in resume state after resumeByPinnedMemory, prevent workers from repeatedly switching between resume and pause states | 0.6.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMax | 1024 | false | Max number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMin | 1 | false | Min number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partitionSorter.directMemoryRatioThreshold | 0.1 | false | Max ratio of partition sorter's memory for sorting, when reserved memory is higher than max partition sorter memory, partition sorter will stop sorting. If this value is set to 0, partition files sorter will skip memory check and ServingState check. | 0.2.0 |  | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -146,6 +146,7 @@ license: |
 | celeborn.worker.monitor.memory.trimFlushWaitInterval | 1s | false | Wait time after worker trigger StorageManger to flush data. | 0.3.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.enabled | true | false | If true, MemoryManager will check worker should resume by pinned memory used. | 0.6.0 |  | 
 | celeborn.worker.monitor.pinnedMemory.check.interval | 10s | false | Interval of worker direct pinned memory checking, only takes effect when celeborn.network.memory.allocator.pooled and celeborn.worker.monitor.pinnedMemory.check.enabled are enabled. | 0.6.0 |  | 
+| celeborn.worker.monitor.resumeByPinnedMemory.keepTime | 1s | false | Time of worker to stay in resume state after resumeByPinnedMemory, prevent workers from repeatedly switching between resume and pause states | 0.6.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMax | 1024 | false | Max number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partition.initial.readBuffersMin | 1 | false | Min number of initial read buffers | 0.3.0 |  | 
 | celeborn.worker.partitionSorter.directMemoryRatioThreshold | 0.1 | false | Max ratio of partition sorter's memory for sorting, when reserved memory is higher than max partition sorter memory, partition sorter will stop sorting. If this value is set to 0, partition files sorter will skip memory check and ServingState check. | 0.2.0 |  | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -351,15 +351,16 @@ public class MemoryManager {
             // trimCounter cannot be increased when channels resume by PinnedMemory, otherwise
             // PauseSpentTime will be increased unexpectedly
             trimCounter += 1;
+            if (trimCounter >= forceAppendPauseSpentTimeThreshold) {
+              logger.debug(
+                  "Trigger action: TRIM for {} times, force to append pause spent time.",
+                  trimCounter);
+              appendPauseSpentTime(servingState);
+            }
           }
         }
         logger.debug("Trigger action: TRIM");
         trimAllListeners();
-        if (trimCounter >= forceAppendPauseSpentTimeThreshold) {
-          logger.debug(
-              "Trigger action: TRIM for {} times, force to append pause spent time.", trimCounter);
-          appendPauseSpentTime(servingState);
-        }
         break;
       case PUSH_AND_REPLICATE_PAUSED:
         if (!tryResumeByPinnedMemory(servingState, lastState)) {
@@ -375,14 +376,15 @@ public class MemoryManager {
               memoryPressureListener ->
                   memoryPressureListener.onPause(TransportModuleConstants.REPLICATE_MODULE));
           trimCounter += 1;
+          if (trimCounter >= forceAppendPauseSpentTimeThreshold) {
+            logger.debug(
+                "Trigger action: TRIM for {} times, force to append pause spent time.",
+                trimCounter);
+            appendPauseSpentTime(servingState);
+          }
         }
         logger.debug("Trigger action: TRIM");
         trimAllListeners();
-        if (trimCounter >= forceAppendPauseSpentTimeThreshold) {
-          logger.debug(
-              "Trigger action: TRIM for {} times, force to append pause spent time.", trimCounter);
-          appendPauseSpentTime(servingState);
-        }
         break;
       case NONE_PAUSED:
         // resume from paused mode, append pause spent time

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -100,7 +100,7 @@ public class MemoryManager {
   private long pinnedMemoryCheckInterval;
   private long pinnedMemoryLastCheckTime = 0;
   private boolean resumingByPinnedMemory = false;
-  private long workerResumeByPinnedMemoryKeepTime;
+  private long workerPinnedMemoryResumeKeepTime;
 
   @VisibleForTesting
   public static MemoryManager initialize(CelebornConf conf) {
@@ -136,7 +136,7 @@ public class MemoryManager {
     long checkInterval = conf.workerDirectMemoryPressureCheckIntervalMs();
     this.pinnedMemoryCheckEnabled = conf.workerPinnedMemoryCheckEnabled();
     this.pinnedMemoryCheckInterval = conf.workerPinnedMemoryCheckIntervalMs();
-    this.workerResumeByPinnedMemoryKeepTime = conf.workerResumeByPinnedMemoryKeepTime();
+    this.workerPinnedMemoryResumeKeepTime = conf.workerPinnedMemoryResumeKeepTime();
     long reportInterval = conf.workerDirectMemoryReportIntervalSecond();
     double readBufferTargetRatio = conf.readBufferTargetRatio();
     long readBufferTargetUpdateInterval = conf.readBufferTargetUpdateInterval();
@@ -618,7 +618,7 @@ public class MemoryManager {
         if (resumingByPinnedMemory
             && lastState != ServingState.NONE_PAUSED
             && System.currentTimeMillis() - pinnedMemoryLastCheckTime
-                < workerResumeByPinnedMemoryKeepTime
+                < workerPinnedMemoryResumeKeepTime
             && getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
           // do nothing, keep resume for a while
           logger.info(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -618,7 +618,8 @@ public class MemoryManager {
 
   private boolean keepResumeByPinnedMemory() {
     return pinnedMemoryCheckEnabled
-            && System.currentTimeMillis() - pinnedMemoryLastCheckTime < workerResumeByPinnedMemoryKeepTime;
+        && System.currentTimeMillis() - pinnedMemoryLastCheckTime
+            < workerResumeByPinnedMemoryKeepTime;
   }
 
   private void resumePush() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -621,11 +621,12 @@ public class MemoryManager {
   }
 
   private boolean keepResumeByPinnedMemory(ServingState lastState) {
+    // getPinnedMemory maybe expensive, so we check it at the end
     return pinnedMemoryCheckEnabled
         && (lastState == ServingState.PUSH_PAUSED
             || lastState == ServingState.PUSH_AND_REPLICATE_PAUSED)
-        && getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio
-        && System.currentTimeMillis() - pinnedMemoryLastCheckTime < pinnedMemoryCheckInterval;
+        && System.currentTimeMillis() - pinnedMemoryLastCheckTime < pinnedMemoryCheckInterval
+        && getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio;
   }
 
   private void resumePush() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -348,10 +348,12 @@ public class MemoryManager {
             memoryPressureListeners.forEach(
                 memoryPressureListener ->
                     memoryPressureListener.onPause(TransportModuleConstants.PUSH_MODULE));
+            // trimCounter cannot be increased when channels resume by PinnedMemory, otherwise
+            // PauseSpentTime will be increased unexpectedly
+            trimCounter += 1;
           }
         }
         logger.debug("Trigger action: TRIM");
-        trimCounter += 1;
         trimAllListeners();
         if (trimCounter >= forceAppendPauseSpentTimeThreshold) {
           logger.debug(
@@ -372,9 +374,9 @@ public class MemoryManager {
           memoryPressureListeners.forEach(
               memoryPressureListener ->
                   memoryPressureListener.onPause(TransportModuleConstants.REPLICATE_MODULE));
+          trimCounter += 1;
         }
         logger.debug("Trigger action: TRIM");
-        trimCounter += 1;
         trimAllListeners();
         if (trimCounter >= forceAppendPauseSpentTimeThreshold) {
           logger.debug(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -384,6 +384,7 @@ public class MemoryManager {
         break;
       case NONE_PAUSED:
         // resume from paused mode, append pause spent time
+        resumingByPinnedMemory = false;
         if (lastState == ServingState.PUSH_AND_REPLICATE_PAUSED) {
           resumeReplicate();
           resumePush();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -603,54 +603,29 @@ public class MemoryManager {
   }
 
   private boolean tryResumeByPinnedMemory(ServingState currentState, ServingState lastState) {
-if (pinnedMemoryCheckEnabled) {
-   long currentTime = System.currentTimeMillis();
-    if (currentTime - pinnedMemoryLastCheckTime >= pinnedMemoryCheckInterval) {
-      if (getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
-        pinnedMemoryLastCheckTime = currentTime;
-        resumingByPinnedMemory = true;
-        resumeByPinnedMemory(currentState);
-        return true;
-      }
-    } else {
-      if (resumingByPinnedMemory
-          && lastState != ServingState.NONE_PAUSED
-          && getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
-        // do nothing, keep resume for a while
-        logger.info(
-            "currentState: {}, keep resume for {}ms after last resumeByPinnedMemory",
-            currentState,
-            currentTime - pinnedMemoryLastCheckTime);
-        return true;
-      }
-    }
-}
-    
-return false;
-    if (!pinnedMemoryCheckEnabled) {
-      return false;
-    }
-    long currentTime = System.currentTimeMillis();
-    if (currentTime - pinnedMemoryLastCheckTime >= pinnedMemoryCheckInterval) {
-      if (getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
-        pinnedMemoryLastCheckTime = currentTime;
-        resumingByPinnedMemory = true;
-        resumeByPinnedMemory(currentState);
-        success = true;
-      }
-    } else {
-      if (resumingByPinnedMemory
-          && lastState != ServingState.NONE_PAUSED
-          && getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
-        // do nothing, keep resume for a while
-        logger.info(
-            "currentState: {}, keep resume for {}ms after last resumeByPinnedMemory",
-            currentState,
-            currentTime - pinnedMemoryLastCheckTime);
-        success = true;
+    if (pinnedMemoryCheckEnabled) {
+      long currentTime = System.currentTimeMillis();
+      if (currentTime - pinnedMemoryLastCheckTime >= pinnedMemoryCheckInterval) {
+        if (getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
+          pinnedMemoryLastCheckTime = currentTime;
+          resumingByPinnedMemory = true;
+          resumeByPinnedMemory(currentState);
+          return true;
+        }
+      } else {
+        if (resumingByPinnedMemory
+            && lastState != ServingState.NONE_PAUSED
+            && getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
+          // do nothing, keep resume for a while
+          logger.info(
+              "currentState: {}, keep resume for {}ms after last resumeByPinnedMemory",
+              currentState,
+              currentTime - pinnedMemoryLastCheckTime);
+          return true;
+        }
       }
     }
-    return success;
+    return false;
   }
 
   private void resumePush() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -599,9 +599,10 @@ public class MemoryManager {
     if (!pinnedMemoryCheckEnabled) {
       return false;
     }
-    if (System.currentTimeMillis() - pinnedMemoryLastCheckTime >= pinnedMemoryCheckInterval) {
+    long currentTime = System.currentTimeMillis();
+    if (currentTime - pinnedMemoryLastCheckTime >= pinnedMemoryCheckInterval) {
       if (getPinnedMemory() / (double) (maxDirectMemory) < pinnedMemoryResumeRatio) {
-        pinnedMemoryLastCheckTime = System.currentTimeMillis();
+        pinnedMemoryLastCheckTime = currentTime;
         resumeByPinnedMemory(currentState);
         success = true;
       }
@@ -612,7 +613,7 @@ public class MemoryManager {
         logger.info(
             "currentState: {}, keep resume for {}ms after last resumeByPinnedMemory",
             currentState,
-            System.currentTimeMillis() - pinnedMemoryLastCheckTime);
+            currentTime - pinnedMemoryLastCheckTime);
         success = true;
       }
     }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -341,12 +341,11 @@ public class MemoryManager {
         } else if (keepResumeByPinnedMemory(lastState)) {
           // do nothing, keep resume for a while
           logger.info(
-              "keep resume for {}ms after last resumeByPinnedMemory",
+              "PUSH_PAUSED keep resume for {}ms after last resumeByPinnedMemory",
               System.currentTimeMillis() - pinnedMemoryLastCheckTime);
         } else {
           pausePushDataCounter.increment();
           if (lastState == ServingState.PUSH_AND_REPLICATE_PAUSED) {
-            logger.info("Trigger action: RESUME REPLICATE");
             resumeReplicate();
           } else {
             logger.info("Trigger action: PAUSE PUSH");
@@ -371,7 +370,7 @@ public class MemoryManager {
         } else if (keepResumeByPinnedMemory(lastState)) {
           // do nothing, keep resume for a while
           logger.info(
-              "keep resume for {}ms after last resumeByPinnedMemory",
+              "PUSH_AND_REPLICATE_PAUSED keep resume for {}ms after last resumeByPinnedMemory",
               System.currentTimeMillis() - pinnedMemoryLastCheckTime);
         } else {
           pausePushDataAndReplicateCounter.increment();

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -17,18 +17,20 @@
 
 package org.apache.celeborn.service.deploy.memory
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.DurationInt
+
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Futures.{interval, timeout}
+
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.{WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE, WORKER_DIRECT_MEMORY_RATIO_PAUSE_REPLICATE}
 import org.apache.celeborn.common.protocol.TransportModuleConstants
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.{MemoryPressureListener, ServingState}
-
-import java.util.concurrent.TimeUnit
 
 class MemoryManagerSuite extends CelebornFunSuite {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the switchServingState after resumeByPinnedMemory, keep the resume channel to prevent the channel from frequently resuming and pausing before memoryUsage decreases to pausePushDataThreshold.

### Why are the changes needed?

Frequent channel resume and pause will result in slow data reception and failure to quickly reduce memoryUsage to below pausePushDataThreshold.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

ut