### PR TITLE
[CELEBORN-1966] Added fix to get userinfo in celeborn

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -97,7 +97,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   // shuffle id -> (partitionId -> newest PartitionLocation)
   val latestPartitionLocation =
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
-  private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide()
+  private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide(conf)
   private val availableStorageTypes = conf.availableStorageTypes
   // app shuffle id -> LinkedHashMap of (app shuffle identifier, (shuffle id, fetch status))
   private val shuffleIdMapping = JavaUtils.newConcurrentHashMap[

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -97,7 +97,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   // shuffle id -> (partitionId -> newest PartitionLocation)
   val latestPartitionLocation =
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
-  private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide(conf)
+  private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide()
   private val availableStorageTypes = conf.availableStorageTypes
   // app shuffle id -> LinkedHashMap of (app shuffle identifier, (shuffle id, fetch status))
   private val shuffleIdMapping = JavaUtils.newConcurrentHashMap[

--- a/common/src/main/scala/org/apache/celeborn/common/identity/DefaultIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/DefaultIdentityProvider.scala
@@ -19,15 +19,8 @@ package org.apache.celeborn.common.identity
 
 import org.apache.celeborn.common.CelebornConf
 
-class DefaultIdentityProvider extends IdentityProvider {
+class DefaultIdentityProvider(conf: CelebornConf) extends IdentityProvider(conf) {
   override def provide(): UserIdentifier = {
-    val conf = new CelebornConf()
-    UserIdentifier(
-      conf.userSpecificTenant,
-      conf.userSpecificUserName)
-  }
-
-  override def provide(conf: CelebornConf): UserIdentifier = {
     UserIdentifier(
       conf.userSpecificTenant,
       conf.userSpecificUserName)

--- a/common/src/main/scala/org/apache/celeborn/common/identity/DefaultIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/DefaultIdentityProvider.scala
@@ -26,4 +26,10 @@ class DefaultIdentityProvider extends IdentityProvider {
       conf.userSpecificTenant,
       conf.userSpecificUserName)
   }
+
+  override def provide(conf: CelebornConf): UserIdentifier = {
+    UserIdentifier(
+      conf.userSpecificTenant,
+      conf.userSpecificUserName)
+  }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
@@ -17,12 +17,21 @@
 
 package org.apache.celeborn.common.identity
 
+import org.apache.celeborn.common.CelebornConf
 import org.apache.hadoop.security.UserGroupInformation
 
 class HadoopBasedIdentityProvider extends IdentityProvider {
-  override def provide(): UserIdentifier = {
+  def provideUserIdentifier(): UserIdentifier = {
     UserIdentifier(
       IdentityProvider.DEFAULT_TENANT_ID,
       UserGroupInformation.getCurrentUser.getShortUserName)
+  }
+
+  override def provide(): UserIdentifier = {
+    provideUserIdentifier()
+  }
+
+  override def provide(conf: CelebornConf): UserIdentifier = {
+    provideUserIdentifier()
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
@@ -21,18 +21,10 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.celeborn.common.CelebornConf
 
-class HadoopBasedIdentityProvider extends IdentityProvider {
-  def provideUserIdentifier(): UserIdentifier = {
+class HadoopBasedIdentityProvider(conf: CelebornConf) extends IdentityProvider(conf) {
+  override def provide(): UserIdentifier = {
     UserIdentifier(
       IdentityProvider.DEFAULT_TENANT_ID,
       UserGroupInformation.getCurrentUser.getShortUserName)
-  }
-
-  override def provide(): UserIdentifier = {
-    provideUserIdentifier()
-  }
-
-  override def provide(conf: CelebornConf): UserIdentifier = {
-    provideUserIdentifier()
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
@@ -17,8 +17,9 @@
 
 package org.apache.celeborn.common.identity
 
-import org.apache.celeborn.common.CelebornConf
 import org.apache.hadoop.security.UserGroupInformation
+
+import org.apache.celeborn.common.CelebornConf
 
 class HadoopBasedIdentityProvider extends IdentityProvider {
   def provideUserIdentifier(): UserIdentifier = {

--- a/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
@@ -32,13 +32,6 @@ object IdentityProvider extends Logging {
   def instantiate(conf: CelebornConf): IdentityProvider = {
     val className = conf.identityProviderClass
     logDebug(s"Creating instance of $className")
-
-    try {
-      Utils.instantiateClassWithCelebornConf[IdentityProvider](className, conf)
-    } catch {
-      case e: NoSuchMethodException =>
-        logError(s"Failed to instantiate class $className", e)
-        throw e
-    }
+    Utils.instantiateClassWithCelebornConf[IdentityProvider](className, conf)
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
@@ -23,6 +23,7 @@ import org.apache.celeborn.common.util.Utils
 
 abstract class IdentityProvider {
   def provide(): UserIdentifier
+  def provide(conf: CelebornConf): UserIdentifier
 }
 
 object IdentityProvider extends Logging {

--- a/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
@@ -37,8 +37,7 @@ object IdentityProvider extends Logging {
       val clazz = Class.forName(
         className,
         true,
-        Thread.currentThread().getContextClassLoader
-      ).asInstanceOf[Class[IdentityProvider]]
+        Thread.currentThread().getContextClassLoader).asInstanceOf[Class[IdentityProvider]]
 
       val ctor = clazz.getDeclaredConstructor(classOf[CelebornConf])
       logDebug(s"Using constructor with CelebornConf for $className")

--- a/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
@@ -34,14 +34,7 @@ object IdentityProvider extends Logging {
     logDebug(s"Creating instance of $className")
 
     try {
-      val clazz = Class.forName(
-        className,
-        true,
-        Thread.currentThread().getContextClassLoader).asInstanceOf[Class[IdentityProvider]]
-
-      val ctor = clazz.getDeclaredConstructor(classOf[CelebornConf])
-      logDebug(s"Using constructor with CelebornConf for $className")
-      ctor.newInstance(conf)
+      Utils.instantiateClassWithCelebornConf[IdentityProvider](className, conf)
     } catch {
       case e: NoSuchMethodException =>
         logError(s"Failed to instantiate class $className", e)

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -613,7 +613,7 @@ object Utils extends Logging {
     }
   }
 
-  def instantiateDynamicConfigStoreBackend[T](className: String, conf: CelebornConf): T = {
+  def instantiateClassWithCelebornConf[T](className: String, conf: CelebornConf): T = {
     try {
       DynConstructors.builder().impl(className, classOf[CelebornConf])
         .build[T]()

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -621,7 +621,7 @@ object Utils extends Logging {
     } catch {
       case e: Throwable =>
         throw new CelebornException(
-          s"Failed to instantiate dynamic config store backend $className.",
+          s"Failed to instantiate class $className with celeborn conf.",
           e)
     }
   }

--- a/common/src/test/scala/org/apache/celeborn/common/identity/DefaultIdentityProviderSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/identity/DefaultIdentityProviderSuite.scala
@@ -1,22 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.celeborn.common.identity
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 
 class DefaultIdentityProviderSuite extends CelebornFunSuite {
-  test("provide() without parameters should use default CelebornConf") {
-    val defaultIdentityProvider = new DefaultIdentityProvider()
-    val DEFAULT_TENANT_ID = "default"
-    val DEFAULT_USERNAME = "default"
-
-    val userIdentifier = defaultIdentityProvider.provide()
-
-    assert(userIdentifier.tenantId == DEFAULT_TENANT_ID)
-    assert(userIdentifier.name == DEFAULT_USERNAME)
-  }
-
-  test("provide(celebornConf) should use provided CelebornConf") {
-    val defaultIdentityProvider = new DefaultIdentityProvider()
+  test("provide() should use provided CelebornConf") {
     val conf = new CelebornConf()
 
     val TEST_TENANT_ID = "test-id"
@@ -25,9 +30,23 @@ class DefaultIdentityProviderSuite extends CelebornFunSuite {
     conf.set(CelebornConf.USER_SPECIFIC_TENANT, TEST_TENANT_ID)
     conf.set(CelebornConf.USER_SPECIFIC_USERNAME, TEST_TENANT_NAME)
 
-    val userIdentifier = defaultIdentityProvider.provide(conf)
+    val defaultIdentityProvider = new DefaultIdentityProvider(conf)
+    val userIdentifier = defaultIdentityProvider.provide()
 
     assert(userIdentifier.tenantId == TEST_TENANT_ID)
     assert(userIdentifier.name == TEST_TENANT_NAME)
+  }
+
+  test("provide() should use default CelebornConf if not provided") {
+    val conf = new CelebornConf()
+    val defaultIdentityProvider = new DefaultIdentityProvider(conf)
+
+    val DEFAULT_TENANT_ID = "default"
+    val DEFAULT_USERNAME = "default"
+
+    val userIdentifier = defaultIdentityProvider.provide()
+
+    assert(userIdentifier.tenantId == DEFAULT_TENANT_ID)
+    assert(userIdentifier.name == DEFAULT_USERNAME)
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/identity/DefaultIdentityProviderSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/identity/DefaultIdentityProviderSuite.scala
@@ -1,0 +1,33 @@
+package org.apache.celeborn.common.identity
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+
+class DefaultIdentityProviderSuite extends CelebornFunSuite {
+  test("provide() without parameters should use default CelebornConf") {
+    val defaultIdentityProvider = new DefaultIdentityProvider()
+    val DEFAULT_TENANT_ID = "default"
+    val DEFAULT_USERNAME = "default"
+
+    val userIdentifier = defaultIdentityProvider.provide()
+
+    assert(userIdentifier.tenantId == DEFAULT_TENANT_ID)
+    assert(userIdentifier.name == DEFAULT_USERNAME)
+  }
+
+  test("provide(celebornConf) should use provided CelebornConf") {
+    val defaultIdentityProvider = new DefaultIdentityProvider()
+    val conf = new CelebornConf()
+
+    val TEST_TENANT_ID = "test-id"
+    val TEST_TENANT_NAME = "test-user"
+
+    conf.set(CelebornConf.USER_SPECIFIC_TENANT, TEST_TENANT_ID)
+    conf.set(CelebornConf.USER_SPECIFIC_USERNAME, TEST_TENANT_NAME)
+
+    val userIdentifier = defaultIdentityProvider.provide(conf)
+
+    assert(userIdentifier.tenantId == TEST_TENANT_ID)
+    assert(userIdentifier.name == TEST_TENANT_NAME)
+  }
+}

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -261,7 +261,9 @@ class UtilsSuite extends CelebornFunSuite {
 
   test("test instantiate") {
     val celebornConf = new CelebornConf()
-    assert(Utils.instantiate[DefaultIdentityProvider](celebornConf.identityProviderClass)
-      .isInstanceOf[DefaultIdentityProvider])
+    val testInstance = Utils.instantiateClassWithCelebornConf[DefaultIdentityProvider](
+      celebornConf.identityProviderClass,
+      celebornConf)
+    assert(testInstance.isInstanceOf[DefaultIdentityProvider])
   }
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfigServiceFactory.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfigServiceFactory.java
@@ -42,7 +42,7 @@ public class DynamicConfigServiceFactory {
               break;
             }
           }
-          _INSTANCE = Utils.instantiateDynamicConfigStoreBackend(configStoreBackend, celebornConf);
+          _INSTANCE = Utils.instantiateClassWithCelebornConf(configStoreBackend, celebornConf);
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Updated the DefaultIdentityProvider to return tenantId, name based on configs provided by the user. Using the CelebornConf object used by LifeCycleManager to get the tenantId and name. 

### Why are the changes needed?
The tenant id and username passed by the user were not being used because the DefaultIdentityProvider creates a new CelebornConf each time the provide function is called. Due to this, the tenantid and username were always coming as default. With these changes, we are using the CelebornConf object used by the LifeCycleManager which includes the configs provided by the user. 

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Added UTs and tested on staging setup
