### PR TITLE
[CELEBORN-1844][Followup] alway try to use memory storage if available

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -185,8 +185,15 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
       if (evict) {
         0
       } else {
-        order.get.indexOf(
-          partitionDataWriterContext.getPartitionLocation.getStorageInfo.getType.name())
+        // keep the old behavior, always try to use memory if worker
+        // has configured to use memory storage, because slots allocator
+        // will not allocate slots on memory storage
+        if (order.contains(StorageInfo.Type.MEMORY.name())) {
+          order.get.indexOf(StorageInfo.Type.MEMORY.name())
+        } else {
+          order.get.indexOf(
+            partitionDataWriterContext.getPartitionLocation.getStorageInfo.getType.name())
+        }
       }
 
     val maxSize = order.get.length


### PR DESCRIPTION
### What changes were proposed in this pull request?
Try to use memory storage first if it is available.
To increase performance, if a cluster is set to use MEMORY and HDFS.


### Why are the changes needed?
To keep the old behavior as in release 0.5, always try to use memory storage first because the slots allocator won't allocate slots on memory storage.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA.
