### PR TITLE
[CELEBORN-1917][FOLLOWUP] Do not wait if total inflight  or inflight to a specific worker is lower than threshold

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
@@ -147,8 +147,8 @@ public class InFlightRequestTracker {
           if ((totalInflightReqs.sum() <= maxInFlightReqsTotal
                   && batchIdSet.size() <= currentMaxReqsInFlight)
               || (maxInFlightBytesSizeEnabled
-                  && totalInflightBytes.sum() <= maxInFlightBytesSizeTotal
-                  && batchBytesSize.sum() <= maxInFlightBytesSizePerWorker)) {
+                  && (totalInflightBytes.sum() <= maxInFlightBytesSizeTotal
+                      || batchBytesSize.sum() <= maxInFlightBytesSizePerWorker))) {
             break;
           }
           if (pushState.exception.get() != null) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

If `maxInFlightBytesSizeEnabled`, break the `limitMaxInFlight` waiting if total inflight or inflight to a specific worker is lower than threshold.


### Why are the changes needed?

Followup for comment https://github.com/apache/celeborn/pull/3248#discussion_r2222783505 incase we miss it.

> My earlier query was, should this be || ?
As in, either total inflight is high, or inflight to a specific worker is high (assuming per worker threshold is lower than total !)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Code review.
