### PR TITLE
[CELEBORN-1988][HELM] Split hostNetwork into master.hostNetwork and worker.hostNetwork

### DIFF
--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -77,9 +77,6 @@ celeborn:
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
 
-# -- Specifies whether to use the host's network namespace
-hostNetwork: true
-
 master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3.
   replicas: 1
@@ -106,6 +103,9 @@ master:
 
   # -- DNS policy for Celeborn master pods.
   dnsPolicy: ClusterFirstWithHostNet
+
+  # -- Whether to use the host's network namespace in Celeborn master pods.
+  hostNetwork: true
 
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
@@ -135,6 +135,9 @@ worker:
 
   # -- DNS policy for Celeborn worker pods.
   dnsPolicy: ClusterFirstWithHostNet
+
+  # -- Whether to use the host's network namespace in Celeborn worker pods.
+  hostNetwork: true
 
 # -- Container security context
 securityContext:

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -144,7 +144,7 @@ spec:
       {{- with .Values.master.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
+      {{- with .Values.master.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
       {{- with .Values.securityContext }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -147,7 +147,7 @@ spec:
       {{- with .Values.worker.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.hostNetwork }}
+      {{- with .Values.worker.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
       {{- with .Values.securityContext }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -275,9 +275,10 @@ tests:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
-  - it: Should enable host network if `hostNetwork` is set to true
+  - it: Should enable host network if `master.hostNetwork` is set to true
     set:
-      hostNetwork: true
+      master:
+        hostNetwork: true
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -274,9 +274,10 @@ tests:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
-  - it: Should enable host network if `hostNetwork` is set to true
+  - it: Should enable host network if `worker.hostNetwork` is set to true
     set:
-      hostNetwork: true
+      worker:
+        hostNetwork: true
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -118,9 +118,6 @@ celeborn:
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
 
-# -- Specifies whether to use the host's network namespace
-hostNetwork: false
-
 # -- Container security context
 securityContext:
   # Specifies the user ID to run the entrypoint of the container process
@@ -211,6 +208,9 @@ master:
   # -- DNS policy for Celeborn master pods.
   dnsPolicy: ClusterFirst
 
+  # -- Whether to use the host's network namespace in Celeborn master pods.
+  hostNetwork: false
+
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
   replicas: 5
@@ -293,6 +293,9 @@ worker:
 
   # -- DNS policy for Celeborn worker pods.
   dnsPolicy: ClusterFirst
+
+  # -- Whether to use the host's network namespace in Celeborn worker pods.
+  hostNetwork: false
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Split `hostNetwork` into `master.hostNetwork` and `worker.hostNetwork`.

### Why are the changes needed?

Unify the values naming by prefixing them with `master` or `worker`.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Run Helm unit tests by `helm unittest charts/celeborn --file "tests/**/*_test.yaml" --strict --debug`.