### PR TITLE
[CELEBORN-1970] Use StatusCode.fromValue instead of Utils.toStatusCode

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/client/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/client/FlinkShuffleClientImpl.java
@@ -537,7 +537,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
             ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
     // per partitionKey only serve single PartitionLocation in Client Cache.
     PbChangeLocationPartitionInfo partitionInfo = response.getPartitionInfo(0);
-    StatusCode respStatus = Utils.toStatusCode(partitionInfo.getStatus());
+    StatusCode respStatus = StatusCode.fromValue(partitionInfo.getStatus());
     if (StatusCode.SUCCESS.equals(respStatus)) {
       logger.debug("revive new partition:{}", partitionInfo.getPartition());
       return Optional.of(PbSerDeUtils.fromPbPartitionLocation(partitionInfo.getPartition()));

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -335,7 +335,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                   + ", revive status "
                   + request.reviveStatus
                   + "("
-                  + Utils.toStatusCode(request.reviveStatus)
+                  + StatusCode.fromValue(request.reviveStatus)
                   + ")"
                   + ", old location: "
                   + request.loc));
@@ -458,7 +458,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                             + " then revive but "
                             + request.reviveStatus
                             + "("
-                            + Utils.toStatusCode(request.reviveStatus)
+                            + StatusCode.fromValue(request.reviveStatus)
                             + ")")));
             return;
           }
@@ -494,7 +494,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                         + " then revive but "
                         + request.reviveStatus
                         + "("
-                        + Utils.toStatusCode(request.reviveStatus)
+                        + StatusCode.fromValue(request.reviveStatus)
                         + ")")));
         return;
       }
