### PR TITLE
[CELEBORN-1865] Update master endpointRef when master leader is abnormal

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -181,6 +181,7 @@ public class MasterClient {
         setRpcEndpointRef(leaderAddr);
       } else {
         LOG.warn("Master leader is not present currently, please check masters' status!");
+        resetRpcEndpointRef(oldRef);
       }
       return true;
     } else if (e.getCause() instanceof IOException || e instanceof RpcTimeoutException) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
`rpcEndpointRef` should be set to `null` When master leader is not present.

### Why are the changes needed?
Attempt master address index can only be updated when `rpcEndpointRef` is `null`.

The index wont update  if `rpcEndpointRef` has been set but some error ocurs to the master leader.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

