### PR TITLE
[CELEBORN-2084] /api/v1/workers adds tagged workers to list tagged workers information

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -69,6 +69,9 @@ final class MasterOptions {
     description = Array("Show decommissioning workers"))
   private[master] var showDecommissioningWorkers: Boolean = _
 
+  @Option(names = Array("--show-tagged-workers"), description = Array("Show tagged workers"))
+  private[master] var showTaggedWorkers: Boolean = _
+
   @Option(
     names = Array("--show-lifecycle-managers"),
     description = Array("Show lifecycle managers"))

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -45,6 +45,7 @@ class MasterSubcommandImpl extends MasterSubcommand {
     if (masterOptions.showManualExcludedWorkers) log(runShowManualExcludedWorkers)
     if (masterOptions.showShutdownWorkers) log(runShowShutdownWorkers)
     if (masterOptions.showDecommissioningWorkers) log(runShowDecommissioningWorkers)
+    if (masterOptions.showTaggedWorkers) log(runShowTaggedWorkers)
     if (masterOptions.showLifecycleManagers) log(runShowLifecycleManagers)
     if (masterOptions.showWorkers) log(runShowWorkers)
     if (masterOptions.showWorkersTopology) log(runShowWorkersTopology)
@@ -167,6 +168,19 @@ class MasterSubcommandImpl extends MasterSubcommand {
       Seq.empty[WorkerData]
     } else {
       decommissioningWorkers.sortBy(_.getHost)
+    }
+  }
+
+  private[master] def runShowTaggedWorkers: Seq[TaggedWorkerData] = {
+    val taggedWorkers = runShowWorkers.getTaggedWorkers.asScala.toSeq
+    if (taggedWorkers.isEmpty) {
+      log("No tagged workers found.")
+      Seq.empty[TaggedWorkerData]
+    } else {
+      taggedWorkers.map(taggedWorkerData => {
+        taggedWorkerData.setWorkers(taggedWorkerData.getWorkers.asScala.sortBy(_.getHost).asJava)
+        taggedWorkerData
+      })
     }
   }
 

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -224,6 +224,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureOutputAndValidateResponse(args, "No decommissioning workers found.")
   }
 
