### PR TITLE
[CELEBORN-1413][FOLLOWUP] Check JAVA_HOME variables for release

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -73,6 +73,14 @@ while (( "$#" )); do
   shift
 done
 
+if [ "$RELEASE" == "true" ]; then
+  JAVA8_HOME=${JAVA8_HOME:?"JAVA8_HOME is required"}
+  JAVA11_HOME=${JAVA11_HOME:?"JAVA11_HOME is required"}
+  JAVA17_HOME=${JAVA17_HOME:?"JAVA17_HOME is required"}
+  # Set JAVA_HOME to JDK 8 by default for release
+  export JAVA_HOME=$JAVA8_HOME
+fi
+
 if [ -z "$JAVA_HOME" ]; then
   # Fall back on JAVA_HOME from rpm, if found
   if [ $(command -v rpm) ]; then

--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -29,6 +29,8 @@ RELEASE_RC_NO=${RELEASE_RC_NO:?"RELEASE_RC_NO is required, e.g. 0"}
 JAVA8_HOME=${JAVA8_HOME:?"JAVA8_HOME is required"}
 JAVA11_HOME=${JAVA11_HOME:?"JAVA11_HOME is required"}
 JAVA17_HOME=${JAVA17_HOME:?"JAVA17_HOME is required"}
+# Set JAVA_HOME to JDK 8 by default for release
+export JAVA_HOME=$JAVA8_HOME
 
 RELEASE_VERSION=$(awk -F'"' '/ThisBuild \/ version/ {print $2}' version.sbt)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
For release mode, check the JAVA_HOME variables and set JDK version to 8 by default

```
./build/make-distribution.sh --sbt-enabled --release
```

### Why are the changes needed?

1. Address comments: https://github.com/apache/celeborn/pull/3282#discussion_r2149146734 
2. Set JDK 8 for release mode by default is necessary
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Manual test.