### PR TITLE
CELEBORN-1928 [CIP-12] Support HARD_SPLIT in PushMergedData should support handle older worker success response

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -638,11 +638,12 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
               // on an older version that does not have these changes.
               // In this scenario, the replica may return a response without any context
               // when status of SUCCESS.
-              val replicaReason = if (response.remaining() > 0) {
-                response.get()
-              } else {
-                StatusCode.SUCCESS
-              }
+              val replicaReason =
+                if (response.remaining() > 0) {
+                  response.get()
+                } else {
+                  StatusCode.SUCCESS
+                }
               if (replicaReason == StatusCode.HARD_SPLIT.getValue) {
                 if (response.remaining() > 0) {
                   try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support HARD_SPLIT in PushMergedData should support handle older worker success response


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

