### PR TITLE
[CELEBORN-1601][FOLLOWUP] Remove redundant logs of expired shuffle in master-worker heartbeat

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -694,8 +694,6 @@ private[celeborn] class Master(
       val (appId, shuffleId) = Utils.splitShuffleKey(shuffleKey)
       val shuffleIds = statusSystem.registeredAppAndShuffles.get(appId)
       if (shuffleIds == null || !shuffleIds.contains(shuffleId)) {
-        logWarning(
-          s"Shuffle $shuffleKey expired on $host:$rpcPort:$pushPort:$fetchPort:$replicatePort.")
         expiredShuffleKeys.add(shuffleKey)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove redundant logs of expired shuffle in master-worker heartbeat

### Why are the changes needed?

- expired key already log in debug level 

https://github.com/apache/celeborn/blob/88661c2c6934ff8695c85408cc02519060b534ef/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala#L702-L703

- Expired shuffle logs is too noisy. And it seems like a common and normal behavior, shouldn't be logged in WARN-level.

![image](https://github.com/user-attachments/assets/179577f3-3f35-4a0f-9a92-0375162b6801)
![image](https://github.com/user-attachments/assets/254cbe3e-98ad-43fc-900f-f1ef258be9e9)

### Does this PR introduce _any_ user-facing change?

yes, master log will be much less.

### How was this patch tested?

