### PR TITLE
[MINOR] Fix a typo buffer to body in ChunkFetchSuccess.toString

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
@@ -95,7 +95,7 @@ public final class ChunkFetchSuccess extends ResponseMessage {
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
         .append("streamChunkId", streamChunkSlice)
-        .append("buffer", body())
+        .append("body", body())
         .toString();
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a typo `buffer` to `body` in `ChunkFetchSuccess.toString`.

### Why are the changes needed?

Since the field name of `AbstractMessage` is body, all the other places show `body=...` instead of `buffer=...`. We had better fix this typo for consistency.

Backport https://github.com/apache/spark/pull/51570.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.