### PR TITLE
[CELEBORN-1875][FOLLOWUP] Support master --show-workers-topology command to show registered workers topology

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -77,6 +77,11 @@ final class MasterOptions {
   @Option(names = Array("--show-workers"), description = Array("Show registered workers"))
   private[master] var showWorkers: Boolean = _
 
+  @Option(
+    names = Array("--show-workers-topology"),
+    description = Array("Show registered workers topology"))
+  private[master] var showWorkersTopology: Boolean = _
+
   @Option(names = Array("--show-conf"), description = Array("Show master conf"))
   private[master] var showConf: Boolean = _
 

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -47,6 +47,7 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
     if (masterOptions.showDecommissioningWorkers) log(runShowDecommissioningWorkers)
     if (masterOptions.showLifecycleManagers) log(runShowLifecycleManagers)
     if (masterOptions.showWorkers) log(runShowWorkers)
+    if (masterOptions.showWorkersTopology) log(runShowWorkersTopology)
     if (masterOptions.showConf) log(runShowConf)
     if (masterOptions.showContainerInfo) log(runShowContainerInfo)
     if (masterOptions.showDynamicConf) log(runShowDynamicConf)
@@ -164,6 +165,8 @@ class MasterSubcommandImpl extends Runnable with MasterSubcommand {
     applicationApi.getApplicationHostNames
 
   private[master] def runShowWorkers: WorkersResponse = workerApi.getWorkers
+
+  private[master] def runShowWorkersTopology: TopologyResponse = workerApi.getWorkersTopology()
 
   private[master] def getWorkerIds: util.List[WorkerId] = {
     val workerIds = commonOptions.workerIds

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -186,6 +186,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureOutputAndValidateResponse(args, "WorkersResponse")
   }
 
+  test("master --show-workers-topology") {
+    val args = prepareMasterArgs() :+ "--show-workers-topology"
+    captureOutputAndValidateResponse(args, "TopologyResponse")
+  }
+
   test("master --show-conf") {
     val args = prepareMasterArgs() :+ "--show-conf"
     captureOutputAndValidateResponse(args, "ConfResponse")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow up #3112.

Support `master --show-workers-topology` command to show registered workers topology.

### Why are the changes needed?

Rest API `/api/v1/workers/topology` supports the grouped workers topology info, which is lack of cli command to show registered workers topology.

### Does this PR introduce _any_ user-facing change?

Introduce `master --show-workers-topology` command.

### How was this patch tested?

`TestCelebornCliCommands#master --show-workers-topology`