+  test("master --show-tagged-workers") {
+    val args = prepareMasterArgs() :+ "--show-tagged-workers"
+    captureOutputAndValidateResponse(args, "No tagged workers found.")
+  }
+
   test("master --show-lifecycle-managers") {
     val args = prepareMasterArgs() :+ "--show-lifecycle-managers"
     captureOutputAndValidateResponse(args, "HostnamesResponse")

--- a/docs/celeborn_cli.md
+++ b/docs/celeborn_cli.md
@@ -94,11 +94,12 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                            --show-manual-excluded-workers |
                            --show-shutdown-workers |
                            --show-decommissioning-workers |
-                           --show-lifecycle-managers | --show-workers |
-                           --show-workers-topology | --show-conf |
-                           --show-dynamic-conf | --upsert-dynamic-conf |
-                           --delete-dynamic-conf | --show-thread-dump |
-                           --show-container-info | --add-cluster-alias=alias |
+                           --show-tagged-workers | --show-lifecycle-managers |
+                           --show-workers | --show-workers-topology |
+                           --show-conf | --show-dynamic-conf |
+                           --upsert-dynamic-conf | --delete-dynamic-conf |
+                           --show-thread-dump | --show-container-info |
+                           --add-cluster-alias=alias |
                            --remove-cluster-alias=alias |
                            --remove-workers-unavailable-info |
                            --revise-lost-shuffles | --delete-apps |
@@ -160,6 +161,7 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
       --show-masters-info    Show master group info
       --show-shutdown-workers
                              Show shutdown workers
+      --show-tagged-workers  Show tagged workers
       --show-thread-dump     Show master thread dump
       --show-worker-event-info
                              Show worker event information

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -21,7 +21,7 @@ import java.io.IOException
 import java.net.BindException
 import java.util
 import java.util.Collections
-import java.util.concurrent.{ExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService, ScheduledFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.ToLongFunction
 
@@ -1499,6 +1499,10 @@ private[celeborn] class Master(
     } else {
       0
     }
+  }
+
+  def getTaggedWorkers: ConcurrentHashMap[String, util.Set[String]] = {
+    tagsManager.getTagStore
   }
 
   override def getWorkerEventInfo(): String = {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/tags/TagsManager.scala
@@ -40,7 +40,7 @@ class TagsManager(configService: Option[ConfigService]) extends Logging {
         ConcurrentHashMap.newKeySet[String]()
     }
 
-  private def getTagStore: ConcurrentHashMap[String, JSet[String]] = {
+  def getTagStore: ConcurrentHashMap[String, JSet[String]] = {
     configService match {
       case Some(cs) =>
         // TODO: Make configStore.getTags return ConcurrentMap

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/http/api/v1/ApiV1MasterResourceSuite.scala
@@ -73,6 +73,7 @@ class ApiV1MasterResourceSuite extends ApiV1BaseResourceSuite with MasterCluster
     assert(workersResponse.getExcludedWorkers.isEmpty)
     assert(workersResponse.getShutdownWorkers.isEmpty)
     assert(workersResponse.getDecommissioningWorkers.isEmpty)
+    assert(workersResponse.getTaggedWorkers.isEmpty)
 
     val worker = new WorkerId()
       .host("unknown.celeborn")

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/master/WorkerApi.java
@@ -191,7 +191,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * List worker information of the service. It will list all registered workers, lost workers, excluded workers, shutdown workers and decommission workers information. 
+   * List worker information of the service. It will list all registered workers, lost workers, excluded workers, shutdown workers, decommission workers and tagged workers information. 
    * @return WorkersResponse
    * @throws ApiException if fails to make API call
    */
@@ -202,7 +202,7 @@ public class WorkerApi extends BaseApi {
 
   /**
    * 
-   * List worker information of the service. It will list all registered workers, lost workers, excluded workers, shutdown workers and decommission workers information. 
+   * List worker information of the service. It will list all registered workers, lost workers, excluded workers, shutdown workers, decommission workers and tagged workers information. 
    * @param additionalHeaders additionalHeaders for this call
    * @return WorkersResponse
    * @throws ApiException if fails to make API call

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/TaggedWorkerData.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/TaggedWorkerData.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.celeborn.rest.v1.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.celeborn.rest.v1.model.WorkerData;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * TaggedWorkerData
+ */
+@JsonPropertyOrder({
+  TaggedWorkerData.JSON_PROPERTY_TAG,
+  TaggedWorkerData.JSON_PROPERTY_WORKERS
+})
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
+public class TaggedWorkerData {
+  public static final String JSON_PROPERTY_TAG = "tag";
+  private String tag;
+
+  public static final String JSON_PROPERTY_WORKERS = "workers";
+  private List<WorkerData> workers = new ArrayList<>();
+
+  public TaggedWorkerData() {
+  }
+
+  public TaggedWorkerData tag(String tag) {
+    
+    this.tag = tag;
+    return this;
+  }
+
+  /**
+   * The tag of the workers.
+   * @return tag
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_TAG)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getTag() {
+    return tag;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_TAG)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setTag(String tag) {
+    this.tag = tag;
+  }
+
+  public TaggedWorkerData workers(List<WorkerData> workers) {
+    
+    this.workers = workers;
+    return this;
+  }
+
+  public TaggedWorkerData addWorkersItem(WorkerData workersItem) {
+    if (this.workers == null) {
+      this.workers = new ArrayList<>();
+    }
+    this.workers.add(workersItem);
+    return this;
+  }
+
+  /**
+   * The workers of the tag.
+   * @return workers
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_WORKERS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<WorkerData> getWorkers() {
+    return workers;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_WORKERS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setWorkers(List<WorkerData> workers) {
+    this.workers = workers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TaggedWorkerData taggedWorkerData = (TaggedWorkerData) o;
+    return Objects.equals(this.tag, taggedWorkerData.tag) &&
+        Objects.equals(this.workers, taggedWorkerData.workers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tag, workers);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class TaggedWorkerData {\n");
+    sb.append("    tag: ").append(toIndentedString(tag)).append("\n");
+    sb.append("    workers: ").append(toIndentedString(workers)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkersResponse.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkersResponse.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.celeborn.rest.v1.model.TaggedWorkerData;
 import org.apache.celeborn.rest.v1.model.WorkerData;
 import org.apache.celeborn.rest.v1.model.WorkerTimestampData;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -42,7 +43,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   WorkersResponse.JSON_PROPERTY_EXCLUDED_WORKERS,
   WorkersResponse.JSON_PROPERTY_MANUAL_EXCLUDED_WORKERS,
   WorkersResponse.JSON_PROPERTY_SHUTDOWN_WORKERS,
-  WorkersResponse.JSON_PROPERTY_DECOMMISSIONING_WORKERS
+  WorkersResponse.JSON_PROPERTY_DECOMMISSIONING_WORKERS,
+  WorkersResponse.JSON_PROPERTY_TAGGED_WORKERS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class WorkersResponse {
@@ -63,6 +65,9 @@ public class WorkersResponse {
 
   public static final String JSON_PROPERTY_DECOMMISSIONING_WORKERS = "decommissioningWorkers";
   private List<WorkerData> decommissioningWorkers = new ArrayList<>();
+
+  public static final String JSON_PROPERTY_TAGGED_WORKERS = "taggedWorkers";
+  private List<TaggedWorkerData> taggedWorkers = new ArrayList<>();
 
   public WorkersResponse() {
   }
@@ -265,6 +270,39 @@ public class WorkersResponse {
     this.decommissioningWorkers = decommissioningWorkers;
   }
 
+  public WorkersResponse taggedWorkers(List<TaggedWorkerData> taggedWorkers) {
+    
+    this.taggedWorkers = taggedWorkers;
+    return this;
+  }
+
+  public WorkersResponse addTaggedWorkersItem(TaggedWorkerData taggedWorkersItem) {
+    if (this.taggedWorkers == null) {
+      this.taggedWorkers = new ArrayList<>();
+    }
+    this.taggedWorkers.add(taggedWorkersItem);
+    return this;
+  }
+
+  /**
+   * The tagged workers.
+   * @return taggedWorkers
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_TAGGED_WORKERS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<TaggedWorkerData> getTaggedWorkers() {
+    return taggedWorkers;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_TAGGED_WORKERS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setTaggedWorkers(List<TaggedWorkerData> taggedWorkers) {
+    this.taggedWorkers = taggedWorkers;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -279,12 +317,13 @@ public class WorkersResponse {
         Objects.equals(this.excludedWorkers, workersResponse.excludedWorkers) &&
         Objects.equals(this.manualExcludedWorkers, workersResponse.manualExcludedWorkers) &&
         Objects.equals(this.shutdownWorkers, workersResponse.shutdownWorkers) &&
-        Objects.equals(this.decommissioningWorkers, workersResponse.decommissioningWorkers);
+        Objects.equals(this.decommissioningWorkers, workersResponse.decommissioningWorkers) &&
+        Objects.equals(this.taggedWorkers, workersResponse.taggedWorkers);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(workers, lostWorkers, excludedWorkers, manualExcludedWorkers, shutdownWorkers, decommissioningWorkers);
+    return Objects.hash(workers, lostWorkers, excludedWorkers, manualExcludedWorkers, shutdownWorkers, decommissioningWorkers, taggedWorkers);
   }
 
   @Override
@@ -297,6 +336,7 @@ public class WorkersResponse {
     sb.append("    manualExcludedWorkers: ").append(toIndentedString(manualExcludedWorkers)).append("\n");
     sb.append("    shutdownWorkers: ").append(toIndentedString(shutdownWorkers)).append("\n");
     sb.append("    decommissioningWorkers: ").append(toIndentedString(decommissioningWorkers)).append("\n");
+    sb.append("    taggedWorkers: ").append(toIndentedString(taggedWorkers)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -196,7 +196,7 @@ paths:
       operationId: getWorkers
       description: |
         List worker information of the service. It will list all registered workers,
-        lost workers, excluded workers, shutdown workers and decommission workers information.
+        lost workers, excluded workers, shutdown workers, decommission workers and tagged workers information.
       responses:
         "200":
           description: The request was successful.
@@ -1026,6 +1026,18 @@ components:
         - worker
         - timestamp
 
+    TaggedWorkerData:
+      type: object
+      properties:
+        tag:
+          type: string
+          description: The tag of the workers.
+        workers:
+          type: array
+          description: The workers of the tag.
+          items:
+            $ref: '#/components/schemas/WorkerData'
+
     WorkersResponse:
       type: object
       properties:
@@ -1059,6 +1071,11 @@ components:
           description: The decommissioning workers.
           items:
             $ref: '#/components/schemas/WorkerData'
+        taggedWorkers:
+          type: array
+          description: The tagged workers.
+          items:
+            $ref: '#/components/schemas/TaggedWorkerData'
       required:
         - workers
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1OpenapiClientSuite.scala
@@ -75,6 +75,7 @@ class ApiV1OpenapiClientSuite extends ApiV1WorkerOpenapiClientSuite {
     assert(workersResponse.getManualExcludedWorkers.isEmpty)
     assert(workersResponse.getShutdownWorkers.isEmpty)
     assert(workersResponse.getDecommissioningWorkers.isEmpty)
+    assert(workersResponse.getTaggedWorkers.isEmpty)
 
     val workerData = workersResponse.getWorkers.get(0)
     val workerId = new WorkerId()


### PR DESCRIPTION
### What changes were proposed in this pull request?

`/api/v1/workers` adds tagged workers to list tagged workers information. Meanwhile, cli adds `master --show-tagged-workers` command to show tagged workers.

### Why are the changes needed?

`/api/v1/workers` API only lists all registered workers, lost workers, excluded workers, shutdown workers and decommission workers information, which could also add tagged workers to list tagged workers information.

### Does this PR introduce _any_ user-facing change?

1. `/api/v1/workers` adds tagged workers.
2.  CLI adds `master --show-tagged-workers` option.

### How was this patch tested?

- `ApiV1MasterResourceSuite`
- `ApiV1OpenapiClientSuite`
- `TestCelebornCliCommands`