### PR TITLE
[CELEBORN-2064] Fix the issue where reading replica partition that returns zero chunk causes tasks to hang

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -805,7 +805,7 @@ public abstract class CelebornInputStream extends InputStream {
         if (firstChunk && currentReader != null) {
           init();
           currentChunk = getNextChunk();
-          while (currentChunk == null && moveToNextChunk()) ;
+          while (currentChunk == null && moveToNextChunk());
           firstChunk = false;
         }
         if (currentChunk == null) {

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -805,7 +805,7 @@ public abstract class CelebornInputStream extends InputStream {
         if (firstChunk && currentReader != null) {
           init();
           currentChunk = getNextChunk();
-          while (currentChunk == null && moveToNextChunk());
+          while (currentChunk == null && moveToNextChunk()) ;
           firstChunk = false;
         }
         if (currentChunk == null) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Re-validate hasNextChunk within getNextChunk.


### Why are the changes needed?
Fix the issue where reading replica partition that returns zero chunk causes tasks to hang


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manual test
