### PR TITLE
[CELEBORN-1947] Reduce log for CelebornShuffleReader sleeping before inputStream ready

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -304,14 +304,14 @@ class CelebornShuffleReader[K, C](
             }
           }
           if (sleepCnt == 0) {
-            logInfo("inputStream is null, sleeping...")
+            logInfo(s"inputStream for partition: $partitionId is null, sleeping...")
           }
           sleepCnt += 1
           Thread.sleep(50)
           inputStream = streams.get(partitionId)
         }
         if (sleepCnt > 0) {
-          logInfo(s"inputStream is not null, sleep count: $sleepCnt")
+          logInfo(s"inputStream for partition: $partitionId is not null, sleep count: $sleepCnt")
         }
         metricsCallback.incReadTime(
           TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startFetchWait))


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
When shuffle read timeout, a large number of logs are output in the executor log.

```
inputStream is null, sleeping...
```

<img width="799" alt="image" src="https://github.com/user-attachments/assets/f5b2bfde-5874-4b1e-8992-7037a9c81aa5" />



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

