### PR TITLE
[CELEBORN-2095][CIP-14] Support RegisterShuffle/Response in cppClient

### DIFF
--- a/cpp/celeborn/protocol/ControlMessages.h
+++ b/cpp/celeborn/protocol/ControlMessages.h
@@ -26,6 +26,23 @@
 
 namespace celeborn {
 namespace protocol {
+
+struct RegisterShuffle {
+  long shuffleId;
+  int numMappers;
+  int numPartitions;
+
+  TransportMessage toTransportMessage() const;
+};
+
+struct RegisterShuffleResponse {
+  StatusCode status;
+  std::vector<std::unique_ptr<const PartitionLocation>> partitionLocations;
+
+  static std::unique_ptr<RegisterShuffleResponse> fromTransportMessage(
+      const TransportMessage& transportMessage);
+};
+
 struct MapperEnd {
   long shuffleId;
   int mapId;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support RegisterShuffle/Response messages in CppClient.


### Why are the changes needed?
To support the procedure of registering shuffle and accepting response in CppClient.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Compilation and UTs.
