### PR TITLE
[CELEBORN-81][FOLLOWUP]Correct scala test plugin args.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -915,7 +915,7 @@
           <version>${maven.plugin.scalatest.version}</version>
           <configuration>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+            <argLine>${argLine} -ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
             <filereports>TestSuite.txt</filereports>
             <!--
               the plugin does not support always now, we must be careful w/ singletons.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modifies the maven configuration to properly pass Jacoco's argLine to ScalaTest plugin, enabling code coverage measurement for Scala tests. 

### Why are the changes needed?
Previously Scala tests were not properly included in code coverage reports

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI
