### PR TITLE
CELEBORN-1334 [CIP-12] Support HARD_SPLIT in PushMergedData should not support new version client with old version worker

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1544,9 +1544,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                     dataBatchReviveInfos);
               } else {
                 callback.onFailure(
-                    new CelebornIOException(
-                        "Parser pushMergedData response failed since no HARD_SPLIT array message. "
-                        "Current version client can't be compatibility with older worker version."));
+                    new CelebornIOException("Parser pushMergedData response failed. " +
+                        "Current client can't be compatibility with older worker version."));
                 return;
               }
               if (batchesNeedResubmit.isEmpty()) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1543,20 +1543,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                     groupedBatchId,
                     dataBatchReviveInfos);
               } else {
-                // Workers that do not incorporate changes from [CELEBORN-1721]
-                // will respond with a status of HARD_SPLIT,
-                // but will not include a PbPushMergedDataSplitPartitionInfo.
-                // For backward compatibility, all batches must be resubmitted.
-                batchesNeedResubmit = batches;
-                logger.info(
-                    "Push merged data to {} hard split required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
-                    addressPair,
-                    shuffleId,
-                    mapId,
-                    attemptId,
-                    Arrays.toString(partitionIds),
-                    groupedBatchId,
-                    Arrays.toString(batchIds));
+                callback.onFailure(
+                    new CelebornIOException("Parser pushMergedData response failed since no HARD_SPLIT array message. "
+                    "Current version client can't be compatibility with older worker version."));
+                return;
               }
               if (batchesNeedResubmit.isEmpty()) {
                 pushState.onSuccess(hostPort);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1544,8 +1544,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                     dataBatchReviveInfos);
               } else {
                 callback.onFailure(
-                    new CelebornIOException("Parser pushMergedData response failed. " +
-                        "Current client can't be compatibility with older worker version."));
+                    new CelebornIOException(
+                        "Parser pushMergedData response failed. " +
+                              "Current client can't be compatibility with older worker version."));
                 return;
               }
               if (batchesNeedResubmit.isEmpty()) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1624,7 +1624,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             } else {
               // Workers that do not incorporate changes from [CELEBORN-1721]
               // will respond with a status of empty response.
-              // For backward compatibility, we should keep logic of check response remaining.
+              //  For backward compatibility, we should keep logic of check response remaining.
               pushState.onSuccess(hostPort);
               callback.onSuccess(response);
             }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1545,8 +1545,8 @@ public class ShuffleClientImpl extends ShuffleClient {
               } else {
                 callback.onFailure(
                     new CelebornIOException(
-                        "Parser pushMergedData response failed. " +
-                              "Current client can't be compatibility with older worker version."));
+                        "Parser pushMergedData response failed. "
+                            + "Current client can't be compatibility with older worker version."));
                 return;
               }
               if (batchesNeedResubmit.isEmpty()) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1544,8 +1544,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                     dataBatchReviveInfos);
               } else {
                 callback.onFailure(
-                    new CelebornIOException("Parser pushMergedData response failed since no HARD_SPLIT array message. "
-                    "Current version client can't be compatibility with older worker version."));
+                    new CelebornIOException(
+                        "Parser pushMergedData response failed since no HARD_SPLIT array message. "
+                        "Current version client can't be compatibility with older worker version."));
                 return;
               }
               if (batchesNeedResubmit.isEmpty()) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1624,7 +1624,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             } else {
               // Workers that do not incorporate changes from [CELEBORN-1721]
               // will respond with a status of empty response.
-              //  For backward compatibility, we should keep logic of check response remaining.
+              // For backward compatibility, we should keep logic of check response remaining.
               pushState.onSuccess(hostPort);
               callback.onSuccess(response);
             }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1490,109 +1490,66 @@ public class ShuffleClientImpl extends ShuffleClient {
         new RpcResponseCallback() {
           @Override
           public void onSuccess(ByteBuffer response) {
-            if (response.remaining() > 0) {
-              byte reason = response.get();
-              if (reason == StatusCode.HARD_SPLIT.getValue()) {
-                ArrayList<DataBatches.DataBatch> batchesNeedResubmit;
-                if (response.remaining() > 0) {
-                  batchesNeedResubmit = new ArrayList<>();
-                  PbPushMergedDataSplitPartitionInfo partitionInfo;
-                  try {
-                    partitionInfo = TransportMessage.fromByteBuffer(response).getParsedPayload();
-                  } catch (CelebornIOException | InvalidProtocolBufferException e) {
-                    callback.onFailure(
-                        new CelebornIOException("parse pushMergedData response failed", e));
-                    return;
-                  }
-                  List<Integer> splitPartitionIndexes = partitionInfo.getSplitPartitionIndexesList();
-                  List<Integer> statusCodeList = partitionInfo.getStatusCodesList();
-                  StringBuilder dataBatchReviveInfos = new StringBuilder();
-                  for (int i = 0; i < splitPartitionIndexes.size(); i++) {
-                    int partitionIndex = splitPartitionIndexes.get(i);
-                    int batchId = batches.get(partitionIndex).batchId;
-                    dataBatchReviveInfos.append(
-                        String.format(
-                            "(batchId=%d, partitionId=%d, cause=%s)",
-                            batchId,
-                            partitionIds[partitionIndex],
-                            StatusCode.fromValue(statusCodeList.get(i).byteValue())));
-                    if (statusCodeList.get(i) == StatusCode.SOFT_SPLIT.getValue()) {
-                      PartitionLocation loc = batches.get(partitionIndex).loc;
-                      if (!newerPartitionLocationExists(
-                          reducePartitionMap.get(shuffleId), loc.getId(), loc.getEpoch(), false)) {
-                        ReviveRequest reviveRequest =
-                            new ReviveRequest(
-                                shuffleId,
-                                mapId,
-                                attemptId,
-                                loc.getId(),
-                                loc.getEpoch(),
-                                loc,
-                                StatusCode.SOFT_SPLIT);
-                        reviveManager.addRequest(reviveRequest);
-                      }
-                    } else {
-                      batchesNeedResubmit.add(batches.get(partitionIndex));
-                    }
-                  }
-                  logger.info(
-                      "Push merged data to {} partial success required for shuffle {} map {} attempt {} groupedBatch {}. split batches {}.",
-                      addressPair,
-                      shuffleId,
-                      mapId,
-                      attemptId,
-                      groupedBatchId,
-                      dataBatchReviveInfos);
-                } else {
-                  // Workers that do not incorporate changes from [CELEBORN-1721]
-                  // will respond with a status of HARD_SPLIT,
-                  // but will not include a PbPushMergedDataSplitPartitionInfo.
-                  // For backward compatibility, all batches must be resubmitted.
-                  batchesNeedResubmit = batches;
-                  logger.info(
-                      "Push merged data to {} hard split required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
-                      addressPair,
-                      shuffleId,
-                      mapId,
-                      attemptId,
-                      Arrays.toString(partitionIds),
-                      groupedBatchId,
-                      Arrays.toString(batchIds));
+            byte reason = response.get();
+            if (reason == StatusCode.HARD_SPLIT.getValue()) {
+              ArrayList<DataBatches.DataBatch> batchesNeedResubmit;
+              if (response.remaining() > 0) {
+                batchesNeedResubmit = new ArrayList<>();
+                PbPushMergedDataSplitPartitionInfo partitionInfo;
+                try {
+                  partitionInfo = TransportMessage.fromByteBuffer(response).getParsedPayload();
+                } catch (CelebornIOException | InvalidProtocolBufferException e) {
+                  callback.onFailure(
+                      new CelebornIOException("parse pushMergedData response failed", e));
+                  return;
                 }
-                if (batchesNeedResubmit.isEmpty()) {
-                  pushState.onSuccess(hostPort);
-                  callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.SOFT_SPLIT.getValue()}));
-                } else {
-                  if (dataPushFailureTrackingEnabled) {
-                    for (DataBatches.DataBatch resubmitBatch : batchesNeedResubmit) {
-                      pushState.addFailedBatch(
-                          resubmitBatch.loc.getUniqueId(),
-                          new PushFailedBatch(mapId, attemptId, resubmitBatch.batchId));
-                    }
-                  }
-                  ReviveRequest[] requests =
-                      addAndGetReviveRequests(
-                          shuffleId, mapId, attemptId, batchesNeedResubmit, StatusCode.HARD_SPLIT);
-                  pushDataRetryPool.submit(
-                      () ->
-                          submitRetryPushMergedData(
-                              pushState,
+                List<Integer> splitPartitionIndexes = partitionInfo.getSplitPartitionIndexesList();
+                List<Integer> statusCodeList = partitionInfo.getStatusCodesList();
+                StringBuilder dataBatchReviveInfos = new StringBuilder();
+                for (int i = 0; i < splitPartitionIndexes.size(); i++) {
+                  int partitionIndex = splitPartitionIndexes.get(i);
+                  int batchId = batches.get(partitionIndex).batchId;
+                  dataBatchReviveInfos.append(
+                      String.format(
+                          "(batchId=%d, partitionId=%d, cause=%s)",
+                          batchId,
+                          partitionIds[partitionIndex],
+                          StatusCode.fromValue(statusCodeList.get(i).byteValue())));
+                  if (statusCodeList.get(i) == StatusCode.SOFT_SPLIT.getValue()) {
+                    PartitionLocation loc = batches.get(partitionIndex).loc;
+                    if (!newerPartitionLocationExists(
+                        reducePartitionMap.get(shuffleId), loc.getId(), loc.getEpoch(), false)) {
+                      ReviveRequest reviveRequest =
+                          new ReviveRequest(
                               shuffleId,
                               mapId,
                               attemptId,
-                              batchesNeedResubmit,
-                              StatusCode.HARD_SPLIT,
-                              groupedBatchId,
-                              requests,
-                              remainReviveTimes,
-                              System.currentTimeMillis()
-                                  + conf.clientRpcRequestPartitionLocationAskTimeout()
-                                  .duration()
-                                  .toMillis()));
+                              loc.getId(),
+                              loc.getEpoch(),
+                              loc,
+                              StatusCode.SOFT_SPLIT);
+                      reviveManager.addRequest(reviveRequest);
+                    }
+                  } else {
+                    batchesNeedResubmit.add(batches.get(partitionIndex));
+                  }
                 }
-              } else if (reason == StatusCode.PUSH_DATA_SUCCESS_PRIMARY_CONGESTED.getValue()) {
-                logger.debug(
-                    "Push merged data to {} primary congestion required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
+                logger.info(
+                    "Push merged data to {} partial success required for shuffle {} map {} attempt {} groupedBatch {}. split batches {}.",
+                    addressPair,
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    groupedBatchId,
+                    dataBatchReviveInfos);
+              } else {
+                // Workers that do not incorporate changes from [CELEBORN-1721]
+                // will respond with a status of HARD_SPLIT,
+                // but will not include a PbPushMergedDataSplitPartitionInfo.
+                // For backward compatibility, all batches must be resubmitted.
+                batchesNeedResubmit = batches;
+                logger.info(
+                    "Push merged data to {} hard split required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
                     addressPair,
                     shuffleId,
                     mapId,
@@ -1600,33 +1557,68 @@ public class ShuffleClientImpl extends ShuffleClient {
                     Arrays.toString(partitionIds),
                     groupedBatchId,
                     Arrays.toString(batchIds));
-                pushState.onCongestControl(hostPort);
-                callback.onSuccess(response);
-              } else if (reason == StatusCode.PUSH_DATA_SUCCESS_REPLICA_CONGESTED.getValue()) {
-                logger.debug(
-                    "Push merged data to {} replica congestion required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
-                    addressPair,
-                    shuffleId,
-                    mapId,
-                    attemptId,
-                    Arrays.toString(partitionIds),
-                    groupedBatchId,
-                    Arrays.toString(batchIds));
-                pushState.onCongestControl(hostPort);
-                callback.onSuccess(response);
-              } else if (reason == StatusCode.MAP_ENDED.getValue()) {
-                pushState.onSuccess(hostPort);
-                callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.MAP_ENDED.getValue()}));
-              } else { // success
-                pushState.onSuccess(hostPort);
-                callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.SUCCESS.getValue()}));
               }
-            } else {
-              // Workers that do not incorporate changes from [CELEBORN-1721]
-              // will respond with a status of empty response.
-              //  For backward compatibility, we should keep logic of check response remaining.
-              pushState.onSuccess(hostPort);
+              if (batchesNeedResubmit.isEmpty()) {
+                pushState.onSuccess(hostPort);
+                callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.SOFT_SPLIT.getValue()}));
+              } else {
+                if (dataPushFailureTrackingEnabled) {
+                  for (DataBatches.DataBatch resubmitBatch : batchesNeedResubmit) {
+                    pushState.addFailedBatch(
+                        resubmitBatch.loc.getUniqueId(),
+                        new PushFailedBatch(mapId, attemptId, resubmitBatch.batchId));
+                  }
+                }
+                ReviveRequest[] requests =
+                    addAndGetReviveRequests(
+                        shuffleId, mapId, attemptId, batchesNeedResubmit, StatusCode.HARD_SPLIT);
+                pushDataRetryPool.submit(
+                    () ->
+                        submitRetryPushMergedData(
+                            pushState,
+                            shuffleId,
+                            mapId,
+                            attemptId,
+                            batchesNeedResubmit,
+                            StatusCode.HARD_SPLIT,
+                            groupedBatchId,
+                            requests,
+                            remainReviveTimes,
+                            System.currentTimeMillis()
+                                + conf.clientRpcRequestPartitionLocationAskTimeout()
+                                    .duration()
+                                    .toMillis()));
+              }
+            } else if (reason == StatusCode.PUSH_DATA_SUCCESS_PRIMARY_CONGESTED.getValue()) {
+              logger.debug(
+                  "Push merged data to {} primary congestion required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
+                  addressPair,
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  Arrays.toString(partitionIds),
+                  groupedBatchId,
+                  Arrays.toString(batchIds));
+              pushState.onCongestControl(hostPort);
               callback.onSuccess(response);
+            } else if (reason == StatusCode.PUSH_DATA_SUCCESS_REPLICA_CONGESTED.getValue()) {
+              logger.debug(
+                  "Push merged data to {} replica congestion required for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}.",
+                  addressPair,
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  Arrays.toString(partitionIds),
+                  groupedBatchId,
+                  Arrays.toString(batchIds));
+              pushState.onCongestControl(hostPort);
+              callback.onSuccess(response);
+            } else if (reason == StatusCode.MAP_ENDED.getValue()) {
+              pushState.onSuccess(hostPort);
+              callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.MAP_ENDED.getValue()}));
+            } else { // success
+              pushState.onSuccess(hostPort);
+              callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.SUCCESS.getValue()}));
             }
           }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current version client can't be compatibility with older worker version.


### Why are the changes needed?
For backward compatibility.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

