### PR TITLE
[CELEBORN-2031] Interruption Aware Slot Selection

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2952,6 +2952,7 @@ object CelebornConf extends Logging {
         "of creating partitions. Default is 50%.")
       .version("0.7.0")
       .intConf
+      .checkValue(v => v >= 0 && v <= 100, "This value must be a percentage.")
       .createWithDefault(50)
 
   val MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_NUM: ConfigEntry[Int] =

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -655,6 +655,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   def masterSlotAssignPolicy: SlotsAssignPolicy =
     SlotsAssignPolicy.valueOf(get(MASTER_SLOT_ASSIGN_POLICY))
+
+  def masterSlotAssignInterruptionAware: Boolean = get(MASTER_SLOT_ASSIGN_INTERRUPTION_AWARE)
+  def masterSlotsAssignInterruptionAwareThreshold: Int =
+    get(MASTER_SLOT_INTERRUPTION_AWARE_THRESHOLD)
   def availableStorageTypes: Int = {
     val types = get(ACTIVE_STORAGE_TYPES).split(",").map(StorageInfo.Type.valueOf).toList
     StorageInfo.getAvailableTypes(types.asJava)
@@ -2931,6 +2935,25 @@ object CelebornConf extends Logging {
         SlotsAssignPolicy.ROUNDROBIN.name,
         SlotsAssignPolicy.LOADAWARE.name))
       .createWithDefault(SlotsAssignPolicy.ROUNDROBIN.name)
