### PR TITLE
[CELEBORN-2067] Clean up deprecated Guava API usage

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -361,7 +361,8 @@ public class TransportClientFactory implements Closeable {
           Utils.nanoDurationToString(bootstrapTime),
           e);
       client.close();
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
     long postBootstrap = System.nanoTime();
     logger.debug(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDBIterator.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDBIterator.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import com.google.common.base.Throwables;
-
 /** Note: code copied from Apache Spark. */
 public class LevelDBIterator implements DBIterator {
 
@@ -48,7 +46,7 @@ public class LevelDBIterator implements DBIterator {
       try {
         close();
       } catch (IOException ioe) {
-        throw Throwables.propagate(ioe);
+        throw new RuntimeException(ioe);
       }
     }
     return next != null;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDB.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDB.java
@@ -19,7 +19,6 @@ package org.apache.celeborn.service.deploy.worker.shuffledb;
 
 import java.io.IOException;
 
-import com.google.common.base.Throwables;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
 
@@ -41,7 +40,7 @@ public class RocksDB implements DB {
     try {
       db.put(key, value);
     } catch (RocksDBException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -54,7 +53,7 @@ public class RocksDB implements DB {
         db.put(key, value);
       }
     } catch (RocksDBException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -63,7 +62,7 @@ public class RocksDB implements DB {
     try {
       return db.get(key);
     } catch (RocksDBException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -72,7 +71,7 @@ public class RocksDB implements DB {
     try {
       db.delete(key);
     } catch (RocksDBException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBIterator.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBIterator.java
@@ -22,7 +22,6 @@ import java.util.AbstractMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import com.google.common.base.Throwables;
 import org.rocksdb.RocksIterator;
 
 /**
@@ -54,7 +53,7 @@ public class RocksDBIterator implements DBIterator {
       try {
         close();
       } catch (IOException ioe) {
-        throw Throwables.propagate(ioe);
+        throw new RuntimeException(ioe);
       }
     }
     return next != null;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clean up deprecated Guava API usage.

### Why are the changes needed?

There are deprecated Guava API usage, including:

1. Made modifications to Throwables.propagate with reference to https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate

- For cases where it is known to be a checked exception, including `IOException`, `GeneralSecurityException`, `SaslException`, and `RocksDBException`, none of which are subclasses of RuntimeException or Error, directly replaced Throwables.propagate(e) with `throw new RuntimeException(e);`.

- For cases where it cannot be determined whether it is a checked exception or an unchecked exception or Error, use

```
throwIfUnchecked(e);
throw new RuntimeException(e);
```

to replace `Throwables.propagate(e)`.

https://github.com/google/guava/blob/0c33dd12b193402cdf6962d43d69743521aa2f76/guava/src/com/google/common/base/Throwables.java#L199-L235

```
  /**
   * ...
   * @deprecated To preserve behavior, use {@code throw e} or {@code throw new RuntimeException(e)}
   *     directly, or use a combination of {@link #throwIfUnchecked} and {@code throw new
   *     RuntimeException(e)}. But consider whether users would be better off if your API threw a
   *     different type of exception. For background on the deprecation, read <a
   *     href="https://goo.gl/Ivn2kc">Why we deprecated {@code Throwables.propagate}</a>.
   */
  @CanIgnoreReturnValue
  @J2ktIncompatible
  @GwtIncompatible
  @Deprecated
  public static RuntimeException propagate(Throwable throwable) {
    throwIfUnchecked(throwable);
    throw new RuntimeException(throwable);
  }
```

Backport https://github.com/apache/spark/pull/48248

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.