### PR TITLE
CELEBORN-1991: add retries for registerShuffle on the lifecycleManager

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -914,6 +914,12 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   def clientCloseIdleConnections: Boolean = get(CLIENT_CLOSE_IDLE_CONNECTIONS)
   def clientRegisterShuffleMaxRetry: Int = get(CLIENT_REGISTER_SHUFFLE_MAX_RETRIES)
+  def clientLifecycleManagerRegisterShuffleRetriesEnabled: Boolean =
+    get(CLIENT_LIFECYCLE_MANAGER_REGISTER_SHUFFLE_RETRIES_ENABLED)
+  def clientLifecycleManagerRegisterShuffleMaxRetry: Int =
+    get(CLIENT_LIFECYCLE_MANAGER_REGISTER_SHUFFLE_MAX_RETRIES)
+  def clientLifecycleManagerRegisterShuffleRetryWaitMs: Long =
+    get(CLIENT_LIFECYCLE_MANAGER_REGISTER_SHUFFLE_RETRY_WAIT)
   def clientRegisterShuffleRetryWaitMs: Long = get(CLIENT_REGISTER_SHUFFLE_RETRY_WAIT)
   def clientReserveSlotsRackAwareEnabled: Boolean = get(CLIENT_RESERVE_SLOTS_RACKAWARE_ENABLED)
   def clientReserveSlotsMaxRetries: Int = get(CLIENT_RESERVE_SLOTS_MAX_RETRIES)
@@ -5066,6 +5072,30 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
+
+  val CLIENT_LIFECYCLE_MANAGER_REGISTER_SHUFFLE_RETRIES_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.lifecycleManager.registerShuffle.retries.enabled")
+      .categories("client")
+      .version("0.3.0")
+      .doc("Max retry times for lifecycleManager to register shuffle.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val CLIENT_LIFECYCLE_MANAGER_REGISTER_SHUFFLE_MAX_RETRIES: ConfigEntry[Int] =
+    buildConf("celeborn.client.lifecycleManager.registerShuffle.maxRetries")
+      .categories("client")
+      .version("0.3.0")
+      .doc("Max retry times for lifecycleManager to register shuffle.")
+      .intConf
+      .createWithDefault(3)
+
+  val CLIENT_LIFECYCLE_MANAGER_REGISTER_SHUFFLE_RETRY_WAIT: ConfigEntry[Long] =
+    buildConf("celeborn.client.lifecycleManager.registerShuffle.retryWait")
+      .categories("client")
+      .version("0.3.0")
+      .doc("Wait time before next retry if register shuffle on the lifecycleManager failed.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10s")
 
   val CLIENT_REGISTER_SHUFFLE_MAX_RETRIES: ConfigEntry[Int] =
     buildConf("celeborn.client.registerShuffle.maxRetries")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -44,6 +44,9 @@ license: |
 | celeborn.client.flink.resultPartition.supportFloatingBuffer | true | false | Whether to support floating buffer for result partitions. | 0.3.0 | remote-shuffle.job.support-floating-buffer-per-output-gate | 
 | celeborn.client.flink.shuffle.fallback.policy | AUTO | false | Celeborn supports the following kind of fallback policies. 1. ALWAYS: always use flink built-in shuffle implementation; 2. AUTO: prefer to use celeborn shuffle implementation, and fallback to use flink built-in shuffle implementation based on certain factors, e.g. availability of enough workers and quota; 3. NEVER: always use celeborn shuffle implementation, and fail fast when it it is concluded that fallback is required based on factors above. | 0.6.0 |  | 
 | celeborn.client.inputStream.creation.window | 16 | false | Window size that CelebornShuffleReader pre-creates CelebornInputStreams, for coalesced scenario where multiple Partitions are read | 0.5.1 |  | 
+| celeborn.client.lifecycleManager.registerShuffle.maxRetries | 3 | false | Max retry times for lifecycleManager to register shuffle. | 0.3.0 |  | 
+| celeborn.client.lifecycleManager.registerShuffle.retries.enabled | false | false | Max retry times for lifecycleManager to register shuffle. | 0.3.0 |  | 
+| celeborn.client.lifecycleManager.registerShuffle.retryWait | 10s | false | Wait time before next retry if register shuffle on the lifecycleManager failed. | 0.3.0 |  | 
 | celeborn.client.mr.pushData.max | 32m | false | Max size for a push data sent from mr client. | 0.4.0 |  | 
 | celeborn.client.partition.reader.checkpoint.enabled | false | false | Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes the amount of unnecessary reads during partition read retries | 0.6.0 |  | 
 | celeborn.client.push.buffer.initial.size | 8k | false |  | 0.3.0 | celeborn.push.buffer.initial.size | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add retries to registerShuffle for lifecycleManager to address failures from FallbackPolicyRunner and/or other manager issues. While we do retry connection failures to manager, this addresses failures such as no active manager for a short period of time as well.

We add three separate configs:
1. retryEnabled
2. maxRetries
3. retryWaitTime


### Why are the changes needed?
We were running into issues in production with manager not being active for a short period of time, which results in application failures due to registerShuffle failure. 
Adding retries fixes these failures.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing unit tests.
Running jobs in our pre-prod environment.
