### PR TITLE
[CELEBORN-1926] updated helmChart to allow different nodeSelector and tolerations for master and worker nodes

### DIFF
--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -125,11 +125,11 @@ spec:
       {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.masterNodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.masterTolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -128,11 +128,11 @@ spec:
       {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.workerNodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.workerTolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -69,9 +69,9 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should add node selector if `masterNodeSelector` is set
     set:
-      nodeSelector:
+      masterNodeSelector:
         key1: value1
         key2: value2
     asserts:
@@ -82,9 +82,9 @@ tests:
           path: spec.template.spec.nodeSelector.key2
           value: value2
 
-  - it: Should add tolerations if `tolerations` is set
+  - it: Should add tolerations if `masterTolerations` is set
     set:
-      tolerations:
+      masterTolerations:
         - key: key1
           operator: Equal
           value: value1

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -69,9 +69,9 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should add node selector if `workerNodeSelector` is set
     set:
-      nodeSelector:
+      workerNodeSelector:
         key1: value1
         key2: value2
     asserts:
@@ -82,9 +82,9 @@ tests:
           path: spec.template.spec.nodeSelector.key2
           value: value2
 
-  - it: Should add tolerations if `tolerations` is set
+  - it: Should add tolerations if `workerTolerations` is set
     set:
-      tolerations:
+      workerTolerations:
         - key: key1
           operator: Equal
           value: value1

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -190,12 +190,25 @@ podAnnotations: {}
 # key2: value2
 
 # -- Pod node selector
-nodeSelector: {}
+masterNodeSelector: {}
+# key1: value1
+# key2: value2
+
+workerNodeSelector: {}
 # key1: value1
 # key2: value2
 
 # -- Pod tolerations
-tolerations: []
+masterTolerations: []
+# - key: key1
+#   operator: Equal
+#   value: value1
+#   effect: NoSchedule
+# - key: key2
+#   operator: Exists
+#   effect: NoSchedule
+
+workerTolerations: []
 # - key: key1
 #   operator: Equal
 #   value: value1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

support different master/worker nodeSelector and tolerations

### Why are the changes needed?

add possibility to run master and worker on different nodeGroups

### Does this PR introduce _any_ user-facing change?

updated helmChart values

### How was this patch tested?

tested on our k8s cluster