### PR TITLE
[CELEBORN-1872] Bump Flink from 1.19.1, 1.20.0 to 1.19.2, 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.9.9</maven.version>
 
-    <flink.version>1.20.0</flink.version>
+    <flink.version>1.20.1</flink.version>
     <spark.version>3.3.4</spark.version>
 
     <!-- use hadoop-3 as default  -->
@@ -1732,7 +1732,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>1.19.1</flink.version>
+        <flink.version>1.19.2</flink.version>
         <flink.binary.version>1.19</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.19_${scala.binary.version}</celeborn.flink.plugin.artifact>
@@ -1752,7 +1752,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
         <flink.binary.version>1.20</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.20_${scala.binary.version}</celeborn.flink.plugin.artifact>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1106,7 +1106,7 @@ object Flink118 extends FlinkClientProjects {
 }
 
 object Flink119 extends FlinkClientProjects {
-  val flinkVersion = "1.19.1"
+  val flinkVersion = "1.19.2"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-1.19"
@@ -1116,7 +1116,7 @@ object Flink119 extends FlinkClientProjects {
 }
 
 object Flink120 extends FlinkClientProjects {
-  val flinkVersion = "1.20.0"
+  val flinkVersion = "1.20.1"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-1.20"
@@ -1146,10 +1146,11 @@ trait FlinkClientProjects {
     .aggregate(flinkCommon, flinkClient, flinkIt)
 
   // get flink major version. e.g:
-  //   1.20.0 -> 1.20
-  //   1.19.1 -> 1.19
+  //   1.20.1 -> 1.20
+  //   1.19.2 -> 1.19
   //   1.18.1 -> 1.18
   //   1.17.2 -> 1.17
+  //   1.16.3 -> 1.16
   lazy val flinkMajorVersion: String = flinkVersion.split("\\.").take(2).reduce(_ + "." + _)
 
   // the output would be something like: celeborn-client-flink-1.17-shaded_2.12-0.4.0-SNAPSHOT.jar


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Flink from 1.19.1, 1.20.0 to 1.19.2, 1.20.1.

### Why are the changes needed?

Flink 1.19.2 and 1.20.1 have already released.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.