### PR TITLE
[CELEBORN-2044] Proactively cleanup stream state from ChunkStreamManager when the stream ends

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
@@ -196,6 +196,10 @@ public class ChunkStreamManager {
     return streams.get(streamId);
   }
 
+  public StreamState removeStreamState(long streamId) {
+    return streams.remove(streamId);
+  }
+
   public int getStreamsCount() {
     return streams.size();
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -478,7 +478,7 @@ class FetchHandler(
       streamType: StreamType): Unit = {
     streamType match {
       case StreamType.ChunkStream =>
-        val streamState = chunkStreamManager.getStreamState(streamId)
+        val streamState = chunkStreamManager.removeStreamState(streamId)
         if (streamState != null) {
           val (shuffleKey, fileName) = (streamState.shuffleKey, streamState.fileName)
           workerSource.recordAppActiveConnection(client, shuffleKey)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Proactively cleanup from ChunkStreamManager when stream is closed.


### Why are the changes needed?

Stream gets closed only when shuffle expires at master, which can take a while.
In meantime, workers incur have nontrivial memory utilization.


### Does this PR introduce _any_ user-facing change?

No. Reduces memory usage in workers.


### How was this patch tested?

Existing unit tests