### PR TITLE
[CELEBORN-1436][FOLLOWUP] Add swagger editor links for RESTful spec

### DIFF
--- a/docs/restapi.md
+++ b/docs/restapi.md
@@ -85,12 +85,8 @@ See the [migration guide](migration.md) for API mappings.
 
 #### Master
 
-See the master openapi spec yaml in the repo `openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml`.
+See the master openapi spec yaml in the repo `openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml`, or use the [Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/celeborn/main/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml) online for visualization.
 
 #### Worker
 
-See the worker openapi spec yaml in the repo `openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml`.
-
-**Note:**
-
-You can locally preview the OpenAPI specification YAML file in IDE, or use the [Swagger Editor](https://editor.swagger.io/) online for visualization.
+See the worker openapi spec yaml in the repo `openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml`, or use the [Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/celeborn/main/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml) online for visualization.

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApplicationResource.scala
@@ -60,7 +60,8 @@ class ApplicationResource extends ApiRequestContext {
     content = Array(new Content(
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[HandleResponse]))))
-  @DELETE
+  @POST
+  @Path("/delete_apps")
   def deleteApps(request: DeleteAppsRequest): HandleResponse = {
     val apps = request.getApps.asScala
     apps.foreach(app => statusSystem.deleteApp(app))

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/ApplicationApi.java
@@ -74,7 +74,7 @@ public class ApplicationApi extends BaseApi {
     Object localVarPostBody = deleteAppsRequest;
     
     // create path and map variables
-    String localVarPath = "/api/v1/applications";
+    String localVarPath = "/api/v1/applications/delete_apps";
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -104,7 +104,7 @@ public class ApplicationApi extends BaseApi {
     TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
     return apiClient.invokeAPI(
         localVarPath,
-        "DELETE",
+        "POST",
         localVarQueryParams,
         localVarCollectionQueryParams,
         localVarQueryStringJoiner.toString(),

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -253,7 +253,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApplicationsHeartbeatResponse'
-    delete:
+
+  /api/v1/applications/delete_apps:
+    post:
       tags:
         - Application
       operationId: deleteApps

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -652,10 +652,8 @@ components:
       properties:
         primaryPartitions:
           $ref: '#/components/schemas/ShufflePartitionLocations'
-          default: { }
         replicaPartitions:
           $ref: '#/components/schemas/ShufflePartitionLocations'
-          default: { }
 
     WorkerId:
       type: object


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Add swagger editor links for RESTful spec.

Fix warn in the spec:
Master spec:
![image](https://github.com/user-attachments/assets/ff71aedf-c68d-472a-b0f8-e526d87d45ed)

Worker spec:
![image](https://github.com/user-attachments/assets/6820a25e-679f-4790-a3c2-d2757b34b0e4)


### Why are the changes needed?

To view the spec online.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
<img width="1103" alt="image" src="https://github.com/user-attachments/assets/0118e47d-da2d-43c8-a41d-085cde2ed06f" />


No warn now, see:
https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/turbofei/incubator-celeborn/openapi/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml

https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/turbofei/incubator-celeborn/openapi/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
