### PR TITLE
[CELEBORN-2092] Inc  COMMIT_FILES_FAIL_COUNT when TimerWriter::close timeout

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1203,7 +1203,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
           logDebug(s"Succeed $message")
           context.reply(MapperEndResponse(StatusCode.SUCCESS))
         case false =>
-          logError(s"Failed $message")
+          logError(s"Failed $message, reply ${StatusCode.SHUFFLE_DATA_LOST}.")
           context.reply(MapperEndResponse(StatusCode.SHUFFLE_DATA_LOST))
       }
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -363,6 +363,7 @@ private[deploy] class Controller(
               } catch {
                 case e: IOException =>
                   logError(s"Commit file for $shuffleKey $uniqueId failed.", e)
+                  workerSource.incCounter(WorkerSource.COMMIT_FILES_FAIL_COUNT)
                   failedIds.add(uniqueId)
               }
             }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -363,8 +363,8 @@ private[deploy] class Controller(
               } catch {
                 case e: IOException =>
                   logError(s"Commit file for $shuffleKey $uniqueId failed.", e)
-                  workerSource.incCounter(WorkerSource.COMMIT_FILES_FAIL_COUNT)
                   failedIds.add(uniqueId)
+                  throw e
               }
             }
           },

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -363,8 +363,8 @@ private[deploy] class Controller(
               } catch {
                 case e: IOException =>
                   logError(s"Commit file for $shuffleKey $uniqueId failed.", e)
+                  workerSource.incCounter(WorkerSource.COMMIT_FILES_FAIL_COUNT)
                   failedIds.add(uniqueId)
-                  throw e
               }
             }
           },

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -155,7 +155,7 @@ abstract class TierWriterBase(
       waitTime -= WAIT_INTERVAL_MS
     }
     if (counter.get > 0 && failWhenTimeout) {
-      val ioe = new IOException("Wait pending actions timeout.")
+      val ioe = new IOException(s"Wait pending actions timeout after $writerCloseTimeoutMs ms.")
       notifier.setException(ioe)
       throw ioe
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Inc COMMIT_FILES_FAIL_COUNT when TimerWriter::close timeout

### Why are the changes needed?

1. the COMMIT_FILES_FAIL_COUNT is 0 even we meet SHUFFLE_DATA_LOST caused by commit files failure

Spark executor log:
```

25/07/30 10:10:39 WARN CelebornShuffleReader: Handle fetch exceptions for 0-0org.apache.celeborn.common.exception.CelebornIOException: Failed to load file group of shuffle 0 partition 441! Request GetReducerFileGroup(0,false,V1) return SHUFFLE_DATA_LOST for 0.
```

Spark driver log:
```
25/07/30 10:10:38 ERROR ReducePartitionCommitHandler: Failed to handle stageEnd for 0, lost file!


25/07/30 10:10:38 ERROR ReducePartitionCommitHandler: 
For shuffle application_1750652300305_10219240_1-0 partition data lost:
Lost partition 307-0 in worker [Host:hdc42-mcc10-01-0910-2704-064-tess0028.stratus.rno.ebay.com:RpcPort:9200:PushPort:9202:FetchPort:9201:ReplicatePort:9203]
Lost partition 1289-0 in worker [Host:hdc42-mcc10-01-0910-2704-064-tess0028.stratus.rno.ebay.com:RpcPort:9200:PushPort:9202:FetchPort:9201:ReplicatePort:9203]
```

Worker log:
```
java.io.IOException: Wait pending actions timeout.
	at org.apache.celeborn.service.deploy.worker.storage.TierWriterBase.waitOnNoPending(TierWriter.scala:158)
```



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

