### PR TITLE
[CELEBORN-1871][CIP-14] Add NettyRpcEndpointRef to cppClient

### DIFF
--- a/cpp/celeborn/network/CMakeLists.txt
+++ b/cpp/celeborn/network/CMakeLists.txt
@@ -17,7 +17,8 @@ add_library(
         STATIC
         Message.cpp
         MessageDispatcher.cpp
-        TransportClient.cpp)
+        TransportClient.cpp
+        NettyRpcEndpointRef.cpp)
 
 target_include_directories(network PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/cpp/celeborn/network/Message.h
+++ b/cpp/celeborn/network/Message.h
@@ -106,6 +106,11 @@ class RpcRequest : public Message {
       : Message(RPC_REQUEST, other.body_->clone()),
         requestId_(other.requestId_) {}
 
+  void operator=(const RpcRequest& lhs) {
+    requestId_ = lhs.requestId();
+    body_ = lhs.body_->clone();
+  }
+
   virtual ~RpcRequest() = default;
 
   long requestId() const {

--- a/cpp/celeborn/network/NettyRpcEndpointRef.cpp
+++ b/cpp/celeborn/network/NettyRpcEndpointRef.cpp
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "celeborn/network/NettyRpcEndpointRef.h"
+
+namespace celeborn {
+namespace network {
+
+NettyRpcEndpointRef::NettyRpcEndpointRef(
+    const std::string& name,
+    const std::string& srcHost,
+    int srcPort,
+    const std::string& dstHost,
+    int dstPort,
+    std::shared_ptr<TransportClient> client)
+    : name_(name),
+      srcHost_(srcHost),
+      srcPort_(srcPort),
+      dstHost_(dstHost),
+      dstPort_(dstPort),
+      client_(client) {}
+
+std::unique_ptr<protocol::GetReducerFileGroupResponse>
+NettyRpcEndpointRef::askSync(
+    const protocol::GetReducerFileGroup& msg,
+    Timeout timeout) {
+  auto rpcRequest = buildRpcRequest(msg);
+  auto rpcResponse = client_->sendRpcRequestSync(rpcRequest, timeout);
+  return fromRpcResponse(std::move(rpcResponse));
+}
+
+RpcRequest NettyRpcEndpointRef::buildRpcRequest(
+    const protocol::GetReducerFileGroup& msg) {
+  auto transportData = msg.toTransportMessage().toReadOnlyByteBuffer();
+  int size =
+      srcHost_.size() + 3 + 4 + dstHost_.size() + 3 + 4 + name_.size() + 2 + 1;
+  auto buffer = memory::ByteBuffer::createWriteOnly(size);
+  // write srcAddr msg
+  utils::writeRpcAddress(*buffer, srcHost_, srcPort_);
+  // write dstAddr msg
+  utils::writeRpcAddress(*buffer, dstHost_, dstPort_);
+  // write srcName
+  utils::writeUTF(*buffer, name_);
+  // write the isTransportMessage flag
+  buffer->write<uint8_t>(kNativeTransportMessageFlag);
+  CELEBORN_CHECK_EQ(buffer->size(), size);
+  auto result = memory::ByteBuffer::toReadOnly(std::move(buffer));
+  auto combined = memory::ByteBuffer::concat(*result, *transportData);
+  return RpcRequest(RpcRequest::nextRequestId(), std::move(combined));
+}
+
+std::unique_ptr<protocol::GetReducerFileGroupResponse>
+NettyRpcEndpointRef::fromRpcResponse(RpcResponse&& response) {
+  auto body = response.body();
+  uint8_t nativeTransportMessageFlag = body->read<uint8_t>();
+  CELEBORN_CHECK_EQ(nativeTransportMessageFlag, kNativeTransportMessageFlag);
+  auto transportMessage = protocol::TransportMessage(std::move(body));
+  return protocol::GetReducerFileGroupResponse::fromTransportMessage(
+      transportMessage);
+}
+} // namespace network
+} // namespace celeborn

--- a/cpp/celeborn/network/NettyRpcEndpointRef.h
+++ b/cpp/celeborn/network/NettyRpcEndpointRef.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "celeborn/network/TransportClient.h"
+#include "celeborn/protocol/ControlMessages.h"
+
+namespace celeborn {
+namespace network {
+/**
+ * RpcEndpointRef is typically used to communicate with LifecycleManager. It
+ * wraps around the TransportClient, add ip and name info to the message as
+ * the LifecycleManager requires the information.
+ */
+class NettyRpcEndpointRef {
+ public:
+  static constexpr uint8_t kNativeTransportMessageFlag = 0xFF;
+
+  NettyRpcEndpointRef(
+      const std::string& name,
+      const std::string& srcHost,
+      int srcPort,
+      const std::string& dstHost,
+      int dstPort,
+      std::shared_ptr<TransportClient> client);
+
+  // TODO: refactor to template function when needed.
+  std::unique_ptr<protocol::GetReducerFileGroupResponse> askSync(
+      const protocol::GetReducerFileGroup& msg,
+      Timeout timeout);
+
+ private:
+  RpcRequest buildRpcRequest(const protocol::GetReducerFileGroup& msg);
+
+  std::unique_ptr<protocol::GetReducerFileGroupResponse> fromRpcResponse(
+      RpcResponse&& response);
+
+  std::string name_;
+  std::string srcHost_;
+  int srcPort_;
+  std::string dstHost_;
+  int dstPort_;
+  std::shared_ptr<TransportClient> client_;
+};
+} // namespace network
+} // namespace celeborn

--- a/cpp/celeborn/network/TransportClient.h
+++ b/cpp/celeborn/network/TransportClient.h
@@ -36,11 +36,11 @@ namespace network {
  * and deserializes folly::IOBuf into Message when read().
  */
 class MessageSerializeHandler : public wangle::Handler<
-                                   std::unique_ptr<folly::IOBuf>,
-                                   std::unique_ptr<Message>,
-                                   std::unique_ptr<Message>,
-                                   std::unique_ptr<folly::IOBuf>> {
-public:
+                                    std::unique_ptr<folly::IOBuf>,
+                                    std::unique_ptr<Message>,
+                                    std::unique_ptr<Message>,
+                                    std::unique_ptr<folly::IOBuf>> {
+ public:
   void read(Context* ctx, std::unique_ptr<folly::IOBuf> msg) override;
 
   folly::Future<folly::Unit> write(Context* ctx, std::unique_ptr<Message> msg)
@@ -51,16 +51,15 @@ using FetchChunkSuccessCallback = std::function<void(
     protocol::StreamChunkSlice,
     std::unique_ptr<memory::ReadOnlyByteBuffer>)>;
 
-using FetchChunkFailureCallback = std::function<void(
-    protocol::StreamChunkSlice,
-    std::unique_ptr<std::exception>)>;
+using FetchChunkFailureCallback = std::function<
+    void(protocol::StreamChunkSlice, std::unique_ptr<std::exception>)>;
 
 /**
  * TransportClient sends the messages to the network layer, and handles
  * the message callback, timeout, error handling, etc.
  */
 class TransportClient {
-public:
+ public:
   TransportClient(
       std::unique_ptr<wangle::ClientBootstrap<SerializePipeline>> client,
       std::unique_ptr<MessageDispatcher> dispatcher,
@@ -70,7 +69,9 @@ public:
     return sendRpcRequestSync(request, defaultTimeout_);
   }
 
-  RpcResponse sendRpcRequestSync(const RpcRequest& request, Timeout timeout);
+  virtual RpcResponse sendRpcRequestSync(
+      const RpcRequest& request,
+      Timeout timeout);
 
   // Ignore the response, return immediately.
   void sendRpcRequestWithoutResponse(const RpcRequest& request);
@@ -87,7 +88,7 @@ public:
 
   ~TransportClient() = default;
 
-private:
+ private:
   std::unique_ptr<wangle::ClientBootstrap<SerializePipeline>> client_;
   std::unique_ptr<MessageDispatcher> dispatcher_;
   Timeout defaultTimeout_;
@@ -95,20 +96,20 @@ private:
 
 class MessagePipelineFactory
     : public wangle::PipelineFactory<SerializePipeline> {
-public:
+ public:
   SerializePipeline::Ptr newPipeline(
       std::shared_ptr<folly::AsyncTransport> sock) override;
 };
 
 class TransportClientFactory {
-public:
+ public:
   TransportClientFactory(const std::shared_ptr<conf::CelebornConf>& conf);
 
   std::shared_ptr<TransportClient> createClient(
       const std::string& host,
       uint16_t port);
 
-private:
+ private:
   struct ClientPool {
     std::mutex mutex;
     std::vector<std::shared_ptr<TransportClient>> clients;

--- a/cpp/celeborn/network/tests/CMakeLists.txt
+++ b/cpp/celeborn/network/tests/CMakeLists.txt
@@ -18,7 +18,8 @@ add_executable(
         FrameDecoderTest.cpp
         MessageTest.cpp
         MessageDispatcherTest.cpp
-        TransportClientTest.cpp)
+        TransportClientTest.cpp
+        NettyRpcEndpointRefTest.cpp)
 
 add_test(NAME celeborn_network_test COMMAND celeborn_network_test)
 

--- a/cpp/celeborn/network/tests/NettyRpcEndpointRefTest.cpp
+++ b/cpp/celeborn/network/tests/NettyRpcEndpointRefTest.cpp
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celeborn/network/NettyRpcEndpointRef.h"
+
+using namespace celeborn;
+using namespace celeborn::network;
+
+namespace {
+using MS = std::chrono::milliseconds;
+
+class MockTransportClient : public TransportClient {
+ public:
+  MockTransportClient()
+      : TransportClient(nullptr, nullptr, MS(100)),
+        response_(
+            RpcResponse(0, memory::ReadOnlyByteBuffer::createEmptyBuffer())),
+        request_(
+            RpcRequest(0, memory::ReadOnlyByteBuffer::createEmptyBuffer())) {}
+  RpcResponse sendRpcRequestSync(const RpcRequest& request, Timeout timeout)
+      override {
+    request_ = request;
+    return response_;
+  }
+
+  void setResponse(const RpcResponse& response) {
+    response_ = response;
+  }
+
+  RpcRequest getRequest() {
+    return request_;
+  }
+
+ private:
+  RpcResponse response_;
+  RpcRequest request_;
+};
+
+void readUTF(memory::ReadOnlyByteBuffer& buffer, std::string& host) {
+  int size = buffer.read<short>();
+  host = buffer.readToString(size);
+}
+
+void readRpcAddress(
+    memory::ReadOnlyByteBuffer& buffer,
+    std::string& host,
+    int& port) {
+  EXPECT_EQ(buffer.read<uint8_t>(), 1);
+  readUTF(buffer, host);
+  port = buffer.read<int32_t>();
+}
+} // namespace
+
+TEST(NettyRpcEndpointRefTest, askSyncGetReducerFileGroup) {
+  auto mockedClient = std::make_shared<MockTransportClient>();
+  const std::string srcName = "test-name";
+  const std::string srcHost = "test-src-host";
+  const int srcPort = 100;
+  const std::string dstHost = "test-dst-host";
+  const int dstPort = 101;
+  auto nettyRpcEndpointRef = NettyRpcEndpointRef(
+      srcName, srcHost, srcPort, dstHost, dstPort, mockedClient);
+
+  const std::string responseBody = "test-response-body";
+
+  // rpcResponse -> transportMessage -> getReducerFileGroupResponse
+  PbGetReducerFileGroupResponse pbGetReducerFileGroupResponse;
+  const int status = 5;
+  pbGetReducerFileGroupResponse.set_status(5);
+  protocol::TransportMessage transportMessage(
+      GET_REDUCER_FILE_GROUP_RESPONSE,
+      pbGetReducerFileGroupResponse.SerializeAsString());
+  auto msgBody = transportMessage.toReadOnlyByteBuffer();
+  auto writeBuffer = memory::ByteBuffer::createWriteOnly(sizeof(uint8_t));
+  writeBuffer->write<uint8_t>(NettyRpcEndpointRef::kNativeTransportMessageFlag);
+  auto flagBody = memory::ByteBuffer::toReadOnly(std::move(writeBuffer));
+  auto concatBody = memory::ByteBuffer::concat(*flagBody, *msgBody);
+
+  auto rpcResponse = std::make_unique<RpcResponse>(1000, std::move(concatBody));
+  mockedClient->setResponse(*rpcResponse);
+
+  protocol::GetReducerFileGroup request{1001};
+  auto response = nettyRpcEndpointRef.askSync(request, MS(100));
+  EXPECT_EQ(response->status, status);
+
+  auto sentRequest = mockedClient->getRequest();
+  auto sentBody = sentRequest.body();
+  std::string host;
+  int port;
+  readRpcAddress(*sentBody, host, port);
+  EXPECT_EQ(host, srcHost);
+  EXPECT_EQ(port, srcPort);
+  readRpcAddress(*sentBody, host, port);
+  EXPECT_EQ(host, dstHost);
+  EXPECT_EQ(port, dstPort);
+  std::string name;
+  readUTF(*sentBody, name);
+  EXPECT_EQ(name, srcName);
+  EXPECT_EQ(
+      sentBody->read<uint8_t>(),
+      NettyRpcEndpointRef::kNativeTransportMessageFlag);
+}

--- a/cpp/celeborn/utils/CMakeLists.txt
+++ b/cpp/celeborn/utils/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
 
 target_link_libraries(
         utils
+        memory
         ${FOLLY_WITH_DEPENDENCIES}
         ${GLOG}
         ${GFLAGS_LIBRARIES}

--- a/cpp/celeborn/utils/CelebornUtils.cpp
+++ b/cpp/celeborn/utils/CelebornUtils.cpp
@@ -19,6 +19,20 @@
 
 namespace celeborn {
 namespace utils {
+void writeUTF(memory::WriteOnlyByteBuffer& buffer, const std::string& msg) {
+  buffer.write<short>(msg.size());
+  buffer.writeFromString(msg);
+}
+
+void writeRpcAddress(
+    memory::WriteOnlyByteBuffer& buffer,
+    const std::string& host,
+    int port) {
+  buffer.write<uint8_t>(1);
+  writeUTF(buffer, host);
+  buffer.write<int32_t>(port);
+}
+
 std::vector<std::string_view> parseColonSeparatedHostPorts(
     const std::string_view& s,
     int num) {
@@ -27,12 +41,11 @@ std::vector<std::string_view> parseColonSeparatedHostPorts(
   std::vector<std::string_view> result;
   result.resize(num + 1);
   size_t size = 0;
-  for (int result_idx = 1, parsed_idx = parsed.size() - num;
-       result_idx <= num;
+  for (int result_idx = 1, parsed_idx = parsed.size() - num; result_idx <= num;
        result_idx++, parsed_idx++) {
     result[result_idx] = parsed[parsed_idx];
     size += parsed[parsed_idx].size() + 1;
-       }
+  }
   result[0] = s.substr(0, s.size() - size);
   return result;
 }

--- a/cpp/celeborn/utils/CelebornUtils.h
+++ b/cpp/celeborn/utils/CelebornUtils.h
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <vector>
 
+#include "celeborn/memory/ByteBuffer.h"
 #include "celeborn/utils/Exceptions.h"
 
 namespace celeborn {
@@ -33,6 +34,13 @@ namespace utils {
 #define CELEBORN_SHUTDOWN_LOG_PREFIX "[CELEBORN_SHUTDOWN] "
 #define CELEBORN_SHUTDOWN_LOG(severity) \
   LOG(severity) << CELEBORN_SHUTDOWN_LOG_PREFIX
+
+void writeUTF(memory::WriteOnlyByteBuffer& buffer, const std::string& msg);
+
+void writeRpcAddress(
+    memory::WriteOnlyByteBuffer& buffer,
+    const std::string& host,
+    int port);
 
 using Duration = std::chrono::duration<double>;
 using Timeout = std::chrono::milliseconds;


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds NettyRpcEndpointRef to cppClient.

### Why are the changes needed?
NettyRpcEndpointRef is responsible for communicating with LifecycleManager.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
