### PR TITLE
[CELEBORN-1932][CIP-14] Adapt java's serialization to support cpp serialization for GetReducerFileGroup/Response

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -53,6 +53,7 @@ import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportClientBootstrap;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
+import org.apache.celeborn.common.network.protocol.LanguageType;
 import org.apache.celeborn.common.network.protocol.PushData;
 import org.apache.celeborn.common.network.protocol.PushMergedData;
 import org.apache.celeborn.common.network.protocol.TransportMessage;
@@ -1803,7 +1804,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
     try {
       GetReducerFileGroup getReducerFileGroup =
-          new GetReducerFileGroup(shuffleId, isSegmentGranularityVisible);
+          new GetReducerFileGroup(shuffleId, isSegmentGranularityVisible, LanguageType.JAVA);
 
       GetReducerFileGroupResponse response =
           lifecycleManagerRef.askSync(

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -34,6 +34,7 @@ import org.apache.celeborn.client.listener.{WorkersStatus, WorkerStatusListener}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.WorkerInfo
+import org.apache.celeborn.common.network.protocol.LanguageType
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType, StorageInfo}
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc.RpcCallContext
@@ -275,8 +276,8 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
     getCommitHandler(shuffleId).waitStageEnd(shuffleId)
   }
 
-  def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
-    getCommitHandler(shuffleId).handleGetReducerFileGroup(context, shuffleId)
+  def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int, languageType: LanguageType): Unit = {
+    getCommitHandler(shuffleId).handleGetReducerFileGroup(context, shuffleId, languageType)
   }
 
   // exposed for test

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -45,6 +45,7 @@ import org.apache.celeborn.common.identity.{IdentityProvider, UserIdentifier}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{ApplicationMeta, ShufflePartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.metrics.source.Role
+import org.apache.celeborn.common.network.protocol.LanguageType
 import org.apache.celeborn.common.network.protocol.TransportMessagesHelper
 import org.apache.celeborn.common.network.sasl.registration.RegistrationInfo
 import org.apache.celeborn.common.protocol._
@@ -432,10 +433,10 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
           throw new UnsupportedOperationException(s"Not support $partitionType yet")
       }
 
-    case GetReducerFileGroup(shuffleId: Int, isSegmentGranularityVisible: Boolean) =>
+    case GetReducerFileGroup(shuffleId: Int, isSegmentGranularityVisible: Boolean, languageType: LanguageType) =>
       logDebug(
         s"Received GetShuffleFileGroup request for shuffleId $shuffleId, isSegmentGranularityVisible $isSegmentGranularityVisible")
-      handleGetReducerFileGroup(context, shuffleId, isSegmentGranularityVisible)
+      handleGetReducerFileGroup(context, shuffleId, isSegmentGranularityVisible, languageType)
 
     case pb: PbGetShuffleId =>
       val appShuffleId = pb.getAppShuffleId
@@ -845,7 +846,8 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   private def handleGetReducerFileGroup(
       context: RpcCallContext,
       shuffleId: Int,
-      isSegmentGranularityVisible: Boolean): Unit = {
+      isSegmentGranularityVisible: Boolean,
+      languageType: LanguageType): Unit = {
     // If isSegmentGranularityVisible is set to true, the downstream reduce task may start early than upstream map task, e.g. flink hybrid shuffle.
     // Under these circumstances, there's a possibility that the shuffle might not yet be registered when the downstream reduce task send GetReduceFileGroup request,
     // so we shouldn't send a SHUFFLE_NOT_REGISTERED response directly, should enqueue this request to pending list, and response to the downstream reduce task the ReduceFileGroup when the upstream map task register shuffle done
@@ -854,10 +856,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       context.reply(GetReducerFileGroupResponse(
         StatusCode.SHUFFLE_NOT_REGISTERED,
         JavaUtils.newConcurrentHashMap(),
-        Array.empty))
+        Array.empty,
+        languageType = languageType))
       return
     }
