### PR TITLE
[CELEBORN-2079] Fix grafana dashboard netty metrics

### DIFF
--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -38,6 +38,7 @@ import org.apache.celeborn.common.meta.MemoryFileInfo;
 import org.apache.celeborn.common.meta.ReduceFileMeta;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.util.NettyUtils;
+import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
@@ -61,7 +62,8 @@ public class MemoryPartitionFilesSorterSuiteJ {
 
     AbstractSource source = Mockito.mock(AbstractSource.class);
     ByteBufAllocator allocator =
-        NettyUtils.getSharedByteBufAllocator(new CelebornConf(), source, false);
+        NettyUtils.getSharedByteBufAllocator(
+            new TransportConf("default", new CelebornConf()), source, false);
     CompositeByteBuf buffer = allocator.compositeBuffer();
     fileInfo.setBuffer(buffer);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title, fix grafana dashboard netty metrics by using module name as the netty metrics prefix.


### Why are the changes needed?
The dashboard for netty metrics broken,
<img width="1714" height="818" alt="image" src="https://github.com/user-attachments/assets/5e305660-b898-4668-b279-3eb596f2f1bc" />


The metrics is formatted as below,
```
metrics_shared_pool_1_chunkSize_Value{instance="hdc42-mcc10-01-0510-3808-050-tess0097.stratus.rno.ebay.com:8080",role="Worker"} 4194304 1753229921511
```
### Does this PR introduce _any_ user-facing change?

No, just fix the dashboard.

### How was this patch tested?

IT.