### PR TITLE
[CELEBORN-2071] Fix the issue where some gauge metrics were not registered to the metricRegistry

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -112,6 +112,10 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
       namedGauges.putIfAbsent(
         metricNameWithCustomizedLabels(name, labels),
         NamedGauge(name, gauge, labels ++ staticLabels))
+      val metricNameWithLabel = metricNameWithCustomizedLabels(name, labels)
+      if (!metricRegistry.getGauges.containsKey(metricNameWithLabel)) {
+        metricRegistry.register(metricNameWithLabel, gauge)
+      }
     } else {
       logWarning(
         s"Add gauge $name failed, the value type ${gauge.getValue.getClass} is not a number")


### PR DESCRIPTION
### What changes were proposed in this pull request?

add code to register gauge to metricRegistry in addGauge method

### Why are the changes needed?

Because one implementation of addGauge does not register the gauge to the metricRegistry, some Sink implementation classes cannot export these gauge metrics. For example, you cannot see JVMCPUTime in the metric file printed by CsvSink, because CsvSink only prints metrics from the registry variable in MetricsSystem.
### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

cluster test