-    commitManager.handleGetReducerFileGroup(context, shuffleId)
+    commitManager.handleGetReducerFileGroup(context, shuffleId, languageType)
   }
 
   private def handleGetShuffleIdForApp(

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -34,6 +34,7 @@ import org.apache.celeborn.client.LifecycleManager.{ShuffleFailedWorkers, Shuffl
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.network.protocol.LanguageType
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
 import org.apache.celeborn.common.protocol.message.ControlMessages.{CommitFiles, CommitFilesResponse}
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -178,7 +179,7 @@ abstract class CommitHandler(
    * partitions are complete by the time the method is called, as downstream tasks may start early before all tasks
    * are completed.So map partition may need refresh reducer file group if needed.
    */
-  def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit
+  def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int, languageType: LanguageType): Unit
 
   def removeExpiredShuffle(shuffleId: Int): Unit = {
     reducerFileGroupsMap.remove(shuffleId)

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -31,6 +31,7 @@ import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, Shu
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.network.protocol.LanguageType
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
 import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -230,7 +231,7 @@ class MapPartitionCommitHandler(
     shuffleIsSegmentGranularityVisible.get(shuffleId)
   }
 
-  override def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
+  override def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int, languageType: LanguageType): Unit = {
     // TODO: if support the downstream map task start early before the upstream reduce task, it should
     //  waiting the upstream task register shuffle, then reply these GetReducerFileGroup.
     //  Note that flink hybrid shuffle should support it in the future.
@@ -244,7 +245,8 @@ class MapPartitionCommitHandler(
       StatusCode.SUCCESS,
       reducerFileGroupsMap.getOrDefault(shuffleId, JavaUtils.newConcurrentHashMap()),
       getMapperAttempts(shuffleId),
-      succeedPartitionIds))
+      succeedPartitionIds,
+      languageType = languageType))
   }
 
   override def releasePartitionResource(shuffleId: Int, partitionId: Int): Unit = {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -34,6 +34,7 @@ import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, Shu
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.ShufflePartitionLocationInfo
+import org.apache.celeborn.common.network.protocol.LanguageType
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
 import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -64,8 +65,11 @@ class ReducePartitionCommitHandler(
     sharedRpcPool)
   with Logging {
 
+  class Record(val ctx: RpcCallContext, val languageType: LanguageType) {
+  }
+
   private val getReducerFileGroupRequest =
-    JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
+    JavaUtils.newConcurrentHashMap[Int, util.Set[Record]]()
   private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
@@ -295,7 +299,7 @@ class ReducePartitionCommitHandler(
       numMappers: Int,
       isSegmentGranularityVisible: Boolean): Unit = {
     super.registerShuffle(shuffleId, numMappers, isSegmentGranularityVisible)
-    getReducerFileGroupRequest.put(shuffleId, new util.HashSet[RpcCallContext]())
+    getReducerFileGroupRequest.put(shuffleId, new util.HashSet[Record]())
     initMapperAttempts(shuffleId, numMappers)
   }
 
@@ -309,7 +313,11 @@ class ReducePartitionCommitHandler(
     }
   }
 
-  private def replyGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
+  private def replyGetReducerFileGroup(record: Record, shuffleId: Int): Unit = {
+    replyGetReducerFileGroup(record.ctx, shuffleId, record.languageType)
+  }
+
+  private def replyGetReducerFileGroup(context: RpcCallContext, shuffleId: Int, languageType: LanguageType): Unit = {
     if (isStageDataLost(shuffleId)) {
       context.reply(
         GetReducerFileGroupResponse(
@@ -323,7 +331,8 @@ class ReducePartitionCommitHandler(
         context.reply(GetReducerFileGroupResponse(
           StatusCode.SUCCESS,
           reducerFileGroupsMap.getOrDefault(shuffleId, JavaUtils.newConcurrentHashMap()),
-          getMapperAttempts(shuffleId)))
+          getMapperAttempts(shuffleId),
+          languageType = languageType))
       } else {
         val cachedMsg = getReducerFileGroupRpcCache.get(
           shuffleId,
@@ -336,7 +345,8 @@ class ReducePartitionCommitHandler(
                 pushFailedBatches =
                   shufflePushFailedBatches.getOrDefault(
                     shuffleId,
-                    new util.HashMap[String, util.Set[PushFailedBatch]]()))
+                    new util.HashMap[String, util.Set[PushFailedBatch]]()),
+                languageType = languageType)
               context.asInstanceOf[RemoteNettyRpcCallContext].nettyEnv.serialize(returnedMsg)
             }
           })
@@ -345,17 +355,17 @@ class ReducePartitionCommitHandler(
     }
   }
 
