### PR TITLE
[WIP] [CIP-20] Dynamically adjust partition write parallelism

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -171,12 +171,6 @@ public class DummyShuffleClient extends ShuffleClient {
   }
 
   @Override
-  public ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
-      int shuffleId, int numMappers, int numPartitions) {
-    return reducePartitionMap.get(shuffleId);
-  }
-
-  @Override
   public PushState getPushState(String mapKey) {
     return new PushState(conf);
   }

--- a/client/src/main/java/org/apache/celeborn/client/LocationManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/LocationManager.java
@@ -1,0 +1,342 @@
+package org.apache.celeborn.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.protocol.ReviveRequest;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+import org.apache.celeborn.common.util.JavaUtils;
+import org.apache.celeborn.common.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class LocationManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(LocationManager.class);
+
+    private class PartitionLocationList {
+        List<PartitionLocation> locations = new ArrayList<>();
+        Set<Integer> locationSet = new HashSet<>();
+        // epoch id -> status
+        Map<Integer, StatusCode> locationStatusCode = new HashMap<>();
+        ReviveRequest latestReviveRequest = null;
+        int[] index = null;
+
+        int used = 0;
+        int size = 0;
+        int maxEpoch = -1;
+
+        final int shuffleId;
+        final int partitionId;
+        public PartitionLocationList(int shuffleId, int partitionId) {
+            this.shuffleId = shuffleId;
+            this.partitionId = partitionId;
+        }
+
+        ReadWriteLock lock = new ReentrantReadWriteLock();
+        Lock readLock = lock.readLock();
+        Lock writeLock = lock.writeLock();
+
+        private void update(List<PartitionLocation> newLocs) {
+            if (newLocs.isEmpty()) {
+                return;
+            }
+            newLocs.sort(Comparator.comparing(PartitionLocation::getEpoch));
+            int newMaxEpoch = newLocs.get(newLocs.size() - 1).getEpoch();
+            try {
+                writeLock.lock();
+                if (newMaxEpoch <= maxEpoch) {
+                    return;
+                }
+                int newSize = newLocs.size() + size - used;
+                ArrayList<PartitionLocation> newLocations = new ArrayList<>(newSize);
+                for (PartitionLocation oldLoc : locations) {
+                    if (locationStatusCode.remove(oldLoc.getEpoch()) != null) {
+                        used--;
+                    } else {
+                        newLocations.add(oldLoc);
+                    }
+                }
+                for (PartitionLocation l : newLocs) {
+                    if (l.getEpoch() >= maxEpoch) {
+                        newLocations.add(l);
+                    }
+                }
+                size = newLocations.size();
+                index = new int[size];
+                for (int i = 0; i < size; i++) {
+                    index[i] = i;
+                }
+                locations = newLocations;
+                locationSet.clear();
+                locations.forEach(l -> locationSet.add(l.getEpoch()));
+                maxEpoch = Math.max(maxEpoch, newMaxEpoch);
+                logger.info("Location updated for shuffleId {}, partitionId {}, new locations: {}, maxEpoch: {}", shuffleId, partitionId, locationSet, maxEpoch);
+                if (latestReviveRequest != null && latestReviveRequest.clientMaxEpoch < maxEpoch) {
+                    logger.debug("outdated latestReviveRequest {}", latestReviveRequest);
+                    this.latestReviveRequest = null;
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        }
+
+        // return partitionLocation for specified mapId
+        // if allowSoftSplit = true, soft split location can be returned
+        // if liveOnly = false, non-living (soft split/hard split/push fail) location can be returned
+        private PartitionLocation nextLoc(int mapId, boolean allowSoftSplit, boolean liveOnly) {
+            try {
+                readLock.lock();
+                int pos = mapId % size;
+                int idx = index[pos];
+                while (locationStatusCode.get(locations.get(idx).getEpoch()) != null) {
+                    if (allowSoftSplit && locationStatusCode.get(locations.get(idx).getEpoch()) == StatusCode.SOFT_SPLIT) {
+                        break;
+                    }
+                    idx = (idx + 1) % size;
+                    // all locations are checked
+                    if (idx == index[pos]) {
+                        break;
+                    }
+                }
+                if (idx != index[pos]) {
+                    index[pos] = idx;
+                }
+                if (locationStatusCode.get(locations.get(idx).getEpoch()) != null) {
+                    if ((allowSoftSplit && locationStatusCode.get(locations.get(idx).getEpoch()) == StatusCode.SOFT_SPLIT) ||
+                            !liveOnly) {
+                        return locations.get(idx);
+                    }
+                    return null;
+                } else {
+                    return locations.get(idx);
+                }
+            } finally {
+                readLock.unlock();
+            }
+        }
+
+        private void reviveBatch(int shuffleId, int partitionId, int mapId, int attemptId) {
+            ReviveRequest reviveRequest = null;
+            try {
+                writeLock.lock();
+                reviveRequest = new ReviveRequest(shuffleId, mapId, attemptId, partitionId, null, StatusCode.URGENT_REVIVE, maxEpoch, true);
+                this.latestReviveRequest = reviveRequest;
+                logger.debug("in reviveBatch latestReviveRequest = {}", reviveRequest);
+            } finally {
+                writeLock.unlock();
+            }
+            reviveManager.addRequest(reviveRequest);
+        }
+
+        private void reportUnusableLocation(int shuffleId, int mapId, int attemptId, PartitionLocation loc, StatusCode reportedStatus) {
+            ReviveRequest reviveRequest = null;
+            try {
+                writeLock.lock();
+                if (!locationSet.contains(loc.getEpoch())) {
+                    return;
+                }
+
+                StatusCode currentStatus = locationStatusCode.get(loc.getEpoch());
+                if (currentStatus != reportedStatus) {
+                    // allow normal/soft split to transition to hard split/push failure
+                    if (currentStatus == null || currentStatus == StatusCode.SOFT_SPLIT) {
+                        locationStatusCode.put(loc.getEpoch(), reportedStatus);
+                    }
+                    if (currentStatus == null) {
+                        used++;
+                    }
+                    boolean urgent = ((used == size) && !hasActiveReviveRequest());
+                    reviveRequest = new ReviveRequest(shuffleId, mapId, attemptId, loc.getId(), loc, reportedStatus, maxEpoch, urgent);
+                    if (urgent) {
+                        this.latestReviveRequest = reviveRequest;
+                        logger.debug("in reportUnusableLocation latestReviveRequest = {}", reviveRequest);
+                    }
+                }
+
+            } finally {
+                writeLock.unlock();
+            }
+            if (reviveRequest != null) {
+                logger.info("Reported worker {}, partitionId {}, epoch {}, shuffle {} map {} attempt {} is unusable, status: {}, urgent: {}",
+                        loc.hostAndPushPort(), loc.getId(), loc.getEpoch(), shuffleId, mapId, attemptId, reportedStatus.name(), reviveRequest.urgent);
+                reviveManager.addRequest(reviveRequest);
+            }
+        }
+
+        private boolean newerPartitionLocationExists(int epoch) {
+            try {
+                readLock.lock();
+                for (PartitionLocation loc : locations) {
+                    if (locationStatusCode.get(loc.getEpoch()) != null && loc.getEpoch() > epoch) {
+                        return true;
+                    }
+                }
+                return false;
+            } finally {
+                readLock.unlock();
+            }
+        }
+
+        private boolean locationExists(int epoch) {
+            try {
+                readLock.lock();
+                return locationSet.contains(epoch);
+            } finally {
+                readLock.unlock();
+            }
+        }
+
+        public boolean hasActiveReviveRequest() {
+            try {
+                readLock.lock();
+                return latestReviveRequest != null && latestReviveRequest.reviveStatus == StatusCode.REVIVE_INITIALIZED.getValue();
+            } finally {
+                readLock.unlock();
+            }
+        }
+
+        public StatusCode getLatestReviveStatus() {
+            try {
+                readLock.lock();
+                if (latestReviveRequest == null) {
+                    return StatusCode.REVIVE_INITIALIZED;
+                } else {
+                    return StatusCode.fromValue(latestReviveRequest.reviveStatus);
+                }
+            } finally {
+                readLock.unlock();
+            }
+        }
+    }
+
+    final Map<Integer, ConcurrentHashMap<Integer, PartitionLocationList>> reducePartitionMap =
+            JavaUtils.newConcurrentHashMap();
+
+    final ReviveManager reviveManager;
+
+    final ShuffleClientImpl shuffleClient;
+
+    public LocationManager(ShuffleClientImpl shuffleClient, ReviveManager reviveManager) {
+        this.shuffleClient = shuffleClient;
+        this.reviveManager = reviveManager;
+    }
+
+    public void registerShuffleLocs(int shuffleId, ConcurrentHashMap<Integer, List<PartitionLocation>> map) {
+        reducePartitionMap.computeIfAbsent(shuffleId, (id) -> {
+            ConcurrentHashMap<Integer, PartitionLocationList> locationMap = JavaUtils.newConcurrentHashMap();
+            for (Map.Entry<Integer, List<PartitionLocation>> e : map.entrySet()) {
+                int partitionId = e.getKey();
+                List<PartitionLocation> locs = e.getValue();
+                PartitionLocationList list = new PartitionLocationList(shuffleId, partitionId);
+                list.update(locs);
+                locationMap.put(partitionId, list);
+                logger.debug("in registerShuffleLocs, shuffleId {}, partitionId {}", id, partitionId);
+            }
+            return locationMap;
+        });
+    }
+
+    public boolean registered(int shuffleId) {
+        return reducePartitionMap.containsKey(shuffleId);
+    }
+
+    public boolean exists(int shuffleId, int partitionId) {
+        if (!registered(shuffleId)) {
+            throw new UnsupportedOperationException("unexpected! must ensure shuffle registered before checking partition exists ");
+        }
+        return reducePartitionMap.get(shuffleId).containsKey(partitionId);
+    }
+
+    public StatusCode getReviveStatus(int shuffleId, int partitionId) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        return locationList.getLatestReviveStatus();
+    }
+
+    public PartitionLocation getLocationOrReviveAsync(int shuffleId, int partitionId, int mapId, int attemptId, boolean doRevive, boolean liveOnly) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        // firstly, try to find a live partition location
+        PartitionLocation loc = locationList.nextLoc(mapId, false, true);
+        if (loc == null) {
+            if (doRevive && !locationList.hasActiveReviveRequest()) {
+                locationList.reviveBatch(shuffleId, partitionId, mapId, attemptId);
+            } else if (doRevive && locationList.hasActiveReviveRequest()) {
+                logger.debug("in getLocationOrReviveAsync, do nothing, current latestReviveRequest is {}", locationList.latestReviveRequest);
+            }
+            // can't get a live partition location, then try to find a location in soft split status
+            // if liveOnly = false, hard split/push fail location can be returned
+            loc = locationList.nextLoc(mapId, true, liveOnly);
+        }
+        return loc;
+    }
+
+    public boolean reviveSync(int shuffleId, int partitionId, int mapId, int attemptId, StatusCode cause) {
+        Set<Integer> mapIds = new HashSet<>();
+        mapIds.add(mapId);
+        List<ReviveRequest> requests = new ArrayList<>();
+        ReviveRequest request = new ReviveRequest(shuffleId, mapId, attemptId, partitionId, null, cause, 0, true);
+        requests.add(request);
+        Map<Integer, Integer> results = shuffleClient.reviveBatch(shuffleId, mapIds, requests, true);
+
+        if (shuffleClient.mapperEnded(shuffleId, mapId)) {
+            logger.debug(
+                    "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    partitionId);
+            return true;
+        } else {
+            return results != null
+                && results.containsKey(partitionId)
+                && results.get(partitionId) == StatusCode.SUCCESS.getValue();
+        }
+    }
+
+    public void updateLocation(int shuffleId, int partitionId, List<PartitionLocation> newLocations) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        locationList.update(newLocations);
+    }
+
+    public void reportUnusableLocation(int shuffleId, int mapId, int attemptId, PartitionLocation reportedPartition, StatusCode reportedStatus) {
+        int partitionId = reportedPartition.getId();
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        locationList.reportUnusableLocation(shuffleId, mapId, attemptId, reportedPartition, reportedStatus);
+    }
+
+    public boolean newerPartitionLocationExists(int shuffleId, int partitionId, int epoch) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        return locationList.newerPartitionLocationExists(epoch);
+    }
+
+    public boolean locationExists(int shuffleId, int partitionId, int epoch) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        return locationList.locationExists(epoch);
+    }
+
+    public boolean hasActiveReviveRequest(int shuffleId, int partitionId) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        return locationList.hasActiveReviveRequest();
+    }
+
+    public void removeShuffle(int shuffleId) {
+        reducePartitionMap.remove(shuffleId);
+    }
+
+    @VisibleForTesting
+    public StatusCode getLocationStatus(int shuffleId, int partitionId, int epochId) {
+        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+        return locationList.locationStatusCode.getOrDefault(epochId, StatusCode.SUCCESS);
+    }
+}

