### PR TITLE
[CELEBORN-1997] RemoteShuffleInputGateDelegation should regard CelebornIOException as data consumption error for RestartPipelinedRegionFailoverStrategy

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.exception.DriverChangedException;
 import org.apache.celeborn.common.exception.PartitionUnRetryAbleException;
 import org.apache.celeborn.common.identity.UserIdentifier;
@@ -260,8 +261,10 @@ public class RemoteShuffleInputGateDelegation {
         if (cause != null) {
           return;
         }
-        Class<?> clazz = PartitionUnRetryAbleException.class;
-        if (throwable.getMessage() != null && throwable.getMessage().contains(clazz.getName())) {
+        String message = throwable.getMessage();
+        if (message != null
+            && (message.contains(CelebornIOException.class.getName())
+                || message.contains(PartitionUnRetryAbleException.class.getName()))) {
           cause = new PartitionNotFoundException(rpID);
         } else {
           cause = throwable;


### PR DESCRIPTION
### What changes were proposed in this pull request?

`RemoteShuffleInputGateDelegation` should regard `CelebornIOException` as data consumption error for `RestartPipelinedRegionFailoverStrategy`.

### Why are the changes needed?

`RemoteShuffleInputGateDelegation` only regards `PartitionUnRetryAbleException` as data consumption error, which marks the corresponding data partition to be failed for failover process. Similar to Spark's behavior in handling fetch exception, `RemoteShuffleInputGateDelegation` should regard `CelebornIOException` as data consumption error to restart upstream task.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.