### PR TITLE
[CELEBORN-2013] Upgrade scala binary version of spark-3.3, spark-3.4, spark-3.5 profile to 2.13.8

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -161,21 +161,21 @@ jobs:
             scala: '2.12.15'
           - spark: '3.3'
             scala-binary: '2.13'
-            scala: '2.13.5'
+            scala: '2.13.8'
           # Spark 3.4
           - spark: '3.4'
             scala-binary: '2.12'
             scala: '2.12.17'
           - spark: '3.4'
             scala-binary: '2.13'
-            scala: '2.13.5'
+            scala: '2.13.8'
           # Spark 3.5
           - spark: '3.5'
             scala-binary: '2.12'
             scala: '2.12.18'
           - spark: '3.5'
             scala-binary: '2.13'
-            scala: '2.13.5'
+            scala: '2.13.8'
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}

--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -108,7 +108,7 @@ upload_nexus_staging() {
   ${PROJECT_DIR}/build/sbt -Pspark-3.4 "clean;celeborn-client-spark-3-shaded/publishSigned"
 
   echo "Deploying celeborn-client-spark-3-shaded_2.13"
-  ${PROJECT_DIR}/build/sbt -Pspark-3.4 ++2.13.5 "clean;celeborn-client-spark-3-shaded/publishSigned"
+  ${PROJECT_DIR}/build/sbt -Pspark-3.4 ++2.13.8 "clean;celeborn-client-spark-3-shaded/publishSigned"
 
   echo "Deploying celeborn-client-flink-1.16-shaded_2.12"
   ${PROJECT_DIR}/build/sbt -Pflink-1.16 "clean;celeborn-client-flink-1_16-shaded/publishSigned"

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -281,8 +281,9 @@ object CelebornCommonSettings {
   val SCALA_2_12_17 = "2.12.17"
   val SCALA_2_12_18 = "2.12.18"
   val scala213 = "2.13.5"
+  val SCALA_2_13_8 = "2.13.8"
   val scala213_11 = "2.13.11"
-  val ALL_SCALA_VERSIONS = Seq(SCALA_2_11_12, SCALA_2_12_10, SCALA_2_12_15, SCALA_2_12_17, SCALA_2_12_18, scala213, scala213_11)
+  val ALL_SCALA_VERSIONS = Seq(SCALA_2_11_12, SCALA_2_12_10, SCALA_2_12_15, SCALA_2_12_17, SCALA_2_12_18, scala213, SCALA_2_13_8, scala213_11)
 
   val DEFAULT_SCALA_VERSION = SCALA_2_12_18
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade scala binary version of `spark-3.3`, `spark-3.4`, `spark-3.5` profile to 2.13.8.

### Why are the changes needed?

The scala binary version of `spark-3.3`, `spark-3.4`, `spark-3.5` profile is 2.13.8 for scala 2.13.

- https://github.com/apache/spark/blob/v3.3.4/pom.xml#L3548
- https://github.com/apache/spark/blob/v3.4.4/pom.xml#L3646
- https://github.com/apache/spark/blob/v3.5.5/pom.xml#L3681

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.