+
+  val MASTER_SLOT_ASSIGN_INTERRUPTION_AWARE: ConfigEntry[Boolean] =
+    buildConf("celeborn.master.slot.assign.interruptionAware")
+      .categories("master")
+      .version("0.6.0")
+      .doc("If this is set to true, Celeborn master will prioritize partition placement on workers that are not " +
+        "in scope for maintenance soon.")
+      .version("0.6.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val MASTER_SLOT_INTERRUPTION_AWARE_THRESHOLD: ConfigEntry[Int] =
+    buildConf("celeborn.master.slot.assign.interruptionAware.threshold")
+      .categories("master")
+      .doc("This controls what percentage of hosts would be selected for slot selection in the first iteration " +
+        "of creating partitions. Default is 50%.")
+      .version("0.6.0")
+      .intConf
+      .createWithDefault(50)
 
   val MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_NUM: ConfigEntry[Int] =
     buildConf("celeborn.master.slot.assign.loadAware.numDiskGroups")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2939,10 +2939,9 @@ object CelebornConf extends Logging {
   val MASTER_SLOT_ASSIGN_INTERRUPTION_AWARE: ConfigEntry[Boolean] =
     buildConf("celeborn.master.slot.assign.interruptionAware")
       .categories("master")
-      .version("0.6.0")
+      .version("0.7.0")
       .doc("If this is set to true, Celeborn master will prioritize partition placement on workers that are not " +
         "in scope for maintenance soon.")
-      .version("0.6.0")
       .booleanConf
       .createWithDefault(false)
 
@@ -2951,7 +2950,7 @@ object CelebornConf extends Logging {
       .categories("master")
       .doc("This controls what percentage of hosts would be selected for slot selection in the first iteration " +
         "of creating partitions. Default is 50%.")
-      .version("0.6.0")
+      .version("0.7.0")
       .intConf
       .createWithDefault(50)
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -289,8 +289,11 @@ class WorkerInfo(
        |WorkerRef: $endpoint
        |WorkerStatus: $workerStatus
        |NetworkLocation: $networkLocation
+       |NextInterruptionNotice: ${if (hasInterruptionNotice) nextInterruptionNotice else "None"}
        |""".stripMargin
   }
+
+  def hasInterruptionNotice: Boolean = nextInterruptionNotice != Long.MaxValue
 
   override def equals(other: Any): Boolean = other match {
     case that: WorkerInfo =>

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -236,6 +236,8 @@ class WorkerInfoSuite extends CelebornFunSuite {
     val worker2 =
       new WorkerInfo("h2", 20001, 20002, 20003, 2000, 20004, null, null)
     worker2.networkLocation = "/1"
+    worker2.nextInterruptionNotice = 1000L
+
 
     val worker3 = new WorkerInfo(
       "h3",
@@ -312,6 +314,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |UserResourceConsumption: empty
            |WorkerRef: null
            |NetworkLocation: /default-rack
+           |NextInterruptionNotice: None
            |""".stripMargin
 
       val exp2 =
@@ -328,6 +331,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
           |UserResourceConsumption: empty
           |WorkerRef: null
           |NetworkLocation: /1
+          |NextInterruptionNotice: 1000
           |""".stripMargin
       val exp3 =
         s"""
@@ -343,6 +347,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |UserResourceConsumption: empty
            |WorkerRef: null
            |NetworkLocation: /default-rack
+           |NextInterruptionNotice: None
            |""".stripMargin
       val exp4 =
         s"""
@@ -362,6 +367,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
            |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MiB, diskFileCount: 1, hdfsBytesWritten: 50.0 MiB, hdfsFileCount: 1, subResourceConsumptions: (application_1697697127390_2171854 -> ResourceConsumption(diskBytesWritten: 20.0 MiB, diskFileCount: 1, hdfsBytesWritten: 50.0 MiB, hdfsFileCount: 1, subResourceConsumptions: empty)))
            |WorkerRef: null
            |NetworkLocation: /default-rack
+           |NextInterruptionNotice: None
            |""".stripMargin
 
       assertEquals(

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -238,7 +238,6 @@ class WorkerInfoSuite extends CelebornFunSuite {
     worker2.networkLocation = "/1"
     worker2.nextInterruptionNotice = 1000L
 
-
     val worker3 = new WorkerInfo(
       "h3",
       30001,

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -72,8 +72,8 @@ license: |
 | celeborn.master.rackResolver.refresh.interval | 30s | false | Interval for refreshing the node rack information periodically. | 0.5.0 |  | 
 | celeborn.master.send.applicationMeta.threads | 8 | false | Number of threads used by the Master to send ApplicationMeta to Workers. | 0.5.0 |  | 
 | celeborn.master.slot.assign.extraSlots | 2 | false | Extra slots number when master assign slots. Provided enough workers are available. | 0.3.0 | celeborn.slots.assign.extraSlots | 
-| celeborn.master.slot.assign.interruptionAware | false | false | If this is set to true, Celeborn master will prioritize partition placement on workers that are not in scope for maintenance soon. | 0.6.0 |  | 
-| celeborn.master.slot.assign.interruptionAware.threshold | 50 | false | This controls what percentage of hosts would be selected for slot selection in the first iteration of creating partitions. Default is 50%. | 0.6.0 |  | 
+| celeborn.master.slot.assign.interruptionAware | false | false | If this is set to true, Celeborn master will prioritize partition placement on workers that are not in scope for maintenance soon. | 0.7.0 |  | 
+| celeborn.master.slot.assign.interruptionAware.threshold | 50 | false | This controls what percentage of hosts would be selected for slot selection in the first iteration of creating partitions. Default is 50%. | 0.7.0 |  | 
 | celeborn.master.slot.assign.loadAware.diskGroupGradient | 0.1 | false | This value means how many more workload will be placed into a faster disk group than a slower group. | 0.3.0 | celeborn.slots.assign.loadAware.diskGroupGradient | 
 | celeborn.master.slot.assign.loadAware.fetchTimeWeight | 1.0 | false | Weight of average fetch time when calculating ordering in load-aware assignment strategy | 0.3.0 | celeborn.slots.assign.loadAware.fetchTimeWeight | 
 | celeborn.master.slot.assign.loadAware.flushTimeWeight | 0.0 | false | Weight of average flush time when calculating ordering in load-aware assignment strategy | 0.3.0 | celeborn.slots.assign.loadAware.flushTimeWeight | 

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -72,6 +72,8 @@ license: |
 | celeborn.master.rackResolver.refresh.interval | 30s | false | Interval for refreshing the node rack information periodically. | 0.5.0 |  | 
 | celeborn.master.send.applicationMeta.threads | 8 | false | Number of threads used by the Master to send ApplicationMeta to Workers. | 0.5.0 |  | 
 | celeborn.master.slot.assign.extraSlots | 2 | false | Extra slots number when master assign slots. Provided enough workers are available. | 0.3.0 | celeborn.slots.assign.extraSlots | 
+| celeborn.master.slot.assign.interruptionAware | false | false | If this is set to true, Celeborn master will prioritize partition placement on workers that are not in scope for maintenance soon. | 0.6.0 |  | 
+| celeborn.master.slot.assign.interruptionAware.threshold | 50 | false | This controls what percentage of hosts would be selected for slot selection in the first iteration of creating partitions. Default is 50%. | 0.6.0 |  | 
 | celeborn.master.slot.assign.loadAware.diskGroupGradient | 0.1 | false | This value means how many more workload will be placed into a faster disk group than a slower group. | 0.3.0 | celeborn.slots.assign.loadAware.diskGroupGradient | 
 | celeborn.master.slot.assign.loadAware.fetchTimeWeight | 1.0 | false | Weight of average fetch time when calculating ordering in load-aware assignment strategy | 0.3.0 | celeborn.slots.assign.loadAware.fetchTimeWeight | 
 | celeborn.master.slot.assign.loadAware.flushTimeWeight | 0.0 | false | Weight of average flush time when calculating ordering in load-aware assignment strategy | 0.3.0 | celeborn.slots.assign.loadAware.flushTimeWeight | 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -482,6 +482,9 @@ public class SlotsAllocator {
   }
 
   /**
+   * Assigns slots in a roundrobin fashion given lists of primary and replica worker candidates and
+   * other restrictions.
+   *
    * @param slots the slots that have been assigned for each partitionId
    * @param partitionIds the partitionIds that require slot selection still
    * @param primaryWorkers list of worker candidates that can be used for primary workers.
@@ -492,7 +495,8 @@ public class SlotsAllocator {
    * @param availableStorageTypes available storage types coming from the offer slots request.
    * @param replicaSameAsPrimary if the worker candidates list for primaries and replicas is the
    *     same. This is to prevent index mismatch while assigning slots across both lists.
-   * @return
+   * @return the partitionIds that were not able to be assigned slots in this iteration with the
+   *     current primary and replica worker candidates and slot restrictions..
    */
   private static List<Integer> roundRobin(
       Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -33,6 +33,8 @@ import org.apache.celeborn.common.meta.DiskStatus;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.protocol.StorageInfo;
+import scala.Tuple3;
+
 
 public class SlotsAllocator {
   static class UsableDiskInfo {
@@ -56,7 +58,9 @@ public class SlotsAllocator {
           List<Integer> partitionIds,
           boolean shouldReplicate,
           boolean shouldRackAware,
-          int availableStorageTypes) {
+          int availableStorageTypes,
+          boolean interruptionAware,
+          int interruptionAwareThreshold) {
     if (partitionIds.isEmpty()) {
       return new HashMap<>();
     }
@@ -101,7 +105,9 @@ public class SlotsAllocator {
         slotsRestrictions,
         shouldReplicate,
         shouldRackAware,
-        availableStorageTypes);
+        availableStorageTypes,
+        interruptionAware,
+        interruptionAwareThreshold);
   }
 
   /**
@@ -119,7 +125,9 @@ public class SlotsAllocator {
           double diskGroupGradient,
           double flushTimeWeight,
           double fetchTimeWeight,
-          int availableStorageTypes) {
+          int availableStorageTypes,
+          boolean interruptionAware,
+          int interruptionAwareThreshold) {
     if (partitionIds.isEmpty()) {
       return new HashMap<>();
     }
@@ -130,7 +138,7 @@ public class SlotsAllocator {
         || StorageInfo.S3Only(availableStorageTypes)
         || StorageInfo.OSSOnly(availableStorageTypes)) {
       return offerSlotsRoundRobin(
-          workers, partitionIds, shouldReplicate, shouldRackAware, availableStorageTypes);
+          workers, partitionIds, shouldReplicate, shouldRackAware, availableStorageTypes, interruptionAware, interruptionAwareThreshold);
     }
 
     List<DiskInfo> usableDisks = new ArrayList<>();
@@ -165,7 +173,7 @@ public class SlotsAllocator {
           StringUtils.join(partitionIds, ','),
           noUsableDisks ? "usable disks" : "available slots");
       return offerSlotsRoundRobin(
-          workers, partitionIds, shouldReplicate, shouldRackAware, availableStorageTypes);
+          workers, partitionIds, shouldReplicate, shouldRackAware, availableStorageTypes, interruptionAware, interruptionAwareThreshold);
     }
 
     if (!initialized) {
@@ -183,7 +191,9 @@ public class SlotsAllocator {
         slotsRestrictions,
         shouldReplicate,
         shouldRackAware,
-        availableStorageTypes);
+        availableStorageTypes,
+        interruptionAware,
+        interruptionAwareThreshold);
   }
 
   private static StorageInfo getStorageInfo(
@@ -247,10 +257,59 @@ public class SlotsAllocator {
   }
 
   /**
+   * If interruptionAware = true, select workers based on 2 main criteria: <br>
+   * 1. Workers that have no nextInterruptionNotice are the first priority and are included in the
+   * 1st pass for slot selection. <br>
+   * 2. Workers that have a later interruption notice are a little less deprioritized, and are
+   * included in the 2nd pass for slot selection. This is determined by nextInterruptionNotice above
+   * a certain percentage threshold.<br>
+   * All other workers are considered least priority, and are only included for slot selection in
+   * the worst case. <br>
+   */
+  static Tuple3<List<WorkerInfo>, List<WorkerInfo>, List<WorkerInfo>>
+  prioritizeWorkersBasedOnInterruptionNotice(
+      List<WorkerInfo> workers,
+      boolean shouldReplicate,
+      boolean shouldRackAware,
+      double percentileThreshold) {
+    Map<Boolean, List<WorkerInfo>> partitioned =
+        workers.stream().collect(Collectors.partitioningBy(WorkerInfo::hasInterruptionNotice));
+    List<WorkerInfo> workersWithInterruptions = partitioned.get(true);
+    List<WorkerInfo> workersWithoutInterruptions = partitioned.get(false);
+    // Timestamps towards the boundary of `percentileThreshold` might be the same. Given this
+    // is a stable sort, it makes sense to randomize these hosts so that the same hosts are not
+    // consistently selected.
+    Collections.shuffle(workersWithInterruptions);
+    workersWithInterruptions.sort(
+        Comparator.comparingLong(WorkerInfo::nextInterruptionNotice).reversed());
+    int requiredNodes =
+        (int) Math.floor((percentileThreshold * workersWithInterruptions.size()) / 100.0);
+
+    List<WorkerInfo> workersWithLateInterruptions =
+        new ArrayList<>(workersWithInterruptions.subList(0, requiredNodes));
+    List<WorkerInfo> workersWithEarlyInterruptions =
+        new ArrayList<>(
+            workersWithInterruptions.subList(requiredNodes, workersWithInterruptions.size()));
+    if (shouldReplicate && shouldRackAware) {
+      return Tuple3.apply(
+          generateRackAwareWorkers(workersWithoutInterruptions),
+          generateRackAwareWorkers(workersWithLateInterruptions),
+          generateRackAwareWorkers(workersWithEarlyInterruptions));
+    }
+    return Tuple3.apply(
+        Collections.unmodifiableList(workersWithoutInterruptions),
+        Collections.unmodifiableList(workersWithLateInterruptions),
+        Collections.unmodifiableList(workersWithEarlyInterruptions));
+  }
+
+  /**
    * Progressive locate slots for all partitions <br>
-   * 1. try to allocate for all partitions under restrictions <br>
-   * 2. allocate remain partitions to all workers <br>
-   * 3. allocate remain partitions to all workers again without considering rack aware <br>
+   * 1. try to allocate for all partitions under restrictions, on workers with no interruption
+   * notice if interruptionAware = true. <br>
+   * 2. try to allocate for all partitions, and attempt the replica selection to be
+   * interruptionAware if interruptionAware = true <br>
+   * 3. allocate remain partitions to all workers <br>
+   * 4. allocate remain partitions to all workers again without considering rack aware <br>
    */
   private static Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
       locateSlots(
@@ -259,7 +318,9 @@ public class SlotsAllocator {
           Map<WorkerInfo, List<UsableDiskInfo>> slotRestrictions,
           boolean shouldReplicate,
           boolean shouldRackAware,
-          int availableStorageTypes) {
+          int availableStorageTypes,
+          boolean interruptionAware,
+          int interruptionAwareThreshold) {
 
     List<WorkerInfo> workersFromSlotRestrictions = new ArrayList<>(slotRestrictions.keySet());
     List<WorkerInfo> workers = workersList;
@@ -270,29 +331,97 @@ public class SlotsAllocator {
 
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         new HashMap<>();
-
+    List<WorkerInfo> workersWithoutInterruptions;
+    List<WorkerInfo> workersWithLateInterruptions;
+    List<WorkerInfo> workersWithEarlyInterruptions;
+    if (interruptionAware) {
+      Tuple3<List<WorkerInfo>, List<WorkerInfo>, List<WorkerInfo>>
+          workersBasedOnInterruptionNotice =
+          prioritizeWorkersBasedOnInterruptionNotice(
+              workersFromSlotRestrictions,
+              shouldReplicate,
+              shouldRackAware,
+              interruptionAwareThreshold);
+      workersWithoutInterruptions = workersBasedOnInterruptionNotice._1();
+      workersWithLateInterruptions = workersBasedOnInterruptionNotice._2();
+      workersWithEarlyInterruptions = workersBasedOnInterruptionNotice._3();
+    } else {
+      workersWithoutInterruptions = workersFromSlotRestrictions;
+      workersWithLateInterruptions = null;
+      workersWithEarlyInterruptions = null;
+    }
+    // In the first pass, we try to place all partitions (primary and replica) from
+    // `workersWithoutInterruptions`.
     List<Integer> remain =
         roundRobin(
             slots,
             partitionIds,
-            workersFromSlotRestrictions,
+            workersWithoutInterruptions,
+            workersWithoutInterruptions,
             slotRestrictions,
             shouldReplicate,
             shouldRackAware,
-            availableStorageTypes);
+            availableStorageTypes,
+            true);
+    logger.debug(
+        "Remaining number of partitionIds after 1st pass slot selection: {}", remain.size());
+    // Do an extra pass for partition placement if interruptionAware = true, to see if we can
+    // assign the remaining partitions with slot restriction still set in place. The goal during
+    // this pass
+    // is to see if we can place primary from `workersWithoutInterruptions +
+    // workersWithLateInterruptions`, while replica can be in
+    // `workersWithEarlyInterruptions`.
+    // This is to avoid the degenerate case in which both primary and replica may end up in
+    // `workersWithEarlyInterruptions`.
+    if (interruptionAware && !remain.isEmpty()) {
+      List<WorkerInfo> primaryWorkerCandidates = new ArrayList<>(workersWithoutInterruptions);
+      primaryWorkerCandidates.addAll(workersWithLateInterruptions);
+      if (shouldReplicate && shouldRackAware) {
+        primaryWorkerCandidates = generateRackAwareWorkers(primaryWorkerCandidates);
+      }
+      remain =
+          roundRobin(
+              slots,
+              remain,
+              primaryWorkerCandidates,
+              workersWithEarlyInterruptions,
+              null,
+              shouldReplicate,
+              shouldRackAware,
+              availableStorageTypes,
+              false);
+      logger.debug(
+          "Remaining number of partitionIds after 2nd pass slot selection: {}", remain.size());
+    }
+    // If partitions are remaining from this point on, and interruptionAware = true, then
+    // this becomes the degenerate case where both primary and replica are likely chosen on
+    // workers with interruptions that are sooner.
     if (!remain.isEmpty()) {
       remain =
           roundRobin(
               slots,
               remain,
               workers,
+              workers,
               null,
               shouldReplicate,
               shouldRackAware,
-              availableStorageTypes);
+              availableStorageTypes,
+              true);
+      logger.debug(
+          "Remaining number of partitionIds after 3rd pass slot selection: {}", remain.size());
     }
     if (!remain.isEmpty()) {
-      roundRobin(slots, remain, workers, null, shouldReplicate, false, availableStorageTypes);
+      roundRobin(
+          slots,
+          remain,
+          workers,
+          workers,
+          null,
+          shouldReplicate,
+          false,
+          availableStorageTypes,
+          true);
     }
     return slots;
   }
@@ -344,19 +473,26 @@ public class SlotsAllocator {
   private static List<Integer> roundRobin(
       Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots,
       List<Integer> partitionIds,
-      List<WorkerInfo> workers,
+      List<WorkerInfo> primaryWorkers,
+      List<WorkerInfo> replicaWorkers,
       Map<WorkerInfo, List<UsableDiskInfo>> slotsRestrictions,
       boolean shouldReplicate,
       boolean shouldRackAware,
-      int availableStorageTypes) {
+      int availableStorageTypes,
+      boolean replicaSameAsPrimary) {
+    if (primaryWorkers.isEmpty() || replicaWorkers.isEmpty()) {
+      return partitionIds;
+    }
     // workerInfo -> (diskIndexForPrimaryAndReplica)
     Map<WorkerInfo, Integer> workerDiskIndex = new HashMap<>();
     List<Integer> partitionIdList = new LinkedList<>(partitionIds);
 
-    final int workerSize = workers.size();
-    final IntUnaryOperator incrementIndex = v -> (v + 1) % workerSize;
-    int primaryIndex = rand.nextInt(workerSize);
-    int replicaIndex = rand.nextInt(workerSize);
+    final int primaryWorkersSize = primaryWorkers.size();
+    final int replicaWorkersSize = replicaWorkers.size();
+    final IntUnaryOperator primaryWorkersIncrementIndex = v -> (v + 1) % primaryWorkersSize;
+    final IntUnaryOperator replicaWorkersIncrementIndex = v -> (v + 1) % replicaWorkersSize;
+    int primaryIndex = rand.nextInt(primaryWorkersSize);
+    int replicaIndex = rand.nextInt(replicaWorkersSize);
 
     ListIterator<Integer> iter = partitionIdList.listIterator(partitionIdList.size());
     // Iterate from the end to preserve O(1) removal of processed partitions.
@@ -370,85 +506,93 @@ public class SlotsAllocator {
       StorageInfo storageInfo;
       if (slotsRestrictions != null && !slotsRestrictions.isEmpty()) {
         // this means that we'll select a mount point
-        while (!haveUsableSlots(slotsRestrictions, workers, nextPrimaryInd)) {
-          nextPrimaryInd = incrementIndex.applyAsInt(nextPrimaryInd);
+        while (!haveUsableSlots(slotsRestrictions, primaryWorkers, nextPrimaryInd)) {
+          nextPrimaryInd = primaryWorkersIncrementIndex.applyAsInt(nextPrimaryInd);
           if (nextPrimaryInd == primaryIndex) {
             break outer;
           }
         }
         storageInfo =
             getStorageInfo(
-                workers, nextPrimaryInd, slotsRestrictions, workerDiskIndex, availableStorageTypes);
+                primaryWorkers, nextPrimaryInd, slotsRestrictions, workerDiskIndex, availableStorageTypes);
       } else {
         if (StorageInfo.localDiskAvailable(availableStorageTypes)) {
-          while (!workers.get(nextPrimaryInd).haveDisk()) {
-            nextPrimaryInd = incrementIndex.applyAsInt(nextPrimaryInd);
+          while (!primaryWorkers.get(nextPrimaryInd).haveDisk()) {
+            nextPrimaryInd = primaryWorkersIncrementIndex.applyAsInt(nextPrimaryInd);
             if (nextPrimaryInd == primaryIndex) {
               break outer;
             }
           }
         }
         storageInfo =
-            getStorageInfo(workers, nextPrimaryInd, null, workerDiskIndex, availableStorageTypes);
+            getStorageInfo(primaryWorkers, nextPrimaryInd, null, workerDiskIndex, availableStorageTypes);
       }
       PartitionLocation primaryPartition =
-          createLocation(partitionId, workers.get(nextPrimaryInd), null, storageInfo, true);
+          createLocation(partitionId, primaryWorkers.get(nextPrimaryInd), null, storageInfo, true);
 
       if (shouldReplicate) {
         int nextReplicaInd = replicaIndex;
         if (slotsRestrictions != null) {
-          while (nextReplicaInd == nextPrimaryInd
-              || !haveUsableSlots(slotsRestrictions, workers, nextReplicaInd)
-              || !satisfyRackAware(shouldRackAware, workers, nextPrimaryInd, nextReplicaInd)) {
-            nextReplicaInd = incrementIndex.applyAsInt(nextReplicaInd);
+          while ((nextReplicaInd == nextPrimaryInd && replicaSameAsPrimary)
+              || !haveUsableSlots(slotsRestrictions, replicaWorkers, nextReplicaInd)
+              || !satisfyRackAware(
+              shouldRackAware,
+              primaryWorkers,
+              nextPrimaryInd,
+              replicaWorkers,
+              nextReplicaInd)) {
+            nextReplicaInd = replicaWorkersIncrementIndex.applyAsInt(nextReplicaInd);
             if (nextReplicaInd == replicaIndex) {
               break outer;
             }
           }
           storageInfo =
               getStorageInfo(
-                  workers,
+                  replicaWorkers,
                   nextReplicaInd,
                   slotsRestrictions,
                   workerDiskIndex,
                   availableStorageTypes);
         } else if (shouldRackAware) {
-          while (nextReplicaInd == nextPrimaryInd
-              || !satisfyRackAware(true, workers, nextPrimaryInd, nextReplicaInd)) {
-            nextReplicaInd = incrementIndex.applyAsInt(nextReplicaInd);
+          while ((nextReplicaInd == nextPrimaryInd && replicaSameAsPrimary)
+              || !satisfyRackAware(
+              true, primaryWorkers, nextPrimaryInd, replicaWorkers, nextReplicaInd)) {
+            nextReplicaInd = replicaWorkersIncrementIndex.applyAsInt(nextReplicaInd);
             if (nextReplicaInd == replicaIndex) {
               break outer;
             }
           }
         } else {
           if (StorageInfo.localDiskAvailable(availableStorageTypes)) {
-            while (nextReplicaInd == nextPrimaryInd || !workers.get(nextReplicaInd).haveDisk()) {
-              nextReplicaInd = incrementIndex.applyAsInt(nextReplicaInd);
+            while ((nextReplicaInd == nextPrimaryInd && replicaSameAsPrimary)
+                || !replicaWorkers.get(nextReplicaInd).haveDisk()) {
+              nextReplicaInd = replicaWorkersIncrementIndex.applyAsInt(nextReplicaInd);
               if (nextReplicaInd == replicaIndex) {
                 break outer;
               }
             }
           }
           storageInfo =
-              getStorageInfo(workers, nextReplicaInd, null, workerDiskIndex, availableStorageTypes);
+              getStorageInfo(replicaWorkers, nextReplicaInd, null, workerDiskIndex, availableStorageTypes);
         }
         PartitionLocation replicaPartition =
             createLocation(
-                partitionId, workers.get(nextReplicaInd), primaryPartition, storageInfo, false);
+                partitionId, replicaWorkers.get(nextReplicaInd), primaryPartition, storageInfo, false);
         primaryPartition.setPeer(replicaPartition);
         Tuple2<List<PartitionLocation>, List<PartitionLocation>> locations =
             slots.computeIfAbsent(
-                workers.get(nextReplicaInd),
+                replicaWorkers.get(nextReplicaInd),
                 v -> new Tuple2<>(new ArrayList<>(), new ArrayList<>()));
         locations._2.add(replicaPartition);
-        replicaIndex = incrementIndex.applyAsInt(nextReplicaInd);
+        replicaIndex = replicaWorkersIncrementIndex.applyAsInt(nextReplicaInd);
       }
 
       Tuple2<List<PartitionLocation>, List<PartitionLocation>> locations =
           slots.computeIfAbsent(
-              workers.get(nextPrimaryInd), v -> new Tuple2<>(new ArrayList<>(), new ArrayList<>()));
+              primaryWorkers.get(nextPrimaryInd),
+              v -> new Tuple2<>(new ArrayList<>(), new ArrayList<>()));
       locations._1.add(primaryPartition);
-      primaryIndex = incrementIndex.applyAsInt(nextPrimaryInd);
+      primaryIndex = primaryWorkersIncrementIndex.applyAsInt(nextPrimaryInd);
       iter.remove();
     }
     return partitionIdList;
@@ -460,11 +604,15 @@ public class SlotsAllocator {
   }
 
   private static boolean satisfyRackAware(
-      boolean shouldRackAware, List<WorkerInfo> workers, int primaryIndex, int nextReplicaInd) {
+      boolean shouldRackAware,
+      List<WorkerInfo> primaryWorkers,
+      int primaryIndex,
+      List<WorkerInfo> replicaWorkers,
+      int nextReplicaInd) {
     return !shouldRackAware
         || !Objects.equals(
-            workers.get(primaryIndex).networkLocation(),
-            workers.get(nextReplicaInd).networkLocation());
+        primaryWorkers.get(primaryIndex).networkLocation(),
+        replicaWorkers.get(nextReplicaInd).networkLocation());
   }
 
   private static void initLoadAwareAlgorithm(int diskGroups, double diskGroupGradient) {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -229,6 +229,9 @@ private[celeborn] class Master(
     estimatedPartitionSizeForEstimationUpdateInterval,
     TimeUnit.MILLISECONDS)
   private val slotsAssignPolicy = conf.masterSlotAssignPolicy
+  private val slotsAssignInterruptionAware = conf.masterSlotAssignInterruptionAware
+  private val slotsAssignInterruptionAwareThreshold =
+    conf.masterSlotsAssignInterruptionAwareThreshold
 
   private var hadoopFs: util.Map[StorageInfo.Type, FileSystem] = _
   masterSource.addGauge(MasterSource.REGISTERED_SHUFFLE_COUNT) { () =>
@@ -939,14 +942,18 @@ private[celeborn] class Master(
               slotsAssignLoadAwareDiskGroupGradient,
               loadAwareFlushTimeWeight,
               loadAwareFetchTimeWeight,
-              requestSlots.availableStorageTypes)
+              requestSlots.availableStorageTypes,
+              slotsAssignInterruptionAware,
+              slotsAssignInterruptionAwareThreshold)
           } else {
             SlotsAllocator.offerSlotsRoundRobin(
               selectedWorkers,
               requestSlots.partitionIdList,
               requestSlots.shouldReplicate,
               requestSlots.shouldRackAware,
-              requestSlots.availableStorageTypes)
+              requestSlots.availableStorageTypes,
+              slotsAssignInterruptionAware,
+              slotsAssignInterruptionAwareThreshold)
           }
         }
       }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorJmhBenchmark.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorJmhBenchmark.java
@@ -63,6 +63,7 @@ public class SlotsAllocatorJmhBenchmark {
               diskPartitionToSize,
               PARTITION_SIZE,
               NUM_NETWORK_LOCATIONS,
+              false,
               new Random());
     }
   }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorJmhBenchmark.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorJmhBenchmark.java
@@ -79,7 +79,13 @@ public class SlotsAllocatorJmhBenchmark {
 
     blackhole.consume(
         SlotsAllocator.offerSlotsRoundRobin(
-            state.workers, state.partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK));
+            state.workers,
+            state.partitionIds,
+            true,
+            true,
+            StorageInfo.ALL_TYPES_AVAILABLE_MASK,
+            false,
+            0));
   }
 
   public static void main(String[] args) throws Exception {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -81,7 +81,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         SlotsAllocator.offerSlotsRoundRobin(
-            workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+            workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK, false, 0);
 
     Consumer<PartitionLocation> assertCustomer =
         new Consumer<PartitionLocation>() {
@@ -121,7 +121,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         SlotsAllocator.offerSlotsRoundRobin(
-            workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+            workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK, false, 0);
 
     Consumer<PartitionLocation> assertConsumer =
         new Consumer<PartitionLocation>() {
@@ -208,7 +208,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
       Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
           SlotsAllocator.offerSlotsRoundRobin(
-              workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+              workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK, false, 0);
 
       Map<String, Long> numReplicaPerHost =
           slots.entrySet().stream()
@@ -246,7 +246,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
         Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
             SlotsAllocator.offerSlotsRoundRobin(
-                workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+                workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK, false, 0);
 
         Map<String, Long> numReplicaPerHost =
             slots.entrySet().stream()

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -683,7 +683,6 @@ public class SlotsAllocatorSuiteJ {
         basePrepareWorkers(
             100, true, diskPartitionToSize, assumedPartitionSize, 20, false, new Random());
     List<Integer> partitionIds = IntStream.range(0, 600).boxed().collect(Collectors.toList());
-    ;
     check(workers, partitionIds, true, true, false, true, 50);
   }
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -17,26 +17,25 @@
 
 package org.apache.celeborn.service.deploy.master;
 
+import static org.junit.Assert.*;
+
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import scala.Tuple2;
+import scala.Tuple3;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.protocol.StorageInfo;
-import scala.Tuple3;
-
-import static org.junit.Assert.*;
-
 
 public class SlotsAllocatorSuiteJ {
   private List<WorkerInfo> prepareWorkers(boolean hasDisks) {
@@ -169,7 +168,12 @@ public class SlotsAllocatorSuiteJ {
     if (roundrobin) {
       slots =
           SlotsAllocator.offerSlotsRoundRobin(
-              workers, partitionIds, shouldReplicate, false, StorageInfo.ALL_TYPES_AVAILABLE_MASK, interruptionAware,
+              workers,
+              partitionIds,
+              shouldReplicate,
+              false,
+              StorageInfo.ALL_TYPES_AVAILABLE_MASK,
+              interruptionAware,
               interruptionAwareThreshold);
     } else {
       slots =
@@ -294,7 +298,9 @@ public class SlotsAllocatorSuiteJ {
               0.1,
               0,
               1,
-              StorageInfo.LOCAL_DISK_MASK | availableStorageTypes, false, 0);
+              StorageInfo.LOCAL_DISK_MASK | availableStorageTypes,
+              false,
+              0);
     }
     int allocatedPartitionCount = 0;
     for (Map.Entry<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
@@ -484,7 +490,8 @@ public class SlotsAllocatorSuiteJ {
     diskPartitionToSize.put("/mnt/disk", 512 * 1024 * 1024L); // 0.5gb disk space
     // Cluster usable space is 50g, with 25g that will not be interrupted.
     List<WorkerInfo> workers =
-        basePrepareWorkers(100, true, diskPartitionToSize, assumedPartitionSize, 20, true, new Random());
+        basePrepareWorkers(
+            100, true, diskPartitionToSize, assumedPartitionSize, 20, true, new Random());
     Map<String, WorkerInfo> workersMap =
         workers.stream().collect(Collectors.toMap(WorkerInfo::host, worker -> worker));
     Tuple3<List<WorkerInfo>, List<WorkerInfo>, List<WorkerInfo>> prioritization =
@@ -524,14 +531,14 @@ public class SlotsAllocatorSuiteJ {
         IntStream.range(0, 150).boxed().collect(Collectors.toList());
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
         slotsFromBestCasePartitionIds =
-        SlotsAllocator.offerSlotsRoundRobin(
-            workers,
-            bestCasePartitionIds,
-            shouldReplicate,
-            shouldRackAware,
-            StorageInfo.ALL_TYPES_AVAILABLE_MASK,
-            true,
-            (int) interruptionAwarePercentileThreshold);
+            SlotsAllocator.offerSlotsRoundRobin(
+                workers,
+                bestCasePartitionIds,
+                shouldReplicate,
+                shouldRackAware,
+                StorageInfo.ALL_TYPES_AVAILABLE_MASK,
+                true,
+                (int) interruptionAwarePercentileThreshold);
     slotsFromBestCasePartitionIds
         .values()
         .forEach(
@@ -579,14 +586,14 @@ public class SlotsAllocatorSuiteJ {
     }
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
         slotsFromSpillOverCasePartitionIds =
-        SlotsAllocator.offerSlotsRoundRobin(
-            workers,
-            spillOverCasePartitionIds,
-            shouldReplicate,
-            shouldRackAware,
-            StorageInfo.ALL_TYPES_AVAILABLE_MASK,
-            true,
-            (int) interruptionAwarePercentileThreshold);
+            SlotsAllocator.offerSlotsRoundRobin(
+                workers,
+                spillOverCasePartitionIds,
+                shouldReplicate,
+                shouldRackAware,
+                StorageInfo.ALL_TYPES_AVAILABLE_MASK,
+                true,
+                (int) interruptionAwarePercentileThreshold);
     slotsFromSpillOverCasePartitionIds
         .values()
         .forEach(
@@ -619,19 +626,19 @@ public class SlotsAllocatorSuiteJ {
                 }
               }
             });
-        // With the slot restrictions in place for LoadAware, we expect to spill replicas into
-        // workersWithEarlyInterruptionsHosts.
-        // But primaries should be in workersWithoutInterruptions + workersWithLateInterruptions.
-        Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
+    // With the slot restrictions in place for LoadAware, we expect to spill replicas into
+    // workersWithEarlyInterruptionsHosts.
+    // But primaries should be in workersWithoutInterruptions + workersWithLateInterruptions.
+    Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
         loadAwareBestCasePartitionIdsSlots =
-        check(
-            workers,
-            spillOverCasePartitionIds,
-            shouldReplicate,
-            true,
-            false,
-            true,
-            (int) interruptionAwarePercentileThreshold);
+            check(
+                workers,
+                spillOverCasePartitionIds,
+                shouldReplicate,
+                true,
+                false,
+                true,
+                (int) interruptionAwarePercentileThreshold);
     loadAwareBestCasePartitionIdsSlots
         .values()
         .forEach(

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -717,7 +717,7 @@ public class SlotsAllocatorSuiteJ {
                               random.nextInt(1000),
                               random.nextInt(1000),
                               0);
-                      diskInfo.maxSlots_$eq(diskInfo.actualUsableSpace() / assumedPartitionSize);
+                      diskInfo.availableSlots_$eq(diskInfo.actualUsableSpace() / assumedPartitionSize);
                       disks.put(diskMountPoint, diskInfo);
                     });
               }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -717,7 +717,8 @@ public class SlotsAllocatorSuiteJ {
                               random.nextInt(1000),
                               random.nextInt(1000),
                               0);
-                      diskInfo.availableSlots_$eq(diskInfo.actualUsableSpace() / assumedPartitionSize);
+                      diskInfo.availableSlots_$eq(
+                          diskInfo.actualUsableSpace() / assumedPartitionSize);
                       disks.put(diskMountPoint, diskInfo);
                     });
               }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR is part of [CIP17: Interruption Aware Slot Selection](https://cwiki.apache.org/confluence/display/CELEBORN/CIP-17%3A+Interruption+Aware+Slot+Selection).

It makes the changes in the slot selection logic to prioritize workers that do not have interruption "soon". See more context about the slot selection logic [here](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=362056201#CIP17:InterruptionAwareSlotSelection-SlotsAllocator). 


### Why are the changes needed?
see [CIP17: Interruption Aware Slot Selection](https://cwiki.apache.org/confluence/display/CELEBORN/CIP-17%3A+Interruption+Aware+Slot+Selection).


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
unit tests. This is also already in production in our cluster for last 4-5 months. 
