### PR TITLE
[CELEBORN-1691][FOLLOWUP] Fix the issue that upstream tasks don't rerun and the current task still retry when failed to deserialize in flink

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -440,7 +440,8 @@ public class RemoteShuffleInputGateDelegation {
     try {
       event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
     } catch (Throwable t) {
-      throw new IOException("Deserialize failure.", t);
+      LOG.error("Failed to deserialize inputChannelInfo: {}.", channelInfo, t);
+      throw new PartitionNotFoundException(channelToResultPartitionId.get(channelInfo));
     } finally {
       buffer.recycleBuffer();
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -440,7 +440,7 @@ public class RemoteShuffleInputGateDelegation {
     try {
       event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
     } catch (Throwable t) {
-      LOG.error("Failed to deserialize inputChannelInfo: {}.", channelInfo, t);
+      LOG.error("Failed to deserialize event: inputChannelInfo {}.", channelInfo, t);
       throw new PartitionNotFoundException(channelToResultPartitionId.get(channelInfo));
     } finally {
       buffer.recycleBuffer();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the issue that upstream tasks don't rerun and the current task still retry when failed to deserialize in flink. `RemoteShuffleInputGateDelegation` should keep the same behavior when failed to decompress.

Follow up #2884.

### Why are the changes needed?

Deserialize error should retry upstream otherwise this is un-recoverable.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.