### PR TITLE
[CELEBORN-2042] Fix FetchFailure handling when TaskSetManager is not found

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -104,7 +104,7 @@ public class SparkShuffleManager implements ShuffleManager {
                 (MapOutputTrackerMaster) SparkEnv.get().mapOutputTracker();
 
             lifecycleManager.registerReportTaskShuffleFetchFailurePreCheck(
-                taskId -> SparkUtils.taskAnotherAttemptRunningOrSuccessful(taskId));
+                taskId -> SparkUtils.shouldReportShuffleFetchFailure(taskId));
             SparkUtils.addSparkListener(new ShuffleFetchFailureReportTaskCleanListener());
 
             lifecycleManager.registerShuffleTrackerCallback(

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -104,7 +104,7 @@ public class SparkShuffleManager implements ShuffleManager {
                 (MapOutputTrackerMaster) SparkEnv.get().mapOutputTracker();
 
             lifecycleManager.registerReportTaskShuffleFetchFailurePreCheck(
-                taskId -> !SparkUtils.taskAnotherAttemptRunningOrSuccessful(taskId));
+                taskId -> SparkUtils.taskAnotherAttemptRunningOrSuccessful(taskId));
             SparkUtils.addSparkListener(new ShuffleFetchFailureReportTaskCleanListener());
 
             lifecycleManager.registerShuffleTrackerCallback(

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -379,7 +379,7 @@ public class SparkUtils {
         }
         return true;
       } else {
-        LOG.error(
+        logger.error(
             "Can not get TaskSetManager for taskId: {}, ignore it. (This typically occurs when: "
                 + " task completed/cleaned up, executor marked as failed, or stage cancelled/completed)",
             taskId);

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -296,15 +296,25 @@ public class SparkUtils {
   protected static volatile Long lastReportedShuffleFetchFailureTaskId = null;
 
   /**
-   * Only used to check for the shuffle fetch failure task whether another attempt is running or
-   * successful. If another attempt(excluding the reported shuffle fetch failure tasks in current
-   * stage) is running or successful, return true. Otherwise, return false.
+   * Determines whether a shuffle fetch failure should be reported for the given task.
+   *
+   * <p>Returns false (should NOT report) in the following scenarios: - Other successful attempts
+   * for the same task - Other running attempts and the current failure count hasn't reached the
+   * maximum retry limit - Other attempts already reported shuffle fetch failures for the same task
+   * - TaskSetManager cannot be found (task completed/cleaned up, executor marked as failed, or
+   * stage cancelled/completed)
+   *
+   * <p>Returns true (should report) in all other cases, typically when: - No other attempts exist
+   * or all other attempts have failed - Current failure count has reached the maximum retry limit
+   *
+   * @param taskId the task ID to check
+   * @return true if the shuffle fetch failure should be reported, false otherwise
    */
-  public static boolean taskAnotherAttemptRunningOrSuccessful(long taskId) {
+  public static boolean shouldReportShuffleFetchFailure(long taskId) {
     SparkContext sparkContext = SparkContext$.MODULE$.getActive().getOrElse(null);
     if (sparkContext == null) {
       logger.error("Can not get active SparkContext.");
-      return false;
+      return true;
     }
     TaskSchedulerImpl taskScheduler = (TaskSchedulerImpl) sparkContext.taskScheduler();
     synchronized (taskScheduler) {
@@ -322,7 +332,7 @@ public class SparkUtils {
 
         Tuple2<TaskInfo, List<TaskInfo>> taskAttempts = getTaskAttempts(taskSetManager, taskId);
 
-        if (taskAttempts == null) return false;
+        if (taskAttempts == null) return true;
 
         TaskInfo taskInfo = taskAttempts._1();
         for (TaskInfo ti : taskAttempts._2()) {
@@ -343,7 +353,7 @@ public class SparkUtils {
                   taskId,
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
-              return true;
+              return false;
             } else if (ti.running()) {
               logger.info(
                   "StageId={} index={} taskId={} attempt={} another attempt {} is running.",
@@ -352,7 +362,7 @@ public class SparkUtils {
                   taskId,
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
-              return true;
+              return false;
             }
           } else {
             if (ti.attemptNumber() >= maxTaskFails - 1) {
@@ -363,13 +373,16 @@ public class SparkUtils {
                   taskId,
                   ti.attemptNumber(),
                   maxTaskFails);
-              return false;
+              return true;
             }
           }
         }
-        return false;
+        return true;
       } else {
-        logger.error("Can not get TaskSetManager for taskId: {}", taskId);
+        LOG.error(
+            "Can not get TaskSetManager for taskId: {}, ignore it. (This typically occurs when: "
+                + " task completed/cleaned up, executor marked as failed, or stage cancelled/completed)",
+            taskId);
         return false;
       }
     }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -21,11 +21,9 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.spark.*;
 import org.apache.spark.internal.config.package$;
 import org.apache.spark.launcher.SparkLauncher;
 import org.apache.spark.rdd.DeterministicLevel;
-import org.apache.spark.shuffle.*;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.apache.spark.sql.internal.SQLConf;
 import org.slf4j.Logger;
@@ -148,7 +146,7 @@ public class SparkShuffleManager implements ShuffleManager {
                 (MapOutputTrackerMaster) SparkEnv.get().mapOutputTracker();
 
             lifecycleManager.registerReportTaskShuffleFetchFailurePreCheck(
-                taskId -> !SparkUtils.taskAnotherAttemptRunningOrSuccessful(taskId));
+                taskId -> SparkUtils.shouldReportShuffleFetchFailure(taskId));
             SparkUtils.addSparkListener(new ShuffleFetchFailureReportTaskCleanListener());
 
             lifecycleManager.registerShuffleTrackerCallback(

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -21,9 +21,11 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.spark.*;
 import org.apache.spark.internal.config.package$;
 import org.apache.spark.launcher.SparkLauncher;
 import org.apache.spark.rdd.DeterministicLevel;
+import org.apache.spark.shuffle.*;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.apache.spark.sql.internal.SQLConf;
 import org.slf4j.Logger;

--- a/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
@@ -93,7 +93,7 @@ class SparkUtilsSuite extends AnyFunSuite
           val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, reportedTaskId)
           assert(taskSetManager != null)
           assert(SparkUtils.getTaskAttempts(taskSetManager, reportedTaskId)._2.size() == 1)
-          assert(!SparkUtils.taskAnotherAttemptRunningOrSuccessful(reportedTaskId))
+          assert(SparkUtils.shouldReportShuffleFetchFailure(reportedTaskId))
         }
 
         sparkSession.sparkContext.cancelAllJobs()
@@ -145,7 +145,7 @@ class SparkUtilsSuite extends AnyFunSuite
         val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, taskId)
         assert(taskSetManager != null)
         assert(SparkUtils.getTaskAttempts(taskSetManager, taskId)._2.size() == 1)
-        assert(!SparkUtils.taskAnotherAttemptRunningOrSuccessful(taskId))
+        assert(SparkUtils.shouldReportShuffleFetchFailure(taskId))
         assert(SparkUtils.reportedStageShuffleFetchFailureTaskIds.size() == 1)
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes the FetchFailure handling logic in shouldReportShuffleFetchFailure method to properly handle cases where TaskSetManager cannot be found for a given task ID.

### Why are the changes needed?
The current implementation incorrectly reports FetchFailure when TaskSetManager is not found, which leads to false positive failures in normal fault tolerance scenarios. This happens because:
1. Executor Lost scenarios: When executors are lost due to resource preemption or failures, the associated TaskSetManager gets cleaned up, making it unavailable for lookup
2. Stage cancellation: Cancelled or completed stages may have their TaskSetManager removed

These are all normal scenarios in Spark's fault tolerance mechanism and should not be treated as shuffle failures. The current behavior can cause unnecessary job failures and confusion in debugging actual shuffle issues.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT, Long-running Production Validation
