### PR TITLE
[CELEBORN-2036]Fix NPE when TransportMessage has null payload

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -132,11 +132,14 @@ public class TransportMessage implements Serializable {
   }
 
   public ByteBuffer toByteBuffer() {
-    int totalBufferSize = payload.length + 4 + 4;
+    int payloadLength = payload != null ? payload.length : 0;
+    int totalBufferSize = payloadLength + 4 + 4;
     ByteBuffer buffer = ByteBuffer.allocate(totalBufferSize);
     buffer.putInt(messageTypeValue);
-    buffer.putInt(payload.length);
-    buffer.put(payload);
+    buffer.putInt(payloadLength);
+    if (payload != null) {
+      buffer.put(payload);
+    }
     buffer.flip();
     return buffer;
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title. 


### Why are the changes needed?
An NPE will be thrown when the ```TransportMessage``` payload is null, and there is no check here.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing ut.
