### PR TITLE
[CELEBORN-2077] Improve toString by JEP-280 instead of ToStringBuilder

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
@@ -25,8 +25,6 @@ import java.nio.file.StandardOpenOption;
 import com.google.common.io.ByteStreams;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.handler.stream.ChunkedStream;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.util.LimitedInputStream;
 import org.apache.celeborn.common.network.util.TransportConf;
@@ -153,10 +151,12 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("file", file)
-        .append("offset", offset)
-        .append("length", length)
-        .toString();
+    return "FileSegmentManagedBuffer[file="
+        + file
+        + ",offset="
+        + offset
+        + ",length="
+        + length
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
@@ -24,8 +24,6 @@ import java.nio.ByteBuffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /** A {@link ManagedBuffer} backed by a Netty {@link ByteBuf}. */
 public class NettyManagedBuffer extends ManagedBuffer {
@@ -83,8 +81,6 @@ public class NettyManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("buf", buf)
-        .toString();
+    return "NettyManagedBuffer[buf=" + buf + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
@@ -23,8 +23,6 @@ import java.nio.ByteBuffer;
 
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /** A {@link ManagedBuffer} backed by {@link ByteBuffer}. */
 public class NioManagedBuffer extends ManagedBuffer {
@@ -71,8 +69,6 @@ public class NioManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("buf", buf)
-        .toString();
+    return "NioManagedBuffer[buf=" + buf + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -33,8 +33,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -368,11 +366,13 @@ public class TransportClient implements Closeable {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("remoteAddress", channel.remoteAddress())
-        .append("clientId", clientId)
-        .append("isActive", isActive())
-        .toString();
+    return "TransportClient[remoteAddress="
+        + channel.remoteAddress()
+        + "clientId="
+        + clientId
+        + ",isActive="
+        + isActive()
+        + "]";
   }
 
   private static final AtomicLong counter = new AtomicLong();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
 
@@ -73,9 +71,10 @@ public final class ChunkFetchFailure extends ResponseMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("streamChunkId", streamChunkSlice)
-        .append("errorString", errorString)
-        .toString();
+    return "ChunkFetchFailure[streamChunkId="
+        + streamChunkSlice
+        + ",errorString="
+        + errorString
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
@@ -18,8 +18,6 @@
 package org.apache.celeborn.common.network.protocol;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Request to fetch a sequence of a single chunk of a stream. This will correspond to a single
@@ -68,8 +66,6 @@ public final class ChunkFetchRequest extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("streamChunkId", streamChunkSlice)
-        .toString();
+    return "ChunkFetchRequest[streamChunkId=" + streamChunkSlice + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
@@ -93,9 +91,6 @@ public final class ChunkFetchSuccess extends ResponseMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("streamChunkId", streamChunkSlice)
-        .append("body", body())
-        .toString();
+    return "ChunkFetchSuccess[streamChunkId=" + streamChunkSlice + ",body=" + body() + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
@@ -83,8 +81,6 @@ public final class OneWayMessage extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("body", body())
-        .toString();
+    return "OneWayMessage[body=" + body() + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Request to read a set of blocks. Returns {@link StreamHandle}. Use PbOpenStream instead of this
@@ -101,11 +99,14 @@ public final class OpenStream extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("shuffleKey", new String(shuffleKey, StandardCharsets.UTF_8))
-        .append("fileName", new String(fileName, StandardCharsets.UTF_8))
-        .append("startMapIndex", startMapIndex)
-        .append("endMapIndex", endMapIndex)
-        .toString();
+    return "OpenStream[shuffleKey="
+        + new String(shuffleKey, StandardCharsets.UTF_8)
+        + ",fileName="
+        + new String(fileName, StandardCharsets.UTF_8)
+        + ",startMapIndex="
+        + startMapIndex
+        + ",endMapIndex="
+        + endMapIndex
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
@@ -107,12 +105,16 @@ public final class PushData extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("requestId", requestId)
-        .append("mode", mode)
-        .append("shuffleKey", shuffleKey)
-        .append("partitionUniqueId", partitionUniqueId)
-        .append("body size", body().size())
-        .toString();
+    return "PushData[requestId="
+        + requestId
+        + ",mode="
+        + mode
+        + ",shuffleKey="
+        + shuffleKey
+        + ",partitionUniqueId="
+        + partitionUniqueId
+        + ",body size="
+        + body().size()
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 @Deprecated
 public final class PushDataHandShake extends RequestMessage {
@@ -106,13 +104,18 @@ public final class PushDataHandShake extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("mode", mode)
-        .append("shuffleKey", shuffleKey)
-        .append("partitionUniqueId", partitionUniqueId)
-        .append("attemptId", attemptId)
-        .append("numSubPartitions", numPartitions)
-        .append("bufferSize", bufferSize)
-        .toString();
+    return "PushDataHandShake[mode="
+        + mode
+        + ",shuffleKey="
+        + shuffleKey
+        + ",partitionUniqueId="
+        + partitionUniqueId
+        + ",attemptId="
+        + attemptId
+        + ",numSubPartitions="
+        + numPartitions
+        + ",bufferSize="
+        + bufferSize
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
@@ -21,8 +21,6 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
@@ -120,13 +118,18 @@ public final class PushMergedData extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("requestId", requestId)
-        .append("mode", mode)
-        .append("shuffleKey", shuffleKey)
-        .append("partitionIds", Arrays.toString(partitionUniqueIds))
-        .append("batchOffsets", Arrays.toString(batchOffsets))
-        .append("body size", body().size())
-        .toString();
+    return "PushMergedData[requestId="
+        + requestId
+        + ",mode="
+        + mode
+        + ",shuffleKey="
+        + shuffleKey
+        + ",partitionIds="
+        + Arrays.toString(partitionUniqueIds)
+        + ",batchOffsets="
+        + Arrays.toString(batchOffsets)
+        + ",body size="
+        + body().size()
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 @Deprecated
 public final class RegionFinish extends RequestMessage {
@@ -89,11 +87,14 @@ public final class RegionFinish extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("mode", mode)
-        .append("shuffleKey", shuffleKey)
-        .append("partitionUniqueId", partitionUniqueId)
-        .append("attemptId", attemptId)
-        .toString();
+    return "RegionFinish[mode="
+        + mode
+        + ",shuffleKey="
+        + shuffleKey
+        + ",partitionUniqueId="
+        + partitionUniqueId
+        + ",attemptId="
+        + attemptId
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 @Deprecated
 public final class RegionStart extends RequestMessage {
@@ -109,13 +107,18 @@ public final class RegionStart extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("mode", mode)
-        .append("shuffleKey", shuffleKey)
-        .append("partitionUniqueId", partitionUniqueId)
-        .append("attemptId", attemptId)
-        .append("currentRegionIndex", currentRegionIndex)
-        .append("isBroadcast", isBroadcast)
-        .toString();
+    return "RegionStart[mode="
+        + mode
+        + ",shuffleKey="
+        + shuffleKey
+        + ",partitionUniqueId="
+        + partitionUniqueId
+        + ",attemptId="
+        + attemptId
+        + ",currentRegionIndex="
+        + currentRegionIndex
+        + ",isBroadcast="
+        + isBroadcast
+        + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /** Response to {@link RpcRequest} for a failed RPC. */
 public final class RpcFailure extends ResponseMessage {
@@ -71,9 +69,6 @@ public final class RpcFailure extends ResponseMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("requestId", requestId)
-        .append("errorString", errorString)
-        .toString();
+    return "RpcFailure[requestId=" + requestId + ",errorString=" + errorString + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
@@ -91,9 +89,6 @@ public final class RpcRequest extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("requestId", requestId)
-        .append("body", body())
-        .toString();
+    return "RpcRequest[requestId=" + requestId + ",body=" + body() + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
@@ -91,9 +89,6 @@ public final class RpcResponse extends ResponseMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("requestId", requestId)
-        .append("body", body())
-        .toString();
+    return "RpcResponse[requestId=" + requestId + ",body=" + body() + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
 
@@ -89,12 +87,15 @@ public final class StreamChunkSlice implements Encodable {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("streamId", streamId)
-        .append("chunkIndex", chunkIndex)
-        .append("offset", offset)
-        .append("len", len)
-        .toString();
+    return "StreamChunkSlice[streamId="
+        + streamId
+        + ",chunkIndex="
+        + chunkIndex
+        + ",offset="
+        + offset
+        + ",len="
+        + len
+        + "]";
   }
 
   public PbStreamChunkSlice toProto() {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
@@ -20,8 +20,6 @@ package org.apache.celeborn.common.network.protocol;
 import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Identifier for a fixed number of chunks to read from a stream created by an "open blocks"
@@ -73,9 +71,6 @@ public final class StreamHandle extends RequestMessage {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-        .append("streamId", streamId)
-        .append("numChunks", numChunks)
-        .toString();
+    return "StreamHandle[streamId=" + streamId + ",numChunks=" + numChunks + "]";
   }
 }

--- a/common/src/main/java/org/apache/celeborn/reflect/DynFields.java
+++ b/common/src/main/java/org/apache/celeborn/reflect/DynFields.java
@@ -26,8 +26,6 @@ import java.security.PrivilegedAction;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 /** this class is copied from Apache Kyuubi, derived from iceberg-common */
 public class DynFields {
 
@@ -67,11 +65,13 @@ public class DynFields {
 
     @Override
     public String toString() {
-      return new ToStringBuilder(this)
-          .append("class", field.getDeclaringClass().toString())
-          .append("name", name)
-          .append("type", field.getType())
-          .toString();
+      return "DynFields[class="
+          + field.getDeclaringClass()
+          + ",name="
+          + name
+          + ",type="
+          + field.getType()
+          + "]";
     }
 
     /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve `toString` by JEP-280 instead of `ToStringBuilder`.

### Why are the changes needed?

Since Java 9, String Concatenation has been handled better by default.

ID | DESCRIPTION
-- | --
JEP-280 | [Indify String Concatenation](https://openjdk.org/jeps/280)

Backport https://github.com/apache/spark/pull/51572.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.