### PR TITLE
[CELEBORN-2061] Introduce metrics to count the amount of data flushed into different storage types

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -63,6 +63,11 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, Role.WORKER)
 
   addCounter(COMMIT_FILES_FAIL_COUNT)
 
+  addCounter(LOCAL_FLUSH_BYTES_COUNT)
+  addCounter(HDFS_FLUSH_BYTES_COUNT)
+  addCounter(OSS_FLUSH_BYTES_COUNT)
+  addCounter(S3_FLUSH_BYTES_COUNT)
+
   // add timers
   addTimer(COMMIT_FILES_TIME)
   addTimer(RESERVE_SLOTS_TIME)
@@ -195,6 +200,10 @@ object WorkerSource {
   val COMMIT_FILES_TIME = "CommitFilesTime"
   val COMMIT_FILES_FAIL_COUNT = "CommitFilesFailCount"
   val FLUSH_WORKING_QUEUE_SIZE = "FlushWorkingQueueSize"
+  val LOCAL_FLUSH_BYTES_COUNT = "LocalFlushBytesCount"
+  val HDFS_FLUSH_BYTES_COUNT = "HdfsFlushBytesCount"
+  val OSS_FLUSH_BYTES_COUNT = "OssFlushBytesCount"
+  val S3_FLUSH_BYTES_COUNT = "S3FlushBytesCount"
 
   // slots
   val SLOTS_ALLOCATED = "SlotsAllocated"

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -71,6 +71,16 @@ abstract private[worker] class Flusher(
                   val flushBeginTime = System.nanoTime()
                   lastBeginFlushTime.set(index, flushBeginTime)
                   task.flush()
+                  task match {
+                    case _: LocalFlushTask =>
+                      workerSource.incCounter(WorkerSource.LOCAL_FLUSH_BYTES_COUNT)
+                    case _: HdfsFlushTask =>
+                      workerSource.incCounter(WorkerSource.HDFS_FLUSH_BYTES_COUNT)
+                    case _: OssFlushTask =>
+                      workerSource.incCounter(WorkerSource.OSS_FLUSH_BYTES_COUNT)
+                    case _: S3FlushTask =>
+                      workerSource.incCounter(WorkerSource.S3_FLUSH_BYTES_COUNT)
+                  }
                   if (flushTimeMetric != null) {
                     val delta = System.nanoTime() - flushBeginTime
                     flushTimeMetric.update(delta)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added metrics for the amount of data written to different storage types, including Local, HDFS, OSS, and S3


### Why are the changes needed?

Currently, there is a lack of data volume written to each storage, and it is impossible to monitor the size and speed of writing.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

Cluster Test
