### PR TITLE
[CELEBORN-1953][HELM] Split podAnnotations into master.annotations and worker.annotations

### DIFF
--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         {{- include "celeborn.master.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.master.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         {{- include "celeborn.worker.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.worker.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -24,11 +24,12 @@ release:
   name: celeborn
 
 tests:
-  - it: Should add extra pod annotations if `podAnnotations` is specified
+  - it: Should add extra pod annotations if `master.annotations` is specified
     set:
-      podAnnotations:
-        key1: value1
-        key2: value2
+      master:
+        annotations:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.metadata.annotations.key1

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -24,11 +24,12 @@ release:
   name: celeborn
 
 tests:
-  - it: Should add extra pod annotations if `podAnnotations` is specified
+  - it: Should add extra pod annotations if `worker.annotations` is specified
     set:
-      podAnnotations:
-        key1: value1
-        key2: value2
+      worker:
+        annotations:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.metadata.annotations.key1

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -186,10 +186,17 @@ priorityClass:
     # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
     value: 999999000
 
-# -- Pod annotations
-podAnnotations: {}
-# key1: value1
-# key2: value2
+master:
+  # -- Annotations for Celeborn master pods.
+  annotations:
+    # key1: value1
+    # key2: value2
+
+worker:
+  # -- Annotations for Celeborn worker pods.
+  annotations:
+    # key1: value1
+    # key2: value2
 
 # -- Pod node selector
 nodeSelector: {}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Split `podAnnotations` into `master.annotations` and `worker.annotations`.

### Why are the changes needed?

Allow separate customization for master  and worker annotations.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Helm unit tests by running `helm unittest charts/celeborn --file "tests/**/*_test.yaml" --strict --debug`.
