### PR TITLE
[CELEBORN-2070][CIP-14] Support RegisterShuffle, MapperEnd/Response in CppClient

### DIFF
--- a/cpp/celeborn/protocol/ControlMessages.h
+++ b/cpp/celeborn/protocol/ControlMessages.h
@@ -26,6 +26,31 @@
 
 namespace celeborn {
 namespace protocol {
+struct RegisterShuffle {
+  long shuffleId;
+  int numMappers;
+  int numPartitions;
+
+  TransportMessage toTransportMessage() const;
+};
+
+struct MapperEnd {
+  long shuffleId;
+  int mapId;
+  int attemptId;
+  int numMappers;
+  int partitionId;
+
+  TransportMessage toTransportMessage() const;
+};
+
+struct MapperEndResponse {
+  StatusCode status;
+
+  static std::unique_ptr<MapperEndResponse> fromTransportMessage(
+      const TransportMessage& transportMessage);
+};
+
 struct GetReducerFileGroup {
   int shuffleId;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for RegisterShuffle, MapperEnd/Response in CppClient.

### Why are the changes needed?
To support writing to Celeborn with CppClient.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By compilation and UTs.
