### PR TITLE
[CELEBORN-2090] Support Lz4 Decompression in CppClient

### DIFF
--- a/.github/workflows/cpp_integration.yml
+++ b/.github/workflows/cpp_integration.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   celeborn_cpp_check_lint:
     runs-on: ubuntu-22.04
-    container: holylow/celeborn-cpp-dev:0.3
+    container: jraaaay/celeborn-cpp-dev:0.4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,7 +43,7 @@ jobs:
             xargs clang-format-15 -style=file:./.clang-format -n --Werror
   celeborn_cpp_unit_test:
     runs-on: ubuntu-22.04
-    container: holylow/celeborn-cpp-dev:0.3
+    container: jraaaay/celeborn-cpp-dev:0.4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,7 +59,7 @@ jobs:
         run: ctest
   celeborn_cpp_integration_test:
     runs-on: ubuntu-22.04
-    container: holylow/celeborn-cpp-dev:0.3
+    container: jraaaay/celeborn-cpp-dev:0.4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -90,5 +90,12 @@ jobs:
           build/mvn -pl worker \
             test-compile exec:java \
             -Dexec.classpathScope="test" \
-            -Dexec.mainClass="org.apache.celeborn.service.deploy.cluster.JavaReadCppWriteTestWithNONE" \
+            -Dexec.mainClass="org.apache.celeborn.service.deploy.cluster.JavaWriteCppReadTestWithNONE" \
+            -Dexec.args="-XX:MaxDirectMemorySize=2G"
+      - name: Run Java-Cpp Hybrid Integration Test (LZ4 Decompression)
+        run: |
+          build/mvn -pl worker \
+            test-compile exec:java \
+            -Dexec.classpathScope="test" \
+            -Dexec.mainClass="org.apache.celeborn.service.deploy.cluster.JavaWriteCppReadTestWithLZ4" \
             -Dexec.args="-XX:MaxDirectMemorySize=2G"

--- a/LICENSE
+++ b/LICENSE
@@ -274,6 +274,9 @@ Meta Velox
 ./cpp/celeborn/conf/BaseConf.h
 ./cpp/celeborn/conf/BaseConf.cpp
 
+Meta Folly
+./cpp/cmake/FindLz4.cmake
+
 ------------------------------------------------------------------------------------
 This product bundles various third-party components under the CC0 license.
 This section summarizes those components.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -129,6 +129,12 @@ find_package(Sodium REQUIRED)
 find_library(FIZZ fizz REQUIRED)
 find_library(WANGLE wangle REQUIRED)
 
+find_package(LZ4 REQUIRED)
+set(LZ4_WITH_DEPENDENCIES
+        ${LZ4_LIBRARY}
+        xxhash
+)
+
 find_library(RE2 re2)
 
 find_package(fizz CONFIG REQUIRED)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -21,7 +21,7 @@ docker run \
     -w /celeborn \
     -it --rm \
     --name celeborn-cpp-dev-container \
