### PR TITLE
[CELEBORN-1976] CommitHandler should use celeborn.client.rpc.commitFiles.askTimeout for timeout of doParallelCommitFiles

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -312,7 +312,7 @@ abstract class CommitHandler(
     val futureSeq = Future.sequence(outFutures)(cbf, ec)
     awaitResult(futureSeq, Duration.Inf)
 
-    val timeout = conf.rpcAskTimeout.duration.toMillis
+    val timeout = clientRpcCommitFilesAskTimeout.duration.toMillis
     var remainingTime = timeout * maxRetries
     val delta = 50
     while (remainingTime >= 0 && !futures.isEmpty) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CommitHandler` should use `celeborn.client.rpc.commitFiles.askTimeout` instead of `celeborn.rpc.askTimeout` for timeout of `doParallelCommitFiles`.

### Why are the changes needed?

`CommitHandler` uses `celeborn.rpc.askTimeout`  for timeout of `doParallelCommitFiles` at present, which should be controlled with `celeborn.client.rpc.commitFiles.askTimeout`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA.