### PR TITLE
[CELEBORN-1874][CIP-14] Add CICD procedure in github action for cppClient

### DIFF
--- a/.github/workflows/cpp_integration.yml
+++ b/.github/workflows/cpp_integration.yml
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Celeborn Cpp Integration Test
+
+on:
+  push:
+    branches:
+      - main
+      - branch-*
+  pull_request:
+    branches:
+      - main
+      - branch-*
+
+jobs:
+  celeborn_cpp_integration_test:
+    runs-on: ubuntu-22.04
+    container: holylow/celeborn-cpp-dev:0.2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
+          fetch-depth: 0
+      - name: Compile Celeborn Cpp
+        working-directory: ./cpp
+        run: |
+          rm -rf build && mkdir -p build && cd build
+          cmake .. && make -j
+      - name: Run Unittests of Celeborn Cpp
+        working-directory: ./cpp/build
+        run: ctest


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds cicd procedure in github action for cppClient.

### Why are the changes needed?
To run the cppClient's unit tests in cicd procedure.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By cicd.
