### PR TITLE
[CELEBORN-2003] Add retry mechanism when completing S3 multipart upload

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1193,8 +1193,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def s3EndpointRegion: String = get(S3_ENDPOINT_REGION).getOrElse("")
 
   def s3MultiplePartUploadMaxRetries: Int = get(S3_MPU_MAX_RETRIES)
-  def s3MultiplePartUploadBaseDelay: Int = get(S3_MPU_BASE_DELAY)
-  def s3MultiplePartUploadMaxBackoff: Int = get(S3_MPU_MAX_BACKOFF)
+  def s3MultiplePartUploadBaseDelay: Int = get(S3_MPU_BASE_DELAY).toInt
+  def s3MultiplePartUploadMaxBackoff: Int = get(S3_MPU_MAX_BACKOFF).toInt
 
   def s3Dir: String = {
     get(S3_DIR).map {
@@ -3189,21 +3189,21 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(5)
 
-  val S3_MPU_BASE_DELAY: ConfigEntry[Int] =
+  val S3_MPU_BASE_DELAY: ConfigEntry[Long] =
     buildConf("celeborn.storage.s3.mpu.baseDelay")
       .categories("worker")
       .version("0.6.0")
       .doc("S3 MPU base sleep time (milliseconds) for retryable exceptions.")
-      .intConf
-      .createWithDefault(100)
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("100ms")
 
-  val S3_MPU_MAX_BACKOFF: ConfigEntry[Int] =
+  val S3_MPU_MAX_BACKOFF: ConfigEntry[Long] =
     buildConf("celeborn.storage.s3.mpu.maxBackoff")
       .categories("worker")
       .version("0.6.0")
       .doc("S3 MPU max sleep time (milliseconds) for retryable exceptions.")
-      .intConf
-      .createWithDefault(20000)
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("20s")
 
   val OSS_ENDPOINT: OptionalConfigEntry[String] =
     buildConf("celeborn.storage.oss.endpoint")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1193,6 +1193,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def s3EndpointRegion: String = get(S3_ENDPOINT_REGION).getOrElse("")
 
   def s3MultiplePartUploadMaxRetries: Int = get(S3_MPU_MAX_RETRIES)
+  def s3MultiplePartUploadBaseDelay: Int = get(S3_MPU_BASE_DELAY)
+  def s3MultiplePartUploadMaxBackoff: Int = get(S3_MPU_MAX_BACKOFF)
 
   def s3Dir: String = {
     get(S3_DIR).map {
@@ -3186,6 +3188,22 @@ object CelebornConf extends Logging {
       .doc("S3 MPU upload max retries.")
       .intConf
       .createWithDefault(5)
+
+  val S3_MPU_BASE_DELAY: ConfigEntry[Int] =
+    buildConf("celeborn.storage.s3.mpu.baseDelay")
+      .categories("worker")
+      .version("0.6.0")
+      .doc("S3 MPU base sleep time (milliseconds) for retryable exceptions.")
+      .intConf
+      .createWithDefault(100)
+
+  val S3_MPU_MAX_BACKOFF: ConfigEntry[Int] =
+    buildConf("celeborn.storage.s3.mpu.maxBackoff")
+      .categories("worker")
+      .version("0.6.0")
+      .doc("S3 MPU max sleep time (milliseconds) for retryable exceptions.")
+      .intConf
+      .createWithDefault(20000)
 
   val OSS_ENDPOINT: OptionalConfigEntry[String] =
     buildConf("celeborn.storage.oss.endpoint")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -53,6 +53,8 @@ license: |
 | celeborn.storage.oss.secret.key | &lt;undefined&gt; | false | OSS secret key for Celeborn to store shuffle data. | 0.6.0 |  | 
 | celeborn.storage.s3.dir | &lt;undefined&gt; | false | S3 base directory for Celeborn to store shuffle data. | 0.6.0 |  | 
 | celeborn.storage.s3.endpoint.region | &lt;undefined&gt; | false | S3 endpoint for Celeborn to store shuffle data. | 0.6.0 |  | 
+| celeborn.storage.s3.mpu.baseDelay | 100 | false | S3 MPU base sleep time (milliseconds) for retryable exceptions. | 0.6.0 |  | 
+| celeborn.storage.s3.mpu.maxBackoff | 20000 | false | S3 MPU max sleep time (milliseconds) for retryable exceptions. | 0.6.0 |  | 
 | celeborn.storage.s3.mpu.maxRetries | 5 | false | S3 MPU upload max retries. | 0.6.0 |  | 
 | celeborn.worker.activeConnection.max | &lt;undefined&gt; | false | If the number of active connections on a worker exceeds this configuration value, the worker will be marked as high-load in the heartbeat report, and the master will not include that node in the response of RequestSlots. | 0.3.1 |  | 
 | celeborn.worker.applicationRegistry.cache.size | 10000 | false | Cache size of the application registry on Workers. | 0.5.0 |  | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -53,8 +53,8 @@ license: |
 | celeborn.storage.oss.secret.key | &lt;undefined&gt; | false | OSS secret key for Celeborn to store shuffle data. | 0.6.0 |  | 
 | celeborn.storage.s3.dir | &lt;undefined&gt; | false | S3 base directory for Celeborn to store shuffle data. | 0.6.0 |  | 
 | celeborn.storage.s3.endpoint.region | &lt;undefined&gt; | false | S3 endpoint for Celeborn to store shuffle data. | 0.6.0 |  | 
-| celeborn.storage.s3.mpu.baseDelay | 100 | false | S3 MPU base sleep time (milliseconds) for retryable exceptions. | 0.6.0 |  | 
-| celeborn.storage.s3.mpu.maxBackoff | 20000 | false | S3 MPU max sleep time (milliseconds) for retryable exceptions. | 0.6.0 |  | 
+| celeborn.storage.s3.mpu.baseDelay | 100ms | false | S3 MPU base sleep time (milliseconds) for retryable exceptions. | 0.6.0 |  | 
+| celeborn.storage.s3.mpu.maxBackoff | 20s | false | S3 MPU max sleep time (milliseconds) for retryable exceptions. | 0.6.0 |  | 
 | celeborn.storage.s3.mpu.maxRetries | 5 | false | S3 MPU upload max retries. | 0.6.0 |  | 
 | celeborn.worker.activeConnection.max | &lt;undefined&gt; | false | If the number of active connections on a worker exceeds this configuration value, the worker will be marked as high-load in the heartbeat report, and the master will not include that node in the response of RequestSlots. | 0.3.1 |  | 
 | celeborn.worker.applicationRegistry.cache.size | 10000 | false | Cache size of the application registry on Workers. | 0.5.0 |  | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/TierWriterHelper.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/TierWriterHelper.java
@@ -24,7 +24,12 @@ import org.apache.celeborn.server.common.service.mpu.MultipartUploadHandler;
 
 public class TierWriterHelper {
   public static MultipartUploadHandler getS3MultipartUploadHandler(
-      FileSystem hadoopFs, String bucketName, String key, int maxRetryies) {
+      FileSystem hadoopFs,
+      String bucketName,
+      String key,
+      int maxRetryies,
+      int baseDelay,
+      int maxBackoff) {
     return (MultipartUploadHandler)
         DynConstructors.builder()
             .impl(
@@ -32,9 +37,11 @@ public class TierWriterHelper {
                 FileSystem.class,
                 String.class,
                 String.class,
+                Integer.class,
+                Integer.class,
                 Integer.class)
             .build()
-            .newInstance(hadoopFs, bucketName, key, maxRetryies);
+            .newInstance(hadoopFs, bucketName, key, maxRetryies, baseDelay, maxBackoff);
   }
 
   public static MultipartUploadHandler getOssMultipartUploadHandler(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -539,7 +539,9 @@ class DfsTierWriter(
         hadoopFs,
         bucketName,
         key,
-        conf.s3MultiplePartUploadMaxRetries)
+        conf.s3MultiplePartUploadMaxRetries,
+        conf.s3MultiplePartUploadBaseDelay,
+        conf.s3MultiplePartUploadMaxBackoff)
       s3MultipartUploadHandler.startUpload()
     } else if (hdfsFileInfo.isOSS) {
       val configuration = hadoopFs.getConf


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Add a retry mechanism when completing S3 multipart upload to ensure that completeMultipartUpload is retry when facing retryable exception like SlowDown one

### Why are the changes needed?

While running a “simple” spark jobs creating 10TiB of shuffle data (repartition from 100k partition to 20) the job was constantly failing when all files should be committed. relying on SOFT `celeborn.client.shuffle.partitionSplit.mode`

Despite an increase of `celeborn.storage.s3.mpu.maxRetries` up to `200`. Job was still failing due to SlowDown exception
Adding some debug logs on the retry policy from AWS S3 SDK I've seen that the policy is never called when doing completeMultipartUpload action while it is well called on other actions. See https://issues.apache.org/jira/browse/CELEBORN-2003

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Created a cluster on a kubernetes server relying on S3 storage.
Launch a 10TiB shuffle from 100000 partitions to 200 partitions with SOFT `celeborn.client.shuffle.partitionSplit.mode`
The job succeed and well display some warn logs indicating that the `completeMultipartUpload` is retried due to SlowDown:
```
bucket ******* key poc/spark-2c86663c948243d19c127e90f704a3d5/0/35-39-0 uploadId Pbaq.pp1qyLvtGbfZrMwA8RgLJ4QYanAMhmv0DvKUk0m6.GlCKdC3ICGngn7Q7iIa0Dw1h3wEn78EoogMlYgFD6.tDqiatOTbFprsNkk0qzLu9KY8YCC48pqaINcvgi8c1gQKKhsf1zZ.5Et5j40wQ-- upload failed to complete, will retry (1/10)
com.amazonaws.services.s3.model.AmazonS3Exception: Please reduce your request rate. (Service: null; Status Code: 0; Error Code: SlowDown; Request ID: RAV5MXX3B9Z3ZHTG; S3 Extended Request ID: 9Qqm3vfJVLFNY1Y3yKAobJHv7JkHQP2+v8hGSW2HYIOputAtiPdkqkY5MfD66lEzAl45m71aiPVB0f1TxTUD+upUo0NxXp6S; Proxy: null), S3 Extended Request ID: 9Qqm3vfJVLFNY1Y3yKAobJHv7JkHQP2+v8hGSW2HYIOputAtiPdkqkY5MfD66lEzAl45m71aiPVB0f1TxTUD+upUo0NxXp6S 	at com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser$CompleteMultipartUploadHandler.doEndElement(XmlResponsesSaxParser.java:1906)
```




