### PR TITLE
[CELEBORN-2018] Support min number of workers selected for shuffle

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -674,6 +674,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(MASTER_SLOT_ASSIGN_LOADAWARE_FETCHTIME_WEIGHT)
   def masterSlotAssignExtraSlots: Int = get(MASTER_SLOT_ASSIGN_EXTRA_SLOTS)
   def masterSlotAssignMaxWorkers: Int = get(MASTER_SLOT_ASSIGN_MAX_WORKERS)
+  def masterSlotAssignMinWorkers: Int = get(MASTER_SLOT_ASSIGN_MIN_WORKERS)
   def initialEstimatedPartitionSize: Long = get(ESTIMATED_PARTITION_SIZE_INITIAL_SIZE)
   def estimatedPartitionSizeUpdaterInitialDelay: Long =
     get(ESTIMATED_PARTITION_SIZE_UPDATE_INITIAL_DELAY)
@@ -2972,9 +2973,9 @@ object CelebornConf extends Logging {
       .withAlternative("celeborn.slots.assign.extraSlots")
       .categories("master")
       .version("0.3.0")
-      .doc("Extra slots number when master assign slots.")
+      .doc("Extra slots number when master assign slots. Provided ")
       .intConf
-      .createWithDefault(100)
+      .createWithDefault(2)
 
   val MASTER_SLOT_ASSIGN_MAX_WORKERS: ConfigEntry[Int] =
     buildConf("celeborn.master.slot.assign.maxWorkers")
@@ -2984,6 +2985,14 @@ object CelebornConf extends Logging {
         s"from Master side and Client side, see `celeborn.client.slot.assign.maxWorkers`.")
       .intConf
       .createWithDefault(10000)
+
+  val MASTER_SLOT_ASSIGN_MIN_WORKERS: ConfigEntry[Int] =
+    buildConf("celeborn.master.slot.assign.minWorkers")
+      .categories("master")
+      .version("0.6.0")
+      .doc("Min workers that slots of one shuffle should be allocated on. Provided we have w")
+      .intConf
+      .createWithDefault(100)
 
   val ESTIMATED_PARTITION_SIZE_INITIAL_SIZE: ConfigEntry[Long] =
     buildConf("celeborn.master.estimatedPartitionSize.initialSize")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2973,7 +2973,7 @@ object CelebornConf extends Logging {
       .withAlternative("celeborn.slots.assign.extraSlots")
       .categories("master")
       .version("0.3.0")
-      .doc("Extra slots number when master assign slots. Provided ")
+      .doc("Extra slots number when master assign slots. Provided enough workers are available.")
       .intConf
       .createWithDefault(2)
 
@@ -2990,7 +2990,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.master.slot.assign.minWorkers")
       .categories("master")
       .version("0.6.0")
-      .doc("Min workers that slots of one shuffle should be allocated on. Provided we have w")
+      .doc("Min workers that slots of one shuffle should be allocated on. Provided we have enough workers available.")
       .intConf
       .createWithDefault(100)
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2990,7 +2990,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.master.slot.assign.minWorkers")
       .categories("master")
       .version("0.6.0")
-      .doc("Min workers that slots of one shuffle should be allocated on. Provided we have enough workers available.")
+      .doc("Min workers that slots of one shuffle should be allocated on. Provided enough workers are available.")
       .intConf
       .createWithDefault(100)
 

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -71,12 +71,13 @@ license: |
 | celeborn.master.port | 9097 | false | Port for master to bind. | 0.2.0 |  | 
 | celeborn.master.rackResolver.refresh.interval | 30s | false | Interval for refreshing the node rack information periodically. | 0.5.0 |  | 
 | celeborn.master.send.applicationMeta.threads | 8 | false | Number of threads used by the Master to send ApplicationMeta to Workers. | 0.5.0 |  | 
-| celeborn.master.slot.assign.extraSlots | 100 | false | Extra slots number when master assign slots. | 0.3.0 | celeborn.slots.assign.extraSlots | 
+| celeborn.master.slot.assign.extraSlots | 2 | false | Extra slots number when master assign slots. Provided enough workers are available. | 0.3.0 | celeborn.slots.assign.extraSlots | 
 | celeborn.master.slot.assign.loadAware.diskGroupGradient | 0.1 | false | This value means how many more workload will be placed into a faster disk group than a slower group. | 0.3.0 | celeborn.slots.assign.loadAware.diskGroupGradient | 
 | celeborn.master.slot.assign.loadAware.fetchTimeWeight | 1.0 | false | Weight of average fetch time when calculating ordering in load-aware assignment strategy | 0.3.0 | celeborn.slots.assign.loadAware.fetchTimeWeight | 
 | celeborn.master.slot.assign.loadAware.flushTimeWeight | 0.0 | false | Weight of average flush time when calculating ordering in load-aware assignment strategy | 0.3.0 | celeborn.slots.assign.loadAware.flushTimeWeight | 
 | celeborn.master.slot.assign.loadAware.numDiskGroups | 5 | false | This configuration is a guidance for load-aware slot allocation algorithm. This value is control how many disk groups will be created. | 0.3.0 | celeborn.slots.assign.loadAware.numDiskGroups | 
 | celeborn.master.slot.assign.maxWorkers | 10000 | false | Max workers that slots of one shuffle can be allocated on. Will choose the smaller positive one from Master side and Client side, see `celeborn.client.slot.assign.maxWorkers`. | 0.3.1 |  | 
+| celeborn.master.slot.assign.minWorkers | 100 | false | Min workers that slots of one shuffle should be allocated on. Provided enough workers are available. | 0.6.0 |  | 
 | celeborn.master.slot.assign.policy | ROUNDROBIN | false | Policy for master to assign slots, Celeborn supports two types of policy: roundrobin and loadaware. Loadaware policy will be ignored when `HDFS` is enabled in `celeborn.storage.availableTypes` | 0.3.0 | celeborn.slots.assign.policy | 
 | celeborn.master.userResourceConsumption.metrics.enabled | false | false | Whether to enable resource consumption metrics. | 0.6.0 |  | 
 | celeborn.master.userResourceConsumption.update.interval | 30s | false | Time length for a window about compute user resource consumption. | 0.3.0 |  | 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,7 +33,7 @@ license: |
 
 - Since 0.6.0, Celeborn modified `celeborn.master.hdfs.expireDirs.timeout` to `celeborn.master.dfs.expireDirs.timeout`. Please use `cceleborn.master.dfs.expireDirs.timeout` if you want to set timeout for an expired dirs to be deleted.
 
-- Since 0.6.0, Celeborn changed the default value of `celeborn.master.slot.assign.extraSlots` from `2` to `100`, which means Celeborn will involve more workers in offering slots.
+- Since 0.6.0, Celeborn introduced `celeborn.master.slot.assign.minWorkers` with default value of `100`, which means Celeborn will involve more workers in offering slots when number of reducers are less.
 
 - Since 0.6.0, Celeborn deprecate `celeborn.worker.congestionControl.low.watermark`. Please use `celeborn.worker.congestionControl.diskBuffer.low.watermark` instead.
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -201,6 +201,8 @@ private[celeborn] class Master(
   private val tagsManager = new TagsManager(Option(configService))
 
   private val slotsAssignMaxWorkers = conf.masterSlotAssignMaxWorkers
+  private val slotsAssignMinWorkers = conf.masterSlotAssignMinWorkers
+  private val slotsAssignExtraSlots = conf.masterSlotAssignExtraSlots
   private val slotsAssignLoadAwareDiskGroupNum = conf.masterSlotAssignLoadAwareDiskGroupNum
   private val slotsAssignLoadAwareDiskGroupGradient =
     conf.masterSlotAssignLoadAwareDiskGroupGradient
@@ -978,7 +980,8 @@ private[celeborn] class Master(
       s" on ${slots.size()} workers.")
 
     val workersNotSelected = availableWorkers.asScala.filter(!slots.containsKey(_))
-    val offerSlotsExtraSize = Math.min(conf.masterSlotAssignExtraSlots, workersNotSelected.size)
+    val offerSlotsExtraSize = Math.min(Math.max(
+      slotsAssignExtraSlots, slots.size() - slotsAssignMinWorkers), workersNotSelected.size)
     if (offerSlotsExtraSize > 0) {
       var index = Random.nextInt(workersNotSelected.size)
       (1 to offerSlotsExtraSize).foreach(_ => {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -982,7 +982,7 @@ private[celeborn] class Master(
     val offerSlotsExtraSize = Math.min(
       Math.max(
         slotsAssignExtraSlots,
-        slots.size() - slotsAssignMinWorkers),
+        slotsAssignMinWorkers - slots.size()),
       workersNotSelected.size)
     if (offerSlotsExtraSize > 0) {
       var index = Random.nextInt(workersNotSelected.size)

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -18,14 +18,20 @@
 package org.apache.celeborn.service.deploy.master
 
 import java.nio.file.Files
-
 import org.mockito.Mockito.mock
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
-
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.protocol.{PbCheckForWorkerTimeout, PbRegisterWorker}
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.metrics.source.Role
+import org.apache.celeborn.common.protocol.message.ControlMessages.RequestSlots
+import org.apache.celeborn.common.protocol.{PbCheckForWorkerTimeout, PbRegisterWorker, TransportModuleConstants}
+import org.apache.celeborn.common.rpc.netty.NettyRpcEnvFactory
+import org.apache.celeborn.common.rpc.{RpcEndpoint, RpcEnv, RpcEnvConfig}
 import org.apache.celeborn.common.util.{CelebornExitKind, ThreadUtils}
+
+import java.util
+import scala.collection.JavaConverters.seqAsJavaListConverter
 
 class MasterSuite extends AnyFunSuite
   with BeforeAndAfterAll
@@ -37,6 +43,26 @@ class MasterSuite extends AnyFunSuite
     tmpDir.deleteOnExit()
     tmpDir.getAbsolutePath
   }
+
+  def createRpcEnv(
+                    conf: CelebornConf,
+                    name: String,
+                    port: Int,
+                    clientMode: Boolean = false): RpcEnv = {
+    val config = RpcEnvConfig(
+      conf,
+      "test",
+      TransportModuleConstants.RPC_MODULE,
+      "localhost",
+      "localhost",
+      port,
+      0,
+      Role.CLIENT,
+      None,
+      None)
+    new NettyRpcEnvFactory().create(config)
+  }
+
 
   test("test single node startup functionality") {
     withRetryOnPortBindException { () =>
@@ -154,4 +180,38 @@ class MasterSuite extends AnyFunSuite
     assert(master.workerHostAllowedToRegister("deny.k8s.io"))
     master.rpcEnv.shutdown()
   }
+
+  test("test min assign slots") {
+    val conf = new CelebornConf()
+    val randomMasterPort = selectRandomPort()
+    val randomHttpPort = selectRandomPort()
+    conf.set(CelebornConf.HA_ENABLED.key, "false")
+    conf.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR.key, getTmpDir())
+    conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, getTmpDir())
+    conf.set(CelebornConf.MASTER_HTTP_HOST.key, "127.0.0.1")
+    conf.set(CelebornConf.MASTER_HTTP_PORT.key, randomHttpPort.toString)
+
+    val args = Array("-h", "localhost", "-p", randomMasterPort.toString)
+
+    val masterArgs = new MasterArguments(args, conf)
+    val master = new Master(conf, masterArgs)
+
+    val requestSlots = RequestSlots("app_id", 0, new util.ArrayList(List[Integer](0, 1).asJava), "localhost", false, false, new UserIdentifier("tenant", "user"), 100, conf.availableStorageTypes)
+
+    val anotherEnv = createRpcEnv(new CelebornConf(), "remote", 0)
+
+    anotherEnv.
+
+//    master.receiveAndReply(
+//      mock(classOf[org.apache.celeborn.common.rpc.RpcCallContext]), requestSlots).applyOrElse(
+//      requestSlots,
+//      (_: Any) => fail("Unexpected message"))
+//    master.handleRequestSlots()
+//    assert(master.workerHostAllowedToRegister("test.k8s.io"))
+//    assert(!master.workerHostAllowedToRegister("test.k8s.io.com"))
+//    assert(!master.workerHostAllowedToRegister("test.example.com"))
+//    assert(!master.workerHostAllowedToRegister("deny.k8s.io"))
+    master.rpcEnv.shutdown()
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Support min number of workers to assign slots on for a shuffle.

### Why are the changes needed?

PR https://github.com/apache/celeborn/pull/3039 updated the default value of `celeborn.master.slot.assign.extraSlots` to avoid skew in shuffle stage with less number of reducers. However, it will also affect the stage with large number of reducers, thus not ideal.

We are introducing a new config `celeborn.master.slot.assign.minWorkers` which will ensure that shuffle stages with less number of reducers will not cause load imbalance on few nodes.


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
NA