--- a/client/src/main/java/org/apache/celeborn/client/LocationManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/LocationManager.java
@@ -1,14 +1,5 @@
 package org.apache.celeborn.client;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.celeborn.common.protocol.PartitionLocation;
-import org.apache.celeborn.common.protocol.ReviveRequest;
-import org.apache.celeborn.common.protocol.message.StatusCode;
-import org.apache.celeborn.common.util.JavaUtils;
-import org.apache.celeborn.common.util.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -21,322 +12,381 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.protocol.ReviveRequest;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+import org.apache.celeborn.common.util.JavaUtils;
+
 public class LocationManager {
 
-    private static final Logger logger = LoggerFactory.getLogger(LocationManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(LocationManager.class);
 
-    private class PartitionLocationList {
-        List<PartitionLocation> locations = new ArrayList<>();
-        Set<Integer> locationSet = new HashSet<>();
-        // epoch id -> status
-        Map<Integer, StatusCode> locationStatusCode = new HashMap<>();
-        ReviveRequest latestReviveRequest = null;
-        int[] index = null;
+  private class PartitionLocationList {
+    List<PartitionLocation> locations = new ArrayList<>();
+    Set<Integer> locationSet = new HashSet<>();
+    // epoch id -> status
+    Map<Integer, StatusCode> locationStatusCode = new HashMap<>();
+    ReviveRequest latestReviveRequest = null;
+    int[] index = null;
 
-        int used = 0;
-        int size = 0;
-        int maxEpoch = -1;
+    int used = 0;
+    int size = 0;
+    int maxEpoch = -1;
 
-        final int shuffleId;
-        final int partitionId;
-        public PartitionLocationList(int shuffleId, int partitionId) {
-            this.shuffleId = shuffleId;
-            this.partitionId = partitionId;
-        }
+    final int shuffleId;
+    final int partitionId;
 
-        ReadWriteLock lock = new ReentrantReadWriteLock();
-        Lock readLock = lock.readLock();
-        Lock writeLock = lock.writeLock();
-
-        private void update(List<PartitionLocation> newLocs) {
-            if (newLocs.isEmpty()) {
-                return;
-            }
-            newLocs.sort(Comparator.comparing(PartitionLocation::getEpoch));
-            int newMaxEpoch = newLocs.get(newLocs.size() - 1).getEpoch();
-            try {
-                writeLock.lock();
-                if (newMaxEpoch <= maxEpoch) {
-                    return;
-                }
-                int newSize = newLocs.size() + size - used;
-                ArrayList<PartitionLocation> newLocations = new ArrayList<>(newSize);
-                for (PartitionLocation oldLoc : locations) {
-                    if (locationStatusCode.remove(oldLoc.getEpoch()) != null) {
-                        used--;
-                    } else {
-                        newLocations.add(oldLoc);
-                    }
-                }
-                for (PartitionLocation l : newLocs) {
-                    if (l.getEpoch() >= maxEpoch) {
-                        newLocations.add(l);
-                    }
-                }
-                size = newLocations.size();
-                index = new int[size];
-                for (int i = 0; i < size; i++) {
-                    index[i] = i;
-                }
-                locations = newLocations;
-                locationSet.clear();
-                locations.forEach(l -> locationSet.add(l.getEpoch()));
-                maxEpoch = Math.max(maxEpoch, newMaxEpoch);
-                logger.info("Location updated for shuffleId {}, partitionId {}, new locations: {}, maxEpoch: {}", shuffleId, partitionId, locationSet, maxEpoch);
-                if (latestReviveRequest != null && latestReviveRequest.clientMaxEpoch < maxEpoch) {
-                    logger.debug("outdated latestReviveRequest {}", latestReviveRequest);
-                    this.latestReviveRequest = null;
-                }
-            } finally {
-                writeLock.unlock();
-            }
-        }
-
-        // return partitionLocation for specified mapId
-        // if allowSoftSplit = true, soft split location can be returned
-        // if liveOnly = false, non-living (soft split/hard split/push fail) location can be returned
-        private PartitionLocation nextLoc(int mapId, boolean allowSoftSplit, boolean liveOnly) {
-            try {
-                readLock.lock();
-                int pos = mapId % size;
-                int idx = index[pos];
-                while (locationStatusCode.get(locations.get(idx).getEpoch()) != null) {
-                    if (allowSoftSplit && locationStatusCode.get(locations.get(idx).getEpoch()) == StatusCode.SOFT_SPLIT) {
-                        break;
-                    }
-                    idx = (idx + 1) % size;
-                    // all locations are checked
-                    if (idx == index[pos]) {
-                        break;
-                    }
-                }
-                if (idx != index[pos]) {
-                    index[pos] = idx;
-                }
-                if (locationStatusCode.get(locations.get(idx).getEpoch()) != null) {
-                    if ((allowSoftSplit && locationStatusCode.get(locations.get(idx).getEpoch()) == StatusCode.SOFT_SPLIT) ||
-                            !liveOnly) {
-                        return locations.get(idx);
-                    }
-                    return null;
-                } else {
-                    return locations.get(idx);
-                }
-            } finally {
-                readLock.unlock();
-            }
-        }
-
-        private void reviveBatch(int shuffleId, int partitionId, int mapId, int attemptId) {
-            ReviveRequest reviveRequest = null;
-            try {
-                writeLock.lock();
-                reviveRequest = new ReviveRequest(shuffleId, mapId, attemptId, partitionId, null, StatusCode.URGENT_REVIVE, maxEpoch, true);
-                this.latestReviveRequest = reviveRequest;
-                logger.debug("in reviveBatch latestReviveRequest = {}", reviveRequest);
-            } finally {
-                writeLock.unlock();
-            }
-            reviveManager.addRequest(reviveRequest);
-        }
-
-        private void reportUnusableLocation(int shuffleId, int mapId, int attemptId, PartitionLocation loc, StatusCode reportedStatus) {
-            ReviveRequest reviveRequest = null;
-            try {
-                writeLock.lock();
-                if (!locationSet.contains(loc.getEpoch())) {
-                    return;
-                }
-
-                StatusCode currentStatus = locationStatusCode.get(loc.getEpoch());
-                if (currentStatus != reportedStatus) {
-                    // allow normal/soft split to transition to hard split/push failure
-                    if (currentStatus == null || currentStatus == StatusCode.SOFT_SPLIT) {
-                        locationStatusCode.put(loc.getEpoch(), reportedStatus);
-                    }
-                    if (currentStatus == null) {
-                        used++;
-                    }
-                    boolean urgent = ((used == size) && !hasActiveReviveRequest());
-                    reviveRequest = new ReviveRequest(shuffleId, mapId, attemptId, loc.getId(), loc, reportedStatus, maxEpoch, urgent);
-                    if (urgent) {
-                        this.latestReviveRequest = reviveRequest;
-                        logger.debug("in reportUnusableLocation latestReviveRequest = {}", reviveRequest);
-                    }
-                }
-
-            } finally {
-                writeLock.unlock();
-            }
-            if (reviveRequest != null) {
-                logger.info("Reported worker {}, partitionId {}, epoch {}, shuffle {} map {} attempt {} is unusable, status: {}, urgent: {}",
-                        loc.hostAndPushPort(), loc.getId(), loc.getEpoch(), shuffleId, mapId, attemptId, reportedStatus.name(), reviveRequest.urgent);
-                reviveManager.addRequest(reviveRequest);
-            }
-        }
-
-        private boolean newerPartitionLocationExists(int epoch) {
-            try {
-                readLock.lock();
-                for (PartitionLocation loc : locations) {
-                    if (locationStatusCode.get(loc.getEpoch()) != null && loc.getEpoch() > epoch) {
-                        return true;
-                    }
-                }
-                return false;
-            } finally {
-                readLock.unlock();
-            }
-        }
-
-        private boolean locationExists(int epoch) {
-            try {
-                readLock.lock();
-                return locationSet.contains(epoch);
-            } finally {
-                readLock.unlock();
-            }
-        }
-
-        public boolean hasActiveReviveRequest() {
-            try {
-                readLock.lock();
-                return latestReviveRequest != null && latestReviveRequest.reviveStatus == StatusCode.REVIVE_INITIALIZED.getValue();
-            } finally {
-                readLock.unlock();
-            }
-        }
-
-        public StatusCode getLatestReviveStatus() {
-            try {
-                readLock.lock();
-                if (latestReviveRequest == null) {
-                    return StatusCode.REVIVE_INITIALIZED;
-                } else {
-                    return StatusCode.fromValue(latestReviveRequest.reviveStatus);
-                }
-            } finally {
-                readLock.unlock();
-            }
-        }
+    public PartitionLocationList(int shuffleId, int partitionId) {
+      this.shuffleId = shuffleId;
+      this.partitionId = partitionId;
     }
 
-    final Map<Integer, ConcurrentHashMap<Integer, PartitionLocationList>> reducePartitionMap =
-            JavaUtils.newConcurrentHashMap();
+    ReadWriteLock lock = new ReentrantReadWriteLock();
+    Lock readLock = lock.readLock();
+    Lock writeLock = lock.writeLock();
 
-    final ReviveManager reviveManager;
-
-    final ShuffleClientImpl shuffleClient;
-
-    public LocationManager(ShuffleClientImpl shuffleClient, ReviveManager reviveManager) {
-        this.shuffleClient = shuffleClient;
-        this.reviveManager = reviveManager;
-    }
-
-    public void registerShuffleLocs(int shuffleId, ConcurrentHashMap<Integer, List<PartitionLocation>> map) {
-        reducePartitionMap.computeIfAbsent(shuffleId, (id) -> {
-            ConcurrentHashMap<Integer, PartitionLocationList> locationMap = JavaUtils.newConcurrentHashMap();
-            for (Map.Entry<Integer, List<PartitionLocation>> e : map.entrySet()) {
-                int partitionId = e.getKey();
-                List<PartitionLocation> locs = e.getValue();
-                PartitionLocationList list = new PartitionLocationList(shuffleId, partitionId);
-                list.update(locs);
-                locationMap.put(partitionId, list);
-                logger.debug("in registerShuffleLocs, shuffleId {}, partitionId {}", id, partitionId);
-            }
-            return locationMap;
-        });
-    }
-
-    public boolean registered(int shuffleId) {
-        return reducePartitionMap.containsKey(shuffleId);
-    }
-
-    public boolean exists(int shuffleId, int partitionId) {
-        if (!registered(shuffleId)) {
-            throw new UnsupportedOperationException("unexpected! must ensure shuffle registered before checking partition exists ");
+    private void update(List<PartitionLocation> newLocs) {
+      if (newLocs.isEmpty()) {
+        return;
+      }
+      newLocs.sort(Comparator.comparing(PartitionLocation::getEpoch));
+      int newMaxEpoch = newLocs.get(newLocs.size() - 1).getEpoch();
+      try {
+        writeLock.lock();
+        if (newMaxEpoch <= maxEpoch) {
+          return;
         }
-        return reducePartitionMap.get(shuffleId).containsKey(partitionId);
-    }
-
-    public StatusCode getReviveStatus(int shuffleId, int partitionId) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        return locationList.getLatestReviveStatus();
-    }
-
-    public PartitionLocation getLocationOrReviveAsync(int shuffleId, int partitionId, int mapId, int attemptId, boolean doRevive, boolean liveOnly) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        // firstly, try to find a live partition location
-        PartitionLocation loc = locationList.nextLoc(mapId, false, true);
-        if (loc == null) {
-            if (doRevive && !locationList.hasActiveReviveRequest()) {
-                locationList.reviveBatch(shuffleId, partitionId, mapId, attemptId);
-            } else if (doRevive && locationList.hasActiveReviveRequest()) {
-                logger.debug("in getLocationOrReviveAsync, do nothing, current latestReviveRequest is {}", locationList.latestReviveRequest);
-            }
-            // can't get a live partition location, then try to find a location in soft split status
-            // if liveOnly = false, hard split/push fail location can be returned
-            loc = locationList.nextLoc(mapId, true, liveOnly);
+        int newSize = newLocs.size() + size - used;
+        ArrayList<PartitionLocation> newLocations = new ArrayList<>(newSize);
+        for (PartitionLocation oldLoc : locations) {
+          if (locationStatusCode.remove(oldLoc.getEpoch()) != null) {
+            used--;
+          } else {
+            newLocations.add(oldLoc);
+          }
         }
-        return loc;
+        for (PartitionLocation l : newLocs) {
+          if (l.getEpoch() >= maxEpoch) {
+            newLocations.add(l);
+          }
+        }
+        size = newLocations.size();
+        index = new int[size];
+        for (int i = 0; i < size; i++) {
+          index[i] = i;
+        }
+        locations = newLocations;
+        locationSet.clear();
+        locations.forEach(l -> locationSet.add(l.getEpoch()));
+        maxEpoch = Math.max(maxEpoch, newMaxEpoch);
+        logger.info(
+            "Location updated for shuffleId {}, partitionId {}, new locations: {}, maxEpoch: {}",
+            shuffleId,
+            partitionId,
+            locationSet,
+            maxEpoch);
+        if (latestReviveRequest != null && latestReviveRequest.clientMaxEpoch < maxEpoch) {
+          logger.debug("outdated latestReviveRequest {}", latestReviveRequest);
+          this.latestReviveRequest = null;
+        }
+      } finally {
+        writeLock.unlock();
+      }
     }
 
-    public boolean reviveSync(int shuffleId, int partitionId, int mapId, int attemptId, StatusCode cause) {
-        Set<Integer> mapIds = new HashSet<>();
-        mapIds.add(mapId);
-        List<ReviveRequest> requests = new ArrayList<>();
-        ReviveRequest request = new ReviveRequest(shuffleId, mapId, attemptId, partitionId, null, cause, 0, true);
-        requests.add(request);
-        Map<Integer, Integer> results = shuffleClient.reviveBatch(shuffleId, mapIds, requests, true);
-
-        if (shuffleClient.mapperEnded(shuffleId, mapId)) {
-            logger.debug(
-                    "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
-                    shuffleId,
-                    mapId,
-                    attemptId,
-                    partitionId);
-            return true;
+    // return partitionLocation for specified mapId
+    // if allowSoftSplit = true, soft split location can be returned
+    // if liveOnly = false, non-living (soft split/hard split/push fail) location can be returned
+    private PartitionLocation nextLoc(int mapId, boolean allowSoftSplit, boolean liveOnly) {
+      try {
+        readLock.lock();
+        int pos = mapId % size;
+        int idx = index[pos];
+        while (locationStatusCode.get(locations.get(idx).getEpoch()) != null) {
+          if (allowSoftSplit
+              && locationStatusCode.get(locations.get(idx).getEpoch()) == StatusCode.SOFT_SPLIT) {
+            break;
+          }
+          idx = (idx + 1) % size;
+          // all locations are checked
+          if (idx == index[pos]) {
+            break;
+          }
+        }
+        if (idx != index[pos]) {
+          index[pos] = idx;
+        }
+        if (locationStatusCode.get(locations.get(idx).getEpoch()) != null) {
+          if ((allowSoftSplit
+                  && locationStatusCode.get(locations.get(idx).getEpoch()) == StatusCode.SOFT_SPLIT)
+              || !liveOnly) {
+            return locations.get(idx);
+          }
+          return null;
         } else {
-            return results != null
-                && results.containsKey(partitionId)
-                && results.get(partitionId) == StatusCode.SUCCESS.getValue();
+          return locations.get(idx);
         }
+      } finally {
+        readLock.unlock();
+      }
     }
 
-    public void updateLocation(int shuffleId, int partitionId, List<PartitionLocation> newLocations) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        locationList.update(newLocations);
+    private void reviveBatch(int shuffleId, int partitionId, int mapId, int attemptId) {
+      ReviveRequest reviveRequest = null;
+      try {
+        writeLock.lock();
+        reviveRequest =
+            new ReviveRequest(
+                shuffleId,
+                mapId,
+                attemptId,
+                partitionId,
+                null,
+                StatusCode.URGENT_REVIVE,
+                maxEpoch,
+                true);
+        this.latestReviveRequest = reviveRequest;
+        logger.debug("in reviveBatch latestReviveRequest = {}", reviveRequest);
+      } finally {
+        writeLock.unlock();
+      }
+      reviveManager.addRequest(reviveRequest);
     }
 
-    public void reportUnusableLocation(int shuffleId, int mapId, int attemptId, PartitionLocation reportedPartition, StatusCode reportedStatus) {
-        int partitionId = reportedPartition.getId();
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        locationList.reportUnusableLocation(shuffleId, mapId, attemptId, reportedPartition, reportedStatus);
+    private void reportUnusableLocation(
+        int shuffleId, int mapId, int attemptId, PartitionLocation loc, StatusCode reportedStatus) {
+      ReviveRequest reviveRequest = null;
+      try {
+        writeLock.lock();
+        if (!locationSet.contains(loc.getEpoch())) {
+          return;
+        }
+
+        StatusCode currentStatus = locationStatusCode.get(loc.getEpoch());
+        if (currentStatus != reportedStatus) {
+          // allow normal/soft split to transition to hard split/push failure
+          if (currentStatus == null || currentStatus == StatusCode.SOFT_SPLIT) {
+            locationStatusCode.put(loc.getEpoch(), reportedStatus);
+          }
+          if (currentStatus == null) {
+            used++;
+          }
+          boolean urgent = ((used == size) && !hasActiveReviveRequest());
+          reviveRequest =
+              new ReviveRequest(
+                  shuffleId, mapId, attemptId, loc.getId(), loc, reportedStatus, maxEpoch, urgent);
+          if (urgent) {
+            this.latestReviveRequest = reviveRequest;
+            logger.debug("in reportUnusableLocation latestReviveRequest = {}", reviveRequest);
+          }
+        }
+
+      } finally {
+        writeLock.unlock();
+      }
+      if (reviveRequest != null) {
+        logger.info(
+            "Reported worker {}, partitionId {}, epoch {}, shuffle {} map {} attempt {} is unusable, status: {}, urgent: {}",
+            loc.hostAndPushPort(),
+            loc.getId(),
+            loc.getEpoch(),
+            shuffleId,
+            mapId,
+            attemptId,
+            reportedStatus.name(),
+            reviveRequest.urgent);
+        reviveManager.addRequest(reviveRequest);
+      }
     }
 
-    public boolean newerPartitionLocationExists(int shuffleId, int partitionId, int epoch) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        return locationList.newerPartitionLocationExists(epoch);
+    private boolean newerPartitionLocationExists(int epoch) {
+      try {
+        readLock.lock();
+        for (PartitionLocation loc : locations) {
+          if (locationStatusCode.get(loc.getEpoch()) != null && loc.getEpoch() > epoch) {
+            return true;
+          }
+        }
+        return false;
+      } finally {
+        readLock.unlock();
+      }
     }
 
-    public boolean locationExists(int shuffleId, int partitionId, int epoch) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        return locationList.locationExists(epoch);
+    private boolean locationExists(int epoch) {
+      try {
+        readLock.lock();
+        return locationSet.contains(epoch);
+      } finally {
+        readLock.unlock();
+      }
     }
 
-    public boolean hasActiveReviveRequest(int shuffleId, int partitionId) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        return locationList.hasActiveReviveRequest();
+    public boolean hasActiveReviveRequest() {
+      try {
+        readLock.lock();
+        return latestReviveRequest != null
+            && latestReviveRequest.reviveStatus == StatusCode.REVIVE_INITIALIZED.getValue();
+      } finally {
+        readLock.unlock();
+      }
     }
 
-    public void removeShuffle(int shuffleId) {
-        reducePartitionMap.remove(shuffleId);
+    public StatusCode getLatestReviveStatus() {
+      try {
+        readLock.lock();
+        if (latestReviveRequest == null) {
+          return StatusCode.REVIVE_INITIALIZED;
+        } else {
+          return StatusCode.fromValue(latestReviveRequest.reviveStatus);
+        }
+      } finally {
+        readLock.unlock();
+      }
     }
+  }
 
-    @VisibleForTesting
-    public StatusCode getLocationStatus(int shuffleId, int partitionId, int epochId) {
-        PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
-        return locationList.locationStatusCode.getOrDefault(epochId, StatusCode.SUCCESS);
+  final Map<Integer, ConcurrentHashMap<Integer, PartitionLocationList>> reducePartitionMap =
+      JavaUtils.newConcurrentHashMap();
+
+  final ReviveManager reviveManager;
+
+  final ShuffleClientImpl shuffleClient;
+
+  public LocationManager(ShuffleClientImpl shuffleClient, ReviveManager reviveManager) {
+    this.shuffleClient = shuffleClient;
+    this.reviveManager = reviveManager;
+  }
+
+  public void registerShuffleLocs(
+      int shuffleId, ConcurrentHashMap<Integer, List<PartitionLocation>> map) {
+    reducePartitionMap.computeIfAbsent(
+        shuffleId,
+        (id) -> {
+          ConcurrentHashMap<Integer, PartitionLocationList> locationMap =
+              JavaUtils.newConcurrentHashMap();
+          for (Map.Entry<Integer, List<PartitionLocation>> e : map.entrySet()) {
+            int partitionId = e.getKey();
+            List<PartitionLocation> locs = e.getValue();
+            PartitionLocationList list = new PartitionLocationList(shuffleId, partitionId);
+            list.update(locs);
+            locationMap.put(partitionId, list);
+            logger.debug("in registerShuffleLocs, shuffleId {}, partitionId {}", id, partitionId);
+          }
+          return locationMap;
+        });
+  }
+
+  public boolean registered(int shuffleId) {
+    return reducePartitionMap.containsKey(shuffleId);
+  }
+
+  public boolean exists(int shuffleId, int partitionId) {
+    if (!registered(shuffleId)) {
+      throw new UnsupportedOperationException(
+          "unexpected! must ensure shuffle registered before checking partition exists ");
     }
+    return reducePartitionMap.get(shuffleId).containsKey(partitionId);
+  }
+
+  public StatusCode getReviveStatus(int shuffleId, int partitionId) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    return locationList.getLatestReviveStatus();
+  }
+
+  public PartitionLocation getLocationOrReviveAsync(
+      int shuffleId,
+      int partitionId,
+      int mapId,
+      int attemptId,
+      boolean doRevive,
+      boolean liveOnly) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    // firstly, try to find a live partition location
+    PartitionLocation loc = locationList.nextLoc(mapId, false, true);
+    if (loc == null) {
+      if (doRevive && !locationList.hasActiveReviveRequest()) {
+        locationList.reviveBatch(shuffleId, partitionId, mapId, attemptId);
+      } else if (doRevive && locationList.hasActiveReviveRequest()) {
+        logger.debug(
+            "in getLocationOrReviveAsync, do nothing, current latestReviveRequest is {}",
+            locationList.latestReviveRequest);
+      }
+      // can't get a live partition location, then try to find a location in soft split status
+      // if liveOnly = false, hard split/push fail location can be returned
+      loc = locationList.nextLoc(mapId, true, liveOnly);
+    }
+    return loc;
+  }
+
+  public boolean reviveSync(
+      int shuffleId, int partitionId, int mapId, int attemptId, StatusCode cause) {
+    Set<Integer> mapIds = new HashSet<>();
+    mapIds.add(mapId);
+    List<ReviveRequest> requests = new ArrayList<>();
+    ReviveRequest request =
+        new ReviveRequest(shuffleId, mapId, attemptId, partitionId, null, cause, 0, true);
+    requests.add(request);
+    Map<Integer, Integer> results = shuffleClient.reviveBatch(shuffleId, mapIds, requests, true);
+
+    if (shuffleClient.mapperEnded(shuffleId, mapId)) {
+      logger.debug(
+          "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId);
+      return true;
+    } else {
+      return results != null
+          && results.containsKey(partitionId)
+          && results.get(partitionId) == StatusCode.SUCCESS.getValue();
+    }
+  }
+
+  public void updateLocation(int shuffleId, int partitionId, List<PartitionLocation> newLocations) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    locationList.update(newLocations);
+  }
+
+  public void reportUnusableLocation(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      PartitionLocation reportedPartition,
+      StatusCode reportedStatus) {
+    int partitionId = reportedPartition.getId();
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    locationList.reportUnusableLocation(
+        shuffleId, mapId, attemptId, reportedPartition, reportedStatus);
+  }
+
+  public boolean newerPartitionLocationExists(int shuffleId, int partitionId, int epoch) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    return locationList.newerPartitionLocationExists(epoch);
+  }
+
+  public boolean locationExists(int shuffleId, int partitionId, int epoch) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    return locationList.locationExists(epoch);
+  }
+
+  public boolean hasActiveReviveRequest(int shuffleId, int partitionId) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    return locationList.hasActiveReviveRequest();
+  }
+
+  public void removeShuffle(int shuffleId) {
+    reducePartitionMap.remove(shuffleId);
+  }
+
+  @VisibleForTesting
+  public StatusCode getLocationStatus(int shuffleId, int partitionId, int epochId) {
+    PartitionLocationList locationList = reducePartitionMap.get(shuffleId).get(partitionId);
+    return locationList.locationStatusCode.getOrDefault(epochId, StatusCode.SUCCESS);
+  }
 }

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -134,10 +134,8 @@ class ReviveManager {
               // Call reviveBatch. Return null means Exception caught or
               // SHUFFLE_NOT_REGISTERED
               // Do not use WriterTracerHere because traceInfo is set afterward
-              long reviveStartTime = System.nanoTime();
               Map<Integer, Integer> results =
                   shuffleClient.reviveBatch(shuffleId, mapIds, requestsToSend.values(), urgent);
-              long reviveCostTime = System.nanoTime() - reviveStartTime;
               if (results == null) {
                 for (ReviveRequest req : filteredRequests) {
                   req.reviveStatus = StatusCode.REVIVE_FAILED.getValue();

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -283,6 +283,14 @@ public abstract class ShuffleClient {
   public abstract ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
       int shuffleId, int numMappers, int numPartitions) throws CelebornIOException;
 
+  public boolean ensureRegistered(int shuffleId, int numMappers, int numPartitions) {
+    return false;
+  }
+
+  public LocationManager getLocationManager() {
+    return null;
+  }
+
   public abstract PushState getPushState(String mapKey);
 
   public abstract int getShuffleId(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiFunction;
 
@@ -279,9 +278,6 @@ public abstract class ShuffleClient {
 
   public abstract PartitionLocation registerMapPartitionTask(
       int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) throws IOException;
-
-  public abstract ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
-      int shuffleId, int numMappers, int numPartitions) throws CelebornIOException;
 
   public boolean ensureRegistered(int shuffleId, int numMappers, int numPartitions) {
     return false;

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -23,10 +23,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.celeborn.client.LocationManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.celeborn.client.LocationManager;
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.PartitionLocation;
@@ -103,7 +103,9 @@ public class DataPushQueue {
         while (iterator.hasNext()) {
           PushTask task = iterator.next();
           int partitionId = task.getPartitionId();
-          PartitionLocation loc = locationManager.getLocationOrReviveAsync(shuffleId, partitionId, mapId, attemptId, true, false);
+          PartitionLocation loc =
+              locationManager.getLocationOrReviveAsync(
+                  shuffleId, partitionId, mapId, attemptId, true, false);
           // According to CELEBORN-560, call rerun task and speculative task after LifecycleManager
           // handle StageEnd will return empty PartitionLocation map, here loc can be null
           if (loc != null) {

--- a/client/src/main/scala/org/apache/celeborn/client/PartitionLocationMonitor.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/PartitionLocationMonitor.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+import scala.math.ceil
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.network.util.ByteUnit
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.message.StatusCode
+import org.apache.celeborn.common.util.ConcurrentSkipListMapWithTracker
+
+class PartitionLocationMonitor(
+    shuffleId: Int,
+    partitionId: Int,
+    conf: CelebornConf,
+    maxActiveLocation: Int) extends Logging {
+
+  private val timeWindowsInSecs = conf.clientActiveFullLocationTimeWindowSecs
+  private val intervalPerBucketInMills = conf.clientActiveFullLocationIntervalPerBucketMs
+  private val expectedWorkerSpeedMBPerSec = conf.clientExpectedWorkerSpeedMBPerSecond
+  private lazy val activeFullLocationHub =
+    new PartitionSplitTimeSlidingHub(timeWindowsInSecs.toInt, intervalPerBucketInMills.toInt)
+  // epochId -> partitionLocation
+  private val activeLocationEpochs = new ConcurrentSkipListMapWithTracker[Int, PartitionLocation]()
+  private val softSplitEpochIds: java.util.Set[Int] = ConcurrentHashMap.newKeySet()
+  private val exceptionEpochIds: java.util.Set[Int] = ConcurrentHashMap.newKeySet()
+  private val softSplitSizeMB =
+    ByteUnit.BYTE.convertTo(conf.shufflePartitionSplitThreshold, ByteUnit.MiB)
+  private val hardSplitSizeMB = softSplitSizeMB * 3 // TODO: @漠云 后续考虑进行修改
+
+  def addActiveLocationEpoch(partitionLocation: PartitionLocation): Unit = {
+    activeLocationEpochs.put(partitionLocation.getEpoch, partitionLocation)
+  }
+
+  def getActiveLocations(clientMaxEpoch: Int): Seq[PartitionLocation] = {
+    activeLocationEpochs.tailMap(clientMaxEpoch + 1).values().asScala.toSeq
+  }
+
+  // if active full location hub changed, return true
+  def receivePartitionSplitOrRevived(epoch: Int, cause: Option[StatusCode]): Boolean = {
+    var changed = false
+    if (cause.isDefined) {
+      if (cause.get == StatusCode.SOFT_SPLIT) { // soft_split
+        if (activeLocationEpochs.remove(epoch) || exceptionEpochIds.remove(epoch)) {
+          activeFullLocationHub.add(new PartitionSplitNode(softSplitSizeMB))
+          softSplitEpochIds.add(epoch)
+          changed = true
+        }
+      } else if (cause.get == StatusCode.HARD_SPLIT) {
+        if (activeLocationEpochs.remove(epoch) || exceptionEpochIds.remove(epoch)) {
+          activeFullLocationHub.add(new PartitionSplitNode(hardSplitSizeMB))
+          changed = true
+        } else if (softSplitEpochIds.remove(epoch)) {
+          activeFullLocationHub.add(new PartitionSplitNode(hardSplitSizeMB - softSplitSizeMB))
+          changed = true
+        }
+      } else {
+        if (activeLocationEpochs.remove(epoch)) {
+          exceptionEpochIds.add(epoch)
+          changed = true
+        }
+      }
+    }
+    if (changed) {
+      logInfo(
+        s"Receive shuffleId: $shuffleId, partitionId: $partitionId, epochId: $epoch, cause: $cause")
+    }
+    changed
+  }
+
+  def activeLocationCount: Int = {
+    activeLocationEpochs.size
+  }
+
+  def nextReserveSlotCount: Int = {
+    val pushSpeed = activeFullLocationHub.getActiveFullLocationSizeMBPerSec()
+    Math.max(
+      Math.min(
+        maxActiveLocation,
+        ceil(pushSpeed.toDouble / expectedWorkerSpeedMBPerSec)).toInt - activeLocationCount,
+      0)
+  }
+
+  def report: String = {
+    activeLocationEpochs.report()
+  }
+}

--- a/client/src/main/scala/org/apache/celeborn/client/PartitionSplitTimeSlidingHub.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/PartitionSplitTimeSlidingHub.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import org.apache.celeborn.common.util.TimeSlidingHub
+
+class PartitionSplitNode(var value: Long) extends TimeSlidingHub.TimeSlidingNode {
+
+  override def combineNode(node: TimeSlidingHub.TimeSlidingNode): Unit = {
+    value += node.asInstanceOf[PartitionSplitNode].value
+  }
+
+  /** Minus the value from the {@param node}. */
+  override def separateNode(node: TimeSlidingHub.TimeSlidingNode): Unit = {
+    value -= node.asInstanceOf[PartitionSplitNode].value
+  }
+
+  override def clone: PartitionSplitNode = new PartitionSplitNode(value)
+}
+
+class PartitionSplitTimeSlidingHub(timeWindowsInSecs: Int, intervalPerBucketInMills: Int)
+  extends TimeSlidingHub[PartitionSplitNode](timeWindowsInSecs, intervalPerBucketInMills) {
+  override protected def newEmptyNode(): PartitionSplitNode = {
+    new PartitionSplitNode(0)
+  }
+
+  def getActiveFullLocationSizeMBPerSec(): Int = {
+    val currentSizeMB = sum().getLeft.value
+    if (currentSizeMB > 0) {
+      currentSizeMB.toInt / timeWindowsInSecs
+    } else {
+      0
+    }
+  }
+}

--- a/client/src/main/scala/org/apache/celeborn/client/RequestLocationCallContext.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/RequestLocationCallContext.scala
@@ -40,7 +40,7 @@ case class ChangeLocationsCallContext(
   extends RequestLocationCallContext with Logging {
   val endedMapIds = new util.HashSet[Integer]()
   val newLocs =
-    JavaUtils.newConcurrentHashMap[Integer, (StatusCode, Boolean, PartitionLocation)](
+    JavaUtils.newConcurrentHashMap[Integer, (StatusCode, Boolean, Seq[PartitionLocation])](
       partitionCount)
 
   def markMapperEnd(mapId: Int): Unit = this.synchronized {
@@ -55,7 +55,8 @@ case class ChangeLocationsCallContext(
     if (newLocs.containsKey(partitionId)) {
       logError(s"PartitionId $partitionId already exists!")
     }
-    newLocs.put(partitionId, (status, available, partitionLocationOpt.getOrElse(null)))
+    //TODO fix later
+//    newLocs.put(partitionId, (status, available, partitionLocationOpt.getOrElse(null)))
 
     if (newLocs.size() == partitionCount || StatusCode.SHUFFLE_NOT_REGISTERED == status
       || StatusCode.STAGE_ENDED == status) {

--- a/common/src/main/java/org/apache/celeborn/common/protocol/ReviveRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/ReviveRequest.java
@@ -18,32 +18,64 @@
 package org.apache.celeborn.common.protocol;
 
 import org.apache.celeborn.common.protocol.message.StatusCode;
+import java.util.Objects;
 
 public class ReviveRequest {
   public int shuffleId;
   public int mapId;
   public int attemptId;
   public int partitionId;
-  public int epoch;
   public PartitionLocation loc;
+  public int clientMaxEpoch;
   public StatusCode cause;
+  public boolean urgent;
   public volatile int reviveStatus;
 
   public ReviveRequest(
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      int partitionId,
-      int epoch,
-      PartitionLocation loc,
-      StatusCode cause) {
+          int shuffleId,
+          int mapId,
+          int attemptId,
+          int partitionId,
+          PartitionLocation loc,
+          StatusCode cause,
+          int clientMaxEpoch,
+          boolean urgent) {
     this.shuffleId = shuffleId;
     this.mapId = mapId;
     this.attemptId = attemptId;
     this.partitionId = partitionId;
-    this.epoch = epoch;
     this.loc = loc;
+    this.clientMaxEpoch = clientMaxEpoch;
     this.cause = cause;
+    this.urgent = urgent;
     reviveStatus = StatusCode.REVIVE_INITIALIZED.getValue();
+  }
+
+  @Override
+  public String toString() {
+    return "ReviveRequest{" +
+            "shuffleId=" + shuffleId +
+            ", mapId=" + mapId +
+            ", attemptId=" + attemptId +
+            ", partitionId=" + partitionId +
+            ", loc=" + loc +
+            ", clientMaxEpoch=" + clientMaxEpoch +
+            ", cause=" + cause +
+            ", urgent=" + urgent +
+            ", reviveStatus=" + reviveStatus +
+            '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ReviveRequest that = (ReviveRequest) o;
+    return shuffleId == that.shuffleId && mapId == that.mapId && attemptId == that.attemptId && partitionId == that.partitionId && clientMaxEpoch == that.clientMaxEpoch && urgent == that.urgent && reviveStatus == that.reviveStatus && loc == that.loc && cause == that.cause;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(shuffleId, mapId, attemptId, partitionId, loc, clientMaxEpoch, cause, urgent, reviveStatus);
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/ReviveRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/ReviveRequest.java
@@ -17,8 +17,9 @@
 
 package org.apache.celeborn.common.protocol;
 
-import org.apache.celeborn.common.protocol.message.StatusCode;
 import java.util.Objects;
+
+import org.apache.celeborn.common.protocol.message.StatusCode;
 
 public class ReviveRequest {
   public int shuffleId;
@@ -32,14 +33,14 @@ public class ReviveRequest {
   public volatile int reviveStatus;
 
   public ReviveRequest(
-          int shuffleId,
-          int mapId,
-          int attemptId,
-          int partitionId,
-          PartitionLocation loc,
-          StatusCode cause,
-          int clientMaxEpoch,
-          boolean urgent) {
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      PartitionLocation loc,
+      StatusCode cause,
+      int clientMaxEpoch,
+      boolean urgent) {
     this.shuffleId = shuffleId;
     this.mapId = mapId;
     this.attemptId = attemptId;
@@ -53,17 +54,26 @@ public class ReviveRequest {
 
   @Override
   public String toString() {
-    return "ReviveRequest{" +
-            "shuffleId=" + shuffleId +
-            ", mapId=" + mapId +
-            ", attemptId=" + attemptId +
-            ", partitionId=" + partitionId +
-            ", loc=" + loc +
-            ", clientMaxEpoch=" + clientMaxEpoch +
-            ", cause=" + cause +
-            ", urgent=" + urgent +
-            ", reviveStatus=" + reviveStatus +
-            '}';
+    return "ReviveRequest{"
+        + "shuffleId="
+        + shuffleId
+        + ", mapId="
+        + mapId
+        + ", attemptId="
+        + attemptId
+        + ", partitionId="
+        + partitionId
+        + ", loc="
+        + loc
+        + ", clientMaxEpoch="
+        + clientMaxEpoch
+        + ", cause="
+        + cause
+        + ", urgent="
+        + urgent
+        + ", reviveStatus="
+        + reviveStatus
+        + '}';
   }
 
   @Override
@@ -71,11 +81,20 @@ public class ReviveRequest {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ReviveRequest that = (ReviveRequest) o;
-    return shuffleId == that.shuffleId && mapId == that.mapId && attemptId == that.attemptId && partitionId == that.partitionId && clientMaxEpoch == that.clientMaxEpoch && urgent == that.urgent && reviveStatus == that.reviveStatus && loc == that.loc && cause == that.cause;
+    return shuffleId == that.shuffleId
+        && mapId == that.mapId
+        && attemptId == that.attemptId
+        && partitionId == that.partitionId
+        && clientMaxEpoch == that.clientMaxEpoch
+        && urgent == that.urgent
+        && reviveStatus == that.reviveStatus
+        && loc == that.loc
+        && cause == that.cause;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(shuffleId, mapId, attemptId, partitionId, loc, clientMaxEpoch, cause, urgent, reviveStatus);
+    return Objects.hash(
+        shuffleId, mapId, attemptId, partitionId, loc, clientMaxEpoch, cause, urgent, reviveStatus);
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -91,7 +91,8 @@ public enum StatusCode {
   OPEN_STREAM_FAILED(51),
   SEGMENT_START_FAIL_REPLICA(52),
   SEGMENT_START_FAIL_PRIMARY(53),
-  NO_SPLIT(54);
+  NO_SPLIT(54),
+  URGENT_REVIVE(55);
 
   private final byte value;
 

--- a/common/src/main/java/org/apache/celeborn/common/util/ConcurrentSkipListMapWithTracker.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ConcurrentSkipListMapWithTracker.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util;
+
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ConcurrentSkipListMapWithTracker<K, V> {
+  private final ConcurrentSkipListMap<K, V> map = new ConcurrentSkipListMap<>();
+  private final long firstTime = System.nanoTime();
+  private long lastTime = firstTime;
+  private int maxCount = 1;
+  private long totalCountAndTime = 0;
+
+  public V put(K key, V value) {
+    return map.computeIfAbsent(
+        key,
+        (v) -> {
+          recordChange();
+          return value;
+        });
+  }
+
+  public boolean remove(K key) {
+    AtomicBoolean exists = new AtomicBoolean(false);
+    map.computeIfPresent(
+        key,
+        (k, v) -> {
+          recordChange();
+          exists.set(true);
+          return null;
+        });
+    return exists.get();
+  }
+
+  public ConcurrentNavigableMap<K, V> tailMap(K key) {
+    return map.tailMap(key);
+  }
+
+  public int size() {
+    return map.size();
+  }
+
+  private void recordChange() {
+    int currentCount = map.size();
+    if (currentCount > maxCount) {
+      maxCount = currentCount;
+    }
+    long currentTime = System.nanoTime();
+    long duration = currentTime - lastTime;
+    lastTime = currentTime;
+    totalCountAndTime += currentCount * TimeUnit.NANOSECONDS.toMillis(duration);
+  }
+
+  public String report() {
+    recordChange();
+    double averageSize =
+        (double) totalCountAndTime / TimeUnit.NANOSECONDS.toMillis(lastTime - firstTime);
+    return String.format(
+        "maxActiveLocationsCount: %d, avgActiveLocationsCount: %.2f", maxCount, averageSize);
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/util/TimeSlidingHub.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/TimeSlidingHub.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.worker.congestcontrol;
+package org.apache.celeborn.common.util;
 
 import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -51,7 +51,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
   }
 
   // 1 second.
-  protected final int intervalPerBucketInMills = 1000;
+  protected final int intervalPerBucketInMills;
   protected final int timeWindowsInMills;
   private final int maxQueueSize;
   private Pair<N, Integer> sumInfo;
@@ -59,7 +59,12 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
   private final LinkedBlockingDeque<Pair<Long, N>> _deque;
 
   public TimeSlidingHub(int timeWindowsInSecs) {
+    this(timeWindowsInSecs, 1000); // intervalPerBucketInMills default 1 second
+  }
+
+  public TimeSlidingHub(int timeWindowsInSecs, int intervalPerBucketInMills) {
     this._deque = new LinkedBlockingDeque<>();
+    this.intervalPerBucketInMills = intervalPerBucketInMills;
     this.maxQueueSize = timeWindowsInSecs * 1000 / intervalPerBucketInMills;
     this.timeWindowsInMills = maxQueueSize * intervalPerBucketInMills;
     this.sumInfo = Pair.of(newEmptyNode(), 0);

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -112,6 +112,7 @@ enum MessageType {
   REVISE_LOST_SHUFFLES = 89;
   REVISE_LOST_SHUFFLES_RESPONSE = 90;
   PUSH_MERGED_DATA_SPLIT_PARTITION_INFO = 91;
+  PARTITION_SPLIT_REPORT = 92;
 }
 
 enum StreamType {
@@ -323,6 +324,7 @@ message PbRevivePartitionInfo {
   int32 epoch = 2;
   PbPartitionLocation partition = 3;
   int32 status = 4;
+  int32 clientMaxEpoch = 5;
 }
 
 message PbRevive {
@@ -331,10 +333,16 @@ message PbRevive {
   repeated PbRevivePartitionInfo partitionInfo = 3;
 }
 
+message PbPartitionSplitReport {
+  int32 shuffleId = 1;
+  repeated int32 mapId = 2;
+  repeated PbRevivePartitionInfo partitionInfo = 3;
+}
+
 message PbChangeLocationPartitionInfo {
   int32 partitionId = 1;
   int32 status = 2;
-  PbPartitionLocation partition = 3;
+  repeated PbPartitionLocation partition = 3;
   bool oldAvailable = 4;
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -237,9 +237,9 @@ object ControlMessages extends Logging {
 
   object PartitionSplitReport {
     def apply(
-               shuffleId: Int,
-               mapIds: util.Set[Integer],
-               reviveRequests: util.Collection[ReviveRequest]): PbPartitionSplitReport = {
+        shuffleId: Int,
+        mapIds: util.Set[Integer],
+        reviveRequests: util.Collection[ReviveRequest]): PbPartitionSplitReport = {
       val builder = PbPartitionSplitReport.newBuilder()
         .setShuffleId(shuffleId)
         .addAllMapId(mapIds)
@@ -291,7 +291,8 @@ object ControlMessages extends Logging {
           .setOldAvailable(available)
         if (locs != null) {
           locs.foreach(loc =>
-            pbChangeLocationPartitionInfoBuilder.addPartition(PbSerDeUtils.toPbPartitionLocation(loc)))
+            pbChangeLocationPartitionInfoBuilder.addPartition(
+              PbSerDeUtils.toPbPartitionLocation(loc)))
         }
         builder.addPartitionInfo(pbChangeLocationPartitionInfoBuilder.build())
       }

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.CelebornConf.{OSS_ACCESS_KEY, OSS_SECRET_KEY}
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.protocol.StorageInfo

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -76,8 +76,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     val reserveSlotsSuccess = lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
@@ -88,7 +87,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
           allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
-          lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)
+          lifecycleManager.addNewPartitionLocations(shuffleId, primaryLocations)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
     }
@@ -104,6 +103,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         shuffleId,
         partitionId,
         -1,
+        0,
         null,
         None)
       changePartitionManager.changePartitionRequests.computeIfAbsent(
@@ -151,8 +151,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     val reserveSlotsSuccess = lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
@@ -163,7 +162,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
           partitionLocationInfo.addPrimaryPartitions(primaryLocations)
           partitionLocationInfo.addReplicaPartitions(replicaLocations)
           allocatedWorkers.put(workerInfo.toUniqueId, partitionLocationInfo)
-          lifecycleManager.updateLatestPartitionLocations(shuffleId, primaryLocations)
+          lifecycleManager.addNewPartitionLocations(shuffleId, primaryLocations)
       }
       lifecycleManager.shuffleAllocatedWorkers.put(shuffleId, allocatedWorkers)
     }
@@ -206,6 +205,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         shuffleId,
         partitionId,
         -1,
+        0,
         null,
         None)
       changePartitionManager.changePartitionRequests.computeIfAbsent(
@@ -259,8 +259,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     val reserveSlotsSuccess = lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
@@ -286,6 +285,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         shuffleId,
         partitionId,
         -1,
+        0,
         null,
         None)
       changePartitionManager.changePartitionRequests.computeIfAbsent(
@@ -330,8 +330,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     val reserveSlotsSuccess = lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     if (reserveSlotsSuccess) {
       val allocatedWorkers =
@@ -358,6 +357,7 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
         shuffleId,
         partitionId,
         -1,
+        0,
         null,
         None)
       changePartitionManager.changePartitionRequests.computeIfAbsent(

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -67,8 +67,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     lifecycleManager.commitManager.registerShuffle(shuffleId, 1, false)
     0 until 10 foreach { partitionId =>
@@ -123,8 +122,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     lifecycleManager.commitManager.registerShuffle(shuffleId, 1, false)
     0 until 10 foreach { partitionId =>
@@ -193,8 +191,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     lifecycleManager.commitManager.registerShuffle(shuffleId, 1, false)
     0 until 1000 foreach { partitionId =>
@@ -253,8 +250,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     lifecycleManager.commitManager.registerShuffle(shuffleId, 1, false)
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
@@ -64,8 +64,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     val slotsToDestroy = new WorkerResource
     val destroyWorkers = workerInfos.keySet.take(2)
@@ -106,8 +105,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     val slotsToDestroy = new WorkerResource
     val destroyWorkers = workerInfos.keySet.take(2)
@@ -148,8 +146,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
     lifecycleManager.reserveSlotsWithRetry(
       shuffleId,
       new util.HashSet(res.workerResource.keySet()),
-      res.workerResource,
-      updateEpoch = false)
+      res.workerResource)
 
     val slotsToDestroy = new WorkerResource
     val destroyWorkers = workerInfos.keySet.take(2)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
@@ -99,6 +99,25 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     lifecycleManager.stop()
   }
 
+  test("allocateEpochIdsAndUpdateCurrentMaxEpoch") {
+    val celebornConf = new CelebornConf()
+    val lifecycleManager = new LifecycleManager(s"app-${System.currentTimeMillis()}", celebornConf)
+    val shuffleId = 0
+    val partitionId = 0
+    val r1 = lifecycleManager.allocateEpochIdsAndUpdateCurrentMaxEpoch(shuffleId, partitionId, 0)
+    assert(r1.length == 1)
+    assert(r1(0) == 0)
+    val r2 = lifecycleManager.allocateEpochIdsAndUpdateCurrentMaxEpoch(shuffleId, partitionId, 3)
+    assert(r2.length == 3)
+    assert(r2(0) == 1)
+    assert(r2(1) == 2)
+    assert(r2(2) == 3)
+    val r3 = lifecycleManager.allocateEpochIdsAndUpdateCurrentMaxEpoch(shuffleId, partitionId, 2)
+    assert(r3.length == 0)
+    val r4 = lifecycleManager.allocateEpochIdsAndUpdateCurrentMaxEpoch(shuffleId, partitionId, 3)
+    assert(r4.length == 0)
+  }
+
   override def afterAll(): Unit = {
     logInfo("all test complete , stop celeborn mini cluster")
     shutdownMiniCluster()

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/PartitionLocationMonitorSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/PartitionLocationMonitorSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.tests.client
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.client.PartitionLocationMonitor
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.message.StatusCode
+
+class PartitionLocationMonitorSuite extends CelebornFunSuite {
+  private def newPartitionLocation(epochId: Int): PartitionLocation = {
+    new PartitionLocation(0, epochId, "localhost", 1, 1, 1, 1, PartitionLocation.Mode.PRIMARY);
+  }
+
+  test("quickly reserve slots") {
+    val conf: CelebornConf = new CelebornConf()
+    val partitionLocationMonitor = new PartitionLocationMonitor(0, 0, conf, 10)
+    val epochGenerator = new AtomicInteger
+    val epochIds = new ArrayBuffer[Int]
+    // start with 1 slot
+    val epochId = epochGenerator.incrementAndGet()
+    epochIds += epochId
+    partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+
+    // 1 slot is split, nextReserveSlotCount should be 1
+    epochIds.foreach {
+      epochId =>
+        partitionLocationMonitor.receivePartitionSplitOrRevived(
+          epochId,
+          Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    var nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 1)
+
+    // reserve 1 new slot
+    for (i <- 0 until nextReserveSlotCount) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+
+    // 1 new slot is split, nextReserveSlotCount should be 2
+    epochIds.foreach { epochId =>
+      partitionLocationMonitor.receivePartitionSplitOrRevived(epochId, Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 2)
+
+    // reserve 2 new slots
+    for (i <- 0 until nextReserveSlotCount) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 2)
+
+    // 2 new slots are split, nextReserveSlotCount should be 3
+    epochIds.foreach { epochId =>
+      partitionLocationMonitor.receivePartitionSplitOrRevived(epochId, Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 3)
+  }
+
+  test("slowly reserve slots") {
+    val conf: CelebornConf = new CelebornConf()
+      .set(CelebornConf.CLIENT_ACTIVE_FULL_LOCATION_TIME_WINDOW.key, "2s")
+      .set(CelebornConf.CLIENT_ACTIVE_FULL_LOCATION_INTERVAL_PER_BUCKET.key, "1s")
+      .set(CelebornConf.CLIENT_EXPECTED_WORKER_SPEED_MB_PER_SECOND.key, "1024")
+    val partitionLocationMonitor = new PartitionLocationMonitor(0, 0, conf, 10)
+    val epochGenerator = new AtomicInteger
+    val epochIds = new ArrayBuffer[Int]
+
+    // reserve 10 new slot
+    for (i <- 0 until 10) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+
+    epochIds.slice(0, 5).foreach { epochId =>
+      partitionLocationMonitor.receivePartitionSplitOrRevived(epochId, Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 5)
+
+    // sleep timeWindowsInSecs = 2s, we expect all active full locations are expired
+    Thread.sleep(2 * 1000L)
+    assert(partitionLocationMonitor.activeLocationCount == 5)
+
+    // 3 slots are split, nextReserveSlotCount should be 0
+    epochIds.slice(5, 8).foreach { epochId =>
+      partitionLocationMonitor.receivePartitionSplitOrRevived(epochId, Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 2)
+    assert(partitionLocationMonitor.nextReserveSlotCount == 0)
+  }
+
+  test("max active location limit") {
+    val conf: CelebornConf = new CelebornConf()
+    val partitionLocationMonitor = new PartitionLocationMonitor(0, 0, conf, 3)
+    val epochGenerator = new AtomicInteger
+    val epochIds = new ArrayBuffer[Int]
+
+    // start with 1 slot
+    val epochId = epochGenerator.incrementAndGet()
+    epochIds += epochId
+    partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+
+    // 1 slot is split, nextReserveSlotCount should be 1
+    epochIds.foreach {
+      epochId =>
+        partitionLocationMonitor.receivePartitionSplitOrRevived(
+          epochId,
+          Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    var nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 1)
+
+    // reserve 1 new slot
+    for (i <- 0 until nextReserveSlotCount) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+
+    // 1 new slot is split, nextReserveSlotCount should be 2
+    epochIds.foreach { epochId =>
+      partitionLocationMonitor.receivePartitionSplitOrRevived(epochId, Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 2)
+
+    // reserve 2 new slots
+    for (i <- 0 until nextReserveSlotCount) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 2)
+
+    // 2 new slots are split, nextReserveSlotCount should be 4
+    // but max active location limit is 3, so nextReserveSlotCount should be 3
+    epochIds.foreach { epochId =>
+      partitionLocationMonitor.receivePartitionSplitOrRevived(epochId, Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 3)
+  }
+
+  test("soft split then hard split and failed") {
+    val conf: CelebornConf = new CelebornConf()
+    val partitionLocationMonitor = new PartitionLocationMonitor(0, 0, conf, 10)
+    val epochGenerator = new AtomicInteger
+    val epochIds = new ArrayBuffer[Int]
+
+    // start with 1 slot
+    val epochId = epochGenerator.incrementAndGet()
+    epochIds += epochId
+    partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+
+    // 1 slot is split, nextReserveSlotCount should be 1
+    epochIds.foreach {
+      epochId =>
+        partitionLocationMonitor.receivePartitionSplitOrRevived(
+          epochId,
+          Some(StatusCode.SOFT_SPLIT))
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 0)
+    var nextReserveSlotCount = partitionLocationMonitor.nextReserveSlotCount
+    assert(nextReserveSlotCount == 1)
+
+    // reserve 1 new slot
+    for (i <- 0 until nextReserveSlotCount) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+
+    // epoch 1 is hard split, new activeLocationCount should be 1, current activeLocationCount is 1 so nextReserveSlotCount should be 1
+    partitionLocationMonitor.receivePartitionSplitOrRevived(1, Some(StatusCode.HARD_SPLIT))
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+    assert(partitionLocationMonitor.nextReserveSlotCount == 1)
+
+    // reserve 1 new slot
+    for (i <- 0 until nextReserveSlotCount) {
+      val epochId = epochGenerator.incrementAndGet()
+      partitionLocationMonitor.addActiveLocationEpoch(newPartitionLocation(epochId))
+      epochIds += epochId
+    }
+    assert(partitionLocationMonitor.activeLocationCount == 2)
+    partitionLocationMonitor.receivePartitionSplitOrRevived(
+      2,
+      Some(StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_PRIMARY))
+    assert(partitionLocationMonitor.activeLocationCount == 1)
+    assert(partitionLocationMonitor.nextReserveSlotCount == 1)
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import org.apache.celeborn.common.util.TimeSlidingHub;
+
 public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatusNode> {
 
   public static class BufferStatusNode implements TimeSlidingHub.TimeSlidingNode {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.celeborn.common.util.TimeSlidingHub;
+
 public class TestTimeSlidingHub {
 
   private static class DummyTimeSlidingHub

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/DynamicallySplitPartitionSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/DynamicallySplitPartitionSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.cluster
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.{Executors, TimeUnit}
+
+import org.apache.commons.lang3.RandomStringUtils
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client.{LifecycleManager, ShuffleClientImpl}
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.service.deploy.MiniClusterFeature
+
+class DynamicallySplitPartitionSuite extends AnyFunSuite
+  with Logging with MiniClusterFeature with BeforeAndAfterAll {
+  val masterPort = 19099
+
+  override def beforeAll(): Unit = {
+    val masterConf = Map(
+      "celeborn.master.host" -> "localhost",
+      "celeborn.master.port" -> masterPort.toString)
+    val workerConf = Map(
+      "celeborn.master.endpoints" -> s"localhost:$masterPort",
+      "celeborn.worker.flusher.buffer.size" -> "0")
+
+    logInfo("test initialized , setup Celeborn mini cluster")
+    setupMiniClusterWithRandomPorts(masterConf, workerConf, 5)
+  }
+
+  class PushTask(shuffleClient: ShuffleClientImpl, shuffleId: Int, mapId: Int, mapNum: Int)
+    extends Runnable {
+    override def run(): Unit = {
+      val startTime = System.nanoTime()
+      var i = 0
+      // 512 KB/s, 4 tasks, 60s
+      // expect 10 M soft_split, require a soft split every 5 seconds.
+      while (i < 60 * 8) {
+        val DATA = RandomStringUtils.random(64 * 1024).getBytes(StandardCharsets.UTF_8)
+        shuffleClient.pushData(shuffleId, mapId, 0, 0, DATA, 0, DATA.length, mapNum, 1)
+        i += 1
+        Thread.sleep(125)
+      }
+      shuffleClient.mapperEnd(shuffleId, mapId, 0, mapNum)
+      val endTime = System.nanoTime()
+      logInfo(
+        s"PushTask $mapId finished, cost ${TimeUnit.NANOSECONDS.toSeconds(endTime - startTime)} s")
+    }
+  }
+
+  test("dynamically split partition") {
+    val appId = s"dynamically-split-partition-test-${System.currentTimeMillis()}"
+    val clientConf = new CelebornConf()
+      .set(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$masterPort")
+      .set(CelebornConf.SHUFFLE_PARTITION_SPLIT_THRESHOLD.key, "10M")
+      .set(CelebornConf.SHUFFLE_PARTITION_SPLIT_MODE.key, "HARD")
+      .set(CelebornConf.CLIENT_ASYNC_SPLIT_PARTITION_ENABLED.key, "true")
+      .set(CelebornConf.CLIENT_ACTIVE_FULL_LOCATION_TIME_WINDOW.key, "10s")
+      .set(CelebornConf.CLIENT_ACTIVE_FULL_LOCATION_INTERVAL_PER_BUCKET.key, "1s")
+      .set(CelebornConf.CLIENT_EXPECTED_WORKER_SPEED_MB_PER_SECOND.key, "1")
+    val lifecycleManager = new LifecycleManager(appId, clientConf)
+    val shuffleClient = new ShuffleClientImpl(appId, clientConf, UserIdentifier("mock", "mock"))
+    shuffleClient.setupLifecycleManagerRef(lifecycleManager.self)
+
+    val executor = Executors.newFixedThreadPool(4)
+    val task0 = new PushTask(shuffleClient, 0, 0, 4)
+    val task1 = new PushTask(shuffleClient, 0, 1, 4)
+    val task2 = new PushTask(shuffleClient, 0, 2, 4)
+    val task3 = new PushTask(shuffleClient, 0, 3, 4)
+    val startTime = System.nanoTime()
+    executor.submit(task0)
+    executor.submit(task1)
+    executor.submit(task2)
+    executor.submit(task3)
+    executor.shutdown()
+    executor.awaitTermination(120, TimeUnit.SECONDS)
+    val endTime = System.nanoTime()
+    assert(TimeUnit.NANOSECONDS.toSeconds(endTime - startTime) < 100)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
enhance celeborn to
1. allow shuffle client to write to one partition with multiple partition locations parallelly
2. allow lifecycle manager to detect  parallel level for each partition by partition splitting frequency

CIP-20: Dynamically optimize shuffle write parallelism
https://docs.google.com/document/d/1CqFswIOP5nR8Cy2THo8tELOwVxUf0ZP_8pDjaYj2HGc/edit?usp=sharing

### Why are the changes needed?
TBD


### Does this PR introduce _any_ user-facing change?
TBD


### How was this patch tested?
TBD
