### PR TITLE
[CELEBORN-1954][HELM] Add a new value image.registry

### DIFF
--- a/charts/celeborn/templates/_helpers.tpl
+++ b/charts/celeborn/templates/_helpers.tpl
@@ -147,7 +147,10 @@ Create the name of the worker priority class to use
 Create the name of the celeborn image to use
 */}}
 {{- define "celeborn.image" -}}
-{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- $imageRegistry := .Values.image.registry | default "docker.io" }}
+{{- $imageRepository := .Values.image.repository | default "apache/celeborn" }}
+{{- $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s/%s:%s" $imageRegistry $imageRepository $imageTag }}
 {{- end }}
 
 {{/*

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName:  {{ include "celeborn.serviceAccountName" . }}
+      serviceAccountName: {{ include "celeborn.serviceAccountName" . }}
       initContainers:
       {{- $dirs := .Values.volumes.master }}
       {{- if eq "hostPath" (index $dirs 0).type }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -37,15 +37,16 @@ tests:
           path: spec.template.metadata.annotations.key2
           value: value2
 
-  - it: Should use the specified image if `image.repository` and `image.tag` is set
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` is set
     set:
       image:
+        registry: test-registry
         repository: test-repository
         tag: test-tag
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].image
-          value: test-repository:test-tag
+          path: spec.template.spec.containers[?(@.name=="celeborn")].image
+          value: test-registry/test-repository:test-tag
 
   - it: Should use the specified image pull policy if `image.pullPolicy` is set
     set:

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -37,15 +37,16 @@ tests:
           path: spec.template.metadata.annotations.key2
           value: value2
 
-  - it: Should use the specified image if `image.repository` and `image.tag` is set
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` is set
     set:
       image:
+        registry: test-registry
         repository: test-repository
         tag: test-tag
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].image
-          value: test-repository:test-tag
+          path: spec.template.spec.containers[?(@.name=="celeborn")].image
+          value: test-registry/test-repository:test-tag
 
   - it: Should use the specified image pull policy if `image.pullPolicy` is set
     set:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -27,10 +27,12 @@ fullnameOverride: ""
 
 # Specifies the Celeborn image to use
 image:
+  # -- Image registry
+  registry: docker.io
   # -- Image repository
-  repository: aliyunemr/remote-shuffle-service
-  # -- Image tag
-  tag: 0.1.1-6badd20
+  repository: apache/celeborn
+  # -- Image tag, default is chart `appVersion`
+  tag: ""
   # -- Image pull policy
   pullPolicy: Always
   # -- Image name for init containter. (your-private-repo/alpine:3.18)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Add a new value `image.registry` to `values.yaml`.

### Why are the changes needed?

Add a new value `image.registry` so we can easily switch between different image registries (e.g. `docker.io`, `ghcr.io`, `quay.io` and private image registries).

This PR is part of #2654.

### Does this PR introduce _any_ user-facing change?

Yes, but it should be backward-compatible.

### How was this patch tested?

Update helm unit test and run `helm unittest charts/celeborn  --file "tests/**/*_test.yaml" --strict --debug`.
