### PR TITLE
[CELEBORN-1572][FOLLOWUP] Support to show Celeborn CLI version for sub command

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/CelebornCli.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/CelebornCli.scala
@@ -19,18 +19,16 @@ package org.apache.celeborn.cli
 import picocli.CommandLine
 import picocli.CommandLine.Command
 
-import org.apache.celeborn.cli.common.{CliLogging, CliVersionProvider}
+import org.apache.celeborn.cli.common.BaseCommand
 import org.apache.celeborn.cli.master.MasterSubcommandImpl
 import org.apache.celeborn.cli.worker.WorkerSubcommandImpl
 @Command(
   name = "celeborn-cli",
-  versionProvider = classOf[CliVersionProvider],
-  mixinStandardHelpOptions = true,
   description = Array("@|bold Scala|@ Celeborn CLI"),
   subcommands = Array(
     classOf[MasterSubcommandImpl],
     classOf[WorkerSubcommandImpl]))
-class CelebornCli extends Runnable with CliLogging {
+class CelebornCli extends BaseCommand {
   override def run(): Unit = {
     logError(
       "Master or Worker subcommand needs to be provided. Please run -h to see the usage info.")

--- a/cli/src/main/scala/org/apache/celeborn/cli/common/BaseCommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/common/BaseCommand.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.cli.common
+
+import picocli.CommandLine.Command
+
+@Command(mixinStandardHelpOptions = true, versionProvider = classOf[CliVersionProvider])
+abstract class BaseCommand extends Runnable with CliLogging {}

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
@@ -23,13 +23,13 @@ import picocli.CommandLine.{ArgGroup, Mixin, ParameterException, ParentCommand, 
 import picocli.CommandLine.Model.CommandSpec
 
 import org.apache.celeborn.cli.CelebornCli
-import org.apache.celeborn.cli.common.{CliLogging, CommonOptions}
+import org.apache.celeborn.cli.common.{BaseCommand, CliLogging, CommonOptions}
 import org.apache.celeborn.cli.config.CliConfigManager
 import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, MasterApi, ShuffleApi, WorkerApi}
 import org.apache.celeborn.rest.v1.master.invoker.ApiClient
 import org.apache.celeborn.rest.v1.model._
 
-trait MasterSubcommand extends CliLogging {
+trait MasterSubcommand extends BaseCommand {
 
   @ParentCommand
   private var celebornCli: CelebornCli = _

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -24,16 +24,12 @@ import scala.collection.JavaConverters._
 import org.apache.commons.lang3.StringUtils
 import picocli.CommandLine.{Command, ParameterException}
 
-import org.apache.celeborn.cli.common.CliVersionProvider
 import org.apache.celeborn.cli.config.CliConfigManager
 import org.apache.celeborn.rest.v1.model._
 import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest.EventTypeEnum
 
-@Command(
-  name = "master",
-  versionProvider = classOf[CliVersionProvider],
-  mixinStandardHelpOptions = true)
-class MasterSubcommandImpl extends Runnable with MasterSubcommand {
+@Command(name = "master")
+class MasterSubcommandImpl extends MasterSubcommand {
   override def run(): Unit = {
     if (masterOptions.showMastersInfo) log(runShowMastersInfo)
     if (masterOptions.showClusterApps) log(runShowClusterApps)

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -20,16 +20,19 @@ package org.apache.celeborn.cli.master
 import java.util
 
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 import org.apache.commons.lang3.StringUtils
 import picocli.CommandLine.{Command, ParameterException}
 
+import org.apache.celeborn.cli.common.CliVersionProvider
 import org.apache.celeborn.cli.config.CliConfigManager
 import org.apache.celeborn.rest.v1.model._
 import org.apache.celeborn.rest.v1.model.SendWorkerEventRequest.EventTypeEnum
 
-@Command(name = "master", mixinStandardHelpOptions = true)
+@Command(
+  name = "master",
+  versionProvider = classOf[CliVersionProvider],
+  mixinStandardHelpOptions = true)
 class MasterSubcommandImpl extends Runnable with MasterSubcommand {
   override def run(): Unit = {
     if (masterOptions.showMastersInfo) log(runShowMastersInfo)

--- a/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommand.scala
@@ -21,12 +21,12 @@ import picocli.CommandLine.{ArgGroup, Mixin, ParameterException, ParentCommand, 
 import picocli.CommandLine.Model.CommandSpec
 
 import org.apache.celeborn.cli.CelebornCli
-import org.apache.celeborn.cli.common.{CliLogging, CommonOptions}
+import org.apache.celeborn.cli.common.{BaseCommand, CliLogging, CommonOptions}
 import org.apache.celeborn.rest.v1.model._
 import org.apache.celeborn.rest.v1.worker.{ApplicationApi, ConfApi, DefaultApi, ShuffleApi, WorkerApi}
 import org.apache.celeborn.rest.v1.worker.invoker.ApiClient
 
-trait WorkerSubcommand extends CliLogging {
+trait WorkerSubcommand extends BaseCommand {
 
   @ParentCommand
   private var celebornCli: CelebornCli = _

--- a/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommandImpl.scala
@@ -19,15 +19,11 @@ package org.apache.celeborn.cli.worker
 
 import picocli.CommandLine.Command
 
-import org.apache.celeborn.cli.common.CliVersionProvider
 import org.apache.celeborn.rest.v1.model._
 import org.apache.celeborn.rest.v1.model.WorkerExitRequest.TypeEnum
 
-@Command(
-  name = "worker",
-  versionProvider = classOf[CliVersionProvider],
-  mixinStandardHelpOptions = true)
-class WorkerSubcommandImpl extends Runnable with WorkerSubcommand {
+@Command(name = "worker")
+class WorkerSubcommandImpl extends WorkerSubcommand {
 
   override def run(): Unit = {
     if (workerOptions.showWorkerInfo) log(runShowWorkerInfo)

--- a/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommandImpl.scala
@@ -19,10 +19,14 @@ package org.apache.celeborn.cli.worker
 
 import picocli.CommandLine.Command
 
+import org.apache.celeborn.cli.common.CliVersionProvider
 import org.apache.celeborn.rest.v1.model._
 import org.apache.celeborn.rest.v1.model.WorkerExitRequest.TypeEnum
 
-@Command(name = "worker", mixinStandardHelpOptions = true)
+@Command(
+  name = "worker",
+  versionProvider = classOf[CliVersionProvider],
+  mixinStandardHelpOptions = true)
 class WorkerSubcommandImpl extends Runnable with WorkerSubcommand {
 
   override def run(): Unit = {

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -305,6 +305,13 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureErrorAndValidateResponse(args, "Invalid timestamp for worker")
   }
 
+  test("--version") {
+    val versionInfo = "Could not resolve version of Celeborn since no RELEASE file was found"
+    captureOutputAndValidateResponse(Array("--version"), versionInfo)
+    captureOutputAndValidateResponse(Array("master", "--version"), versionInfo)
+    captureOutputAndValidateResponse(Array("worker", "--version"), versionInfo)
+  }
+
   private def prepareMasterArgs(): Array[String] = {
     Array(
       "master",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Support to show Celeborn CLI version for sub command.


### Why are the changes needed?

celeborn-cli [master|worker] -V does not show anything.

```
(base) ➜  apache-celeborn-0.6.0-bin-ebay ./sbin/celeborn-cli -V
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Celeborn CLI - Celeborn 0.6.0
(base) ➜  apache-celeborn-0.6.0-bin-ebay ./sbin/celeborn-cli -V
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Celeborn CLI - Celeborn 0.6.0
(base) ➜  apache-celeborn-0.6.0-bin-ebay ./sbin/celeborn-cli master -V
(base) ➜  apache-celeborn-0.6.0-bin-ebay ./sbin/celeborn-cli worker -V
(base) ➜  apache-celeborn-0.6.0-bin-ebay ./sbin/celeborn-cli master -h
Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
...
(base) ➜  apache-celeborn-0.6.0-bin-ebay ./sbin/celeborn-cli worker -h
Usage: celeborn-cli worker [-hV] [--apps=appId] [--auth-header=authHeader]
...
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

UT.

```
(base) ➜  celeborn git:(cli_version) ./dist/sbin/celeborn-cli -V
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Celeborn CLI - Celeborn 0.7.0-SNAPSHOT
(base) ➜  celeborn git:(cli_version) ./dist/sbin/celeborn-cli master -V
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Celeborn CLI - Celeborn 0.7.0-SNAPSHOT
(base) ➜  celeborn git:(cli_version) ./dist/sbin/celeborn-cli worker -V
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Celeborn CLI - Celeborn 0.7.0-SNAPSHOT
(base) ➜  celeborn git:(cli_version) 

```