### PR TITLE
[CIP-19][CELEBORN-1939] CongestionController should not limit user push speed when worker load is low

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1381,6 +1381,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(WORKER_CONGESTION_CONTROL_USER_INACTIVE_INTERVAL)
   def workerCongestionControlCheckIntervalMs: Long = get(WORKER_CONGESTION_CONTROL_CHECK_INTERVAL)
 
+  def onlyCongestOnHighWatermark: Boolean =
+    get(WORKER_CONGESTION_CONTROL_ONLY_CONGESTION_ON_HIGH_WATERMARK)
+
   // //////////////////////////////////////////////////////
   //                 Columnar Shuffle                    //
   // //////////////////////////////////////////////////////
@@ -6466,4 +6469,12 @@ object CelebornConf extends Logging {
       .version("0.6.0")
       .booleanConf
       .createWithDefaultString("false")
+
+  val WORKER_CONGESTION_CONTROL_ONLY_CONGESTION_ON_HIGH_WATERMARK: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.congestionControl.onlyCongestOnHighWatermark")
+      .categories("worker")
+      .doc("Only trigger congestion when the worker on high watermark")
+      .version("0.7.0")
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfig.java
@@ -249,6 +249,14 @@ public abstract class DynamicConfig {
         ConfigType.BOOLEAN);
   }
 
+  public boolean getOnlyCongestOnHighWatermark() {
+    return getValue(
+        CelebornConf.WORKER_CONGESTION_CONTROL_ONLY_CONGESTION_ON_HIGH_WATERMARK().key(),
+        CelebornConf.WORKER_CONGESTION_CONTROL_ONLY_CONGESTION_ON_HIGH_WATERMARK(),
+        Boolean.TYPE,
+        ConfigType.BOOLEAN);
+  }
+
   public Map<String, String> getConfigs() {
     return configs;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
CongestionController should not limit user push speed when worker load is low


### Why are the changes needed?
Improve worker resource utilization


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.
