### PR TITLE
[CELEBORN-1877] Bump zstd-jni version from 1.5.2-1 to 1.5.7-1

### DIFF
--- a/dev/deps/dependencies-client-flink-1.16
+++ b/dev/deps/dependencies-client-flink-1.16
@@ -78,4 +78,4 @@ scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -78,4 +78,4 @@ scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -78,4 +78,4 @@ scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-client-flink-1.19
+++ b/dev/deps/dependencies-client-flink-1.19
@@ -78,4 +78,4 @@ scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-client-flink-1.20
+++ b/dev/deps/dependencies-client-flink-1.20
@@ -78,4 +78,4 @@ scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -199,4 +199,4 @@ woodstox-core/5.4.0//woodstox-core-5.4.0.jar
 xz/1.0//xz-1.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-client-tez
+++ b/dev/deps/dependencies-client-tez
@@ -175,4 +175,4 @@ token-provider/1.0.1//token-provider-1.0.1.jar
 woodstox-core/5.4.0//woodstox-core-5.4.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -145,4 +145,4 @@ swagger-integration/2.2.1//swagger-integration-2.2.1.jar
 swagger-jaxrs2/2.2.1//swagger-jaxrs2-2.2.1.jar
 swagger-models/2.2.1//swagger-models-2.2.1.jar
 swagger-ui/4.9.1//swagger-ui-4.9.1.jar
-zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar
+zstd-jni/1.5.7-1//zstd-jni-1.5.7-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <slf4j.version>1.7.36</slf4j.version>
     <roaringbitmap.version>1.0.6</roaringbitmap.version>
     <snakeyaml.version>2.2</snakeyaml.version>
-    <zstd-jni.version>1.5.2-1</zstd-jni.version>
+    <zstd-jni.version>1.5.7-1</zstd-jni.version>
     <kubernetes-client.version>6.7.0</kubernetes-client.version>
     <rocksdbjni.version>9.5.2</rocksdbjni.version>
     <jackson.version>2.15.3</jackson.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -37,7 +37,7 @@ import CelebornCommonSettings._
 
 object Dependencies {
 
-  val zstdJniVersion = sparkClientProjects.map(_.zstdJniVersion).getOrElse("1.5.2-1")
+  val zstdJniVersion = sparkClientProjects.map(_.zstdJniVersion).getOrElse("1.5.7-1")
   val lz4JavaVersion = sparkClientProjects.map(_.lz4JavaVersion).getOrElse("1.8.0")
 
   // Dependent library versions


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump zstd-jni version from 1.5.2-1 to 1.5.7-1.

### Why are the changes needed?

Bump zstd-jni to the latest version.

Backport https://github.com/apache/spark/pull/50057.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.