-  override def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
+  override def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int, languageType: LanguageType): Unit = {
     // Quick return for ended stage, avoid occupy sync lock.
     if (isStageEnd(shuffleId)) {
-      replyGetReducerFileGroup(context, shuffleId)
+      replyGetReducerFileGroup(context, shuffleId, languageType)
     } else {
       getReducerFileGroupRequest.synchronized {
         // If setStageEnd() called after isStageEnd and before got lock, should reply here.
         if (isStageEnd(shuffleId)) {
-          replyGetReducerFileGroup(context, shuffleId)
+          replyGetReducerFileGroup(context, shuffleId, languageType)
         } else {
-          getReducerFileGroupRequest.get(shuffleId).add(context)
+          getReducerFileGroupRequest.get(shuffleId).add(new Record(context, languageType))
         }
       }
     }

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -38,6 +38,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.celeborn.common.network.protocol.LanguageType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -427,7 +428,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     when(endpointRef.askSync(any(), any(), any(Integer.class), any(Long.class), any()))
@@ -439,7 +441,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     shuffleClient =
@@ -482,7 +485,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     when(endpointRef.askSync(any(), any(), any(Integer.class), any(Long.class), any()))
@@ -493,7 +497,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     shuffleClient =
@@ -514,7 +519,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     when(endpointRef.askSync(any(), any(), any(Integer.class), any(Long.class), any()))
@@ -525,7 +531,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     shuffleClient =
@@ -546,7 +553,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     when(endpointRef.askSync(any(), any(), any(Integer.class), any(Long.class), any()))
@@ -557,7 +565,8 @@ public class ShuffleClientSuiteJ {
                   locations,
                   new int[0],
                   Collections.emptySet(),
-                  Collections.emptyMap());
+                  Collections.emptyMap(),
+                  LanguageType.JAVA);
             });
 
     shuffleClient =

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/LanguageType.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/LanguageType.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+// todo: add some annotation...
+public enum LanguageType {
+    // todo: the marker for java should be verified again...
+    JAVA((byte) 0xAC),
+    CPP((byte) 0xFF);
+
+    private final byte marker;
+
+    LanguageType(byte marker) {
+        this.marker = marker;
+    }
+
+    public byte getMarker() {
+        return marker;
+    }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -36,11 +36,17 @@ public class TransportMessage implements Serializable {
   @Deprecated private final transient MessageType type;
   private final int messageTypeValue;
   private final byte[] payload;
+  private final LanguageType languageType;
 
   public TransportMessage(MessageType type, byte[] payload) {
+    this(type, payload, LanguageType.JAVA);
+  }
+
+  public TransportMessage(MessageType type, byte[] payload, LanguageType languageType) {
     this.type = type;
     this.messageTypeValue = type.getNumber();
     this.payload = payload;
+    this.languageType = languageType;
   }
 
   public MessageType getType() {
@@ -53,6 +59,10 @@ public class TransportMessage implements Serializable {
 
   public byte[] getPayload() {
     return payload;
+  }
+
+  public LanguageType getLanguageType() {
+    return languageType;
   }
 
   public <T extends GeneratedMessageV3> T getParsedPayload() throws InvalidProtocolBufferException {
@@ -132,6 +142,10 @@ public class TransportMessage implements Serializable {
   }
 
   public static TransportMessage fromByteBuffer(ByteBuffer buffer) throws CelebornIOException {
+    return fromByteBuffer(buffer, LanguageType.JAVA);
+  }
+
+  public static TransportMessage fromByteBuffer(ByteBuffer buffer, LanguageType languageType) throws CelebornIOException {
     int messageTypeValue = buffer.getInt();
     if (MessageType.forNumber(messageTypeValue) == null) {
       throw new CelebornIOException("Decode failed, fallback to legacy messages.");
@@ -140,6 +154,6 @@ public class TransportMessage implements Serializable {
     byte[] payload = new byte[payloadLen];
     buffer.get(payload);
     MessageType msgType = MessageType.forNumber(messageTypeValue);
-    return new TransportMessage(msgType, payload);
+    return new TransportMessage(msgType, payload, languageType);
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
@@ -34,7 +34,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.network.TransportContext
 import org.apache.celeborn.common.network.client._
-import org.apache.celeborn.common.network.protocol.{RequestMessage => NRequestMessage, RpcRequest}
+import org.apache.celeborn.common.network.protocol.{LanguageType, RpcRequest, TransportMessage, RequestMessage => NRequestMessage}
 import org.apache.celeborn.common.network.sasl.{SaslClientBootstrap, SaslServerBootstrap}
 import org.apache.celeborn.common.network.sasl.registration.{RegistrationClientBootstrap, RegistrationServerBootstrap}
 import org.apache.celeborn.common.network.server._
@@ -504,6 +504,20 @@ private[celeborn] class RequestMessage(
       writeRpcAddress(out, senderAddress)
       writeRpcAddress(out, receiver.address)
       out.writeUTF(receiver.name)
+      val msg = Utils.toTransportMessage(content)
+      msg match {
+        case transMsg : TransportMessage =>
+          // Check if the msg is a TransportMessage with CPP languageType.
+          // If so, write the marker and the body explicitly.
+          if (transMsg.getLanguageType == LanguageType.CPP) {
+            val out = new DataOutputStream(bos)
+            out.writeByte(LanguageType.CPP.getMarker)
+            out.write(transMsg.toByteBuffer.array)
+            out.close()
+            return bos.toByteBuffer
+          }
+        case _ =>
+      }
       val s = nettyEnv.serializeStream(out)
       try {
         s.writeObject(Utils.toTransportMessage(content))

--- a/common/src/main/scala/org/apache/celeborn/common/serializer/JavaSerializer.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/serializer/JavaSerializer.scala
@@ -19,10 +19,9 @@ package org.apache.celeborn.common.serializer
 
 import java.io._
 import java.nio.ByteBuffer
-
 import scala.reflect.ClassTag
-
 import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.network.protocol.{LanguageType, TransportMessage}
 import org.apache.celeborn.common.util.{ByteBufferInputStream, ByteBufferOutputStream, Utils}
 
 private[celeborn] class JavaSerializationStream(
@@ -98,6 +97,20 @@ private[celeborn] class JavaSerializerInstance(
 
   override def serialize[T: ClassTag](t: T): ByteBuffer = {
     val bos = new ByteBufferOutputStream()
+    val msg = Utils.toTransportMessage(t)
+    msg match {
+      case transMsg : TransportMessage =>
+        // Check if the msg is a TransportMessage with CPP languageType.
+        // If so, write the marker and the body explicitly.
+        if (transMsg.getLanguageType == LanguageType.CPP) {
+          val out = new DataOutputStream(bos)
+          out.writeByte(LanguageType.CPP.getMarker)
+          out.write(transMsg.toByteBuffer.array)
+          out.close()
+          return bos.toByteBuffer
+        }
+      case _ =>
+    }
     val out = serializeStream(bos)
     out.writeObject(Utils.toTransportMessage(t))
     out.close()
@@ -105,12 +118,28 @@ private[celeborn] class JavaSerializerInstance(
   }
 
   override def deserialize[T: ClassTag](bytes: ByteBuffer): T = {
+    bytes.mark
+    val languageMarker = bytes.get
+    bytes.reset
+    // If the languageMarker byte is CPP, deserialize directly.
+    if (languageMarker == LanguageType.CPP.getMarker) {
+      bytes.get
+      return Utils.fromTransportMessage(TransportMessage.fromByteBuffer(bytes, LanguageType.CPP)).asInstanceOf[T]
+    }
     val bis = new ByteBufferInputStream(bytes)
     val in = deserializeStream(bis)
     Utils.fromTransportMessage(in.readObject()).asInstanceOf[T]
   }
 
   override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T = {
+    bytes.mark
+    val languageMarker = bytes.get
+    bytes.reset
+    // If the languageMarker byte is CPP, deserialize directly.
+    if (languageMarker == LanguageType.CPP.getMarker) {
+      bytes.get
+      return Utils.fromTransportMessage(TransportMessage.fromByteBuffer(bytes, LanguageType.CPP)).asInstanceOf[T]
+    }
     val bis = new ByteBufferInputStream(bytes)
     val in = deserializeStream(bis, loader)
     Utils.fromTransportMessage(in.readObject()).asInstanceOf[T]


### PR DESCRIPTION
### What changes were proposed in this pull request?
The java's existing serialization is adapted to support multi-language serialization. Besides, the GetReducerFileGroup/Response is adapted to java/cpp modes.

### Why are the changes needed?
To support CppClient communicates with JavaServer.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation.
