### PR TITLE
[CELEBORN-2008] SlotsAllocator should select disks randomly in RoundRobin mode

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -197,7 +197,8 @@ public class SlotsAllocator {
     if (restrictions != null) {
       List<UsableDiskInfo> usableDiskInfos = restrictions.get(selectedWorker);
       int diskIndex =
-        workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(usableDiskInfos.size()));
+          workerDiskIndex.computeIfAbsent(
+              selectedWorker, v -> rand.nextInt(usableDiskInfos.size()));
       while (usableDiskInfos.get(diskIndex).usableSlots <= 0) {
         diskIndex = (diskIndex + 1) % usableDiskInfos.size();
       }
@@ -227,7 +228,7 @@ public class SlotsAllocator {
                 .collect(Collectors.toList())
                 .toArray(new DiskInfo[0]);
         int diskIndex =
-          workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(diskInfos.length));
+            workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(diskInfos.length));
         storageInfo =
             new StorageInfo(
                 diskInfos[diskIndex].mountPoint(),

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -194,9 +194,10 @@ public class SlotsAllocator {
       int availableStorageTypes) {
     WorkerInfo selectedWorker = workers.get(workerIndex);
     StorageInfo storageInfo;
-    int diskIndex = workerDiskIndex.computeIfAbsent(selectedWorker, v -> 0);
     if (restrictions != null) {
       List<UsableDiskInfo> usableDiskInfos = restrictions.get(selectedWorker);
+      int diskIndex =
+        workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(usableDiskInfos.size()));
       while (usableDiskInfos.get(diskIndex).usableSlots <= 0) {
         diskIndex = (diskIndex + 1) % usableDiskInfos.size();
       }
@@ -225,6 +226,8 @@ public class SlotsAllocator {
                 .filter(p -> p.storageType() != StorageInfo.Type.OSS)
                 .collect(Collectors.toList())
                 .toArray(new DiskInfo[0]);
+        int diskIndex =
+                workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(diskInfos.length));
         storageInfo =
             new StorageInfo(
                 diskInfos[diskIndex].mountPoint(),

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -227,7 +227,7 @@ public class SlotsAllocator {
                 .collect(Collectors.toList())
                 .toArray(new DiskInfo[0]);
         int diskIndex =
-                workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(diskInfos.length));
+          workerDiskIndex.computeIfAbsent(selectedWorker, v -> rand.nextInt(diskInfos.length));
         storageInfo =
             new StorageInfo(
                 diskInfos[diskIndex].mountPoint(),


### PR DESCRIPTION
### What changes were proposed in this pull request?
SlotsAllocator should select disks randomly in RoundRobin mode


### Why are the changes needed?
The current round robin selection mechanism is to select the first disk of each worker first, then the second disk of each worker, and finally the third disk. This can easily cause disk storage space skew. We should select disks randomly instead of selecting the first disk first.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.
