### PR TITLE
[CELEBORN-2027] Allow CelebornShuffleReader to decompress data on demand

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -57,8 +57,30 @@ class CelebornShuffleReader[K, C](
     context: TaskContext,
     conf: CelebornConf,
     metrics: ShuffleReadMetricsReporter,
-    shuffleIdTracker: ExecutorShuffleIdTracker)
+    shuffleIdTracker: ExecutorShuffleIdTracker,
+    needDecompress: Boolean)
   extends ShuffleReader[K, C] with Logging {
+
+  def this(
+      handle: CelebornShuffleHandle[K, _, C],
+      startPartition: Int,
+      endPartition: Int,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      context: TaskContext,
+      conf: CelebornConf,
+      metrics: ShuffleReadMetricsReporter,
+      shuffleIdTracker: ExecutorShuffleIdTracker) = this(
+    handle,
+    startPartition,
+    endPartition,
+    startMapIndex,
+    endMapIndex,
+    context,
+    conf,
+    metrics,
+    shuffleIdTracker,
+    true)
 
   private val dep = handle.dependency
 
@@ -314,7 +336,8 @@ class CelebornShuffleReader[K, C](
             fileGroups.pushFailedBatches,
             partitionId2ChunkRange.get(partitionId),
             fileGroups.mapAttempts,
-            metricsCallback)
+            metricsCallback,
+            needDecompress)
           streams.put(partitionId, inputStream)
         } catch {
           case e: IOException =>

--- a/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -151,7 +151,8 @@ public class DummyShuffleClient extends ShuffleClient {
       Map<String, LocationPushFailedBatches> failedBatchSetMap,
       Map<String, Pair<Integer, Integer>> chunksRange,
       int[] mapAttempts,
-      MetricsCallback metricsCallback)
+      MetricsCallback metricsCallback,
+      boolean needDecompress)
       throws IOException {
     return null;
   }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -256,7 +256,8 @@ public abstract class ShuffleClient {
         null,
         null,
         null,
-        metricsCallback);
+        metricsCallback,
+        true);
   }
 
   public abstract CelebornInputStream readPartition(
@@ -273,7 +274,8 @@ public abstract class ShuffleClient {
       Map<String, LocationPushFailedBatches> failedBatchSetMap,
       Map<String, Pair<Integer, Integer>> chunksRange,
       int[] mapAttempts,
-      MetricsCallback metricsCallback)
+      MetricsCallback metricsCallback,
+      boolean needDecompress)
       throws IOException;
 
   public abstract boolean cleanupShuffle(int shuffleId);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1930,7 +1930,8 @@ public class ShuffleClientImpl extends ShuffleClient {
       Map<String, LocationPushFailedBatches> failedBatchSetMap,
       Map<String, Pair<Integer, Integer>> chunksRange,
       int[] mapAttempts,
-      MetricsCallback metricsCallback)
+      MetricsCallback metricsCallback,
+      boolean needDecompress)
       throws IOException {
     if (shuffleId == Utils$.MODULE$.UNKNOWN_APP_SHUFFLE_ID()) {
       logger.warn("Shuffle data is empty for shuffle {}: UNKNOWN_APP_SHUFFLE_ID.", shuffleId);
@@ -1973,7 +1974,8 @@ public class ShuffleClientImpl extends ShuffleClient {
           shuffleId,
           partitionId,
           exceptionMaker,
-          metricsCallback);
+          metricsCallback,
+          needDecompress);
     }
   }
 

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -166,7 +166,8 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
       null,
       null,
       null,
-      metricsCallback)
+      metricsCallback,
+      true)
     Assert.assertEquals(stream.read(), -1)
 
     // reduce normal null partition for CelebornInputStream
@@ -184,7 +185,8 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
       null,
       null,
       null,
-      metricsCallback)
+      metricsCallback,
+      true)
     Assert.assertEquals(stream.read(), -1)
   }
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/LocalReadByChunkOffsetsTest.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/LocalReadByChunkOffsetsTest.scala
@@ -144,7 +144,8 @@ class LocalReadByChunkOffsetsTest extends AnyFunSuite
       Collections.emptyMap(), // failed batch could not be null
       subMap, // sub-partition chunk range
       null,
-      metricsCallback)
+      metricsCallback,
+      true)
     val outputStream = new ByteArrayOutputStream()
 
     var b = inputStream.read()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -118,7 +118,8 @@ trait ReadWriteTestBase extends AnyFunSuite
       null,
       null,
       null,
-      metricsCallback)
+      metricsCallback,
+      true)
     val outputStream = new ByteArrayOutputStream()
 
     var b = inputStream.read()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestWithFailures.scala
@@ -116,7 +116,8 @@ class ReadWriteTestWithFailures extends AnyFunSuite
       null,
       null,
       null,
-      metricsCallback)
+      metricsCallback,
+      true)
 
     val outputStream = new ByteArrayOutputStream()
     var b = inputStream.read()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
At a new parameter, allow CelebornShuffleReader to decompress data on demand


### Why are the changes needed?
In the current scenario of Gluten Fallback, a stage can have both Native and Java shuffles simultaneously. In [CELEBORN-1625](https://issues.apache.org/jira/browse/CELEBORN-1625), we introduced a new parameter to conditionally skip compression. Alongside this, we should add a corresponding parameter to ensure that the Celeborn shuffle reader does not decompress data when compression is skipped at pushOrMergeData.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA
