### PR TITLE
[CELEBORN-2088] Fix NPE if `celeborn.client.spark.fetch.cleanFailedShuffle` enabled

### DIFF
--- a/client-spark/common/src/main/scala/org/apache/celeborn/spark/FailedShuffleCleaner.scala
+++ b/client-spark/common/src/main/scala/org/apache/celeborn/spark/FailedShuffleCleaner.scala
@@ -37,8 +37,7 @@ private[celeborn] class FailedShuffleCleaner(lifecycleManager: LifecycleManager)
   private lazy val cleanInterval =
     lifecycleManager.conf.clientFetchCleanFailedShuffleIntervalMS
 
-  // for test
-  def reset(): Unit = {
+  def stop(): Unit = {
     shufflesToBeCleaned.clear()
     cleanedShuffleIds.clear()
     if (cleanerThreadPool != null) {

--- a/client-spark/common/src/main/scala/org/apache/celeborn/spark/FailedShuffleCleaner.scala
+++ b/client-spark/common/src/main/scala/org/apache/celeborn/spark/FailedShuffleCleaner.scala
@@ -83,7 +83,7 @@ private[celeborn] class FailedShuffleCleaner(lifecycleManager: LifecycleManager)
     shufflesToBeCleaned.clear()
     cleanedShuffleIds.clear()
     if (cleanerThreadPool != null) {
-      cleanerThreadPool.shutdownNow()
+      ThreadUtils.shutdown(cleanerThreadPool)
       cleanerThreadPool = null
     }
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -268,8 +268,9 @@ public class SparkShuffleManager implements ShuffleManager {
       _sortShuffleManager.stop();
       _sortShuffleManager = null;
     }
-    if (celebornConf.clientFetchCleanFailedShuffle()) {
-      failedShuffleCleaner.reset();
+    if (failedShuffleCleaner != null) {
+      failedShuffleCleaner.stop();
+      failedShuffleCleaner = null;
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?


Fix NPE if `celeborn.client.spark.fetch.cleanFailedShuffle` is true.

This PR also refine the code for `FailedShuffleCleaner`.
### Why are the changes needed?

`failedShuffleCleaner` is null in executor end.
```
25/07/29 17:58:40 ERROR SparkUncaughtExceptionHandler: Uncaught exception in thread Thread[CoarseGrainedExecutorBackend-stop-executor,5,main]
java.lang.NullPointerException: Cannot invoke "org.apache.celeborn.spark.FailedShuffleCleaner.reset()" because "this.failedShuffleCleaner" is null
	at org.apache.spark.shuffle.celeborn.SparkShuffleManager.stop(SparkShuffleManager.java:272) ~[celeborn-client-spark-3-shaded_2.12-0.6.0-rc3.jar:?]
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UT.
