### PR TITLE
[CELEBORN-1987][HELM] Split dnsPolicy into master.dnsPolicy and worker.dnsPolicy

### DIFF
--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -77,9 +77,6 @@ celeborn:
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
 
-# -- Specifies the DNS policy for Celeborn pods to use
-dnsPolicy: ClusterFirstWithHostNet
-
 # -- Specifies whether to use the host's network namespace
 hostNetwork: true
 
@@ -107,6 +104,9 @@ master:
       cpu: 100m
       memory: 800Mi
 
+  # -- DNS policy for Celeborn master pods.
+  dnsPolicy: ClusterFirstWithHostNet
+
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
   replicas: 1
@@ -132,6 +132,9 @@ worker:
     limits:
       cpu: 100m
       memory: 1Gi
+
+  # -- DNS policy for Celeborn worker pods.
+  dnsPolicy: ClusterFirstWithHostNet
 
 # -- Container security context
 securityContext:

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -141,7 +141,7 @@ spec:
       {{- if or .Values.master.priorityClass.name .Values.master.priorityClass.create }}
       priorityClassName: {{ include "celeborn.master.priorityClass.name" . }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
+      {{- with .Values.master.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.hostNetwork }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -144,7 +144,7 @@ spec:
       {{- if or .Values.worker.priorityClass.name .Values.worker.priorityClass.create }}
       priorityClassName: {{ include "celeborn.worker.priorityClass.name" . }}
       {{- end }}
-      {{- with .Values.dnsPolicy }}
+      {{- with .Values.worker.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.hostNetwork }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -266,9 +266,10 @@ tests:
           path: spec.template.spec.priorityClassName
           value: test-priority-class
 
-  - it: Should use the specified dns policy if `dnsPolicy` is set
+  - it: Should use the specified dns policy if `master.dnsPolicy` is set
     set:
-      dnsPolicy: ClusterFirstWithHostNet
+      master:
+        dnsPolicy: ClusterFirstWithHostNet
     asserts:
       - equal:
           path: spec.template.spec.dnsPolicy

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -265,9 +265,10 @@ tests:
           path: spec.template.spec.priorityClassName
           value: test-priority-class
 
-  - it: Should use the specified dns policy if `dnsPolicy` is set
+  - it: Should use the specified dns policy if `worker.dnsPolicy` is set
     set:
-      dnsPolicy: ClusterFirstWithHostNet
+      worker:
+        dnsPolicy: ClusterFirstWithHostNet
     asserts:
       - equal:
           path: spec.template.spec.dnsPolicy

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -118,9 +118,6 @@ celeborn:
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
 
-# -- Specifies the DNS policy for Celeborn pods to use
-dnsPolicy: ClusterFirst
-
 # -- Specifies whether to use the host's network namespace
 hostNetwork: false
 
@@ -211,6 +208,9 @@ master:
     # -- Specifies the integer value of this priority class, default is half of system-cluster-critical.
     value: 1000000000
 
+  # -- DNS policy for Celeborn master pods.
+  dnsPolicy: ClusterFirst
+
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
   replicas: 5
@@ -290,6 +290,9 @@ worker:
     name: ""
     # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
     value: 999999000
+
+  # -- DNS policy for Celeborn worker pods.
+  dnsPolicy: ClusterFirst
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Split `dnsPolicy` into `master.dnsPolicy` and `worker.dnsPolicy`

### Why are the changes needed?

Unify the values naming by prefixing them with `master` or `worker`.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Run Helm unit tests by `helm unittest charts/celeborn --file "tests/**/*_test.yaml" --strict --debug`.