### PR TITLE
[CELEBORN-2082] Add the log of excluded workers with high workloads

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -294,7 +294,10 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                 && !conf.hasOssStorage())
             || highWorkload)) {
       LOG.warn(
-          "Worker {} (unhealthy disks num: {}) adds to excluded workers", worker, unhealthyDiskNum);
+          "Worker {} (unhealthy disks num: {}, high workload: {}) adds to excluded workers",
+          worker,
+          unhealthyDiskNum,
+          highWorkload);
       excludedWorkers.add(worker);
     } else if ((availableSlots.get() > 0
             || conf.hasHDFSStorage()


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
When workers with higher workloads are excluded, the master does not have a clear log.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
