### PR TITLE
[CELEBORN-2009] Commit files request failure should exclude worker in LifecycleManager

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -158,6 +158,8 @@ class WorkerStatusTracker(
         case (workerInfo: WorkerInfo, (statusCode, registerTime)) =>
           statusCode match {
             case StatusCode.WORKER_UNKNOWN |
+                StatusCode.WORKER_UNRESPONSIVE |
+                StatusCode.COMMIT_FILE_EXCEPTION |
                 StatusCode.NO_AVAILABLE_WORKING_DIR |
                 StatusCode.RESERVE_SLOTS_FAILED |
                 StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY |

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -357,7 +357,9 @@ abstract class CommitHandler(
                     logError(
                       s"Request commitFiles return ${StatusCode.COMMIT_FILES_MOCK_FAILURE} for " +
                         s"$shuffleKey for ${status.retriedTimes}/$maxRetries, will not retry")
-                    commitFilesFailedWorkers.put(worker, (StatusCode.COMMIT_FILES_MOCK_FAILURE, System.currentTimeMillis()))
+                    commitFilesFailedWorkers.put(
+                      worker,
+                      (StatusCode.COMMIT_FILES_MOCK_FAILURE, System.currentTimeMillis()))
                     val res = createFailResponse(status)
                     processResponse(res, worker)
                     iter.remove()
@@ -378,7 +380,9 @@ abstract class CommitHandler(
                   s"Ask worker(${worker.readableAddress()}) CommitFiles for $shuffleKey failed" +
                     s" (attempt ${status.retriedTimes}/$maxRetries), will not retry.",
                   e)
-                commitFilesFailedWorkers.put(worker, (StatusCode.WORKER_UNRESPONSIVE, System.currentTimeMillis()))
+                commitFilesFailedWorkers.put(
+                  worker,
+                  (StatusCode.WORKER_UNRESPONSIVE, System.currentTimeMillis()))
                 val res = createFailResponse(status)
                 processResponse(res, status.workerInfo)
                 iter.remove()
@@ -394,7 +398,9 @@ abstract class CommitHandler(
             logError(
               s"Ask worker(${worker.readableAddress()}) CommitFiles for $shuffleKey failed because of Timeout" +
                 s" (attempt ${status.retriedTimes}/$maxRetries), will not retry.")
-            commitFilesFailedWorkers.put(worker, (StatusCode.WORKER_UNRESPONSIVE, System.currentTimeMillis()))
+            commitFilesFailedWorkers.put(
+              worker,
+              (StatusCode.WORKER_UNRESPONSIVE, System.currentTimeMillis()))
           }
         }
       }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -357,6 +357,7 @@ abstract class CommitHandler(
                     logError(
                       s"Request commitFiles return ${StatusCode.COMMIT_FILES_MOCK_FAILURE} for " +
                         s"$shuffleKey for ${status.retriedTimes}/$maxRetries, will not retry")
+                    commitFilesFailedWorkers.put(worker, (StatusCode.COMMIT_FILES_MOCK_FAILURE, System.currentTimeMillis()))
                     val res = createFailResponse(status)
                     processResponse(res, worker)
                     iter.remove()
@@ -377,6 +378,7 @@ abstract class CommitHandler(
                   s"Ask worker(${worker.readableAddress()}) CommitFiles for $shuffleKey failed" +
                     s" (attempt ${status.retriedTimes}/$maxRetries), will not retry.",
                   e)
+                commitFilesFailedWorkers.put(worker, (StatusCode.WORKER_UNRESPONSIVE, System.currentTimeMillis()))
                 val res = createFailResponse(status)
                 processResponse(res, status.workerInfo)
                 iter.remove()
@@ -392,6 +394,7 @@ abstract class CommitHandler(
             logError(
               s"Ask worker(${worker.readableAddress()}) CommitFiles for $shuffleKey failed because of Timeout" +
                 s" (attempt ${status.retriedTimes}/$maxRetries), will not retry.")
+            commitFilesFailedWorkers.put(worker, (StatusCode.WORKER_UNRESPONSIVE, System.currentTimeMillis()))
           }
         }
       }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -91,7 +91,8 @@ public enum StatusCode {
   OPEN_STREAM_FAILED(51),
   SEGMENT_START_FAIL_REPLICA(52),
   SEGMENT_START_FAIL_PRIMARY(53),
-  NO_SPLIT(54);
+  NO_SPLIT(54),
+  WORKER_UNRESPONSIVE(55);
 
   private final byte value;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Exclude worker in lifecycle manager if the commit files request on workers fails with `COMMIT_FILE_EXCEPTION` or after multiple retries. 

### Why are the changes needed?

If worker is under high load and not able to process request because of high CPU, we should exclude it so it will not affect the next retry to shuffle stage.

Internally, we are seeing commit file futures in worker under high load are getting timed out and next retry of the stage is again picking same servers and failing. Similarly, we are seeing continuous RpcTimeout for workers but those workers are again getting selected for next retry.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

NA