### PR TITLE
[CELEBORN-1884] Bump rocksdbjni version from 9.5.2 to 9.10.0

### DIFF
--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -133,7 +133,7 @@ ratis-server-api/3.1.3//ratis-server-api-3.1.3.jar
 ratis-server/3.1.3//ratis-server-3.1.3.jar
 ratis-shell/3.1.3//ratis-shell-3.1.3.jar
 ratis-thirdparty-misc/1.0.8//ratis-thirdparty-misc-1.0.8.jar
-rocksdbjni/9.5.2//rocksdbjni-9.5.2.jar
+rocksdbjni/9.10.0//rocksdbjni-9.10.0.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <snakeyaml.version>2.2</snakeyaml.version>
     <zstd-jni.version>1.5.7-1</zstd-jni.version>
     <kubernetes-client.version>6.7.0</kubernetes-client.version>
-    <rocksdbjni.version>9.5.2</rocksdbjni.version>
+    <rocksdbjni.version>9.10.0</rocksdbjni.version>
     <jackson.version>2.15.3</jackson.version>
     <snappy.version>1.1.10.5</snappy.version>
     <ap.loader.version>3.0-9</ap.loader.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -62,7 +62,7 @@ object Dependencies {
   val nettyVersion = "4.1.118.Final"
   val ratisVersion = "3.1.3"
   val roaringBitmapVersion = "1.0.6"
-  val rocksdbJniVersion = "9.5.2"
+  val rocksdbJniVersion = "9.10.0"
   val jacksonVersion = "2.15.3"
   val jakartaActivationApiVersion = "1.2.1"
   val scalatestMockitoVersion = "1.17.14"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump rocksdbjni version from 9.5.2 to 9.10.0.

### Why are the changes needed?

There are some bug fixes and performance Improvements. The full release notes:

- https://github.com/facebook/rocksdb/releases/tag/v9.6.1
- https://github.com/facebook/rocksdb/releases/tag/v9.7.3
- https://github.com/facebook/rocksdb/releases/tag/v9.7.4
- https://github.com/facebook/rocksdb/releases/tag/v9.8.4
- https://github.com/facebook/rocksdb/releases/tag/v9.9.3
- https://github.com/facebook/rocksdb/releases/tag/v9.10.0

Backport:

- https://github.com/apache/spark/pull/48155
- https://github.com/apache/spark/pull/49538
- https://github.com/apache/spark/pull/50076

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.