### PR TITLE
[CELEBORN-1983] Fix fetch fail not throw due to reach spark maxTaskFa…

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -302,6 +302,7 @@ public class SparkUtils {
       if (taskSetManager != null) {
         int stageId = taskSetManager.stageId();
         int stageAttemptId = taskSetManager.taskSet().stageAttemptId();
+        int maxTaskFails = taskSetManager.maxTaskFailures();
         String stageUniqId = stageId + "-" + stageAttemptId;
         Set<Long> reportedStageTaskIds =
             reportedStageShuffleFetchFailureTaskIds.computeIfAbsent(
@@ -341,6 +342,17 @@ public class SparkUtils {
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
               return true;
+            }
+          } else {
+            if (ti.attemptNumber() >= maxTaskFails - 1) {
+              logger.info(
+                  "StageId={} index={} taskId={} attemptNumber {} reach maxTaskFails {}.",
+                  stageId,
+                  taskInfo.index(),
+                  taskId,
+                  ti.attemptNumber(),
+                  maxTaskFails);
+              return false;
             }
           }
         }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -419,6 +419,7 @@ public class SparkUtils {
       if (taskSetManager != null) {
         int stageId = taskSetManager.stageId();
         int stageAttemptId = taskSetManager.taskSet().stageAttemptId();
+        int maxTaskFails = taskSetManager.maxTaskFailures();
         String stageUniqId = stageId + "-" + stageAttemptId;
         Set<Long> reportedStageTaskIds =
             reportedStageShuffleFetchFailureTaskIds.computeIfAbsent(
@@ -458,6 +459,17 @@ public class SparkUtils {
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
               return true;
+            }
+          } else {
+            if (ti.attemptNumber() >= maxTaskFails - 1) {
+              LOG.info(
+                  "StageId={} index={} taskId={} attemptNumber {} reach maxTaskFails {}.",
+                  stageId,
+                  taskInfo.index(),
+                  taskId,
+                  ti.attemptNumber(),
+                  maxTaskFails);
+              return false;
             }
           }
         }


### PR DESCRIPTION
…ilures

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
change sparkUtils  taskAnotherAttemptRunningOrSuccessful method
(https://issues.apache.org/jira/browse/CELEBORN-1983)


### Why are the changes needed?

Because it will lead to job failure.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
Test it on online ETL jobs
