### PR TITLE
[CELEBORN-1893] Support jemalloc.so.2

### DIFF
--- a/sbin/load-celeborn-env.sh
+++ b/sbin/load-celeborn-env.sh
@@ -84,16 +84,19 @@ fi
 maybe_enable_jemalloc() {
   if [ "${CELEBORN_PREFER_JEMALLOC:-false}" == "true" ]; then
     JEMALLOC_PATH="${CELEBORN_JEMALLOC_PATH:-/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so}"
+    JEMALLOC2_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"
     JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
     if [ -f "$JEMALLOC_PATH" ]; then
       export LD_PRELOAD="$LD_PRELOAD:$JEMALLOC_PATH"
+    elif [ -f "$JEMALLOC2_PATH" ]; then
+      export LD_PRELOAD="$LD_PRELOAD:$JEMALLOC2_PATH"
     elif [ -f "$JEMALLOC_FALLBACK" ]; then
       export LD_PRELOAD="$LD_PRELOAD:$JEMALLOC_FALLBACK"
     else
       if [ "$JEMALLOC_PATH" == "$JEMALLOC_FALLBACK" ]; then
         MSG_PATH="$JEMALLOC_PATH"
       else
-        MSG_PATH="$JEMALLOC_PATH and $JEMALLOC_FALLBACK"
+        MSG_PATH="$JEMALLOC_PATH and $JEMALLOC2_PATH and $JEMALLOC_FALLBACK"
       fi
       echo "WARNING: attempted to load jemalloc from $MSG_PATH but the library couldn't be found. glibc will be used instead."
     fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Support `libjemalloc.so.2` by default when CELEBORN_PREFER_JEMALLOC is set to true


### Why are the changes needed?
Currently only `libjemalloc.so` is supported. We can manually set CELEBORN_JEMALLOC_PATH to the `.so.2` path but would be nice to be able to support this by default. Happy to close this if community prefers just setting CELEBORN_JEMALLOC_PATH manually.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually tested that the .so.2 path gets set when the .so.2 path doesn't exist and running in prod.
