### PR TITLE
[CELEBORN-2100] Fix performance issue on readToReadOnlyBuffer

### DIFF
--- a/cpp/celeborn/memory/ByteBuffer.cpp
+++ b/cpp/celeborn/memory/ByteBuffer.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<ReadOnlyByteBuffer> ReadOnlyByteBuffer::readToReadOnlyBuffer(
       break;
     }
     std::unique_ptr<folly::IOBuf> newBlock =
-        std::move(this->cursor_->currentBuffer()->clone());
+        std::move(this->cursor_->currentBuffer()->cloneOne());
     newBlock->pop();
     newBlock->trimStart(this->cursor_->getPositionInCurrentBuffer());
     if (newBlock->length() > len - cnt) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix performance issue on ReadOnlyByteBuffer::readToReadOnlyBuffer.


### Why are the changes needed?
ReadOnlyByteBuffer::readToReadOnlyBuffer now is slow on a long iobuf chain because it used wrong api to clone an iobuf block.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By compilation and UTs.
