### PR TITLE
[CELEBORN-1889] Fix scala 2.13 complie error

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -371,7 +371,7 @@ class LocalTierWriter(
   private val channel: FileChannel =
     FileChannelUtils.createWritableFileChannel(diskFileInfo.getFilePath);
 
-  override def needEvict: Boolean = {
+  override def needEvict(): Boolean = {
     false
   }
 
@@ -518,7 +518,7 @@ class DfsTierWriter(
       hadoopFs.create(hdfsFileInfo.getDfsPath, true).close()
   }
 
-  override def needEvict: Boolean = {
+  override def needEvict(): Boolean = {
     false
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

add '()' to override method, because method in parent class has '()'

### Why are the changes needed?

./build/make-distribution.sh -Dscala.version=2.13.5 -Dscala.binary.version=2.13 -Pjdk-17
complains error

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit test