### PR TITLE
[CELEBORN-2091]Support Zstd Decompression in CppClient

### DIFF
--- a/.github/workflows/cpp_integration.yml
+++ b/.github/workflows/cpp_integration.yml
@@ -99,3 +99,10 @@ jobs:
             -Dexec.classpathScope="test" \
             -Dexec.mainClass="org.apache.celeborn.service.deploy.cluster.JavaWriteCppReadTestWithLZ4" \
             -Dexec.args="-XX:MaxDirectMemorySize=2G"
+      - name: Run Java-Cpp Hybrid Integration Test (ZSTD Decompression)
+        run: |
+          build/mvn -pl worker \
+            test-compile exec:java \
+            -Dexec.classpathScope="test" \
+            -Dexec.mainClass="org.apache.celeborn.service.deploy.cluster.JavaWriteCppReadTestWithZSTD" \
+            -Dexec.args="-XX:MaxDirectMemorySize=2G"

--- a/cpp/celeborn/client/CMakeLists.txt
+++ b/cpp/celeborn/client/CMakeLists.txt
@@ -18,7 +18,8 @@ add_library(
         reader/CelebornInputStream.cpp
         ShuffleClient.cpp
         compress/Decompressor.cpp
-        compress/Lz4Decompressor.cpp)
+        compress/Lz4Decompressor.cpp
+        compress/ZstdDecompressor.cpp)
 
 target_include_directories(client PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/cpp/celeborn/client/compress/ZstdDecompressor.cpp
+++ b/cpp/celeborn/client/compress/ZstdDecompressor.cpp
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "celeborn/client/compress/ZstdDecompressor.h"
+#include <zlib.h>
+#include <zstd.h>
+#include <cstring>
+#include <iostream>
+#include "celeborn/utils/Exceptions.h"
+
+namespace celeborn {
+namespace client {
+namespace compress {
+int ZstdDecompressor::getOriginalLen(const uint8_t* src) {
+  return readIntLE(src, kMagicLength + 5);
+}
+
+int ZstdDecompressor::decompress(const uint8_t* src, uint8_t* dst, int dstOff) {
+  const int compressionMethod = src[kMagicLength];
+  const int compressedLen = readIntLE(src, kMagicLength + 1);
+  const int originalLen = readIntLE(src, kMagicLength + 5);
+  const int expectedCheck = readIntLE(src, kMagicLength + 9);
+
+  const uint8_t* compressedDataPtr = src + kHeaderLength;
+  uint8_t* dstPtr = dst + dstOff;
+
+  switch (compressionMethod) {
+    case kCompressionMethodRaw:
+      std::memcpy(dstPtr, compressedDataPtr, originalLen);
+      break;
+
+    case kCompressionMethodZstd: {
+      const size_t decompressedBytes = ZSTD_decompress(
+          dstPtr, originalLen, compressedDataPtr, compressedLen);
+
+      if (decompressedBytes != originalLen) {
+        CELEBORN_FAIL(
+            std::string("Decompression failed! Zstd error or size mismatch. ") +
+            "Expected: " + std::to_string(originalLen) +
+            ", Got: " + std::to_string(decompressedBytes));
+      }
+      break;
+    }
+    default:
+      CELEBORN_FAIL(
+          std::string("Unsupported compression method: ") +
+          std::to_string(compressionMethod));
+  }
+
+  uLong actualCheck = crc32(0L, Z_NULL, 0);
+  actualCheck = crc32(actualCheck, dstPtr, originalLen);
+
+  if (static_cast<uint32_t>(actualCheck) != expectedCheck) {
+    CELEBORN_FAIL(
+        std::string("Checksum mismatch! Expected: ") +
+        std::to_string(expectedCheck) +
+        ", Actual: " + std::to_string(actualCheck));
+  }
+
+  return originalLen;
+}
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/ZstdDecompressor.h
+++ b/cpp/celeborn/client/compress/ZstdDecompressor.h
@@ -15,27 +15,23 @@
  * limitations under the License.
  */
 
-#include <stdexcept>
+#pragma once
 
-#include "celeborn/client/compress/Lz4Decompressor.h"
-#include "celeborn/client/compress/ZstdDecompressor.h"
-#include "celeborn/utils/Exceptions.h"
+#include "celeborn/client/compress/Decompressor.h"
+#include "celeborn/client/compress/ZstdTrait.h"
 
 namespace celeborn {
 namespace client {
 namespace compress {
 
-std::unique_ptr<Decompressor> Decompressor::createDecompressor(
-    protocol::CompressionCodec codec) {
-  switch (codec) {
-    case protocol::CompressionCodec::LZ4:
-      return std::make_unique<Lz4Decompressor>();
-    case protocol::CompressionCodec::ZSTD:
-      return std::make_unique<ZstdDecompressor>();
-    default:
-      CELEBORN_FAIL("Unknown compression codec.");
-  }
-}
+class ZstdDecompressor final : public Decompressor, ZstdTrait {
+ public:
+  ZstdDecompressor() = default;
+  ~ZstdDecompressor() override = default;
+
+  int getOriginalLen(const uint8_t* src) override;
+  int decompress(const uint8_t* src, uint8_t* dst, int dstOff) override;
+};
 
 } // namespace compress
 } // namespace client

--- a/cpp/celeborn/client/compress/ZstdTrait.h
+++ b/cpp/celeborn/client/compress/ZstdTrait.h
@@ -15,27 +15,22 @@
  * limitations under the License.
  */
 
-#include <stdexcept>
-
-#include "celeborn/client/compress/Lz4Decompressor.h"
-#include "celeborn/client/compress/ZstdDecompressor.h"
-#include "celeborn/utils/Exceptions.h"
+#pragma once
 
 namespace celeborn {
 namespace client {
 namespace compress {
 
-std::unique_ptr<Decompressor> Decompressor::createDecompressor(
-    protocol::CompressionCodec codec) {
-  switch (codec) {
-    case protocol::CompressionCodec::LZ4:
-      return std::make_unique<Lz4Decompressor>();
-    case protocol::CompressionCodec::ZSTD:
-      return std::make_unique<ZstdDecompressor>();
-    default:
-      CELEBORN_FAIL("Unknown compression codec.");
-  }
-}
+struct ZstdTrait {
+  static constexpr char kMagic[] =
+      {'Z', 'S', 'T', 'D', 'B', 'l', 'o', 'c', 'k'};
+  static constexpr int kMagicLength = sizeof(kMagic);
+
+  static constexpr int kHeaderLength = kMagicLength + 1 + 4 + 4 + 4;
+
+  static constexpr int kCompressionMethodRaw = 0x10;
+  static constexpr int kCompressionMethodZstd = 0x30;
+};
 
 } // namespace compress
 } // namespace client

--- a/cpp/celeborn/client/tests/CMakeLists.txt
+++ b/cpp/celeborn/client/tests/CMakeLists.txt
@@ -16,7 +16,8 @@
 add_executable(
         celeborn_client_test
         WorkerPartitionReaderTest.cpp
-        Lz4DecompressorTest.cpp)
+        Lz4DecompressorTest.cpp
+        ZstdDecompressorTest.cpp)
 
 add_test(NAME celeborn_client_test COMMAND celeborn_client_test)
 

--- a/cpp/celeborn/client/tests/ZstdDecompressorTest.cpp
+++ b/cpp/celeborn/client/tests/ZstdDecompressorTest.cpp
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "celeborn/client/compress/ZstdDecompressor.h"
+
+using namespace celeborn;
+using namespace celeborn::client;
+using namespace celeborn::protocol;
+
+TEST(ZstdDecompressorTest, DecompressWithZstd) {
+  compress::ZstdDecompressor decompressor;
+
+  std::vector<uint8_t> compressedData = {
+      90,  83, 84,  68,  66,  108, 111, 99,  107, 48,  34,  0,   0,   0,
+      39,  0,  0,   0,   56,  207, 204, 32,  40,  181, 47,  253, 32,  39,
+      205, 0,  0,   136, 72,  101, 108, 108, 111, 111, 32,  67,  101, 108,
+      101, 98, 111, 114, 110, 33,  33,  2,   0,   128, 251, 13,  20,  1,
+  };
+
+  const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+  const auto decompressedData = new uint8_t[originalLen + 1];
+  decompressedData[originalLen] = '\0';
+
+  const bool success =
+      decompressor.decompress(compressedData.data(), decompressedData, 0);
+
+  EXPECT_TRUE(success);
+
+  EXPECT_EQ(
+      reinterpret_cast<char*>(decompressedData),
+      std::string("Helloooooooooooo Celeborn!!!!!!!!!!!!!!"));
+}
+
+TEST(ZstdDecompressorTest, DecompressWithRaw) {
+  compress::ZstdDecompressor decompressor;
+
+  std::vector<uint8_t> compressedData = {
+      90,  83,  84,  68,  66,  108, 111, 99,  107, 16,  15,  0,
+      0,   0,   15,  0,   0,   0,   15,  118, 81,  228, 72,  101,
+      108, 108, 111, 32,  67,  101, 108, 101, 98,  111, 114, 110,
+      33,  67,  101, 108, 101, 98,  111, 114, 110, 33,  33,
+  };
+
+  const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+  const auto decompressedData = new uint8_t[originalLen + 1];
+  decompressedData[originalLen] = '\0';
+
+  const bool success =
+      decompressor.decompress(compressedData.data(), decompressedData, 0);
+
+  EXPECT_TRUE(success);
+
+  EXPECT_EQ(
+      reinterpret_cast<char*>(decompressedData),
+      std::string("Hello Celeborn!"));
+}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/JavaWriteCppReadTestWithZSTD.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/JavaWriteCppReadTestWithZSTD.scala
@@ -15,28 +15,13 @@
  * limitations under the License.
  */
 
-#include <stdexcept>
+package org.apache.celeborn.service.deploy.cluster
 
-#include "celeborn/client/compress/Lz4Decompressor.h"
-#include "celeborn/client/compress/ZstdDecompressor.h"
-#include "celeborn/utils/Exceptions.h"
+import org.apache.celeborn.common.protocol.CompressionCodec
 
-namespace celeborn {
-namespace client {
-namespace compress {
+object JavaWriteCppReadTestWithZSTD extends JavaWriteCppReadTestBase {
 
-std::unique_ptr<Decompressor> Decompressor::createDecompressor(
-    protocol::CompressionCodec codec) {
-  switch (codec) {
-    case protocol::CompressionCodec::LZ4:
-      return std::make_unique<Lz4Decompressor>();
-    case protocol::CompressionCodec::ZSTD:
-      return std::make_unique<ZstdDecompressor>();
-    default:
-      CELEBORN_FAIL("Unknown compression codec.");
+  def main(args: Array[String]) = {
+    testJavaWriteCppRead(CompressionCodec.ZSTD)
   }
 }
-
-} // namespace compress
-} // namespace client
-} // namespace celeborn


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR adds support for zstd decompression in CppClient.


### Why are the changes needed?
To support reading from Celeborn with CppClient.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By compilation and UTs.
