### PR TITLE
[CELEBORN-1891] Improve the state reconciliation on worker restart

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/ShuffleRecoverHelper.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/ShuffleRecoverHelper.java
@@ -22,17 +22,20 @@ import java.nio.charset.StandardCharsets;
 import org.apache.celeborn.service.deploy.worker.shuffledb.StoreVersion;
 
 public abstract class ShuffleRecoverHelper {
-  protected String SHUFFLE_KEY_PREFIX = "SHUFFLE-KEY";
   protected StoreVersion CURRENT_VERSION = new StoreVersion(1, 0);
 
   protected byte[] dbShuffleKey(String shuffleKey) {
-    return (SHUFFLE_KEY_PREFIX + ";" + shuffleKey).getBytes(StandardCharsets.UTF_8);
+    return (getKeyPrefix() + ";" + shuffleKey).getBytes(StandardCharsets.UTF_8);
   }
 
   protected String parseDbShuffleKey(String s) {
-    if (!s.startsWith(SHUFFLE_KEY_PREFIX)) {
-      throw new IllegalArgumentException("Expected a string starting with " + SHUFFLE_KEY_PREFIX);
+    if (!s.startsWith(getKeyPrefix())) {
+      throw new IllegalArgumentException("Expected a string starting with " + getKeyPrefix());
     }
-    return s.substring(SHUFFLE_KEY_PREFIX.length() + 1);
+    return s.substring(getKeyPrefix().length() + 1);
+  }
+
+  protected String getKeyPrefix() {
+    return "SHUFFLE-KEY";
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Adding unique shuffle prefix for different use case. Improve the worker state reconciliation performance after worker restart by avoiding double reads for the entries present in the DB.
- Fail at startup if corrupted records are detected. (This should not happen in ideal scenarios)

### Why are the changes needed?

To improve the worker reconciliation process.

### Does this PR introduce _any_ user-facing change?
Yes, it will break the reload on restart on major version upgrade to 0.6.0 from lower versions. 

### How was this patch tested?
Existing UTs for StorageManager and PartitionSorter will cover it.
