### PR TITLE
[CELEBORN-1894][0.5] Allow skipping already read chunks during unreplicated shuffle read retries

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.client.read.checkpoint.PartitionReaderCheckpointMetadata;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.network.client.TransportClient;
@@ -264,5 +266,11 @@ public class LocalPartitionReader implements PartitionReader {
   @Override
   public PartitionLocation getLocation() {
     return location;
+  }
+
+  @Override
+  public Optional<PartitionReaderCheckpointMetadata> getPartitionReaderCheckpointMetadata() {
+    // TODO implement similar to {@link WorkerPartitionReader}
+    return Optional.empty();
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/read/MetricsCallback.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/MetricsCallback.java
@@ -21,4 +21,6 @@ public interface MetricsCallback {
   void incBytesRead(long bytesRead);
 
   void incReadTime(long time);
+
+  default void incDuplicateBytesRead(long bytesRead) {}
 }

--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -19,16 +19,18 @@ package org.apache.celeborn.client.read;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.ReferenceCounted;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.client.read.checkpoint.PartitionReaderCheckpointMetadata;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -53,10 +55,12 @@ public class WorkerPartitionReader implements PartitionReader {
   private TransportClient client;
   private MetricsCallback metricsCallback;
 
+  private int lastReturnedChunkId = -1;
   private int returnedChunks;
   private int chunkIndex;
 
-  private final LinkedBlockingQueue<ByteBuf> results;
+  private int inflightRequestCount;
+  private final LinkedBlockingQueue<Pair<Integer, ByteBuf>> results;
   private final ChunkReceivedCallback callback;
 
   private final AtomicReference<IOException> exception = new AtomicReference<>();
@@ -70,6 +74,8 @@ public class WorkerPartitionReader implements PartitionReader {
   private int fetchChunkMaxRetry;
   private final boolean testFetch;
 
+  private Optional<PartitionReaderCheckpointMetadata> partitionReaderCheckpointMetadata;
+
   WorkerPartitionReader(
       CelebornConf conf,
       String shuffleKey,
@@ -80,12 +86,14 @@ public class WorkerPartitionReader implements PartitionReader {
       int endMapIndex,
       int fetchChunkRetryCnt,
       int fetchChunkMaxRetry,
-      MetricsCallback metricsCallback)
+      MetricsCallback metricsCallback,
+      Optional<PartitionReaderCheckpointMetadata> checkpointMetadata)
       throws IOException, InterruptedException {
     this.shuffleKey = shuffleKey;
     fetchMaxReqsInFlight = conf.clientFetchMaxReqsInFlight();
     results = new LinkedBlockingQueue<>();
     fetchTimeoutMs = conf.clientFetchTimeoutMs();
+    inflightRequestCount = 0;
     this.metricsCallback = metricsCallback;
     // only add the buffer to results queue if this reader is not closed.
     callback =
@@ -97,7 +105,7 @@ public class WorkerPartitionReader implements PartitionReader {
               ByteBuf buf = ((NettyManagedBuffer) buffer).getBuf();
               if (!closed) {
                 buf.retain();
-                results.add(buf);
+                results.add(Pair.of(chunkIndex, buf));
               }
             }
           }
@@ -138,6 +146,15 @@ public class WorkerPartitionReader implements PartitionReader {
     this.clientFactory = clientFactory;
     this.fetchChunkRetryCnt = fetchChunkRetryCnt;
     this.fetchChunkMaxRetry = fetchChunkMaxRetry;
+    if (checkpointMetadata.isPresent()) {
+      this.partitionReaderCheckpointMetadata = checkpointMetadata;
+      this.returnedChunks = checkpointMetadata.get().getReturnedChunks().size();
+    } else {
+      this.partitionReaderCheckpointMetadata =
+          conf.isPartitionReaderCheckpointEnabled()
+              ? Optional.of(new PartitionReaderCheckpointMetadata())
+              : Optional.empty();
+    }
     testFetch = conf.testFetchFailure();
     ShuffleClient.incrementTotalReadCounter();
   }
@@ -147,13 +164,21 @@ public class WorkerPartitionReader implements PartitionReader {
     return returnedChunks < streamHandler.getNumChunks();
   }
 
+  private void checkpoint() {
+    if (lastReturnedChunkId != -1) {
+      partitionReaderCheckpointMetadata.ifPresent(
+          readerCheckpointMetadata -> readerCheckpointMetadata.checkpoint(lastReturnedChunkId));
+    }
+  }
+
   @Override
   public ByteBuf next() throws IOException, InterruptedException {
+    checkpoint();
     checkException();
     if (chunkIndex < streamHandler.getNumChunks()) {
       fetchChunks();
     }
-    ByteBuf chunk = null;
+    Pair<Integer, ByteBuf> chunk = null;
     try {
       while (chunk == null) {
         checkException();
@@ -167,7 +192,9 @@ public class WorkerPartitionReader implements PartitionReader {
       throw e;
     }
     returnedChunks++;
-    return chunk;
+    inflightRequestCount--;
+    lastReturnedChunkId = chunk.getLeft();
+    return chunk.getRight();
   }
 
   @Override
@@ -176,7 +203,10 @@ public class WorkerPartitionReader implements PartitionReader {
       closed = true;
     }
     if (results.size() > 0) {
-      results.forEach(ReferenceCounted::release);
+      results.forEach(
+          chunk -> {
+            chunk.getRight().release();
+          });
     }
     results.clear();
     closeStream();
@@ -201,14 +231,32 @@ public class WorkerPartitionReader implements PartitionReader {
     return location;
   }
 
+  @Override
+  public Optional<PartitionReaderCheckpointMetadata> getPartitionReaderCheckpointMetadata() {
+    return partitionReaderCheckpointMetadata;
+  }
+
   private void fetchChunks() throws IOException, InterruptedException {
-    final int inFlight = chunkIndex - returnedChunks;
+    final int inFlight = inflightRequestCount;
     if (inFlight < fetchMaxReqsInFlight) {
-      final int toFetch =
-          Math.min(fetchMaxReqsInFlight - inFlight + 1, streamHandler.getNumChunks() - chunkIndex);
-      for (int i = 0; i < toFetch; i++) {
-        if (testFetch && fetchChunkRetryCnt < fetchChunkMaxRetry - 1 && chunkIndex == 3) {
+      int toFetch = Math.min(fetchMaxReqsInFlight - inFlight + 1, streamHandler.getNumChunks() - chunkIndex);
+
+      while (toFetch > 0 && chunkIndex < streamHandler.getNumChunks()) {
+        if (partitionReaderCheckpointMetadata.isPresent()
+            && partitionReaderCheckpointMetadata.get().isCheckpointed(chunkIndex)) {
+          logger.info(
+              "Skipping chunk {} as it has already been returned,"
+                  + " likely by a previous reader for the same partition.",
+              chunkIndex);
+          chunkIndex++;
+          // IMP Since we're skipping fetching this chunk, we must not decrement toFetch here
+          // Eg: If chunkIndex=1, toFetch=2, endChunkIndex = 4 and chunkIdsAlreadyReturned = {1,2}
+          // if we skip chunk 1 and 2, decrementing toFetch here would wrongly exit the loop
+          // without ever fetching chunk {3, 4}, and next() would end up waiting for chunk {3,4}
+          // infinitely.
+        } else if (testFetch && fetchChunkRetryCnt < fetchChunkMaxRetry - 1 && chunkIndex == 3) {
           callback.onFailure(chunkIndex, new CelebornIOException("Test fetch chunk failure"));
+          toFetch--;
         } else {
           if (!client.isActive()) {
             try {
@@ -227,7 +275,9 @@ public class WorkerPartitionReader implements PartitionReader {
             }
           }
           client.fetchChunk(streamHandler.getStreamId(), chunkIndex, fetchTimeoutMs, callback);
+          inflightRequestCount++;
           chunkIndex++;
+          toFetch--;
         }
       }
     }

--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -239,7 +239,8 @@ public class WorkerPartitionReader implements PartitionReader {
   private void fetchChunks() throws IOException, InterruptedException {
     final int inFlight = inflightRequestCount;
     if (inFlight < fetchMaxReqsInFlight) {
-      int toFetch = Math.min(fetchMaxReqsInFlight - inFlight + 1, streamHandler.getNumChunks() - chunkIndex);
+      int toFetch =
+          Math.min(fetchMaxReqsInFlight - inFlight + 1, streamHandler.getNumChunks() - chunkIndex);
 
       while (toFetch > 0 && chunkIndex < streamHandler.getNumChunks()) {
         if (partitionReaderCheckpointMetadata.isPresent()

--- a/client/src/main/java/org/apache/celeborn/client/read/checkpoint/PartitionReaderCheckpointMetadata.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/checkpoint/PartitionReaderCheckpointMetadata.java
@@ -15,24 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.client.read;
+package org.apache.celeborn.client.read.checkpoint;
 
-import java.io.IOException;
-import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
 
-import io.netty.buffer.ByteBuf;
+/** Checkpoint metadata interface for a partition reader. */
+public class PartitionReaderCheckpointMetadata {
+  private final Set<Integer> returnedChunks;
 
-import org.apache.celeborn.client.read.checkpoint.PartitionReaderCheckpointMetadata;
-import org.apache.celeborn.common.protocol.PartitionLocation;
+  /** Create an instance of the checkpoint metadata. */
+  public PartitionReaderCheckpointMetadata() {
+    this.returnedChunks = new HashSet<>();
+  }
 
-public interface PartitionReader {
-  boolean hasNext();
+  public void checkpoint(int chunkId) {
+    returnedChunks.add(chunkId);
+  }
 
-  ByteBuf next() throws IOException, InterruptedException;
+  public boolean isCheckpointed(int chunkId) {
+    return returnedChunks.contains(chunkId);
+  }
 
-  void close();
-
-  PartitionLocation getLocation();
-
-  Optional<PartitionReaderCheckpointMetadata> getPartitionReaderCheckpointMetadata();
+  public Set<Integer> getReturnedChunks() {
+    return returnedChunks;
+  }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -4046,7 +4046,7 @@ object CelebornConf extends Logging {
       .doc("Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes" +
         " the amount of unnecessary reads during partition read retries")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val CLIENT_FETCH_MAX_REQS_IN_FLIGHT: ConfigEntry[Int] =
     buildConf("celeborn.client.fetch.maxReqsInFlight")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -941,6 +941,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def clientFetchTimeoutMs: Long = get(CLIENT_FETCH_TIMEOUT)
   def clientFetchBufferSize: Int = get(CLIENT_FETCH_BUFFER_SIZE).toInt
   def clientFetchMaxReqsInFlight: Int = get(CLIENT_FETCH_MAX_REQS_IN_FLIGHT)
+  def isPartitionReaderCheckpointEnabled: Boolean =
+    get(PARTITION_READER_CHECKPOINT_ENABLED)
+
   def clientFetchMaxRetriesForEachReplica: Int = get(CLIENT_FETCH_MAX_RETRIES_FOR_EACH_REPLICA)
   def clientFetchThrowsFetchFailure: Boolean = get(CLIENT_FETCH_THROWS_FETCH_FAILURE)
   def clientFetchExcludeWorkerOnFailureEnabled: Boolean =
@@ -4035,6 +4038,15 @@ object CelebornConf extends Logging {
         s"this buffer size not less than `${CLIENT_PUSH_BUFFER_MAX_SIZE.key}`.")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("64k")
+
+  val PARTITION_READER_CHECKPOINT_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.partition.reader.checkpoint.enabled")
+      .categories("client")
+      .version("0.6.0")
+      .doc("Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes" +
+        " the amount of unnecessary reads during partition read retries")
+      .booleanConf
+      .createWithDefault(false)
 
   val CLIENT_FETCH_MAX_REQS_IN_FLIGHT: ConfigEntry[Int] =
     buildConf("celeborn.client.fetch.maxReqsInFlight")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -4042,7 +4042,7 @@ object CelebornConf extends Logging {
   val PARTITION_READER_CHECKPOINT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.client.partition.reader.checkpoint.enabled")
       .categories("client")
-      .version("0.6.0")
+      .version("0.5.5")
       .doc("Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes" +
         " the amount of unnecessary reads during partition read retries")
       .booleanConf

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -42,6 +42,7 @@ license: |
 | celeborn.client.flink.resultPartition.supportFloatingBuffer | true | false | Whether to support floating buffer for result partitions. | 0.3.0 | remote-shuffle.job.support-floating-buffer-per-output-gate | 
 | celeborn.client.inputStream.creation.window | 16 | false | Window size that CelebornShuffleReader pre-creates CelebornInputStreams, for coalesced scenariowhere multiple Partitions are read | 0.6.0 |  | 
 | celeborn.client.mr.pushData.max | 32m | false | Max size for a push data sent from mr client. | 0.4.0 |  | 
+| celeborn.client.partition.reader.checkpoint.enabled | false | false | Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes the amount of unnecessary reads during partition read retries | 0.6.0 |  | 
 | celeborn.client.push.buffer.initial.size | 8k | false |  | 0.3.0 | celeborn.push.buffer.initial.size | 
 | celeborn.client.push.buffer.max.size | 64k | false | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.3.0 | celeborn.push.buffer.max.size | 
 | celeborn.client.push.excludeWorkerOnFailure.enabled | false | false | Whether to enable shuffle client-side push exclude workers on failures. | 0.3.0 |  | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -42,7 +42,7 @@ license: |
 | celeborn.client.flink.resultPartition.supportFloatingBuffer | true | false | Whether to support floating buffer for result partitions. | 0.3.0 | remote-shuffle.job.support-floating-buffer-per-output-gate | 
 | celeborn.client.inputStream.creation.window | 16 | false | Window size that CelebornShuffleReader pre-creates CelebornInputStreams, for coalesced scenariowhere multiple Partitions are read | 0.6.0 |  | 
 | celeborn.client.mr.pushData.max | 32m | false | Max size for a push data sent from mr client. | 0.4.0 |  | 
-| celeborn.client.partition.reader.checkpoint.enabled | false | false | Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes the amount of unnecessary reads during partition read retries | 0.6.0 |  | 
+| celeborn.client.partition.reader.checkpoint.enabled | true | false | Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes the amount of unnecessary reads during partition read retries | 0.5.5 |  | 
 | celeborn.client.push.buffer.initial.size | 8k | false |  | 0.3.0 | celeborn.push.buffer.initial.size | 
 | celeborn.client.push.buffer.max.size | 64k | false | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.3.0 | celeborn.push.buffer.max.size | 
 | celeborn.client.push.excludeWorkerOnFailure.enabled | false | false | Whether to enable shuffle client-side push exclude workers on failures. | 0.3.0 |  | 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.cluster
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+import org.junit.Assert
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client.{LifecycleManager, ShuffleClientImpl}
+import org.apache.celeborn.client.read.MetricsCallback
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.protocol.CompressionCodec
+import org.apache.celeborn.service.deploy.MiniClusterFeature
+
+class ReadWriteTestWithFailures extends AnyFunSuite
+  with Logging with MiniClusterFeature with BeforeAndAfterAll {
+
+  var masterPort = 0
+
+  override def beforeAll(): Unit = {
+    logInfo("test initialized , setup Celeborn mini cluster")
+    val (m, _) = setupMiniClusterWithRandomPorts(workerConf =
+      Map("celeborn.shuffle.chunk.size" -> "100B", "celeborn.worker.flusher.buffer.size" -> "10B"))
+    masterPort = m.conf.masterPort
+  }
+
+  override def afterAll(): Unit = {
+    logInfo("all test complete , stop Celeborn mini cluster")
+    shutdownMiniCluster()
+  }
+
+  test(s"test MiniCluster with connection resets, ensure no duplicate reads") {
+    Assert.assertEquals(performTest("true"), 0)
+  }
+
+  test(s"test MiniCluster with connection resets, assert duplicate reads") {
+    Assert.assertTrue(performTest("false") > 0)
+  }
+
+  def performTest(workerChunkLevelCheckpointEnabled: String): Long = {
+    val APP = "app-1"
+
+    val clientConf = new CelebornConf()
+      .set(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$masterPort")
+      .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "true")
+      .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
+      .set("celeborn.data.io.numConnectionsPerPeer", "1")
+      .set("celeborn.client.fetch.maxReqsInFlight", "1")
+      .set("celeborn.client.shuffle.compression.codec", CompressionCodec.NONE.toString)
+      .set(CelebornConf.TEST_CLIENT_FETCH_FAILURE.key, "true")
+      .set(
+        CelebornConf.PARTITION_READER_CHECKPOINT_ENABLED.key,
+        workerChunkLevelCheckpointEnabled)
+      .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "false")
+
+    val lifecycleManager = new LifecycleManager(APP, clientConf)
+    val shuffleClient = new ShuffleClientImpl(APP, clientConf, UserIdentifier("mock", "mock"))
+    shuffleClient.setupLifecycleManagerRef(lifecycleManager.self)
+
+    // push 100 random strings
+    val numuuids = 100
+    val stringSet = new util.HashSet[String]()
+    for (i <- 0 until numuuids) {
+      val str = UUID.randomUUID().toString
+      stringSet.add(str)
+      val data = ("_" + str).getBytes(StandardCharsets.UTF_8)
+      shuffleClient.pushData(1, 0, 0, 0, data, 0, data.length, 1, 1)
+    }
+    shuffleClient.pushMergedData(1, 0, 0)
+    Thread.sleep(1000)
+
+    shuffleClient.mapperEnd(1, 0, 0, 1)
+
+    var duplicateBytesRead = new AtomicLong(0)
+    val metricsCallback = new MetricsCallback {
+      override def incBytesRead(bytesWritten: Long): Unit = {}
+      override def incReadTime(time: Long): Unit = {}
+      override def incDuplicateBytesRead(bytesRead: Long): Unit = {
+        duplicateBytesRead.addAndGet(bytesRead)
+      }
+    }
+    val inputStream = shuffleClient.readPartition(
+      1,
+      1,
+      0,
+      0,
+      0,
+      0,
+      Integer.MAX_VALUE,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      metricsCallback)
+
+    val outputStream = new ByteArrayOutputStream()
+    var b = inputStream.read()
+    while (b != -1) {
+      outputStream.write(b)
+      b = inputStream.read()
+    }
+
+    val readStrings =
+      new String(outputStream.toByteArray, StandardCharsets.UTF_8).substring(1).split("_")
+    Assert.assertEquals(readStrings.length, numuuids)
+    readStrings.foreach { str =>
+      Assert.assertTrue(stringSet.contains(str))
+    }
+
+    Thread.sleep(5000L)
+    shuffleClient.shutdown()
+    lifecycleManager.rpcEnv.shutdown()
+
+    duplicateBytesRead.get()
+  }
+}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
@@ -108,6 +108,11 @@ class ReadWriteTestWithFailures extends AnyFunSuite
       0,
       0,
       0,
+      Integer.MAX_VALUE,
+      null,
+      null,
+      null,
+      null,
       metricsCallback)
 
     val outputStream = new ByteArrayOutputStream()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
@@ -108,14 +108,6 @@ class ReadWriteTestWithFailures extends AnyFunSuite
       0,
       0,
       0,
-      0,
-      Integer.MAX_VALUE,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
       metricsCallback)
 
     val outputStream = new ByteArrayOutputStream()


### PR DESCRIPTION
This ports https://github.com/apache/celeborn/pull/3132 to branch-0.5

### What changes were proposed in this pull request?

Whenever a `WorkerPartitionReader` is recreated (due celeborn worker restarts / any other chunk fetch failure), the entire shuffle partition file is re-read from beginning, discarding already read chunks in `CelebornInputStream` based on the batchIdSet metadata maintained.

This can be improved (only for cases where shuffle data is unreplicated) by skipping already read chunk id since they'd be discarded anyway. This improves overall shuffle read performance (reducer's total time, network usage etc).

### Why are the changes needed?

Allow skipping already read shuffle chunks

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

UTs added

Closes #3132 from saurabhd336/skipReadChunks.

Authored-by: Saurabh Dubey <saurabhd336@uber.com>















