### PR TITLE
[WIP][CELEBORN-1904] Cancel the stage running tasks on stage rerun to save resource

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -241,6 +241,16 @@ public class SparkUtils {
     }
   }
 
+  public static TaskSetManager getTaskSetManager(long taskId) {
+    SparkContext sparkContext = SparkContext$.MODULE$.getActive().getOrElse(null);
+    if (sparkContext == null) {
+      logger.error("Can not get active SparkContext.");
+      return null;
+    }
+    TaskSchedulerImpl taskScheduler = (TaskSchedulerImpl) sparkContext.taskScheduler();
+    return getTaskSetManager(taskScheduler, taskId);
+  }
+
   @VisibleForTesting
   protected static Tuple2<TaskInfo, List<TaskInfo>> getTaskAttempts(
       TaskSetManager taskSetManager, long taskId) {
@@ -268,9 +278,9 @@ public class SparkUtils {
   protected static Map<String, Set<Long>> reportedStageShuffleFetchFailureTaskIds =
       JavaUtils.newConcurrentHashMap();
 
-  protected static void removeStageReportedShuffleFetchFailureTaskIds(
+  protected static Set<Long> removeStageReportedShuffleFetchFailureTaskIds(
       int stageId, int stageAttemptId) {
-    reportedStageShuffleFetchFailureTaskIds.remove(stageId + "-" + stageAttemptId);
+    return reportedStageShuffleFetchFailureTaskIds.remove(stageId + "-" + stageAttemptId);
   }
 
   /**

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -234,6 +234,9 @@ public class SparkUtils {
       TASK_SETS_BY_STAGE_ID_AND_ATTEMPT_FIELD =
           DynFields.builder()
               .hiddenImpl(TaskSchedulerImpl.class, "taskSetsByStageIdAndAttempt")
+              .hiddenImpl(
+                  TaskSchedulerImpl.class,
+                  "org$apache$spark$scheduler$TaskSchedulerImpl$$taskSetsByStageIdAndAttempt")
               .defaultAlwaysNull()
               .build();
   private static final DynFields.UnboundField<scala.collection.mutable.HashSet<Long>>

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/ShuffleFetchFailureReportTaskCleanListener.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/ShuffleFetchFailureReportTaskCleanListener.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.shuffle.celeborn
 
-import scala.collection.JavaConverters._
-
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted}
 
 import org.apache.celeborn.common.internal.Logging
@@ -30,16 +28,14 @@ class ShuffleFetchFailureReportTaskCleanListener extends SparkListener with Logg
     val shuffleFetchFailureTaskIds =
       SparkUtils.removeStageReportedShuffleFetchFailureTaskIds(stageId, stageAttemptId)
     if (shuffleFetchFailureTaskIds != null) {
-      shuffleFetchFailureTaskIds.asScala.headOption.foreach { case taskId =>
-        val taskSetManager = SparkUtils.getTaskSetManager(taskId)
-        if (taskSetManager != null && taskSetManager.runningTasks > 0) {
-          logInfo(s"Killing the ${taskSetManager.runningTasks} running tasks in stage" +
-            s" $stageId (attempt $stageAttemptId) due to shuffle fetch failure." +
-            s" The entire stage will be rerun.")
-          SparkUtils.killTaskSetManagerRunningTasks(
-            taskSetManager,
-            "The entire stage will be rerun due to shuffle fetch failure.")
-        }
+      val taskSetManager = SparkUtils.getTaskSetManager(stageId, stageAttemptId)
+      if (taskSetManager != null && taskSetManager.runningTasks > 0) {
+        logInfo(s"Killing the ${taskSetManager.runningTasks} running tasks in stage" +
+          s" $stageId (attempt $stageAttemptId) due to shuffle fetch failure." +
+          s" The entire stage will be rerun.")
+        SparkUtils.killTaskSetManagerRunningTasks(
+          taskSetManager,
+          "The entire stage will be rerun due to shuffle fetch failure.")
       }
     }
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -425,19 +425,21 @@ public class SparkUtils {
     }
     int killedTasks = 0;
     TaskSchedulerImpl taskScheduler = (TaskSchedulerImpl) sparkContext.taskScheduler();
-    for (Long taskId :
-        scala.collection.JavaConverters.asJavaCollectionConverter(
-                RUNNING_TASKS_SET_FIELD.bind(taskSetManager).get())
-            .asJavaCollection()) {
-      try {
-        taskScheduler.killTaskAttempt(taskId, true, reason);
-        killedTasks++;
-      } catch (Throwable e) {
-        LOG.error("Failed to kill running task {} in {}", taskId, taskSetManager.name(), e);
+    synchronized (taskScheduler) {
+      for (Long taskId :
+          scala.collection.JavaConverters.asJavaCollectionConverter(
+                  RUNNING_TASKS_SET_FIELD.bind(taskSetManager).get())
+              .asJavaCollection()) {
+        try {
+          taskScheduler.killTaskAttempt(taskId, true, reason);
+          killedTasks++;
+        } catch (Throwable e) {
+          LOG.error("Failed to kill running task {} in {}", taskId, taskSetManager.name(), e);
+        }
       }
+      LOG.info("Killed {} running tasks in {}", killedTasks, taskSetManager.name());
+      return killedTasks;
     }
-    LOG.info("Killed {} running tasks in {}", killedTasks, taskSetManager.name());
-    return killedTasks;
   }
 
   protected static Map<String, Set<Long>> reportedStageShuffleFetchFailureTaskIds =

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -371,6 +371,9 @@ public class SparkUtils {
     }
   }
 
+  /**
+   * TaskSetManager - it is not designed to be used outside the spark scheduler. Please be careful.
+   */
   public static TaskSetManager getTaskSetManager(int stageId, int stageAttemptId) {
     SparkContext sparkContext = SparkContext$.MODULE$.getActive().getOrElse(null);
     if (sparkContext == null) {
@@ -378,17 +381,19 @@ public class SparkUtils {
       return null;
     }
     TaskSchedulerImpl taskScheduler = (TaskSchedulerImpl) sparkContext.taskScheduler();
-    scala.collection.mutable.HashMap<
-            Integer, scala.collection.mutable.HashMap<Integer, TaskSetManager>>
-        taskSetsByStageIdAndAttempt =
-            TASK_SETS_BY_STAGE_ID_AND_ATTEMPT_FIELD.bind(taskScheduler).get();
-    scala.Option<scala.collection.mutable.HashMap<Integer, TaskSetManager>> stageTaskSetAttempts =
-        taskSetsByStageIdAndAttempt.get(stageId);
-    if (stageTaskSetAttempts.isDefined()) {
-      return stageTaskSetAttempts.get().get(stageAttemptId).getOrElse(null);
-    } else {
-      LOG.error("Can not get TaskSetManager for stage {} (attempt {})", stageId, stageAttemptId);
-      return null;
+    synchronized (taskScheduler) {
+      scala.collection.mutable.HashMap<
+              Integer, scala.collection.mutable.HashMap<Integer, TaskSetManager>>
+          taskSetsByStageIdAndAttempt =
+              TASK_SETS_BY_STAGE_ID_AND_ATTEMPT_FIELD.bind(taskScheduler).get();
+      scala.Option<scala.collection.mutable.HashMap<Integer, TaskSetManager>> stageTaskSetAttempts =
+          taskSetsByStageIdAndAttempt.get(stageId);
+      if (stageTaskSetAttempts.isDefined()) {
+        return stageTaskSetAttempts.get().get(stageAttemptId).getOrElse(null);
+      } else {
+        LOG.error("Can not get TaskSetManager for stage {} (attempt {})", stageId, stageAttemptId);
+        return null;
+      }
     }
   }
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -357,6 +357,16 @@ public class SparkUtils {
     }
   }
 
+  public static TaskSetManager getTaskSetManager(long taskId) {
+    SparkContext sparkContext = SparkContext$.MODULE$.getActive().getOrElse(null);
+    if (sparkContext == null) {
+      LOG.error("Can not get active SparkContext.");
+      return null;
+    }
+    TaskSchedulerImpl taskScheduler = (TaskSchedulerImpl) sparkContext.taskScheduler();
+    return getTaskSetManager(taskScheduler, taskId);
+  }
+
   @VisibleForTesting
   protected static Tuple2<TaskInfo, List<TaskInfo>> getTaskAttempts(
       TaskSetManager taskSetManager, long taskId) {
@@ -384,9 +394,9 @@ public class SparkUtils {
   protected static Map<String, Set<Long>> reportedStageShuffleFetchFailureTaskIds =
       JavaUtils.newConcurrentHashMap();
 
-  protected static void removeStageReportedShuffleFetchFailureTaskIds(
+  protected static Set<Long> removeStageReportedShuffleFetchFailureTaskIds(
       int stageId, int stageAttemptId) {
-    reportedStageShuffleFetchFailureTaskIds.remove(stageId + "-" + stageAttemptId);
+    return reportedStageShuffleFetchFailureTaskIds.remove(stageId + "-" + stageAttemptId);
   }
 
   /**

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -344,6 +344,12 @@ public class SparkUtils {
               .hiddenImpl(TaskSetManager.class, "taskInfos")
               .defaultAlwaysNull()
               .build();
+  private static final DynFields.UnboundField<scala.collection.mutable.HashSet<Long>>
+      RUNNING_TASKS_SET_FIELD =
+          DynFields.builder()
+              .hiddenImpl(TaskSetManager.class, "runningTasksSet")
+              .defaultAlwaysNull()
+              .build();
 
   /**
    * TaskSetManager - it is not designed to be used outside the spark scheduler. Please be careful.
@@ -388,6 +394,24 @@ public class SparkUtils {
     } else {
       LOG.error("Can not get TaskSetManager for taskId: {}", taskId);
       return null;
+    }
+  }
+
+  protected static void killTaskSetManagerRunningTasks(
+      TaskSetManager taskSetManager, String reason) {
+    SparkContext sparkContext = SparkContext$.MODULE$.getActive().getOrElse(null);
+    if (sparkContext == null) {
+      LOG.error("Can not get active SparkContext.");
+      return;
+    }
+    TaskSchedulerImpl taskScheduler = (TaskSchedulerImpl) sparkContext.taskScheduler();
+    try {
+      scala.collection.JavaConverters.asJavaCollectionConverter(
+              RUNNING_TASKS_SET_FIELD.bind(taskSetManager).get())
+          .asJavaCollection().stream()
+          .forEach(taskId -> taskScheduler.killTaskAttempt(taskId, true, reason));
+    } catch (Exception e) {
+      LOG.error("Failed to kill running tasks in " + taskSetManager.name(), e);
     }
   }
 

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/ShuffleFetchFailureReportTaskCleanListener.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/ShuffleFetchFailureReportTaskCleanListener.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.shuffle.celeborn
 
-import scala.collection.JavaConverters._
-
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted}
 
 import org.apache.celeborn.common.internal.Logging
@@ -30,16 +28,14 @@ class ShuffleFetchFailureReportTaskCleanListener extends SparkListener with Logg
     val shuffleFetchFailureTaskIds =
       SparkUtils.removeStageReportedShuffleFetchFailureTaskIds(stageId, stageAttemptId)
     if (shuffleFetchFailureTaskIds != null) {
-      shuffleFetchFailureTaskIds.asScala.headOption.foreach { case taskId =>
-        val taskSetManager = SparkUtils.getTaskSetManager(taskId)
-        if (taskSetManager != null && taskSetManager.runningTasks > 0) {
-          logInfo(s"Killing the ${taskSetManager.runningTasks} running tasks in stage" +
-            s" $stageId (attempt $stageAttemptId) due to shuffle fetch failure." +
-            s" The entire stage will be rerun.")
-          SparkUtils.killTaskSetManagerRunningTasks(
-            taskSetManager,
-            "The entire stage will be rerun due to shuffle fetch failure.")
-        }
+      val taskSetManager = SparkUtils.getTaskSetManager(stageId, stageAttemptId)
+      if (taskSetManager != null && taskSetManager.runningTasks > 0) {
+        logInfo(s"Killing the ${taskSetManager.runningTasks} running tasks in stage" +
+          s" $stageId (attempt $stageAttemptId) due to shuffle fetch failure." +
+          s" The entire stage will be rerun.")
+        SparkUtils.killTaskSetManagerRunningTasks(
+          taskSetManager,
+          "The entire stage will be rerun due to shuffle fetch failure.")
       }
     }
   }

--- a/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
@@ -141,9 +141,13 @@ class SparkUtilsSuite extends AnyFunSuite
         val taskId = 0
         val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, taskId)
         assert(taskSetManager != null)
+        assert(taskSetManager == SparkUtils.getTaskSetManager(
+          taskSetManager.taskSet.stageId,
+          taskSetManager.taskSet.stageAttemptId))
         assert(SparkUtils.getTaskAttempts(taskSetManager, taskId)._2.size() == 1)
         assert(!SparkUtils.taskAnotherAttemptRunningOrSuccessful(taskId))
         assert(SparkUtils.reportedStageShuffleFetchFailureTaskIds.size() == 1)
+        assert(SparkUtils.killTaskSetManagerRunningTasks(taskSetManager, "test") > 0)
       }
 
       sparkSession.sparkContext.cancelAllJobs()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
On `SparkListenerStageCompleted` event, check whether the shuffle fetch failure reported in the stage, if that, cancel the running tasks due celeborn client will rerun the whole stage.

### Why are the changes needed?

If the task failed due to FetchFailed, dag scheduler would `markStageAsFinished`.
https://github.com/apache/spark/blob/3a872b7ca11faa128a2667de55f6dca13807057a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L2022-L2060

But it will not cancel the running tasks in the stage.

For example, in below stage, a task failed due to fetch failure, and the stage duration is 39s.
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/2649d3d2-10c3-4d0c-b49b-565cb626fab3" />

However, it does not cancel the running tasks, the launched 2496 tasks keep running and the maximum task duration is 31 minutes.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/fcb5b82d-0316-4024-a87d-30da7109cdf5" />

It wastes a lot of compute resource.

For celeborn shuffle fetch failure, it will rerun the whole stage, so it is fine to cancel all the running tasks.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
UT & Cluster testing.

The stage terminated quickly.
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/e76d562c-9e43-4839-9d7a-d11515f43d69" />

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/bb4175d5-eb1b-4a93-a8ca-a384b8d68cf9" />
