### PR TITLE
[CELEBORN-2107] When loadFileGroup failed, retry send GetReducerFileG…

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -931,6 +931,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def clientCloseIdleConnections: Boolean = get(CLIENT_CLOSE_IDLE_CONNECTIONS)
   def clientRegisterShuffleMaxRetry: Int = get(CLIENT_REGISTER_SHUFFLE_MAX_RETRIES)
   def clientRegisterShuffleRetryWaitMs: Long = get(CLIENT_REGISTER_SHUFFLE_RETRY_WAIT)
+  def clientLoadReducerFileGroupMaxRetries: Int = get(CLIENT_LOAD_REDUCER_FILE_GROUP_MAX_RETRIES)
+  def clientLoadReducerFileGroupRetryWaitMs: Long = get(CLIENT_LOAD_REDUCER_FILE_GROUP_RETRY_WAIT)
   def clientReserveSlotsRackAwareEnabled: Boolean = get(CLIENT_RESERVE_SLOTS_RACKAWARE_ENABLED)
   def clientReserveSlotsMaxRetries: Int = get(CLIENT_RESERVE_SLOTS_MAX_RETRIES)
   def clientReserveSlotsRetryWait: Long = get(CLIENT_RESERVE_SLOTS_RETRY_WAIT)
@@ -5243,6 +5245,23 @@ object CelebornConf extends Logging {
       .categories("client")
       .version("0.3.0")
       .doc("Wait time before next retry if register shuffle failed.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("3s")
+
+  val CLIENT_LOAD_REDUCER_FILE_GROUP_MAX_RETRIES: ConfigEntry[Int] =
+    buildConf("celeborn.client.loadFileGroup.maxRetries")
+      .categories("client")
+      .version("0.3.1")
+      .doc("Max retry times for client to load file group.")
+      .intConf
+      .checkValue(v => v > 0, "Value must be positive")
+      .createWithDefault(3)
+
+  val CLIENT_LOAD_REDUCER_FILE_GROUP_RETRY_WAIT: ConfigEntry[Long] =
+    buildConf("celeborn.client.loadFileGroup.retryWait")
+      .categories("client")
+      .version("0.3.1")
+      .doc("Wait time before next retry if laod file group failed.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("3s")
 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -46,6 +46,8 @@ license: |
 | celeborn.client.flink.resultPartition.memory | 64m | false | Memory reserved for a result partition. | 0.3.0 | remote-shuffle.job.memory-per-partition | 
 | celeborn.client.flink.resultPartition.supportFloatingBuffer | true | false | Whether to support floating buffer for result partitions. | 0.3.0 | remote-shuffle.job.support-floating-buffer-per-output-gate | 
 | celeborn.client.flink.shuffle.fallback.policy | AUTO | false | Celeborn supports the following kind of fallback policies. 1. ALWAYS: always use flink built-in shuffle implementation; 2. AUTO: prefer to use celeborn shuffle implementation, and fallback to use flink built-in shuffle implementation based on certain factors, e.g. availability of enough workers and quota; 3. NEVER: always use celeborn shuffle implementation, and fail fast when it it is concluded that fallback is required based on factors above. | 0.6.0 |  | 
+| celeborn.client.loadFileGroup.maxRetries | 3 | Max retry times for client to get file group. | 0.6.0 |  | 
+| celeborn.client.loadFileGroup.retryWait | 3s | Wait time before next retry if get file group failed. | 0.6.0 |  | 
 | celeborn.client.inputStream.creation.window | 16 | false | Window size that CelebornShuffleReader pre-creates CelebornInputStreams, for coalesced scenario where multiple Partitions are read | 0.5.1 |  | 
 | celeborn.client.mr.pushData.max | 32m | false | Max size for a push data sent from mr client. | 0.4.0 |  | 
 | celeborn.client.partition.reader.checkpoint.enabled | false | false | Whether or not checkpoint reads when re-creating a partition reader. Setting to true minimizes the amount of unnecessary reads during partition read retries | 0.6.0 |  | 


### PR DESCRIPTION
…roup rpc

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

When loadFileGroup failed, retry send GetReducerFileGroup rpc

### Why are the changes needed?

When sending loadFileGroup fails, it may be due to a network connection failure. We should increase the number of retries to obtain the ReducerFileGroup.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI

