### PR TITLE
[CELEBORN-1990] Add support for kubernetes PVC in helm chart

### DIFF
--- a/charts/celeborn/templates/master/_helpers.tpl
+++ b/charts/celeborn/templates/master/_helpers.tpl
@@ -89,3 +89,16 @@ prometheus.io/scheme: 'http'
 prometheus.io/scrape: 'true'
 {{- end }}
 {{- end }}
+
+{{/*
+Indicate if PVC is used on master volumes
+*/}}
+{{- define "celeborn.master.withPvc" -}}
+{{- $withPvc := "false" -}}
+{{- range $index, $volume := .Values.volumes.master }}
+{{- if eq "pvc" $volume.type }}
+{{- $withPvc = "true" -}}
+{{- end }}
+{{- end }}
+{{- $withPvc -}}
+{{- end }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -122,8 +122,6 @@ spec:
         hostPath:
           path: {{ $volume.hostPath | default $volume.mountPath }}/master
           type: DirectoryOrCreate
-      {{- else }}
-      {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}
       {{- end }}
       {{- end }}
       {{- with .Values.master.nodeSelector }}
@@ -152,3 +150,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 30
+  {{- if eq (include "celeborn.master.withPvc" .) "true" }}
+  volumeClaimTemplates:
+  {{- range $index, $volume := .Values.volumes.master }}
+  {{- if eq "pvc" $volume.type }}
+  - metadata:
+      name: {{ $.Release.Name }}-master-vol-{{ $index }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ $volume.storageClassName }}
+      resources:
+        requests:
+          storage: {{ $volume.capacity }}
+      volumeMode: Filesystem
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/celeborn/templates/worker/_helpers.tpl
+++ b/charts/celeborn/templates/worker/_helpers.tpl
@@ -111,3 +111,16 @@ prometheus.io/scheme: 'http'
 prometheus.io/scrape: 'true'
 {{- end }}
 {{- end }}
+
+{{/*
+Indicate if PVC is used on worker volumes
+*/}}
+{{- define "celeborn.worker.withPvc" -}}
+{{- $withPvc := "false" -}}
+{{- range $index, $volume := .Values.volumes.worker }}
+{{- if eq "pvc" $volume.type }}
+{{- $withPvc = "true" -}}
+{{- end }}
+{{- end }}
+{{- $withPvc -}}
+{{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -125,8 +125,6 @@ spec:
         hostPath:
           path: {{ $volume.hostPath | default $volume.mountPath }}/worker
           type: DirectoryOrCreate
-      {{- else }}
-      {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}
       {{- end }}
       {{- end }}
       {{- with .Values.worker.nodeSelector }}
@@ -155,4 +153,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 30
-  
+  {{- if eq (include "celeborn.worker.withPvc" .) "true" }}
+  volumeClaimTemplates:
+  {{- range $index, $volume := .Values.volumes.worker }}
+  {{- if eq "pvc" $volume.type }}
+  - metadata:
+      name: {{ $.Release.Name }}-worker-vol-{{ $index }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ $volume.storageClassName }}
+      resources:
+        requests:
+          storage: {{ $volume.capacity }}
+      volumeMode: Filesystem
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -298,3 +298,26 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 3000
+
+  - it: Should define volumeClaimTemplates
+    set:
+      volumes:
+        master:
+          - mountPath: /mnt/celeborn_ratis
+            type: pvc
+            storageClassName: gp3
+            capacity: 100Gi
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates
+          value:
+            - metadata:
+                name: celeborn-master-vol-0
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 100Gi
+                storageClassName: gp3
+                volumeMode: Filesystem

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -297,3 +297,27 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 3000
+
+  - it: Should define volumeClaimTemplates
+    set:
+      volumes:
+        worker:
+          - mountPath: /mnt/celeborn_ratis
+            type: pvc
+            diskType: SSD
+            storageClassName: gp3
+            capacity: 100Gi
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates
+          value:
+            - metadata:
+                name: celeborn-worker-vol-0
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 100Gi
+                storageClassName: gp3
+                volumeMode: Filesystem

--- a/charts/celeborn/values.schema.json
+++ b/charts/celeborn/values.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "volumes": {
+      "type": "object",
+      "properties": {
+        "master": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "emptyDir",
+                  "hostPath",
+                  "pvc"
+                ]
+              }
+            }
+          }
+        },
+      "worker": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "emptyDir",
+                "hostPath",
+                "pvc"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+},
+"title": "Values",
+"type": "object"
+}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -64,10 +64,10 @@ cluster:
   name: cluster
 
 # Specifies Celeborn volumes.
-# Currently supported volume types are `emptyDir` and `hostPath`.
+# Currently supported volume types are `emptyDir`, `hostPath` and `pvc`.
 # Note that `hostPath` only works in hostPath type using to set `volumes hostPath path`.
 # Celeborn Master will pick first volumes for store raft log.
-# `diskType` only works in Celeborn Worker with hostPath type to manifest local disk type.
+# `diskType` only works in Celeborn Worker with hostPath and pvc type to manifest disk type.
 volumes:
   # -- Specifies volumes for Celeborn master pods
   master:
@@ -75,6 +75,10 @@ volumes:
       hostPath: /mnt/celeborn_ratis
       type: hostPath
       capacity: 100Gi
+#    - mountPath: /mnt/celeborn_ratis
+#      type: pvc
+#      storageClassName: gp3
+#      capacity: 100Gi
   # -- Specifies volumes for Celeborn worker pods
   worker:
     - mountPath: /mnt/disk1
@@ -97,6 +101,11 @@ volumes:
       type: hostPath
       diskType: SSD
       capacity: 100Gi
+#    - mountPath: /mnt/disk5
+#      type: pvc
+#      diskType: SSD
+#      storageClassName: gp3
+#      capacity: 100Gi
 
 # -- Celeborn configurations
 celeborn:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Add capability to set [PVC](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) as master and worker volumes 

Also rely on [helm schema file](https://helm.sh/docs/topics/charts/#schema-files) to validate that volume type is within the authorised enum instead of relying on if-else-fail within the statefulset yaml file

### Why are the changes needed?

Usage of [PVC](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) is a common pattern to assign storage volumes to POD within kubernetes
Those [PVC](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) can be of different type (local storage, distant storage like [EBS](https://aws.amazon.com/ebs/)...)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added helm test and deployed a celeborn cluster in our kube infrastructure based on pvc for master and workers:
```
volumes:
  master:
    - type: pvc
      mountPath: /mnt/disk1
      capacity: 10Gi
      storageClassName: gp3
  worker:
    - type: pvc
      mountPath: /mnt/disk1
      capacity: 2000Gi
      storageClassName: gp3
```

