### PR TITLE
[CELEBORN-1487][FOLLOWUP] Fix updateProduceBytes

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/UserCongestionControlContext.java
@@ -67,7 +67,7 @@ public class UserCongestionControlContext {
     long timeNow = System.currentTimeMillis();
     BufferStatusHub.BufferStatusNode node = new BufferStatusHub.BufferStatusNode(numBytes);
     userBufferInfo.updateInfo(timeNow, node);
-    workerBufferStatusHub.add(timeNow, node);
+    workerBufferStatusHub.add(timeNow, (BufferStatusHub.BufferStatusNode) node.clone());
   }
 
   public UserBufferInfo getUserBufferInfo() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
In the `updateProduceBytes` method, `userBufferInfo.bufferStatusHub` and `workerBufferStatusHub` add the same node. This results in the lastNode's numBytes being repeatedly accumulated in the `_deque` of both hubs if updateProduceBytes is called multiple times within one second, since the `lastNode` is the same object.

This will cause the numBytes of `nodeToSeparate` to become negative when the `removeExpiredNodes` method is called, specifically at the line `nodeToSeparate.separateNode(removed.getRight());` , which will make avgBytesPerSec return 0.

As shown in the figure below, this value remains at 0 for a long period of time in the Dashborad.

![image](https://github.com/user-attachments/assets/4d85d4d1-45f9-4ba0-8cc7-ad2ceb504abe)


### Why are the changes needed?
Fix updateProduceBytes method.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
UT
AND Dashborad：
![image](https://github.com/user-attachments/assets/08212f13-39d3-42a8-b178-8ec8be6d0822)


