### PR TITLE
[CELEBORN-1931] use gather API for local flusher to optimize write io pattern

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1276,7 +1276,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerHdfsFlusherThreads: Int = get(WORKER_FLUSHER_HDFS_THREADS)
   def workerS3FlusherThreads: Int = get(WORKER_FLUSHER_S3_THREADS)
   def workerCreateWriterMaxAttempts: Int = get(WORKER_WRITER_CREATE_MAX_ATTEMPTS)
-  def workerWriterGatherApiEnabled: Boolean = get(WORKER_WRITER_GATHER_API_ENABLED)
+  def workerFlusherLocalGatherAPIEnabled: Boolean = get(WORKER_FLUSHER_LOCAL_GATHER_API_ENABLED)
 
   // //////////////////////////////////////////////////////
   //                    Disk Monitor                     //
@@ -3899,13 +3899,14 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(3)
 
-  val WORKER_WRITER_GATHER_API_ENABLED: ConfigEntry[Boolean] =
-    buildConf("celeborn.worker.writer.gatherApi.enabled")
+  val WORKER_FLUSHER_LOCAL_GATHER_API_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.flusher.local.gatherAPI.enabled")
+      .internal
       .categories("worker")
       .version("0.6.0")
       .doc("Worker will use gather API if this config is true.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val WORKER_PARTITION_SORTER_DIRECT_MEMORY_RATIO_THRESHOLD: ConfigEntry[Double] =
     buildConf("celeborn.worker.partitionSorter.directMemoryRatioThreshold")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1276,6 +1276,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerHdfsFlusherThreads: Int = get(WORKER_FLUSHER_HDFS_THREADS)
   def workerS3FlusherThreads: Int = get(WORKER_FLUSHER_S3_THREADS)
   def workerCreateWriterMaxAttempts: Int = get(WORKER_WRITER_CREATE_MAX_ATTEMPTS)
+  def workerWriterGatherApiEnabled: Boolean = get(WORKER_WRITER_GATHER_API_ENABLED)
 
   // //////////////////////////////////////////////////////
   //                    Disk Monitor                     //
@@ -3897,6 +3898,14 @@ object CelebornConf extends Logging {
       .doc("Retry count for a file writer to create if its creation was failed.")
       .intConf
       .createWithDefault(3)
+
+  val WORKER_WRITER_GATHER_API_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.writer.gatherApi.enabled")
+      .categories("worker")
+      .version("0.6.0")
+      .doc("Worker will use gather API if this config is true.")
+      .booleanConf
+      .createWithDefault(false)
 
   val WORKER_PARTITION_SORTER_DIRECT_MEMORY_RATIO_THRESHOLD: ConfigEntry[Double] =
     buildConf("celeborn.worker.partitionSorter.directMemoryRatioThreshold")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -186,4 +186,5 @@ license: |
 | celeborn.worker.storage.workingDir | celeborn-worker/shuffle_data | false | Worker's working dir path name. | 0.3.0 | celeborn.worker.workingDir | 
 | celeborn.worker.writer.close.timeout | 120s | false | Timeout for a file writer to close | 0.2.0 |  | 
 | celeborn.worker.writer.create.maxAttempts | 3 | false | Retry count for a file writer to create if its creation was failed. | 0.2.0 |  | 
+| celeborn.worker.writer.gatherApi.enabled | false | false | Worker will use gather API if this config is true. | 0.6.0 |  | 
 <!--end-include-->

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -186,5 +186,4 @@ license: |
 | celeborn.worker.storage.workingDir | celeborn-worker/shuffle_data | false | Worker's working dir path name. | 0.3.0 | celeborn.worker.workingDir | 
 | celeborn.worker.writer.close.timeout | 120s | false | Timeout for a file writer to close | 0.2.0 |  | 
 | celeborn.worker.writer.create.maxAttempts | 3 | false | Retry count for a file writer to create if its creation was failed. | 0.2.0 |  | 
-| celeborn.worker.writer.gatherApi.enabled | false | false | Worker will use gather API if this config is true. | 0.6.0 |  | 
 <!--end-include-->

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
@@ -41,8 +41,8 @@ private[worker] class LocalFlushTask(
     gatherApiEnabled: Boolean) extends FlushTask(buffer, notifier, keepBuffer) {
   override def flush(): Unit = {
     val buffers = buffer.nioBuffers()
-    val readableBytes = buffer.readableBytes()
     if (gatherApiEnabled) {
+      val readableBytes = buffer.readableBytes()
       var written = 0L
       do {
         written = fileChannel.write(buffers) + written

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
@@ -37,15 +37,23 @@ private[worker] class LocalFlushTask(
     buffer: CompositeByteBuf,
     fileChannel: FileChannel,
     notifier: FlushNotifier,
-    keepBuffer: Boolean) extends FlushTask(buffer, notifier, keepBuffer) {
+    keepBuffer: Boolean,
+    gatherApiEnabled: Boolean) extends FlushTask(buffer, notifier, keepBuffer) {
   override def flush(): Unit = {
     val buffers = buffer.nioBuffers()
-    for (buffer <- buffers) {
-      while (buffer.hasRemaining) {
-        fileChannel.write(buffer)
+    val readableBytes = buffer.readableBytes()
+    if (gatherApiEnabled) {
+      var written = 0L
+      do {
+        written = fileChannel.write(buffers) + written
+      } while (written != readableBytes)
+    } else {
+      for (buffer <- buffers) {
+        while (buffer.hasRemaining) {
+          fileChannel.write(buffer)
+        }
       }
     }
-
     // TODO: force flush file channel in scenarios where the upstream task writes and the downstream task reads simultaneously, such as flink hybrid shuffle.
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -388,13 +388,15 @@ class LocalTierWriter(
   private lazy val channel: FileChannel =
     FileChannelUtils.createWritableFileChannel(diskFileInfo.getFilePath)
 
+  val gatherApiEnabled: Boolean = conf.workerWriterGatherApiEnabled
+
   override def needEvict(): Boolean = {
     false
   }
 
   override def genFlushTask(finalFlush: Boolean, keepBuffer: Boolean): FlushTask = {
     notifier.numPendingFlushes.incrementAndGet()
-    new LocalFlushTask(flushBuffer, channel, notifier, true)
+    new LocalFlushTask(flushBuffer, channel, notifier, true, gatherApiEnabled)
   }
 
   override def writeInternal(buf: ByteBuf): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -388,7 +388,7 @@ class LocalTierWriter(
   private lazy val channel: FileChannel =
     FileChannelUtils.createWritableFileChannel(diskFileInfo.getFilePath)
 
-  val gatherApiEnabled: Boolean = conf.workerWriterGatherApiEnabled
+  val gatherApiEnabled: Boolean = conf.workerFlusherLocalGatherAPIEnabled
 
   override def needEvict(): Boolean = {
     false


### PR DESCRIPTION
### What changes were proposed in this pull request?
To optimize the Celeborn worker flusher IO pattern.


### Why are the changes needed?
Celeborn bytebuf has many small parts to write. Gather API can reduce the need to traverse the small buffers. 


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
Cluster tests.
