### PR TITLE
[CELEBORN-2032] Create reader should change to peer by taskAttemptId

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -246,7 +246,9 @@ class CelebornShuffleReader[K, C](
         val hasReplicate = originLocations.asScala.exists(p => p != null && p.hasPeer)
         var locations =
           if (encodedAttemptId % 2 == 1 && hasReplicate) {
-            originLocations.asScala.map(_.getPeer).asJava
+            originLocations.asScala.map { p =>
+              if (p != null && p.hasPeer) p.getPeer else p
+            }.asJava
           } else {
             originLocations
           }

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -245,7 +245,7 @@ class CelebornShuffleReader[K, C](
         val originLocations = fileGroups.partitionGroups.get(partitionId)
         val hasReplicate = originLocations.asScala.exists(p => p != null && p.hasPeer)
         var locations =
-          if (encodedAttemptId % 2 == 1 && hasReplicate) {
+          if (context.attemptNumber % 2 == 1 && hasReplicate) {
             originLocations.asScala.map { p =>
               if (p != null && p.hasPeer) p.getPeer else p
             }.asJava
@@ -266,8 +266,8 @@ class CelebornShuffleReader[K, C](
               partitionLocation2ChunkRange.containsKey(location.getUniqueId)
             }
           locations = filterLocations.asJava
-          partitionId2PartitionLocations.put(partitionId, locations)
         }
+        partitionId2PartitionLocations.put(partitionId, locations)
         makeOpenStreamList(locations)
       }
     }
@@ -310,12 +310,7 @@ class CelebornShuffleReader[K, C](
     val streams = JavaUtils.newConcurrentHashMap[Integer, CelebornInputStream]()
 
     def createInputStream(partitionId: Int): Unit = {
-      val locations =
-        if (splitSkewPartitionWithoutMapRange) {
-          partitionId2PartitionLocations.get(partitionId)
-        } else {
-          fileGroups.partitionGroups.get(partitionId)
-        }
+      val locations = partitionId2PartitionLocations.get(partitionId)
 
       val locationList =
         if (null == locations) {

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -568,13 +568,6 @@ public abstract class CelebornInputStream extends InputStream {
         Optional<PartitionReaderCheckpointMetadata> checkpointMetadata)
         throws IOException, InterruptedException {
 
-      // CELEBORN-2032. For the first creation of a reader (non-retries) and
-      // attemptNumber % 2 = 1, we should read the replica data first.
-      if (location.hasPeer() && fetchChunkRetryCnt == 0 && attemptNumber % 2 == 1) {
-        location = location.getPeer();
-        logger.debug("Read peer {} for attempt {}.", location, attemptNumber);
-      }
-
       StorageInfo storageInfo = location.getStorageInfo();
 
       int startChunkIndex = -1;

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -568,6 +568,13 @@ public abstract class CelebornInputStream extends InputStream {
         Optional<PartitionReaderCheckpointMetadata> checkpointMetadata)
         throws IOException, InterruptedException {
 
+      // CELEBORN-2032. For the first creation of a reader (non-retries) and
+      // attemptNumber % 2 = 1, we should read the replica data first.
+      if (location.hasPeer() && fetchChunkRetryCnt == 0 && attemptNumber % 2 == 1) {
+        location = location.getPeer();
+        logger.debug("Read peer {} for attempt {}.", location, attemptNumber);
+      }
+
       StorageInfo storageInfo = location.getStorageInfo();
 
       int startChunkIndex = -1;


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the dual-replica scenario, when creating a reader, we should select the replica based on taskAttemptId. Usually, taskAttempt0 selects primary partitionLocation, task Attempt1 selects replica partitionLocation, and so on. This will provide better fault tolerance.


### Why are the changes needed?
Since https://github.com/apache/celeborn/pull/3079, we deleted the code logic which should use replica data when task attempt is odd, but if the data of primary partitionLocation is corrupted and CelebornInputStream#fillBuffer throws exception, such as decompression failure or some other exceptions, the replica prititionLocation will not be used when the task is retried. In fact, if taskAttempt1 uses the replica partitionLocation, taskAttempt1 can run successfully.

![image](https://github.com/user-attachments/assets/3e9ec15d-a82a-40d2-8dc4-6eff46371249)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.
