### PR TITLE
[CELEBORN-2075] Fix `OpenStreamTime` metrics for `PbOpenStreamList` request

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -1280,6 +1280,14 @@ object Utils extends Logging {
     s"$shuffleKey-$clientChannelId-$rpcRequestId"
   }
 
+  def makeOpenStreamListRequestId(
+      shuffleKey: String,
+      clientChannelId: String,
+      rpcRequestId: Long,
+      idx: Int): String = {
+    s"$shuffleKey-$clientChannelId-$rpcRequestId-$idx"
+  }
+
   def withRetryOnTimeoutOrIOException[T](numRetries: Int, retryWait: Long)(block: => T): T = {
     var retriesLeft = numRetries
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -1280,14 +1280,6 @@ object Utils extends Logging {
     s"$shuffleKey-$clientChannelId-$rpcRequestId"
   }
 
-  def makeOpenStreamListRequestId(
-      shuffleKey: String,
-      clientChannelId: String,
-      rpcRequestId: Long,
-      idx: Int): String = {
-    s"$shuffleKey-$clientChannelId-$rpcRequestId-$idx"
-  }
-
   def withRetryOnTimeoutOrIOException[T](numRetries: Int, retryWait: Long)(block: => T): T = {
     var retriesLeft = numRetries
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -580,6 +580,7 @@ class FetchHandler(
         streamChunkSlice.chunkIndex,
         streamChunkSlice.offset,
         streamChunkSlice.len)
+      val bufSize = buf.size()
       chunkStreamManager.chunkBeingSent(streamChunkSlice.streamId)
       client.getChannel.writeAndFlush(new ChunkFetchSuccess(streamChunkSlice, buf))
         .addListener(new GenericFutureListener[Future[_ >: Void]] {
@@ -587,12 +588,14 @@ class FetchHandler(
             if (future.isSuccess) {
               if (log.isDebugEnabled) {
                 logDebug(
-                  s"Sending ChunkFetchSuccess to $remoteAddr succeeded, chunk $streamChunkSlice")
+                  s"Sending ChunkFetchSuccess to $remoteAddr succeeded," +
+                    s" chunk $streamChunkSlice, buf size: $bufSize")
               }
               workerSource.incCounter(WorkerSource.FETCH_CHUNK_SUCCESS_COUNT)
             } else {
               logWarning(
-                s"Sending ChunkFetchSuccess to $remoteAddr failed, chunk $streamChunkSlice",
+                s"Sending ChunkFetchSuccess to $remoteAddr failed," +
+                  s" chunk $streamChunkSlice, buf size: $bufSize",
                 future.cause())
               workerSource.incCounter(WorkerSource.FETCH_CHUNK_FAIL_COUNT)
             }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix OpenStreamTime metrics for PbOpenStreamList request


### Why are the changes needed?

For `PbOpenStreamList` request, the `OpenStreamTime` metrics is not calculated.

https://github.com/apache/celeborn/blob/cf3c05d6683eb1f96895478ba3e9c2668f3aaca2/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala#L140-L160


And the   `workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey) ` is meaningless inside `handleReduceOpenStreamInternal`. https://github.com/apache/celeborn/blob/cf3c05d6683eb1f96895478ba3e9c2668f3aaca2/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala#L335-L341


The `handleReduceOpenStreamInternal` is called in 
1. inside `handleOpenStreamInternal`, the `OpenStreamTime` metrics is handled correctly
2. for `PbOpenStreamList, the `OpenStreamTime` metrics is not handled.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually testing.