### PR TITLE
[CELEBORN-1989][HELM] Split securityContext into master.podSecurityContext and worker.podSecurityContext

### DIFF
--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -107,15 +107,6 @@ master:
   # -- Whether to use the host's network namespace in Celeborn master pods.
   hostNetwork: true
 
-  # -- Pod-level security configurations for Celeborn master pods.
-  podSecurityContext:
-    # The user ID to use when running the entrypoint of the container process.
-    runAsUser: 10006
-    # The group ID to use when running the entrypoint of the container process.
-    runAsGroup: 10006
-    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
-    fsGroup: 10006
-
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
   replicas: 1
@@ -147,15 +138,6 @@ worker:
 
   # -- Whether to use the host's network namespace in Celeborn worker pods.
   hostNetwork: true
-
-  # -- Pod-level security configurations for Celeborn worker pods.
-  podSecurityContext:
-    # The user ID to use when running the entrypoint of the container process.
-    runAsUser: 10006
-    # The group ID to use when running the entrypoint of the container process.
-    runAsGroup: 10006
-    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
-    fsGroup: 10006
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/ci/values.yaml
+++ b/charts/celeborn/ci/values.yaml
@@ -107,6 +107,15 @@ master:
   # -- Whether to use the host's network namespace in Celeborn master pods.
   hostNetwork: true
 
+  # -- Pod-level security configurations for Celeborn master pods.
+  podSecurityContext:
+    # The user ID to use when running the entrypoint of the container process.
+    runAsUser: 10006
+    # The group ID to use when running the entrypoint of the container process.
+    runAsGroup: 10006
+    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
+    fsGroup: 10006
+
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
   replicas: 1
@@ -139,14 +148,14 @@ worker:
   # -- Whether to use the host's network namespace in Celeborn worker pods.
   hostNetwork: true
 
-# -- Container security context
-securityContext:
-  # Specifies the user ID to run the entrypoint of the container process
-  runAsUser: 10006
-  # Specifies the group ID to run the entrypoint of the container process
-  runAsGroup: 10006
-  # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
-  fsGroup: 10006
+  # -- Pod-level security configurations for Celeborn worker pods.
+  podSecurityContext:
+    # The user ID to use when running the entrypoint of the container process.
+    runAsUser: 10006
+    # The group ID to use when running the entrypoint of the container process.
+    runAsGroup: 10006
+    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
+    fsGroup: 10006
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -105,6 +105,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.master.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/celeborn/templates/master/statefulset.yaml
+++ b/charts/celeborn/templates/master/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         command:
         - chown
-        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
+        - {{ .Values.master.podSecurityContext.runAsUser | default 10006 }}:{{ .Values.master.podSecurityContext.runAsGroup | default 10006 }}
         - {{ (index $dirs 0).mountPath }}
         volumeMounts:
         - name: {{ $.Release.Name }}-master-vol-0
@@ -147,7 +147,7 @@ spec:
       {{- with .Values.master.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.master.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -108,6 +108,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.worker.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         command:
         - chown
-        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
+        - {{ .Values.worker.podSecurityContext.runAsUser | default 10006 }}:{{ .Values.worker.podSecurityContext.runAsGroup | default 10006 }}
         {{- range $dir := $dirs }}
         - {{ $dir.mountPath }}
         {{- end}}
@@ -150,7 +150,7 @@ spec:
       {{- with .Values.worker.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.worker.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -284,12 +284,13 @@ tests:
           path: spec.template.spec.hostNetwork
           value: true
 
-  - it: Should use the specified security context if `podSecurityContext` is set
+  - it: Should use the specified security context if `master.podSecurityContext` is set
     set:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      master:
+        podSecurityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsUser

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -164,6 +164,35 @@ tests:
               cpu: 100m
               memory: 128Mi
 
+  - it: Should add container securityContext if `master.securityContext` is set
+    set:
+      master:
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          privileged: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            privileged: false
+
   - it: Should add secrets if `imagePullSecrets` is set
     set:
       imagePullSecrets:

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -283,12 +283,13 @@ tests:
           path: spec.template.spec.hostNetwork
           value: true
 
-  - it: Should use the specified security context if `podSecurityContext` is set
+  - it: Should use the specified security context if `worker.podSecurityContext` is set
     set:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      worker:
+        podSecurityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsUser

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -163,6 +163,35 @@ tests:
               cpu: 100m
               memory: 128Mi
 
+  - it: Should add container securityContext if `worker.securityContext` is set
+    set:
+      worker:
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          privileged: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            privileged: false
+
   - it: Should add secrets if `imagePullSecrets` is set
     set:
       imagePullSecrets:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -118,15 +118,6 @@ celeborn:
   celeborn.application.heartbeat.timeout: 120s
   celeborn.worker.heartbeat.timeout: 120s
 
-# -- Container security context
-securityContext:
-  # Specifies the user ID to run the entrypoint of the container process
-  runAsUser: 10006
-  # Specifies the group ID to run the entrypoint of the container process
-  runAsGroup: 10006
-  # Specifies the group ID to use when modifying ownership and permissions of the mounted volumes
-  fsGroup: 10006
-
 master:
   # -- Number of Celeborn master replicas to deploy, should not less than 3.
   replicas: 3
@@ -164,6 +155,14 @@ master:
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
+
+  # -- Security configurations for Celeborn master containers.
+  securityContext:
+    # privileged: false
+    # allowPrivilegeEscalation: false
+    # runAsUser: 10006
+    # runAsGroup: 10006
+    # fsGroup: 10006
 
   # -- Node selector for Celeborn master pods.
   nodeSelector:
@@ -210,6 +209,15 @@ master:
 
   # -- Whether to use the host's network namespace in Celeborn master pods.
   hostNetwork: false
+
+  # -- Pod-level security configurations for Celeborn master pods.
+  podSecurityContext:
+    # The user ID to use when running the entrypoint of the container process.
+    runAsUser: 10006
+    # The group ID to use when running the entrypoint of the container process.
+    runAsGroup: 10006
+    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
+    fsGroup: 10006
 
 worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
@@ -296,6 +304,15 @@ worker:
 
   # -- Whether to use the host's network namespace in Celeborn worker pods.
   hostNetwork: false
+
+  # -- Pod-level security configurations for Celeborn worker pods.
+  podSecurityContext:
+    # The user ID to use when running the entrypoint of the container process.
+    runAsUser: 10006
+    # The group ID to use when running the entrypoint of the container process.
+    runAsGroup: 10006
+    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
+    fsGroup: 10006
 
 podMonitor:
   # -- Specifies whether to enable creating pod monitors for Celeborn pods

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -259,6 +259,14 @@ worker:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # -- Security configurations for Celeborn worker containers.
+  securityContext:
+    # privileged: false
+    # allowPrivilegeEscalation: false
+    # runAsUser: 10006
+    # runAsGroup: 10006
+    # fsGroup: 10006
+
   # -- Node selector for Celeborn worker pods.
   nodeSelector:
     # key1: value1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Split `securityContext` into `master.podSecurityContext` and `worker.podSecurityContext`.
- Add `master.securityContext` and `worker.securityContext` for container-level security configurations.

### Why are the changes needed?

Allow separate configurations for master/worker pod-level/container-level security context.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Run Helm unit tests by `helm unittest charts/celeborn --file "tests/**/*_test.yaml" --strict --debug`.