### PR TITLE
[CELEBORN-2043] Fix IndexOutOfBoundsException exception in getEvictedFileWriter

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -97,6 +97,12 @@ license: |
 
 - Since 0.6.0, the out-of-dated Flink 1.14 and Flink 1.15 have been removed from the official support list.
 
+- Since 0.6.0, the client respects the spark.celeborn.storage.availableTypes configuration, 
+    ensuring revived partition locations no longer default to memory storage. In contrast, clients prior 
+    to 0.6.0 default to memory storage for revived partitions. This means that if memory storage is enabled in 
+    worker nodes, pre-0.6.0 clients may inadvertently utilize memory storage for an application even when memory 
+    storage is not enabled for that app.
+
 ## Upgrading from 0.5.0 to 0.5.1
 
 - Since 0.5.1, Celeborn master REST API `/exclude` request uses media type `application/x-www-form-urlencoded` instead of `text/plain`.

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -123,7 +123,12 @@ public class MemoryReducePartitionDataWriterSuiteJ {
                     storageManager))
         .when(storagePolicy)
         .createFileWriter(
-            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.anyBoolean());
 
     return storageManager;
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
@@ -116,4 +116,23 @@ class StoragePolicyCase3 extends CelebornFunSuite {
     assert(nFile.isInstanceOf[LocalTierWriter])
   }
 
+  test("test evict file case2") {
+    when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(memoryHintPartitionLocation)
+    when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    val mockedMemoryFile = mock[LocalTierWriter]
+    val conf = new CelebornConf()
+    val flushLock = new AnyRef
+    val storagePolicy = new StoragePolicy(conf, mockedStorageManager, mockedSource)
+    val pendingWriters = new AtomicInteger()
+    val notifier = new FlushNotifier
+    when(mockedMemoryFile.storageType).thenAnswer(StorageInfo.Type.MEMORY)
+    val nFile = storagePolicy.getEvictedFileWriter(
+      mockedMemoryFile,
+      mockedPartitionWriterContext,
+      PartitionType.REDUCE,
+      pendingWriters,
+      notifier)
+    assert(nFile.isInstanceOf[LocalTierWriter])
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
If the create file order list doesn't have the corresponding storage types, use 0 as the index. 


### Why are the changes needed?
This is needed in two scenarios:
1. For existing clients, the change partition will select MEMORY as the default storage tier, which will cause the revived partition to utilize memory storage even if the application is not configured to do so. This is the cause of [CELEBORN-2043], and fixed by [CELEBORN-2021](https://github.com/apache/celeborn/pull/3302).
2. Evicted files will need to exclude itself storage type in the create file order list. which means that the storage type does not exist in the create file order list.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA and cluster.
