### PR TITLE
[CELEBORN-1866][Flink] Fix CelebornChannelBufferReader request more buffers than needed

### DIFF
--- a/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornChannelBufferManager.java
+++ b/client-flink/flink-1.20/src/main/java/org/apache/celeborn/plugin/flink/tiered/CelebornChannelBufferManager.java
@@ -80,6 +80,7 @@ public class CelebornChannelBufferManager implements BufferListener, BufferRecyc
         bufferQueue.add(buffer);
         isBufferUsed = true;
         numBuffers = 1 + tryRequestBuffers();
+        decreaseRequiredCredits(numBuffers);
       }
       bufferReader.notifyAvailableCredits(numBuffers);
     } catch (Throwable t) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
I found a case where a Flink job is hanging which utilize Celeborn hybrid integration strategy.

The issue seems to be that the CelebornChannelBufferReader is requesting more buffers than needed, which prevents other readers from getting enough buffers to continue reading data. This problem usually happens when memory competition is high.

When other readers recycle buffers back to the LocalBufferPool, the LocalBufferPool calls CelebornChannelBufferManager#notifyBufferAvailable to notify about the available buffer, and then CelebornChannelBufferManager requests buffers from the LocalBufferPool.

For instance, if CelebornBufferManager#numRequiredBuffers is set to 5 and it only gets 4 buffers from the LocalBufferPool, it won't immediately decrease numRequiredBuffers to 1. Instead, it will keep trying to request more buffers from the LocalBufferPool until it exits the synchronized block, at which point it will reduce numRequiredBuffers.

I think the bug occurs when the CelebornBufferManager exits the synchronized block. If a reader requests a buffer from this CelebornBufferManager, the number of buffers in BufferManager#bufferQueue _drops from 4 to 3. When the _LocalBufferPool has buffers again and tries to offer them to the CelebornBufferManager, the CelebornBufferManager mistakenly thinks it should request 2 buffers instead of just 1.

### Why are the changes needed?
It may cause flink job hang.


### Does this PR introduce _any_ user-facing change?
no.


### How was this patch tested?
We have a job that can reproduce this case. After the fix, it can be completed stably.
