### PR TITLE
[CELEBORN-1841][FOLLOWUP] Support custom implementation of EventExecutorChooser to avoid deadlock when calling await in EventLoop thread for EpollEventLoopGroup

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -79,7 +79,13 @@ public class NettyUtils {
                 DefaultSelectStrategyFactory.INSTANCE)
             : new NioEventLoopGroup(numThreads, threadFactory);
       case EPOLL:
-        return new EpollEventLoopGroup(numThreads, threadFactory);
+        return conflictAvoidChooserEnable
+            ? new EpollEventLoopGroup(
+                numThreads,
+                new ThreadPerTaskExecutor(threadFactory),
+                ConflictAvoidEventExecutorChooserFactory.INSTANCE,
+                DefaultSelectStrategyFactory.INSTANCE)
+            : new EpollEventLoopGroup(numThreads, threadFactory);
       default:
         throw new IllegalArgumentException("Unknown io mode: " + mode);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support custom implementation of `EventExecutorChooser` to avoid deadlock when calling await in EventLoop thread for `EpollEventLoopGroup`.

Follow up #3071.

### Why are the changes needed?

In Flink Celeborn Client, you can create a new connection in the EventLoop thread. To wait for the connection to complete, cf.await is called, which can cause a deadlock because the thread bound to the newly connected channel may be the same as the current EventLoop thread. The current thread is suspended by wait and needs to wait for the current thread to notify. This change is to avoid binding the same thread.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.