### PR TITLE
[CELEBORN-1949][FOLLOWUP] Fix typo for `kind:deploy` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,7 +35,7 @@
 
 "kind:deploy":
   - changed-files:
-    - all-globs-to-any-file: [
+    - any-glob-to-any-file: [
       'bin/**/*',
       'sbin/**/*',
       'assets/grafana/*',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix typo, followup for https://github.com/apache/celeborn/pull/3189

### Why are the changes needed?

Fix typo for kind:deploy label 

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

I have confirmed, now all the match conditions are `any-glob-to-any-file`.
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/dde86439-b7b9-4690-99a2-889ff64fdd8b" />

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/f3b8be49-c0d5-46bd-8c1a-9ae2518c7958" />


