### PR TITLE
[CELEBORN-894][CELEBORN-474][FOLLOWUP] PushState uses JavaUtils#newConcurrentHashMap to speed up ConcurrentHashMap#computeIfAbsent

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/write/PushState.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/PushState.java
@@ -36,7 +36,7 @@ public class PushState {
   private final InFlightRequestTracker inFlightRequestTracker;
   // partition id -> CommitMetadata
   private final ConcurrentHashMap<Integer, CommitMetadata> commitMetadataMap =
-      new ConcurrentHashMap<>();
+      JavaUtils.newConcurrentHashMap();
 
   private final Map<String, LocationPushFailedBatches> failedBatchMap;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`PushState`  uses `JavaUtils#newConcurrentHashMap` to speed up `ConcurrentHashMap#computeIfAbsent`.

### Why are the changes needed?

Celeborn supports JDK8, which could meet the bug mentioned in [JDK-8161372](https://bugs.openjdk.org/browse/JDK-8161372). Therefore, it's better to use `JavaUtils#newConcurrentHashMap` to speed up `ConcurrentHashMap#computeIfAbsent`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.