### PR TITLE
[CELEBORN-1897] Avoid calling toString for too long messages

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
@@ -253,7 +253,7 @@ class NettyRpcEnv(
       case RpcFailure(e) => onFailure(e)
       case rpcReply =>
         if (!promise.trySuccess(rpcReply)) {
-          logWarning(s"Ignored message: $reply")
+          logWarning(s"Ignored message: ${reply.getClass.getCanonicalName}")
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

https://github.com/apache/celeborn/blob/196ad607cd62af83b1ace887b8eb91d548fc36ac/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala#L256 we hit the issue that the ignored message is too long , and when calling toString, it applies for a too large array which is beyond the JVM's limit 




I don't think this log convey too much info, , so we could avoid calling toString to improve robustness of the applications



### Why are the changes needed?

more details in JIRA


### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

prod