@@ -689,7 +689,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     while (numRetries > 0) {
       try {
         PbRegisterShuffleResponse response = callable.call();
-        StatusCode respStatus = Utils.toStatusCode(response.getStatus());
+        StatusCode respStatus = StatusCode.fromValue(response.getStatus());
         if (StatusCode.SUCCESS.equals(respStatus)) {
           ConcurrentHashMap<Integer, PartitionLocation> result = JavaUtils.newConcurrentHashMap();
           Tuple2<List<PartitionLocation>, List<PartitionLocation>> locations =

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -386,7 +386,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         } else {
           oldPartitions.add(null)
         }
-        causes.add(Utils.toStatusCode(info.getStatus))
+        causes.add(StatusCode.fromValue(info.getStatus))
       }
       logDebug(s"Received Revive request, number of partitions ${partitionIds.size()}")
       handleRevive(
@@ -1676,7 +1676,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
           val unregisterShuffleResponse = requestMasterUnregisterShuffle(
             UnregisterShuffle(appUniqueId, shuffleId, MasterClient.genRequestId()))
           // if unregister shuffle not success, wait next turn
-          if (StatusCode.SUCCESS == Utils.toStatusCode(unregisterShuffleResponse.getStatus)) {
+          if (StatusCode.SUCCESS == StatusCode.fromValue(unregisterShuffleResponse.getStatus)) {
             unregisterShuffleTime.remove(shuffleId)
           }
         } else {
@@ -1691,7 +1691,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
           appUniqueId,
           batchRemoveShuffleIds.asJava,
           MasterClient.genRequestId()))
-      if (StatusCode.SUCCESS == Utils.toStatusCode(unregisterShuffleResponse.getStatus)) {
+      if (StatusCode.SUCCESS == StatusCode.fromValue(unregisterShuffleResponse.getStatus)) {
         batchRemoveShuffleIds.foreach { shuffleId: Integer =>
           unregisterShuffleTime.remove(shuffleId)
         }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -112,4 +112,9 @@ public enum StatusCode {
     }
     throw new IllegalArgumentException("Unknown status code: " + value);
   }
+
+  public static StatusCode fromValue(int value) {
+    assert (value >= 0 && value < 256);
+    return fromValue((byte) value);
+  }
 }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
+
 public enum StatusCode {
   // 1/0 Status
   SUCCESS(0),
@@ -114,7 +116,8 @@ public enum StatusCode {
   }
 
   public static StatusCode fromValue(int value) {
-    assert (value >= 0 && value < 256);
+    Preconditions.checkArgument(
+        value >= 0 && value < 256, "Value:" + value + " is out of range [0,256).");
     return fromValue((byte) value);
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -1068,7 +1068,7 @@ object ControlMessages extends Logging {
 
       case RELEASE_SLOTS_RESPONSE_VALUE =>
         val pbReleaseSlotsResponse = PbReleaseSlotsResponse.parseFrom(message.getPayload)
-        ReleaseSlotsResponse(Utils.toStatusCode(pbReleaseSlotsResponse.getStatus))
+        ReleaseSlotsResponse(StatusCode.fromValue(pbReleaseSlotsResponse.getStatus))
 
       case REGISTER_WORKER_VALUE =>
         PbRegisterWorker.parseFrom(message.getPayload)
@@ -1152,7 +1152,7 @@ object ControlMessages extends Logging {
               pbRequestSlotsResponse.getWorkerResourceMap)
           }
         RequestSlotsResponse(
-          Utils.toStatusCode(pbRequestSlotsResponse.getStatus),
+          StatusCode.fromValue(pbRequestSlotsResponse.getStatus),
           workerResource)
 
       case CHANGE_LOCATION_VALUE =>
@@ -1176,7 +1176,7 @@ object ControlMessages extends Logging {
 
       case MAPPER_END_RESPONSE_VALUE =>
         val pbMapperEndResponse = PbMapperEndResponse.parseFrom(message.getPayload)
-        MapperEndResponse(Utils.toStatusCode(pbMapperEndResponse.getStatus))
+        MapperEndResponse(StatusCode.fromValue(pbMapperEndResponse.getStatus))
 
       case GET_REDUCER_FILE_GROUP_VALUE =>
         val pbGetReducerFileGroup = PbGetReducerFileGroup.parseFrom(message.getPayload)
@@ -1215,7 +1215,7 @@ object ControlMessages extends Logging {
         }.toMap.asJava
         val broadcast = pbGetReducerFileGroupResponse.getBroadcast.toByteArray
         GetReducerFileGroupResponse(
-          Utils.toStatusCode(pbGetReducerFileGroupResponse.getStatus),
+          StatusCode.fromValue(pbGetReducerFileGroupResponse.getStatus),
           fileGroup,
           attempts,
           partitionIds,
@@ -1252,7 +1252,7 @@ object ControlMessages extends Logging {
 
       case APPLICATION_LOST_RESPONSE_VALUE =>
         val pbApplicationLostResponse = PbApplicationLostResponse.parseFrom(message.getPayload)
-        ApplicationLostResponse(Utils.toStatusCode(pbApplicationLostResponse.getStatus))
+        ApplicationLostResponse(StatusCode.fromValue(pbApplicationLostResponse.getStatus))
 
       case HEARTBEAT_FROM_APPLICATION_VALUE =>
         val pbHeartbeatFromApplication = PbHeartbeatFromApplication.parseFrom(message.getPayload)
@@ -1273,7 +1273,7 @@ object ControlMessages extends Logging {
           PbHeartbeatFromApplicationResponse.parseFrom(message.getPayload)
         val pbCheckQuotaResponse = pbHeartbeatFromApplicationResponse.getCheckQuotaResponse
         HeartbeatFromApplicationResponse(
-          Utils.toStatusCode(pbHeartbeatFromApplicationResponse.getStatus),
+          StatusCode.fromValue(pbHeartbeatFromApplicationResponse.getStatus),
           pbHeartbeatFromApplicationResponse.getExcludedWorkersList.asScala
             .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava,
           pbHeartbeatFromApplicationResponse.getUnknownWorkersList.asScala
@@ -1351,7 +1351,7 @@ object ControlMessages extends Logging {
       case RESERVE_SLOTS_RESPONSE_VALUE =>
         val pbReserveSlotsResponse = PbReserveSlotsResponse.parseFrom(message.getPayload)
         ReserveSlotsResponse(
-          Utils.toStatusCode(pbReserveSlotsResponse.getStatus),
+          StatusCode.fromValue(pbReserveSlotsResponse.getStatus),
           pbReserveSlotsResponse.getReason)
 
       case COMMIT_FILES_VALUE =>
@@ -1378,7 +1378,7 @@ object ControlMessages extends Logging {
           committedBitMap.put(entry._1, Utils.byteStringToRoaringBitmap(entry._2))
         }
         CommitFilesResponse(
-          Utils.toStatusCode(pbCommitFilesResponse.getStatus),
+          StatusCode.fromValue(pbCommitFilesResponse.getStatus),
           pbCommitFilesResponse.getCommittedPrimaryIdsList,
           pbCommitFilesResponse.getCommittedReplicaIdsList,
           pbCommitFilesResponse.getFailedPrimaryIdsList,
@@ -1400,7 +1400,7 @@ object ControlMessages extends Logging {
       case DESTROY_RESPONSE_VALUE =>
         val pbDestroyResponse = PbDestroyWorkerSlotsResponse.parseFrom(message.getPayload)
         DestroyWorkerSlotsResponse(
-          Utils.toStatusCode(pbDestroyResponse.getStatus),
+          StatusCode.fromValue(pbDestroyResponse.getStatus),
           pbDestroyResponse.getFailedPrimariesList,
           pbDestroyResponse.getFailedReplicasList)
 
@@ -1434,7 +1434,7 @@ object ControlMessages extends Logging {
 
       case STAGE_END_RESPONSE_VALUE =>
         val pbStageEndResponse = PbStageEndResponse.parseFrom(message.getPayload)
-        StageEndResponse(Utils.toStatusCode(pbStageEndResponse.getStatus))
+        StageEndResponse(StatusCode.fromValue(pbStageEndResponse.getStatus))
 
       case CHECK_WORKERS_AVAILABLE_VALUE =>
         PbCheckWorkersAvailable.parseFrom(message.getPayload)

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -50,7 +50,7 @@ import org.apache.celeborn.common.meta.{DiskStatus, WorkerInfo}
 import org.apache.celeborn.common.network.protocol.TransportMessage
 import org.apache.celeborn.common.network.util.TransportConf
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType, RpcNameConstants, TransportModuleConstants}
-import org.apache.celeborn.common.protocol.message.{ControlMessages, Message, StatusCode}
+import org.apache.celeborn.common.protocol.message.{ControlMessages, Message}
 import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
 import org.apache.celeborn.reflect.DynConstructors
 
@@ -1055,121 +1055,6 @@ object Utils extends Logging {
       case transportMessage: TransportMessage =>
         ControlMessages.fromTransportMessage(transportMessage)
       case _ => message
-    }
-  }
-
-  def toStatusCode(status: Int): StatusCode = {
-    status match {
-      case 0 =>
-        StatusCode.SUCCESS
-      case 1 =>
-        StatusCode.PARTIAL_SUCCESS
-      case 2 =>
-        StatusCode.REQUEST_FAILED
-      case 3 =>
-        StatusCode.SHUFFLE_ALREADY_REGISTERED
-      case 4 =>
-        StatusCode.SHUFFLE_NOT_REGISTERED
-      case 5 =>
-        StatusCode.RESERVE_SLOTS_FAILED
-      case 6 =>
-        StatusCode.SLOT_NOT_AVAILABLE
-      case 7 =>
-        StatusCode.WORKER_NOT_FOUND
-      case 8 =>
-        StatusCode.PARTITION_NOT_FOUND
-      case 9 =>
-        StatusCode.REPLICA_PARTITION_NOT_FOUND
-      case 10 =>
-        StatusCode.DELETE_FILES_FAILED
-      case 11 =>
-        StatusCode.PARTITION_EXISTS
-      case 12 =>
-        StatusCode.REVIVE_FAILED
-      case 13 =>
-        StatusCode.REPLICATE_DATA_FAILED
-      case 14 =>
-        StatusCode.NUM_MAPPER_ZERO
-      case 15 =>
-        StatusCode.MAP_ENDED
-      case 16 =>
-        StatusCode.STAGE_ENDED
-      case 17 =>
-        StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_PRIMARY
-      case 18 =>
-        StatusCode.PUSH_DATA_WRITE_FAIL_REPLICA
-      case 19 =>
-        StatusCode.PUSH_DATA_WRITE_FAIL_PRIMARY
-      case 20 =>
-        StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND
-      case 21 =>
-        StatusCode.HARD_SPLIT
-      case 22 =>
-        StatusCode.SOFT_SPLIT
-      case 23 =>
-        StatusCode.STAGE_END_TIME_OUT
-      case 24 =>
-        StatusCode.SHUFFLE_DATA_LOST
-      case 25 =>
-        StatusCode.WORKER_SHUTDOWN
-      case 26 =>
-        StatusCode.NO_AVAILABLE_WORKING_DIR
-      case 27 =>
-        StatusCode.WORKER_EXCLUDED
-      case 28 =>
-        StatusCode.WORKER_UNKNOWN
-      case 29 =>
-        StatusCode.COMMIT_FILE_EXCEPTION
-      case 30 =>
-        StatusCode.PUSH_DATA_SUCCESS_PRIMARY_CONGESTED
-      case 31 =>
-        StatusCode.PUSH_DATA_SUCCESS_REPLICA_CONGESTED
-      case 32 =>
-        StatusCode.PUSH_DATA_HANDSHAKE_FAIL_REPLICA
-      case 33 =>
-        StatusCode.PUSH_DATA_HANDSHAKE_FAIL_PRIMARY
-      case 34 =>
-        StatusCode.REGION_START_FAIL_REPLICA
-      case 35 =>
-        StatusCode.REGION_START_FAIL_PRIMARY
-      case 36 =>
-        StatusCode.REGION_FINISH_FAIL_REPLICA
-      case 37 =>
-        StatusCode.REGION_FINISH_FAIL_PRIMARY
-      case 38 =>
-        StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY
-      case 39 =>
-        StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_REPLICA
-      case 40 =>
-        StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_PRIMARY
-      case 41 =>
-        StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA
-      case 42 =>
-        StatusCode.PUSH_DATA_TIMEOUT_PRIMARY
-      case 43 =>
-        StatusCode.PUSH_DATA_TIMEOUT_REPLICA
-      case 44 =>
-        StatusCode.PUSH_DATA_PRIMARY_WORKER_EXCLUDED
-      case 45 =>
-        StatusCode.PUSH_DATA_REPLICA_WORKER_EXCLUDED
-      case 46 =>
-        StatusCode.FETCH_DATA_TIMEOUT
-      case 47 =>
-        StatusCode.REVIVE_INITIALIZED
-      case 48 =>
-        StatusCode.DESTROY_SLOTS_MOCK_FAILURE
-      case 49 =>
-        StatusCode.COMMIT_FILES_MOCK_FAILURE
-      case 50 =>
-        StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE_REPLICA
-      case 51 =>
-        StatusCode.OPEN_STREAM_FAILED
-      case 52 =>
-        StatusCode.SEGMENT_START_FAIL_REPLICA
-      case 53 =>
-        StatusCode.SEGMENT_START_FAIL_PRIMARY
-      case _ =>
-        null
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
If we add a new StatusCode and want to convert from int/byte to StatusCode, we should modify Utils.toStatusCode synchronously. But with StatusCode.fromValue, this step is not necessary.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually tested
