### PR TITLE
[CELEBORN-1921][FOLLOWUP] Log the GetReducerFileGroupResponse size to provide insights

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -366,6 +366,8 @@ class ReducePartitionCommitHandler(
 
               val serializedMsg =
                 context.asInstanceOf[RemoteNettyRpcCallContext].nettyEnv.serialize(returnedMsg)
+              logInfo(
+                s"Shuffle $shuffleId GetReducerFileGroupResponse size " + serializedMsg.capacity())
 
               if (getReducerFileGroupResponseBroadcastEnabled &&
                 serializedMsg.capacity() >= getReducerFileGroupResponseBroadcastMiniSize) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Always log the size of GetReducerFileGroupResponse, which is the most heaviest RPC in client end. 

### Why are the changes needed?
To provide more insights if meet rpc timeout for GetReducerFileGroupResponse.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA.