### PR TITLE
[CELEBORN-1951][HELM] Rename resources.{master,worker} to {master,worker}.resoruces

### DIFF
--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -96,21 +96,23 @@ dnsPolicy: ClusterFirstWithHostNet
 # -- Specifies whether to use the host's network namespace
 hostNetwork: true
 
-resources:
-  # -- Pod resources for Celeborn master pods
-  master:
-    limits:
-      cpu: 100m
-      memory: 800Mi
+# -- Resources for Celeborn master containers.
+master:
+  resources:
     requests:
       cpu: 100m
       memory: 800Mi
-  # -- Pod resources for Celeborn worker pods
-  worker:
     limits:
+      cpu: 100m
+      memory: 800Mi
+
+# -- Resources for Celeborn worker containers.
+worker:
+  resources:
+    requests:
       cpu: 100m
       memory: 1Gi
-    requests:
+    limits:
       cpu: 100m
       memory: 1Gi
 

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         volumeMounts:
         - name: {{ $.Release.Name }}-master-vol-0
           mountPath: {{ (index $dirs 0).mountPath }}
-        {{- with .Values.resources.master }}
+        {{- with .Values.master.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -97,7 +97,7 @@ spec:
         - name: {{ $.Release.Name }}-master-vol-{{ $index }}
           mountPath: {{ .mountPath }}
         {{- end }}
-        {{- with .Values.resources.master }}
+        {{- with .Values.master.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
           mountPath: {{ $dir.mountPath }}
         {{- end}}
-        {{- with .Values.resources.worker }}
+        {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -100,7 +100,7 @@ spec:
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
           mountPath: {{ .mountPath }}
         {{- end }}
-        {{- with .Values.resources.worker }}
+        {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -58,6 +58,36 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
+  - it: Should use the specified resources if `master.resources` is set
+    set:
+      master:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='celeborn')].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
   - it: Should add secrets if `imagePullSecrets` is set
     set:
       imagePullSecrets:

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -58,6 +58,36 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
+  - it: Should use the specified resources if `worker.resources` is set
+    set:
+      worker:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='celeborn')].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
   - it: Should add secrets if `imagePullSecrets` is set
     set:
       imagePullSecrets:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -139,25 +139,6 @@ dnsPolicy: ClusterFirst
 # -- Specifies whether to use the host's network namespace
 hostNetwork: false
 
-resources:
-  # -- Pod resources for Celeborn master pods
-  master: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  # -- Pod resources for Celeborn worker pods
-  worker: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
 # -- Container security context
 securityContext:
   # Specifies the user ID to run the entrypoint of the container process
@@ -192,6 +173,15 @@ master:
     # key1: value1
     # key2: value2
 
+  # -- Resources for Celeborn master containers.
+  resources:
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+
   # -- Node selector for Celeborn master pods.
   nodeSelector:
     # key1: value1
@@ -212,6 +202,15 @@ worker:
   annotations:
     # key1: value1
     # key2: value2
+
+  # -- Resources for Celeborn worker containers.
+  resources:
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
 
   # -- Node selector for Celeborn worker pods.
   nodeSelector:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Rename `resources.master` to `master.resources`.
- Rename `resources.worker` to `worker.resources`.
- Add corresponding Helm unit tests.

### Why are the changes needed?

Unify the values naming by prefixing them with `master` or `worker`.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Helm unit test by `helm unittest charts/celeborn --file "tests/**/*_test.yaml" --strict --debug`.