### PR TITLE
[CELEBORN-1955][HELM] Split nodeSelector into master.nodeSelector and worker.nodeSelector

### DIFF
--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -122,7 +122,7 @@ spec:
       {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.master.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -125,7 +125,7 @@ spec:
       {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -71,11 +71,12 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should add node selector if `master.nodeSelector` is set
     set:
-      nodeSelector:
-        key1: value1
-        key2: value2
+      master:
+        nodeSelector:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector.key1

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -71,11 +71,12 @@ tests:
           path: spec.template.spec.imagePullSecrets[1].name
           value: test-secret2
 
-  - it: Should add node selector if `nodeSelector` is set
+  - it: Should add node selector if `worker.nodeSelector` is set
     set:
-      nodeSelector:
-        key1: value1
-        key2: value2
+      worker:
+        nodeSelector:
+          key1: value1
+          key2: value2
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector.key1

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -192,16 +192,21 @@ master:
     # key1: value1
     # key2: value2
 
+  # -- Node selector for Celeborn master pods.
+  nodeSelector:
+    # key1: value1
+    # key2: value2
+
 worker:
   # -- Annotations for Celeborn worker pods.
   annotations:
     # key1: value1
     # key2: value2
 
-# -- Pod node selector
-nodeSelector: {}
-# key1: value1
-# key2: value2
+  # -- Node selector for Celeborn worker pods.
+  nodeSelector:
+    # key1: value1
+    # key2: value2
 
 # -- Pod tolerations
 tolerations: []


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Split `nodeSelector` into `master.nodeSelector` and `worker.nodeSelector`.

### Why are the changes needed?

Users are able to configure nodeSelector for Celeborn master and worker pods separately.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Run Helm unit tests by `helm unittest charts/celeborn --file "tests/**/*_test.yaml" --strict --debug`.