### PR TITLE
[CELEBORN-2098][CIP-14] Support Revive/Response in cppClient

### DIFF
--- a/cpp/celeborn/protocol/ControlMessages.h
+++ b/cpp/celeborn/protocol/ControlMessages.h
@@ -60,6 +60,49 @@ struct MapperEndResponse {
       const TransportMessage& transportMessage);
 };
 
+struct ReviveRequest {
+  int shuffleId;
+  int mapId;
+  int attemptId;
+  int partitionId;
+  int epoch;
+  std::shared_ptr<const PartitionLocation> loc;
+  StatusCode cause;
+  std::atomic<int> reviveStatus{StatusCode::REVIVE_INITIALIZED};
+
+  ReviveRequest(
+      int _shuffleId,
+      int _mapId,
+      int _attemptId,
+      int _partitionId,
+      int _epoch,
+      std::shared_ptr<const PartitionLocation> _loc,
+      StatusCode _cause);
+};
+
+struct Revive {
+  int shuffleId;
+  std::unordered_set<int> mapIds;
+  std::unordered_set<std::shared_ptr<ReviveRequest>> reviveRequests;
+
+  TransportMessage toTransportMessage() const;
+};
+
+struct ChangeLocationPartitionInfo {
+  int partitionId;
+  StatusCode status;
+  std::shared_ptr<const PartitionLocation> partition;
+  bool oldAvailable;
+};
+
+struct ChangeLocationResponse {
+  std::vector<int> endedMapIds;
+  std::vector<ChangeLocationPartitionInfo> partitionInfos;
+
+  static std::unique_ptr<ChangeLocationResponse> fromTransportMessage(
+      const TransportMessage& transportMessage);
+};
+
 struct GetReducerFileGroup {
   int shuffleId;
 

--- a/cpp/celeborn/protocol/PartitionLocation.cpp
+++ b/cpp/celeborn/protocol/PartitionLocation.cpp
@@ -33,6 +33,16 @@ std::unique_ptr<StorageInfo> StorageInfo::fromPb(const PbStorageInfo& pb) {
   return std::move(result);
 }
 
+std::unique_ptr<PbStorageInfo> StorageInfo::toPb() const {
+  auto pbStorageInfo = std::make_unique<PbStorageInfo>();
+  pbStorageInfo->set_type(type);
+  pbStorageInfo->set_mountpoint(mountPoint);
+  pbStorageInfo->set_finalresult(finalResult);
+  pbStorageInfo->set_filepath(filePath);
+  pbStorageInfo->set_availablestoragetypes(availableStorageTypes);
+  return pbStorageInfo;
+}
+
 std::unique_ptr<const PartitionLocation> PartitionLocation::fromPb(
     const PbPartitionLocation& pb) {
   auto result = fromPbWithoutPeer(pb);
@@ -98,6 +108,15 @@ PartitionLocation::PartitionLocation(const PartitionLocation& other)
               : nullptr),
       storageInfo(std::make_unique<StorageInfo>(*other.storageInfo)) {}
 
+std::unique_ptr<PbPartitionLocation> PartitionLocation::toPb() const {
+  auto pbPartitionLocation = toPbWithoutPeer();
+  if (replicaPeer) {
+    auto pbPeerPartitionLocation = replicaPeer->toPbWithoutPeer();
+    pbPartitionLocation->set_allocated_peer(pbPeerPartitionLocation.release());
+  }
+  return pbPartitionLocation;
+}
+
 std::unique_ptr<PartitionLocation> PartitionLocation::fromPbWithoutPeer(
     const PbPartitionLocation& pb) {
   auto result = std::make_unique<PartitionLocation>();
@@ -112,6 +131,22 @@ std::unique_ptr<PartitionLocation> PartitionLocation::fromPbWithoutPeer(
   result->replicaPeer = nullptr;
   result->storageInfo = StorageInfo::fromPb(pb.storageinfo());
   return std::move(result);
+}
+
+std::unique_ptr<PbPartitionLocation> PartitionLocation::toPbWithoutPeer()
+    const {
+  auto pbPartitionLocation = std::make_unique<PbPartitionLocation>();
+  pbPartitionLocation->set_id(id);
+  pbPartitionLocation->set_epoch(epoch);
+  pbPartitionLocation->set_host(host);
+  pbPartitionLocation->set_rpcport(rpcPort);
+  pbPartitionLocation->set_pushport(pushPort);
+  pbPartitionLocation->set_fetchport(fetchPort);
+  pbPartitionLocation->set_replicateport(replicatePort);
+  pbPartitionLocation->set_mode(static_cast<PbPartitionLocation_Mode>(mode));
+  pbPartitionLocation->set_allocated_storageinfo(
+      storageInfo->toPb().release());
+  return pbPartitionLocation;
 }
 
 StatusCode toStatusCode(int32_t code) {

--- a/cpp/celeborn/protocol/PartitionLocation.cpp
+++ b/cpp/celeborn/protocol/PartitionLocation.cpp
@@ -144,8 +144,7 @@ std::unique_ptr<PbPartitionLocation> PartitionLocation::toPbWithoutPeer()
   pbPartitionLocation->set_fetchport(fetchPort);
   pbPartitionLocation->set_replicateport(replicatePort);
   pbPartitionLocation->set_mode(static_cast<PbPartitionLocation_Mode>(mode));
-  pbPartitionLocation->set_allocated_storageinfo(
-      storageInfo->toPb().release());
+  pbPartitionLocation->set_allocated_storageinfo(storageInfo->toPb().release());
   return pbPartitionLocation;
 }
 

--- a/cpp/celeborn/protocol/PartitionLocation.h
+++ b/cpp/celeborn/protocol/PartitionLocation.h
@@ -31,6 +31,8 @@ struct StorageInfo {
 
   StorageInfo(const StorageInfo& other) = default;
 
+  std::unique_ptr<PbStorageInfo> toPb() const;
+
   enum Type {
     MEMORY = 0,
     HDD = 1,
@@ -88,6 +90,8 @@ struct PartitionLocation {
 
   PartitionLocation(const PartitionLocation& other);
 
+  std::unique_ptr<PbPartitionLocation> toPb() const;
+
   std::string filename() const {
     return std::to_string(id) + "-" + std::to_string(epoch) + "-" +
         std::to_string(mode);
@@ -96,6 +100,8 @@ struct PartitionLocation {
  private:
   static std::unique_ptr<PartitionLocation> fromPbWithoutPeer(
       const PbPartitionLocation& pb);
+
+  std::unique_ptr<PbPartitionLocation> toPbWithoutPeer() const;
 };
 } // namespace protocol
 } // namespace celeborn


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR supports Revive/ChangeLocationResponse messages in cppClient.

### Why are the changes needed?
These messages are used when writing triggers revive operation.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
