### PR TITLE
[CELEBORN-1998] RemoteShuffleEnvironment should not register InputChannelMetrics repeatedly

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
@@ -222,11 +222,14 @@ public class RemoteShuffleEnvironment
     synchronized (lock) {
       checkState(!isClosed, "The RemoteShuffleEnvironment has already been shut down.");
 
+      InputChannelMetrics inputChannelMetrics =
+          new InputChannelMetrics(ownerContext.getInputGroup(), ownerContext.getParentGroup());
       IndexedInputGate[] inputGates = new IndexedInputGate[inputGateDescriptors.size()];
       for (int gateIndex = 0; gateIndex < inputGates.length; gateIndex++) {
         InputGateDeploymentDescriptor igdd = inputGateDescriptors.get(gateIndex);
         IndexedInputGate inputGate =
-            createInputGateInternal(ownerContext, producerStateProvider, gateIndex, igdd);
+            createInputGateInternal(
+                ownerContext, producerStateProvider, gateIndex, igdd, inputChannelMetrics);
         inputGates[gateIndex] = inputGate;
       }
       return Arrays.asList(inputGates);
@@ -237,17 +240,12 @@ public class RemoteShuffleEnvironment
       ShuffleIOOwnerContext ownerContext,
       PartitionProducerStateProvider producerStateProvider,
       int gateIndex,
-      InputGateDeploymentDescriptor igdd) {
+      InputGateDeploymentDescriptor igdd,
+      InputChannelMetrics inputChannelMetrics) {
     return nettyResultIds.contains(igdd.getConsumedResultId())
         ? shuffleEnvironmentWrapper
             .nettyInputGateFactory()
-            .create(
-                ownerContext,
-                gateIndex,
-                igdd,
-                producerStateProvider,
-                new InputChannelMetrics(
-                    ownerContext.getInputGroup(), ownerContext.getParentGroup()))
+            .create(ownerContext, gateIndex, igdd, producerStateProvider, inputChannelMetrics)
         : inputGateFactory.create(ownerContext.getOwnerName(), gateIndex, igdd);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`RemoteShuffleEnvironment` should not register `InputChannelMetrics` repeatedly, which only create once in `RemoteShuffleEnvironment#createInputGates`.

### Why are the changes needed?

If a task has multiple input gates, It will create as many `InputChannelMetrics` as the number of gates, so the corresponding metrics are registered repeatedly. Therefore, `RemoteShuffleEnvironment` should not register `InputChannelMetrics` repeatedly for `createInputGates`.

Backport https://github.com/apache/flink/pull/21437.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.