### PR TITLE
[CELEBORN-2006] LifecycleManager should avoid parsing shufflePartitionType every time

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -329,8 +329,10 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     rpcEnv.address.port
   }
 
+  private val partitionType = conf.shufflePartitionType
+
   def getPartitionType(shuffleId: Int): PartitionType = {
-    shufflePartitionType.getOrDefault(shuffleId, conf.shufflePartitionType)
+    shufflePartitionType.getOrDefault(shuffleId, partitionType)
   }
 
   override def receive: PartialFunction[Any, Unit] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
`org.apache.celeborn.client.LifecycleManager.getPartitionType` may be called frequently, but in Spark scenario it requires each parsing configuration, which is not necessary.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA

