### PR TITLE
[CELEBORN-1879] Ignore invalid chunk range generated by splitSkewedPartitionLocations

### DIFF
--- a/client-spark/spark-3-4/src/main/java/org/apache/spark/shuffle/celeborn/CelebornPartitionUtil.java
+++ b/client-spark/spark-3-4/src/main/java/org/apache/spark/shuffle/celeborn/CelebornPartitionUtil.java
@@ -85,7 +85,7 @@ public class CelebornPartitionUtil {
         if (currentOffset <= endOffset) {
           right = j - 1;
         }
-        if (left >= 0 && right >= 0) {
+        if (left >= 0 && right >= 0 && right >= left) {
           chunkRange.put(p.getUniqueId(), Pair.of(left, right));
         }
         j++;

--- a/client-spark/spark-3-4/src/test/java/org/apache/spark/shuffle/celeborn/CelebornPartitionUtilSuiteJ.java
+++ b/client-spark/spark-3-4/src/test/java/org/apache/spark/shuffle/celeborn/CelebornPartitionUtilSuiteJ.java
@@ -30,25 +30,26 @@ public class CelebornPartitionUtilSuiteJ {
   @Test
   public void testSkewPartitionSplitIgnoreEmpty1() {
     ArrayList<PartitionLocation> locations = new ArrayList<>();
-    PartitionLocation loc = genPartitionLocation(0, new Long[]{0L, 20L, 30L});
+    PartitionLocation loc = genPartitionLocation(0, new Long[] {0L, 20L, 30L});
     List<Long> offsets = loc.getStorageInfo().getChunkOffsets();
     locations.add(loc);
     int partitionNumber = 10;
     Long sum = 0L;
-    for(int i = 0; i < partitionNumber; i++) {
+    for (int i = 0; i < partitionNumber; i++) {
       Map<String, Pair<Integer, Integer>> res =
-              CelebornPartitionUtil.splitSkewedPartitionLocations(locations, partitionNumber, i);
-      if(!res.isEmpty()) {
+          CelebornPartitionUtil.splitSkewedPartitionLocations(locations, partitionNumber, i);
+      if (!res.isEmpty()) {
         int l = res.get(loc.getUniqueId()).getLeft();
         int r = res.get(loc.getUniqueId()).getRight();
         Assert.assertTrue(r >= l);
-        for(int j = l; j <= r; j++) {
+        for (int j = l; j <= r; j++) {
           sum += offsets.get(j + 1) - offsets.get(j);
         }
       }
     }
     Assert.assertEquals(offsets.get(offsets.size() - 1), sum);
   }
+
   @Test
   public void testSkewPartitionSplit() {
 

--- a/client-spark/spark-3-4/src/test/java/org/apache/spark/shuffle/celeborn/CelebornPartitionUtilSuiteJ.java
+++ b/client-spark/spark-3-4/src/test/java/org/apache/spark/shuffle/celeborn/CelebornPartitionUtilSuiteJ.java
@@ -28,6 +28,28 @@ import org.apache.celeborn.common.protocol.StorageInfo;
 
 public class CelebornPartitionUtilSuiteJ {
   @Test
+  public void testSkewPartitionSplitIgnoreEmpty1() {
+    ArrayList<PartitionLocation> locations = new ArrayList<>();
+    PartitionLocation loc = genPartitionLocation(0, new Long[]{0L, 20L, 30L});
+    List<Long> offsets = loc.getStorageInfo().getChunkOffsets();
+    locations.add(loc);
+    int partitionNumber = 10;
+    Long sum = 0L;
+    for(int i = 0; i < partitionNumber; i++) {
+      Map<String, Pair<Integer, Integer>> res =
+              CelebornPartitionUtil.splitSkewedPartitionLocations(locations, partitionNumber, i);
+      if(!res.isEmpty()) {
+        int l = res.get(loc.getUniqueId()).getLeft();
+        int r = res.get(loc.getUniqueId()).getRight();
+        Assert.assertTrue(r >= l);
+        for(int j = l; j <= r; j++) {
+          sum += offsets.get(j + 1) - offsets.get(j);
+        }
+      }
+    }
+    Assert.assertEquals(offsets.get(offsets.size() - 1), sum);
+  }
+  @Test
   public void testSkewPartitionSplit() {
 
     ArrayList<PartitionLocation> locations = new ArrayList<>();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

 Ignore invalid chunk range generated by splitSkewedPartitionLocations

### Why are the changes needed?

Current implementation of skew partition split method (`splitSkewedPartitionLocations`)  may generate chunk range where `range.left` > `range.right`. Such chunk range is invalid and will cause unnecessary initialization of `PartitionReader`

### Does this PR introduce _any_ user-facing change?

no 

### How was this patch tested?

ut 