-    holylow/celeborn-cpp-dev:0.3 \
+    jraaaay/celeborn-cpp-dev:0.4 \
     /bin/bash
 ```
 

--- a/cpp/celeborn/client/CMakeLists.txt
+++ b/cpp/celeborn/client/CMakeLists.txt
@@ -17,9 +17,6 @@ add_library(
         reader/WorkerPartitionReader.cpp
         reader/CelebornInputStream.cpp
         ShuffleClient.cpp
-        compress/Decompressor.h
-        compress/Lz4Trait.h
-        compress/Lz4Decompressor.h
         compress/Decompressor.cpp
         compress/Lz4Decompressor.cpp)
 

--- a/cpp/celeborn/client/CMakeLists.txt
+++ b/cpp/celeborn/client/CMakeLists.txt
@@ -16,7 +16,12 @@ add_library(
         client
         reader/WorkerPartitionReader.cpp
         reader/CelebornInputStream.cpp
-        ShuffleClient.cpp)
+        ShuffleClient.cpp
+        compress/Decompressor.h
+        compress/Lz4Trait.h
+        compress/Lz4Decompressor.h
+        compress/Decompressor.cpp
+        compress/Lz4Decompressor.cpp)
 
 target_include_directories(client PUBLIC ${CMAKE_BINARY_DIR})
 
@@ -31,6 +36,7 @@ target_link_libraries(
         ${FIZZ}
         ${LIBSODIUM_LIBRARY}
         ${FOLLY_WITH_DEPENDENCIES}
+        ${LZ4_WITH_DEPENDENCIES}
         ${GLOG}
         ${GFLAGS_LIBRARIES}
 )

--- a/cpp/celeborn/client/ShuffleClient.cpp
+++ b/cpp/celeborn/client/ShuffleClient.cpp
@@ -48,6 +48,17 @@ std::unique_ptr<CelebornInputStream> ShuffleClientImpl::readPartition(
     int attemptNumber,
     int startMapIndex,
     int endMapIndex) {
+  return ShuffleClientImpl::readPartition(
+      shuffleId, partitionId, attemptNumber, startMapIndex, endMapIndex, true);
+}
+
+std::unique_ptr<CelebornInputStream> ShuffleClientImpl::readPartition(
+    int shuffleId,
+    int partitionId,
+    int attemptNumber,
+    int startMapIndex,
+    int endMapIndex,
+    bool needCompression) {
   const auto& reducerFileGroupInfo = getReducerFileGroupInfo(shuffleId);
   std::string shuffleKey = utils::makeShuffleKey(appUniqueId_, shuffleId);
   std::vector<std::shared_ptr<const protocol::PartitionLocation>> locations;
@@ -64,7 +75,8 @@ std::unique_ptr<CelebornInputStream> ShuffleClientImpl::readPartition(
       reducerFileGroupInfo.attempts,
       attemptNumber,
       startMapIndex,
-      endMapIndex);
+      endMapIndex,
+      needCompression);
 }
 
 void ShuffleClientImpl::updateReducerFileGroup(int shuffleId) {

--- a/cpp/celeborn/client/ShuffleClient.h
+++ b/cpp/celeborn/client/ShuffleClient.h
@@ -38,6 +38,14 @@ class ShuffleClient {
       int startMapIndex,
       int endMapIndex) = 0;
 
+  virtual std::unique_ptr<CelebornInputStream> readPartition(
+      int shuffleId,
+      int partitionId,
+      int attemptNumber,
+      int startMapIndex,
+      int endMapIndex,
+      bool needCompression) = 0;
+
   virtual bool cleanupShuffle(int shuffleId) = 0;
 
   virtual void shutdown() = 0;
@@ -61,6 +69,14 @@ class ShuffleClientImpl : public ShuffleClient {
       int attemptNumber,
       int startMapIndex,
       int endMapIndex) override;
+
+  std::unique_ptr<CelebornInputStream> readPartition(
+      int shuffleId,
+      int partitionId,
+      int attemptNumber,
+      int startMapIndex,
+      int endMapIndex,
+      bool needCompression) override;
 
   void updateReducerFileGroup(int shuffleId) override;
 

--- a/cpp/celeborn/client/compress/Decompressor.cpp
+++ b/cpp/celeborn/client/compress/Decompressor.cpp
@@ -24,7 +24,7 @@ namespace celeborn {
 namespace client {
 namespace compress {
 
-std::unique_ptr<Decompressor> Decompressor::getDecompressor(
+std::unique_ptr<Decompressor> Decompressor::createDecompressor(
     protocol::CompressionCodec codec) {
   switch (codec) {
     case protocol::CompressionCodec::LZ4:

--- a/cpp/celeborn/client/compress/Decompressor.cpp
+++ b/cpp/celeborn/client/compress/Decompressor.cpp
@@ -15,13 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.cluster
+#include <stdexcept>
 
-import org.apache.celeborn.common.protocol.CompressionCodec
+#include "celeborn/client/compress/Lz4Decompressor.h"
+#include "celeborn/utils/Exceptions.h"
 
-object JavaReadCppWriteTestWithNONE extends JavaReadCppWriteTestBase {
+namespace celeborn {
+namespace client {
+namespace compress {
 
-  def main(args: Array[String]) = {
-    testJavaReadCppWrite(CompressionCodec.NONE)
+std::unique_ptr<Decompressor> Decompressor::getDecompressor(
+    protocol::CompressionCodec codec) {
+  switch (codec) {
+    case protocol::CompressionCodec::LZ4:
+      return std::make_unique<Lz4Decompressor>();
+    case protocol::CompressionCodec::ZSTD:
+      // TODO: impl zstd
+      CELEBORN_FAIL("Compression codec ZSTD is not supported.");
+    default:
+      CELEBORN_FAIL("Unknown compression codec.");
   }
 }
+
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/Decompressor.h
+++ b/cpp/celeborn/client/compress/Decompressor.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "celeborn/protocol/CompressionCodec.h"
+
+namespace celeborn {
+namespace client {
+namespace compress {
+
+class Decompressor {
+ public:
+  virtual ~Decompressor() = default;
+
+  virtual int decompress(const char* src, char* dst, int dst_off) = 0;
+
+  virtual int getOriginalLen(const char* src) = 0;
+
+  static std::unique_ptr<Decompressor> getDecompressor(
+      protocol::CompressionCodec codec);
+
+ protected:
+  static int32_t readIntLE(const char* buf, int i) {
+    const auto p = reinterpret_cast<const unsigned char*>(buf);
+    return (p[i]) | (p[i + 1] << 8) | (p[i + 2] << 16) | (p[i + 3] << 24);
+  }
+};
+
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/Decompressor.h
+++ b/cpp/celeborn/client/compress/Decompressor.h
@@ -29,16 +29,16 @@ class Decompressor {
  public:
   virtual ~Decompressor() = default;
 
-  virtual int decompress(const char* src, char* dst, int dst_off) = 0;
+  virtual int decompress(const uint8_t* src, uint8_t* dst, int dst_off) = 0;
 
-  virtual int getOriginalLen(const char* src) = 0;
+  virtual int getOriginalLen(const uint8_t* src) = 0;
 
-  static std::unique_ptr<Decompressor> getDecompressor(
+  static std::unique_ptr<Decompressor> createDecompressor(
       protocol::CompressionCodec codec);
 
  protected:
-  static int32_t readIntLE(const char* buf, int i) {
-    const auto p = reinterpret_cast<const unsigned char*>(buf);
+  static int32_t readIntLE(const uint8_t* buf, const int i) {
+    const auto p = buf;
     return (p[i]) | (p[i + 1] << 8) | (p[i + 2] << 16) | (p[i + 3] << 24);
   }
 };

--- a/cpp/celeborn/client/compress/Lz4Decompressor.cpp
+++ b/cpp/celeborn/client/compress/Lz4Decompressor.cpp
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "celeborn/client/compress/Lz4Decompressor.h"
+#include <lz4.h>
+#include <cstring>
+#include <iostream>
+#include "celeborn/utils/Exceptions.h"
+
+namespace celeborn {
+namespace client {
+namespace compress {
+Lz4Decompressor::Lz4Decompressor() {
+  xxhash_state_ = XXH32_createState();
+  if (!xxhash_state_) {
+    CELEBORN_FAIL("Failed to create XXH32 state.")
+  }
+  XXH32_reset(xxhash_state_, DEFAULT_SEED);
+}
+
+Lz4Decompressor::~Lz4Decompressor() {
+  if (xxhash_state_) {
+    XXH32_freeState(xxhash_state_);
+  }
+}
+
+int Lz4Decompressor::getOriginalLen(const char* src) {
+  return readIntLE(src, MAGIC_LENGTH + 5);
+}
+
+int Lz4Decompressor::decompress(const char* src, char* dst, int dstOff) {
+  const int compressionMethod = static_cast<unsigned char>(src[MAGIC_LENGTH]);
+  const int compressedLen = readIntLE(src, MAGIC_LENGTH + 1);
+  const int originalLen = readIntLE(src, MAGIC_LENGTH + 5);
+  const int expectedCheck = readIntLE(src, MAGIC_LENGTH + 9);
+
+  const char* compressedDataPtr = src + HEADER_LENGTH;
+  char* dstPtr = dst + dstOff;
+
+  switch (compressionMethod) {
+    case COMPRESSION_METHOD_RAW:
+      std::memcpy(dstPtr, compressedDataPtr, originalLen);
+      break;
+    case COMPRESSION_METHOD_LZ4: {
+      const int decompressedBytes = LZ4_decompress_safe(
+          compressedDataPtr, dstPtr, compressedLen, originalLen);
+
+      if (decompressedBytes != originalLen) {
+        CELEBORN_FAIL(
+            std::string("Decompression failed! LZ4 error or size mismatch. ") +
+            "Expected: " + std::to_string(originalLen) +
+            ", Got: " + std::to_string(decompressedBytes));
+      }
+      break;
+    }
+    default:
+      CELEBORN_FAIL(
+          std::string("Unsupported compression method: ") +
+          std::to_string(compressionMethod));
+  }
+
+  XXH32_reset(xxhash_state_, DEFAULT_SEED);
+  XXH32_update(xxhash_state_, dstPtr, originalLen);
+  const uint32_t actualCheck = XXH32_digest(xxhash_state_) & 0xFFFFFFFL;
+
+  if (static_cast<uint32_t>(expectedCheck) != actualCheck) {
+    CELEBORN_FAIL(
+        std::string("Checksum mismatch! Expected: ") +
+        std::to_string(expectedCheck) +
+        ", Actual: " + std::to_string(actualCheck));
+  }
+
+  return originalLen;
+}
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/Lz4Decompressor.h
+++ b/cpp/celeborn/client/compress/Lz4Decompressor.h
@@ -30,8 +30,8 @@ class Lz4Decompressor final : public Decompressor, Lz4Trait {
   Lz4Decompressor();
   ~Lz4Decompressor() override;
 
-  int getOriginalLen(const char* src) override;
-  int decompress(const char* src, char* dst, int dstOff) override;
+  int getOriginalLen(const uint8_t* src) override;
+  int decompress(const uint8_t* src, uint8_t* dst, int dstOff) override;
 
   Lz4Decompressor(const Lz4Decompressor&) = delete;
   Lz4Decompressor& operator=(const Lz4Decompressor&) = delete;

--- a/cpp/celeborn/client/compress/Lz4Decompressor.h
+++ b/cpp/celeborn/client/compress/Lz4Decompressor.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <xxhash.h>
+#include "celeborn/client/compress/Decompressor.h"
+#include "celeborn/client/compress/Lz4Trait.h"
+
+namespace celeborn {
+namespace client {
+namespace compress {
+
+class Lz4Decompressor final : public Decompressor, Lz4Trait {
+ public:
+  Lz4Decompressor();
+  ~Lz4Decompressor() override;
+
+  int getOriginalLen(const char* src) override;
+  int decompress(const char* src, char* dst, int dstOff) override;
+
+  Lz4Decompressor(const Lz4Decompressor&) = delete;
+  Lz4Decompressor& operator=(const Lz4Decompressor&) = delete;
+
+ private:
+  XXH32_state_t* xxhash_state_;
+};
+
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/Lz4Trait.h
+++ b/cpp/celeborn/client/compress/Lz4Trait.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace celeborn {
+namespace client {
+namespace compress {
+
+struct Lz4Trait {
+  static constexpr int MAGIC_LENGTH = 8;
+  static constexpr char MAGIC[MAGIC_LENGTH] =
+      {'L', 'Z', '4', 'B', 'l', 'o', 'c', 'k'};
+
+  static constexpr int HEADER_LENGTH = MAGIC_LENGTH + 1 + 4 + 4 + 4;
+
+  static constexpr int COMPRESSION_METHOD_RAW = 0x10;
+  static constexpr int COMPRESSION_METHOD_LZ4 = 0x20;
+
+  static constexpr int DEFAULT_SEED = 0x9747b28c;
+};
+
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/Lz4Trait.h
+++ b/cpp/celeborn/client/compress/Lz4Trait.h
@@ -22,16 +22,15 @@ namespace client {
 namespace compress {
 
 struct Lz4Trait {
-  static constexpr int MAGIC_LENGTH = 8;
-  static constexpr char MAGIC[MAGIC_LENGTH] =
-      {'L', 'Z', '4', 'B', 'l', 'o', 'c', 'k'};
+  static constexpr char kMagic[] = {'L', 'Z', '4', 'B', 'l', 'o', 'c', 'k'};
+  static constexpr int kMagicLength = sizeof(kMagic);
 
-  static constexpr int HEADER_LENGTH = MAGIC_LENGTH + 1 + 4 + 4 + 4;
+  static constexpr int kHeaderLength = kMagicLength + 1 + 4 + 4 + 4;
 
-  static constexpr int COMPRESSION_METHOD_RAW = 0x10;
-  static constexpr int COMPRESSION_METHOD_LZ4 = 0x20;
+  static constexpr int kCompressionMethodRaw = 0x10;
+  static constexpr int kCompressionMethodLZ4 = 0x20;
 
-  static constexpr int DEFAULT_SEED = 0x9747b28c;
+  static constexpr int kDefaultSeed = 0x9747b28c;
 };
 
 } // namespace compress

--- a/cpp/celeborn/client/reader/CelebornInputStream.cpp
+++ b/cpp/celeborn/client/reader/CelebornInputStream.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "celeborn/client/reader/CelebornInputStream.h"
+#include <lz4.h>
+#include "celeborn/client/compress/Decompressor.h"
 
 namespace celeborn {
 namespace client {
@@ -27,7 +29,8 @@ CelebornInputStream::CelebornInputStream(
     const std::vector<int>& attempts,
     int attemptNumber,
     int startMapIndex,
-    int endMapIndex)
+    int endMapIndex,
+    bool needCompression)
     : shuffleKey_(shuffleKey),
       conf_(conf),
       clientFactory_(clientFactory),
@@ -38,7 +41,15 @@ CelebornInputStream::CelebornInputStream(
       endMapIndex_(endMapIndex),
       currLocationIndex_(0),
       currBatchPos_(0),
-      currBatchSize_(0) {
+      currBatchSize_(0),
+      shouldDecompress_(
+          conf_->shuffleCompressionCodec() !=
+              protocol::CompressionCodec::NONE &&
+          needCompression) {
+  if (shouldDecompress_) {
+    decompressor_ = compress::Decompressor::getDecompressor(
+        conf_->shuffleCompressionCodec());
+  }
   moveToNextReader();
 }
 
@@ -57,9 +68,7 @@ int CelebornInputStream::read(uint8_t* buffer, size_t offset, size_t len) {
     }
     size_t batchRemainingSize = currBatchSize_ - currBatchPos_;
     size_t toReadBytes = std::min(len - readBytes, batchRemainingSize);
-    CELEBORN_CHECK_GE(currChunk_->remainingSize(), toReadBytes);
-    auto size = currChunk_->readToBuffer(&buf[readBytes], toReadBytes);
-    CELEBORN_CHECK_EQ(toReadBytes, size);
+    memcpy(buf + readBytes, rawDataBuf_.data() + currBatchPos_, toReadBytes);
     readBytes += toReadBytes;
     currBatchPos_ += toReadBytes;
   }
@@ -83,13 +92,33 @@ bool CelebornInputStream::fillBuffer() {
     CELEBORN_CHECK_GE(currChunk_->remainingSize(), size);
     CELEBORN_CHECK_LT(mapId, attempts_.size());
 
-    // TODO: compression is not supported yet!
+    if (shouldDecompress_) {
+      if (size > compressedBuf_.size()) {
+        compressedBuf_.resize(size);
+      }
+      currChunk_->readToBuffer(compressedBuf_.data(), size);
+    } else {
+      if (size > rawDataBuf_.size()) {
+        rawDataBuf_.resize(size);
+      }
+      currChunk_->readToBuffer(rawDataBuf_.data(), size);
+    }
 
     if (attemptId == attempts_[mapId]) {
       auto& batchRecord = getBatchRecord(mapId);
       if (batchRecord.count(batchId) <= 0) {
         batchRecord.insert(batchId);
-        currBatchSize_ = size;
+        if (shouldDecompress_) {
+          const auto originalLength =
+              decompressor_->getOriginalLen(compressedBuf_.data());
+          if (rawDataBuf_.size() < originalLength) {
+            rawDataBuf_.resize(originalLength);
+          }
+          currBatchSize_ = decompressor_->decompress(
+              compressedBuf_.data(), rawDataBuf_.data(), 0);
+        } else {
+          currBatchSize_ = size;
+        }
         currBatchPos_ = 0;
         hasData = true;
         break;

--- a/cpp/celeborn/client/reader/CelebornInputStream.h
+++ b/cpp/celeborn/client/reader/CelebornInputStream.h
@@ -72,11 +72,11 @@ class CelebornInputStream {
   int endMapIndex_;
   bool shouldDecompress_;
   std::unique_ptr<compress::Decompressor> decompressor_;
-  std::vector<char> rawDataBuf_;
-  std::vector<char> compressedBuf_;
+  std::vector<uint8_t> compressedBuf_;
 
   int currLocationIndex_;
   std::unique_ptr<memory::ReadOnlyByteBuffer> currChunk_;
+  std::unique_ptr<memory::ReadOnlyByteBuffer> decompressedChunk_;
   size_t currBatchPos_;
   size_t currBatchSize_;
   std::shared_ptr<PartitionReader> currReader_;

--- a/cpp/celeborn/client/reader/CelebornInputStream.h
+++ b/cpp/celeborn/client/reader/CelebornInputStream.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "celeborn/client/compress/Decompressor.h"
 #include "celeborn/client/reader/WorkerPartitionReader.h"
 #include "celeborn/conf/CelebornConf.h"
 
@@ -33,7 +34,8 @@ class CelebornInputStream {
       const std::vector<int>& attempts,
       int attemptNumber,
       int startMapIndex,
-      int endMapIndex);
+      int endMapIndex,
+      bool needCompression);
 
   int read(uint8_t* buffer, size_t offset, size_t len);
 
@@ -68,6 +70,10 @@ class CelebornInputStream {
   int attemptNumber_;
   int startMapIndex_;
   int endMapIndex_;
+  bool shouldDecompress_;
+  std::unique_ptr<compress::Decompressor> decompressor_;
+  std::vector<char> rawDataBuf_;
+  std::vector<char> compressedBuf_;
 
   int currLocationIndex_;
   std::unique_ptr<memory::ReadOnlyByteBuffer> currChunk_;

--- a/cpp/celeborn/client/tests/CMakeLists.txt
+++ b/cpp/celeborn/client/tests/CMakeLists.txt
@@ -15,7 +15,8 @@
 
 add_executable(
         celeborn_client_test
-        WorkerPartitionReaderTest.cpp)
+        WorkerPartitionReaderTest.cpp
+        Lz4DecompressorTest.cpp)
 
 add_test(NAME celeborn_client_test COMMAND celeborn_client_test)
 

--- a/cpp/celeborn/client/tests/Lz4DecompressorTest.cpp
+++ b/cpp/celeborn/client/tests/Lz4DecompressorTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "celeborn/client/compress/Lz4Decompressor.h"
+
+using namespace celeborn;
+using namespace celeborn::client;
+using namespace celeborn::protocol;
+
+TEST(Lz4DecompressorTest, DecompressWithLz4) {
+  compress::Lz4Decompressor decompressor;
+
+  std::vector<char> compressed_data = {
+      76,  90, 52, 66,  108, 111, 99,  107, 32,  29,  0,   0,   0,
+      31,  0,  0,  0,   116, 18,  -79, 8,   83,  72,  101, 108, 108,
+      111, 1,  0,  -16, 4,   32,  67,  101, 108, 101, 98,  111, 114,
+      110, 33, 33, 33,  33,  33,  33,  33,  33,  33,  33};
+
+  const int original_len = decompressor.getOriginalLen(compressed_data.data());
+
+  const auto decompressedData = new char[original_len + 1];
+  decompressedData[original_len] = '\0';
+
+  const bool success =
+      decompressor.decompress(compressed_data.data(), decompressedData, 0);
+
+  EXPECT_TRUE(success);
+
+  EXPECT_EQ(decompressedData, std::string("Helloooooooo Celeborn!!!!!!!!!!"));
+}
+
+TEST(Lz4DecompressorTest, DecompressWithRaw) {
+  compress::Lz4Decompressor decompressor;
+
+  std::vector<char> compressed_data = {
+      76, 90, 52,  66,  108, 111, 99,  107, 16,  15,  0,   0,   0,
+      15, 0,  0,   0,   -68, 66,  58,  13,  72,  101, 108, 108, 111,
+      32, 67, 101, 108, 101, 98,  111, 114, 110, 33,  110, 33};
+
+  const int original_len = decompressor.getOriginalLen(compressed_data.data());
+
+  const auto decompressedData = new char[original_len + 1];
+  decompressedData[original_len] = '\0';
+
+  const bool success =
+      decompressor.decompress(compressed_data.data(), decompressedData, 0);
+
+  EXPECT_TRUE(success);
+
+  EXPECT_EQ(decompressedData, std::string("Hello Celeborn!"));
+}

--- a/cpp/celeborn/client/tests/Lz4DecompressorTest.cpp
+++ b/cpp/celeborn/client/tests/Lz4DecompressorTest.cpp
@@ -25,42 +25,46 @@ using namespace celeborn::protocol;
 TEST(Lz4DecompressorTest, DecompressWithLz4) {
   compress::Lz4Decompressor decompressor;
 
-  std::vector<char> compressed_data = {
+  std::vector<uint8_t> compressedData = {
       76,  90, 52, 66,  108, 111, 99,  107, 32,  29,  0,   0,   0,
-      31,  0,  0,  0,   116, 18,  -79, 8,   83,  72,  101, 108, 108,
-      111, 1,  0,  -16, 4,   32,  67,  101, 108, 101, 98,  111, 114,
+      31,  0,  0,  0,   116, 18,  177, 8,   83,  72,  101, 108, 108,
+      111, 1,  0,  240, 4,   32,  67,  101, 108, 101, 98,  111, 114,
       110, 33, 33, 33,  33,  33,  33,  33,  33,  33,  33};
 
-  const int original_len = decompressor.getOriginalLen(compressed_data.data());
+  const int originalLen = decompressor.getOriginalLen(compressedData.data());
 
-  const auto decompressedData = new char[original_len + 1];
-  decompressedData[original_len] = '\0';
+  const auto decompressedData = new uint8_t[originalLen + 1];
+  decompressedData[originalLen] = '\0';
 
   const bool success =
-      decompressor.decompress(compressed_data.data(), decompressedData, 0);
+      decompressor.decompress(compressedData.data(), decompressedData, 0);
 
   EXPECT_TRUE(success);
 
-  EXPECT_EQ(decompressedData, std::string("Helloooooooo Celeborn!!!!!!!!!!"));
+  EXPECT_EQ(
+      reinterpret_cast<char*>(decompressedData),
+      std::string("Helloooooooo Celeborn!!!!!!!!!!"));
 }
 
 TEST(Lz4DecompressorTest, DecompressWithRaw) {
   compress::Lz4Decompressor decompressor;
 
-  std::vector<char> compressed_data = {
+  std::vector<uint8_t> compressedData = {
       76, 90, 52,  66,  108, 111, 99,  107, 16,  15,  0,   0,   0,
-      15, 0,  0,   0,   -68, 66,  58,  13,  72,  101, 108, 108, 111,
+      15, 0,  0,   0,   188, 66,  58,  13,  72,  101, 108, 108, 111,
       32, 67, 101, 108, 101, 98,  111, 114, 110, 33,  110, 33};
 
-  const int original_len = decompressor.getOriginalLen(compressed_data.data());
+  const int originalLen = decompressor.getOriginalLen(compressedData.data());
 
-  const auto decompressedData = new char[original_len + 1];
-  decompressedData[original_len] = '\0';
+  const auto decompressedData = new uint8_t[originalLen + 1];
+  decompressedData[originalLen] = '\0';
 
   const bool success =
-      decompressor.decompress(compressed_data.data(), decompressedData, 0);
+      decompressor.decompress(compressedData.data(), decompressedData, 0);
 
   EXPECT_TRUE(success);
 
-  EXPECT_EQ(decompressedData, std::string("Hello Celeborn!"));
+  EXPECT_EQ(
+      reinterpret_cast<char*>(decompressedData),
+      std::string("Hello Celeborn!"));
 }

--- a/cpp/celeborn/conf/CMakeLists.txt
+++ b/cpp/celeborn/conf/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
 
 target_link_libraries(
         conf
+        protocol
         utils
         memory
         ${FOLLY_WITH_DEPENDENCIES}

--- a/cpp/celeborn/conf/CelebornConf.cpp
+++ b/cpp/celeborn/conf/CelebornConf.cpp
@@ -140,6 +140,9 @@ const std::unordered_map<std::string, folly::Optional<std::string>>
         NUM_PROP(kNetworkIoNumConnectionsPerPeer, "1"),
         NUM_PROP(kNetworkIoClientThreads, 0),
         NUM_PROP(kClientFetchMaxReqsInFlight, 3),
+        STR_PROP(
+            kShuffleCompressionCodec,
+            protocol::toString(protocol::CompressionCodec::NONE)),
         // NUM_PROP(kNumExample, 50'000),
         // BOOL_PROP(kBoolExample, false),
 };
@@ -201,6 +204,11 @@ int CelebornConf::networkIoClientThreads() const {
 
 int CelebornConf::clientFetchMaxReqsInFlight() const {
   return std::stoi(optionalProperty(kClientFetchMaxReqsInFlight).value());
+}
+
+protocol::CompressionCodec CelebornConf::shuffleCompressionCodec() const {
+  return protocol::toCompressionCodec(
+      optionalProperty(kShuffleCompressionCodec).value());
 }
 } // namespace conf
 } // namespace celeborn

--- a/cpp/celeborn/conf/CelebornConf.h
+++ b/cpp/celeborn/conf/CelebornConf.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "celeborn/conf/BaseConf.h"
+#include "celeborn/protocol/CompressionCodec.h"
 #include "celeborn/utils/CelebornUtils.h"
 
 namespace celeborn {
@@ -60,6 +61,9 @@ class CelebornConf : public BaseConf {
   static constexpr std::string_view kClientFetchMaxReqsInFlight{
       "celeborn.client.fetch.maxReqsInFlight"};
 
+  static constexpr std::string_view kShuffleCompressionCodec{
+      "celeborn.client.shuffle.compression.codec"};
+
   CelebornConf();
 
   CelebornConf(const std::string& filename);
@@ -83,6 +87,8 @@ class CelebornConf : public BaseConf {
   int networkIoClientThreads() const;
 
   int clientFetchMaxReqsInFlight() const;
+
+  protocol::CompressionCodec shuffleCompressionCodec() const;
 };
 } // namespace conf
 } // namespace celeborn

--- a/cpp/celeborn/memory/ByteBuffer.cpp
+++ b/cpp/celeborn/memory/ByteBuffer.cpp
@@ -74,5 +74,27 @@ std::unique_ptr<folly::IOBuf> ByteBuffer::trimBuffer(
   }
   return std::move(data);
 }
+
+std::unique_ptr<ReadOnlyByteBuffer> ReadOnlyByteBuffer::readToReadOnlyBuffer(
+    const size_t len) const {
+  std::unique_ptr<folly::IOBuf> leftData = folly::IOBuf::create(0);
+  auto cnt = 0;
+  while (cnt < len) {
+    if (this->remainingSize() == 0) {
+      break;
+    }
+    std::unique_ptr<folly::IOBuf> newBlock =
+        std::move(this->cursor_->currentBuffer()->clone());
+    newBlock->pop();
+    newBlock->trimStart(this->cursor_->getPositionInCurrentBuffer());
+    if (newBlock->length() > len - cnt) {
+      newBlock->trimEnd(newBlock->length() - (len - cnt));
+    }
+    this->cursor_->skip(newBlock->length());
+    cnt += newBlock->length();
+    leftData->appendToChain(std::move(newBlock));
+  }
+  return createReadOnly(std::move(leftData), isBigEndian_);
+}
 } // namespace memory
 } // namespace celeborn

--- a/cpp/celeborn/memory/ByteBuffer.h
+++ b/cpp/celeborn/memory/ByteBuffer.h
@@ -171,6 +171,10 @@ class WriteOnlyByteBuffer : public ByteBuffer {
     appender_->push(reinterpret_cast<const uint8_t*>(ptr), data.size());
   }
 
+  void writeFromBuffer(const void* data, const size_t len) const {
+    appender_->push(static_cast<const uint8_t*>(data), len);
+  }
+
   size_t size() const {
     return data_->computeChainDataLength();
   }

--- a/cpp/celeborn/memory/ByteBuffer.h
+++ b/cpp/celeborn/memory/ByteBuffer.h
@@ -48,12 +48,11 @@ class ByteBuffer {
     assert(data_);
   }
 
-  std::unique_ptr<folly::IOBuf> data_;
-  bool isBigEndian_;
-
- private:
   static std::unique_ptr<folly::IOBuf> trimBuffer(
       const ReadOnlyByteBuffer& buffer);
+
+  std::unique_ptr<folly::IOBuf> data_;
+  bool isBigEndian_;
 };
 
 class ReadOnlyByteBuffer : public ByteBuffer {
@@ -125,6 +124,8 @@ class ReadOnlyByteBuffer : public ByteBuffer {
   size_t readToBuffer(void* buf, size_t len) const {
     return cursor_->pullAtMost(buf, len);
   }
+
+  std::unique_ptr<ReadOnlyByteBuffer> readToReadOnlyBuffer(size_t len) const;
 
   std::unique_ptr<folly::IOBuf> getData() const {
     return data_->clone();

--- a/cpp/celeborn/protocol/CMakeLists.txt
+++ b/cpp/celeborn/protocol/CMakeLists.txt
@@ -17,7 +17,9 @@ add_library(
         STATIC
         PartitionLocation.cpp
         TransportMessage.cpp
-        ControlMessages.cpp)
+        ControlMessages.cpp
+        CompressionCodec.h
+        CompressionCodec.cpp)
 
 target_include_directories(protocol PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/cpp/celeborn/protocol/CMakeLists.txt
+++ b/cpp/celeborn/protocol/CMakeLists.txt
@@ -18,7 +18,6 @@ add_library(
         PartitionLocation.cpp
         TransportMessage.cpp
         ControlMessages.cpp
-        CompressionCodec.h
         CompressionCodec.cpp)
 
 target_include_directories(protocol PUBLIC ${CMAKE_BINARY_DIR})

--- a/cpp/celeborn/protocol/CompressionCodec.cpp
+++ b/cpp/celeborn/protocol/CompressionCodec.cpp
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "celeborn/protocol/CompressionCodec.h"
+
+namespace celeborn {
+namespace protocol {
+CompressionCodec toCompressionCodec(std::string_view code) {
+  if (code == "LZ4") {
+    return CompressionCodec::LZ4;
+  }
+  if (code == "ZSTD") {
+    return CompressionCodec::ZSTD;
+  }
+  return CompressionCodec::NONE;
+}
+
+std::string_view toString(CompressionCodec codec) {
+  switch (codec) {
+    case CompressionCodec::LZ4:
+      return "LZ4";
+    case CompressionCodec::ZSTD:
+      return "ZSTD";
+    case CompressionCodec::NONE:
+      return "NONE";
+    default:
+      return "UNKNOWN";
+  }
+}
+} // namespace protocol
+} // namespace celeborn

--- a/cpp/celeborn/protocol/CompressionCodec.h
+++ b/cpp/celeborn/protocol/CompressionCodec.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <string_view>
+
+namespace celeborn {
+namespace protocol {
+enum class CompressionCodec {
+  LZ4,
+  ZSTD,
+  NONE,
+};
+
+CompressionCodec toCompressionCodec(std::string_view code);
+
+std::string_view toString(CompressionCodec codec);
+} // namespace protocol
+} // namespace celeborn

--- a/cpp/celeborn/tests/DataSumWithReaderClient.cpp
+++ b/cpp/celeborn/tests/DataSumWithReaderClient.cpp
@@ -23,7 +23,7 @@
 
 int main(int argc, char** argv) {
   // Read the configs.
-  assert(argc == 8);
+  assert(argc == 9);
   std::string lifecycleManagerHost = argv[1];
   int lifecycleManagerPort = std::atoi(argv[2]);
   std::string appUniqueId = argv[3];
@@ -31,15 +31,19 @@ int main(int argc, char** argv) {
   int attemptId = std::atoi(argv[5]);
   int numPartitions = std::atoi(argv[6]);
   std::string resultFile = argv[7];
+  std::string compressCodec = argv[8];
   std::cout << "lifecycleManagerHost = " << lifecycleManagerHost
             << ", lifecycleManagerPort = " << lifecycleManagerPort
             << ", appUniqueId = " << appUniqueId
             << ", shuffleId = " << shuffleId << ", attemptId = " << attemptId
             << ", numPartitions = " << numPartitions
-            << ", resultFile = " << resultFile << std::endl;
+            << ", resultFile = " << resultFile << std::endl
+            << ", compressCodec = " << compressCodec << std::endl;
 
   // Create shuffleClient and setup.
   auto conf = std::make_shared<celeborn::conf::CelebornConf>();
+  conf->registerProperty(
+      celeborn::conf::CelebornConf::kShuffleCompressionCodec, compressCodec);
   auto clientFactory =
       std::make_shared<celeborn::network::TransportClientFactory>(conf);
   auto shuffleClient = std::make_unique<celeborn::client::ShuffleClientImpl>(
@@ -61,6 +65,9 @@ int main(int argc, char** argv) {
         result[partitionId] += data;
         data = 0;
         dataCnt++;
+        continue;
+      }
+      if (c == '+') {
         continue;
       }
       assert(c >= '0' && c <= '9');

--- a/cpp/cmake/FindLZ4.cmake
+++ b/cpp/cmake/FindLZ4.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Finds liblz4.
+#
+# This module defines:
+# LZ4_FOUND
+# LZ4_INCLUDE_DIR
+# LZ4_LIBRARY
+#
+
+find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
+
+find_library(LZ4_LIBRARY_DEBUG NAMES lz4d)
+find_library(LZ4_LIBRARY_RELEASE NAMES lz4)
+
+include(SelectLibraryConfigurations)
+SELECT_LIBRARY_CONFIGURATIONS(LZ4)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    LZ4 DEFAULT_MSG
+    LZ4_LIBRARY LZ4_INCLUDE_DIR
+)
+
+if (LZ4_FOUND)
+    message(STATUS "Found LZ4: ${LZ4_LIBRARY}")
+endif()
+
+mark_as_advanced(LZ4_INCLUDE_DIR LZ4_LIBRARY)

--- a/cpp/scripts/setup-ubuntu.sh
+++ b/cpp/scripts/setup-ubuntu.sh
@@ -126,6 +126,8 @@ function install_celeborn_cpp_deps_from_apt {
     libgmock-dev \
     libevent-dev \
     libsodium-dev \
+    libxxhash-dev \
+    liblz4-dev \
     libzstd-dev \
     libre2-dev
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/JavaWriteCppReadTestWithLZ4.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/JavaWriteCppReadTestWithLZ4.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.cluster
+
+import org.apache.celeborn.common.protocol.CompressionCodec
+
+object JavaWriteCppReadTestWithLZ4 extends JavaWriteCppReadTestBase {
+
+  def main(args: Array[String]) = {
+    testJavaWriteCppRead(CompressionCodec.LZ4)
+  }
+}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/JavaWriteCppReadTestWithNONE.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/JavaWriteCppReadTestWithNONE.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.cluster
+
+import org.apache.celeborn.common.protocol.CompressionCodec
+
+object JavaWriteCppReadTestWithNONE extends JavaWriteCppReadTestBase {
+
+  def main(args: Array[String]) = {
+    testJavaWriteCppRead(CompressionCodec.NONE)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR adds support for lz4 decompression in CppClient.


### Why are the changes needed?
To support reading from Celeborn with CppClient.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By compilation and UTs.
