### PR TITLE
[CELEBORN-1721][FOLLOWUP] Return softsplit if there is no hardsplit for pushMergeData

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1488,7 +1488,8 @@ public class ShuffleClientImpl extends ShuffleClient {
           @Override
           public void onSuccess(ByteBuffer response) {
             byte reason = response.get();
-            if (reason == StatusCode.HARD_SPLIT.getValue()) {
+            if (reason == StatusCode.HARD_SPLIT.getValue()
+                || reason == StatusCode.SOFT_SPLIT.getValue()) {
               ArrayList<DataBatches.DataBatch> batchesNeedResubmit;
               if (response.remaining() > 0) {
                 batchesNeedResubmit = new ArrayList<>();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->


### What changes were proposed in this pull request?
Return SoftSplit status when there is no hard split for pushMergeData

### Why are the changes needed?
HardSplit support was introduced in [CELEBORN-1721](https://issues.apache.org/jira/browse/CELEBORN-1721), and it works well when the client and server are of the same version. However, using a 0.5.x client with a 0.6.x server can significantly impact shuffle write performance. This is because the 0.6.x server returns hardsplit status whenever there is any soft or hard split, leading the 0.5.x client to perform hardsplit on every partition. To maintain compatibility during upgrades, it's essential to preserve the original behavior for 0.5.x clients.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA & 1T tpcds with 0.5.4 version client, according to the test results, after applying this PR, revive decreased significantly, and performance improved.

#### test use 0.6.0-rc2 server, 0.5.4 client
![image](https://github.com/user-attachments/assets/f9d640d7-1dc4-438b-8320-428a7d23dc93)

#### test use 0.7.0 server + this pr,  0.5.4 client
![image](https://github.com/user-attachments/assets/d198055a-698c-48ec-9246-9170d2ac64cc)




