### PR TITLE
[CELEBORN-2087] Refine the docs configuration table view

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .md-typeset__table {
     width: 100%;
     overflow-x: visible;  /* Allow horizontal overflow content to be visible instead of clipped or scrollable */

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -17,7 +17,8 @@
 
 .md-typeset__table {
     width: 100%;
-    overflow-x: visible;  /* Allow horizontal overflow content to be visible instead of clipped or scrollable */
+    /* Allow horizontal overflow content to be visible instead of clipped or scrollable */
+    overflow-x: visible;
 }
 
 .md-typeset__table table {
@@ -29,6 +30,18 @@
 
 .md-typeset__table td,
 .md-typeset__table th {
+    max-width: 35%;
     word-break: break-word;
     white-space: normal;
+}
+
+.md-typeset__table tr {
+    background-color: white;
+}
+
+/* Set a different background color for even rows so that the row
+   color alternates.
+ */
+.md-typeset__table tr:nth-child(2n) {
+    background-color: #F1F4F5;
 }

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,0 +1,42 @@
+.md-typeset__table {
+    width: 100%;
+    overflow-x: visible;  /* Allow horizontal overflow content to be visible instead of clipped or scrollable */
+}
+
+.md-typeset__table table {
+    table-layout: fixed;
+    width: 100%;
+    word-wrap: break-word;
+    white-space: normal;
+}
+
+.md-typeset__table td,
+.md-typeset__table th {
+    word-break: break-word;
+    white-space: normal;
+}
+
+/* CSS does not respect max-width on tables or table parts (like cells, columns, etc.),
+   so we have to pick a fixed width for each column.
+   See: https://stackoverflow.com/a/8465980
+ */
+.md-typeset__table th:nth-child(1),
+.md-typeset__table td:nth-child(1) {
+    width: 20%;
+}
+
+.md-typeset__table th:nth-child(2),
+.md-typeset__table td:nth-child(2),
+.md-typeset__table th:nth-child(3),
+.md-typeset__table td:nth-child(3),
+.md-typeset__table th:nth-child(5),
+.md-typeset__table td:nth-child(5),
+.md-typeset__table th:nth-child(6),
+.md-typeset__table td:nth-child(6) {
+    width: 90px;
+}
+
+.md-typeset__table th:nth-child(4),
+.md-typeset__table td:nth-child(4) {
+    width: 30%;
+}

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -32,28 +32,3 @@
     word-break: break-word;
     white-space: normal;
 }
-
-/* CSS does not respect max-width on tables or table parts (like cells, columns, etc.),
-   so we have to pick a fixed width for each column.
-   See: https://stackoverflow.com/a/8465980
- */
-.md-typeset__table th:nth-child(1),
-.md-typeset__table td:nth-child(1) {
-    width: 20%;
-}
-
-.md-typeset__table th:nth-child(2),
-.md-typeset__table td:nth-child(2),
-.md-typeset__table th:nth-child(3),
-.md-typeset__table td:nth-child(3),
-.md-typeset__table th:nth-child(5),
-.md-typeset__table td:nth-child(5),
-.md-typeset__table th:nth-child(6),
-.md-typeset__table td:nth-child(6) {
-    width: 90px;
-}
-
-.md-typeset__table th:nth-child(4),
-.md-typeset__table td:nth-child(4) {
-    width: 30%;
-}

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -30,13 +30,17 @@
 
 .md-typeset__table td,
 .md-typeset__table th {
-    max-width: 35%;
     word-break: break-word;
     white-space: normal;
 }
 
 .md-typeset__table tr {
     background-color: white;
+}
+
+.md-typeset__table th:nth-child(1),
+.md-typeset__table td:nth-child(1) {
+    width: 30%;
 }
 
 /* Set a different background color for even rows so that the row

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,9 @@ extra:
   social:
     - icon: fontawesome/brands/github
 
+extra_css:
+  - assets/css/custom.css
+
 copyright: >
   <br>
   Copyright © 2022-2024 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Enhance the docs configuration view.

### Why are the changes needed?

Currently, it is hard for me to review the config items, I have to scroll for every config item. 
https://celeborn.apache.org/docs/latest/configuration/#master
<img width="1188" height="666" alt="image" src="https://github.com/user-attachments/assets/acc02440-f302-452d-9c1c-734332756bde" />




### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
mkdocs server
```
<img width="1629" height="925" alt="image" src="https://github.com/user-attachments/assets/772c9f19-283d-4080-82d6-5b49494adf4f" />
