### PR TITLE
[CELEBORN-2086] S3FlushTask and OssFlushTask should close ByteArrayInputStream to avoid resource leak

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
@@ -23,6 +23,7 @@ import java.nio.channels.FileChannel
 import io.netty.buffer.{ByteBufUtil, CompositeByteBuf}
 import org.apache.hadoop.fs.Path
 
+import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.protocol.StorageInfo.Type
 import org.apache.celeborn.server.common.service.mpu.MultipartUploadHandler
@@ -69,7 +70,7 @@ abstract private[worker] class DfsFlushTask(
     buffer: CompositeByteBuf,
     notifier: FlushNotifier,
     keepBuffer: Boolean,
-    source: AbstractSource) extends FlushTask(buffer, notifier, keepBuffer, source) {
+    source: AbstractSource) extends FlushTask(buffer, notifier, keepBuffer, source) with Logging {
   def flush(stream: Closeable)(block: => Unit): Unit = {
     try {
       block
@@ -77,7 +78,7 @@ abstract private[worker] class DfsFlushTask(
       try {
         stream.close()
       } catch {
-        case _: IOException =>
+        case e: IOException => logWarning("Close flush dfs stream failed.", e)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`S3FlushTask` and `OssFlushTask` should close `ByteArrayInputStream` to avoid resource leak.

### Why are the changes needed?

`S3FlushTask` and `OssFlushTask` don't close `ByteArrayInputStream` at present, which may cause resource leak.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.