### PR TITLE
[CELEBORN-1844][FOLLOWUP] Fix the condition of StoragePolicy that worker uses memory storage

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -188,7 +188,7 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
         // keep the old behavior, always try to use memory if worker
         // has configured to use memory storage, because slots allocator
         // will not allocate slots on memory storage
-        if (order.contains(StorageInfo.Type.MEMORY.name())) {
+        if (order.exists(_.contains(StorageInfo.Type.MEMORY.name()))) {
           order.get.indexOf(StorageInfo.Type.MEMORY.name())
         } else {
           order.get.indexOf(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the condition of `StoragePolicy` that worker uses memory storage

### Why are the changes needed?

The condition of `StoragePolicy` that worker uses memory storage is `order.contains(StorageInfo.Type.MEMORY.name())`, which condition is wrong because `Option#contains` is as follows:

```
final def contains[A1 >: A](elem: A1): Boolean = !isEmpty && this.get == elem
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.