### PR TITLE
[RFT] Enable run java UT (not a formal PR, just for discussion purposes)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,6 +577,10 @@
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -592,6 +596,10 @@
           <exclusion>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-continuation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
not a formal PR, just for discussion purposes.

### What changes were proposed in this pull request?
Exclude JUnit 5 dependencies to enable running Java unit tests for modules such as master and worker.


