### PR TITLE
[CELEBORN-2108] Remove redundant PartitionType

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -470,8 +470,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           workerSource,
           conf,
           deviceMonitor,
-          partitionDataWriterContext,
-          partitionType)
+          partitionDataWriterContext)
       } catch {
         case e: Exception =>
           logError("Create partition data writer failed", e)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -36,7 +36,6 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
   def getEvictedFileWriter(
       celebornFile: TierWriterBase,
       partitionDataWriterContext: PartitionDataWriterContext,
-      partitionType: PartitionType,
       numPendingWrites: AtomicInteger,
       notifier: FlushNotifier): TierWriterBase = {
     evictFileOrder.foreach { order =>
@@ -44,7 +43,6 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
       if (orderList != null) {
         return createFileWriter(
           partitionDataWriterContext,
-          partitionType,
           numPendingWrites,
           notifier,
           orderList,
@@ -57,12 +55,10 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
 
   def createFileWriter(
       partitionDataWriterContext: PartitionDataWriterContext,
-      partitionType: PartitionType,
       numPendingWrites: AtomicInteger,
       notifier: FlushNotifier): TierWriterBase = {
     createFileWriter(
       partitionDataWriterContext: PartitionDataWriterContext,
-      partitionType: PartitionType,
       numPendingWrites: AtomicInteger,
       notifier: FlushNotifier,
       createFileOrder)
@@ -70,7 +66,6 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
 
   def createFileWriter(
       partitionDataWriterContext: PartitionDataWriterContext,
-      partitionType: PartitionType,
       numPendingWrites: AtomicInteger,
       notifier: FlushNotifier,
       order: Option[List[String]] = createFileOrder,
@@ -84,7 +79,7 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
     }
 
     def getPartitionMetaHandler(fileInfo: FileInfo) = {
-      partitionType match {
+      partitionDataWriterContext.getPartitionType match {
         case PartitionType.REDUCE =>
           new ReducePartitionMetaHandler(partitionDataWriterContext.isRangeReadFilter, fileInfo)
         case PartitionType.MAP =>

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
@@ -103,7 +103,7 @@ public class PartitionDataWriterSuiteUtils {
                     context,
                     storageManager))
         .when(storagePolicy)
-        .createFileWriter(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        .createFileWriter(Mockito.any(), Mockito.any(), Mockito.any());
 
     return storageManager;
   }
@@ -148,7 +148,7 @@ public class PartitionDataWriterSuiteUtils {
                     writerContext,
                     storageManager))
         .when(storagePolicy)
-        .createFileWriter(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        .createFileWriter(Mockito.any(), Mockito.any(), Mockito.any());
 
     return storageManager;
   }
@@ -223,7 +223,7 @@ public class PartitionDataWriterSuiteUtils {
                     writerContext,
                     storageManager))
         .when(storagePolicy)
-        .createFileWriter(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        .createFileWriter(Mockito.any(), Mockito.any(), Mockito.any());
 
     Mockito.doAnswer(
             invocation ->
@@ -240,8 +240,7 @@ public class PartitionDataWriterSuiteUtils {
                     writerContext,
                     storageManager))
         .when(storagePolicy)
-        .getEvictedFileWriter(
-            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        .getEvictedFileWriter(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
     return storageManager;
   }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskMapPartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskMapPartitionDataWriterSuiteJ.java
@@ -141,8 +141,7 @@ public class DiskMapPartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.MAP);
+            context);
     fileWriter.handleEvents(
         PbPushDataHandShake.newBuilder().setNumPartitions(2).setBufferSize(32).build());
     fileWriter.handleEvents(

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
@@ -288,8 +288,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.REDUCE);
+            context);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-1");
@@ -343,8 +342,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.REDUCE);
+            context);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-1");
@@ -399,8 +397,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.REDUCE);
+            context);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-2");
@@ -470,8 +467,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.REDUCE);
+            context);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-2");
@@ -590,8 +586,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context1,
-            PartitionType.REDUCE);
+            context1);
     partitionDataWriter.write(generateData(8 * 1024 * 1024));
     partitionDataWriter.close();
     ReduceFileMeta reduceFileMeta =
@@ -623,8 +618,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context2,
-            PartitionType.REDUCE);
+            context2);
     for (int i = 0; i < 8; i++) {
       partitionDataWriter.write(generateData(128));
     }
@@ -656,8 +650,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context3,
-            PartitionType.REDUCE);
+            context3);
     partitionDataWriter.write(generateData(1020));
     partitionDataWriter.write(generateData(3));
     partitionDataWriter.close();
@@ -688,8 +681,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context4,
-            PartitionType.REDUCE);
+            context4);
     for (int i = 0; i < 8; i++) {
       partitionDataWriter.write(generateData(128));
     }
@@ -722,8 +714,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context5,
-            PartitionType.REDUCE);
+            context5);
     for (int i = 0; i < 16; i++) {
       partitionDataWriter.write(generateData(128));
     }
@@ -755,8 +746,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context6,
-            PartitionType.REDUCE);
+            context6);
     for (int i = 0; i < 16; i++) {
       partitionDataWriter.write(generateData(128));
     }
@@ -790,8 +780,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context7,
-            PartitionType.REDUCE);
+            context7);
     for (int i = 0; i < 16; i++) {
       partitionDataWriter.write(generateData(128));
     }
@@ -824,8 +813,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context8,
-            PartitionType.REDUCE);
+            context8);
     partitionDataWriter.write(generateData(1024));
     for (int i = 0; i < 9; i++) {
       partitionDataWriter.write(generateData(128));
@@ -859,8 +847,7 @@ public class DiskReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context9,
-            PartitionType.REDUCE);
+            context9);
     partitionDataWriter.write(generateData(1024));
     for (int i = 0; i < 9; i++) {
       partitionDataWriter.write(generateData(128));

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -123,12 +123,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
                     storageManager))
         .when(storagePolicy)
         .createFileWriter(
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.anyBoolean());
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
 
     return storageManager;
   }
@@ -305,8 +300,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext,
-            PartitionType.REDUCE);
+            writerContext);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-1");
@@ -360,8 +354,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext,
-            PartitionType.REDUCE);
+            writerContext);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-1");
@@ -424,8 +417,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context1,
-            PartitionType.REDUCE);
+            context1);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-2");
@@ -486,8 +478,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.REDUCE);
+            context);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-2");
@@ -575,8 +566,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            context,
-            PartitionType.REDUCE);
+            context);
 
     List<Future<?>> futures = new ArrayList<>();
     ExecutorService es = ThreadUtils.newDaemonFixedThreadPool(threadsNum, "FileWriter-UT-2");
@@ -698,8 +688,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext1,
-            PartitionType.REDUCE);
+            writerContext1);
     partitionDataWriter.write(generateDataWithHeader(8 * 1024 * 1024));
     partitionDataWriter.close();
     ReduceFileMeta reduceFileMeta =
@@ -731,8 +720,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext2,
-            PartitionType.REDUCE);
+            writerContext2);
     for (int i = 0; i < 8; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));
     }
@@ -764,8 +752,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext3,
-            PartitionType.REDUCE);
+            writerContext3);
     partitionDataWriter.write(generateDataWithHeader(1020));
     partitionDataWriter.write(generateDataWithHeader(3));
     partitionDataWriter.close();
@@ -796,8 +783,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext4,
-            PartitionType.REDUCE);
+            writerContext4);
     for (int i = 0; i < 8; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));
     }
@@ -830,8 +816,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext5,
-            PartitionType.REDUCE);
+            writerContext5);
     for (int i = 0; i < 16; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));
     }
@@ -863,8 +848,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext6,
-            PartitionType.REDUCE);
+            writerContext6);
     for (int i = 0; i < 16; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));
     }
@@ -898,8 +882,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext7,
-            PartitionType.REDUCE);
+            writerContext7);
     for (int i = 0; i < 16; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));
     }
@@ -932,8 +915,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext8,
-            PartitionType.REDUCE);
+            writerContext8);
     partitionDataWriter.write(generateDataWithHeader(1024));
     for (int i = 0; i < 9; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));
@@ -967,8 +949,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             source,
             conf,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
-            writerContext9,
-            PartitionType.REDUCE);
+            writerContext9);
     partitionDataWriter.write(generateDataWithHeader(1024));
     for (int i = 0; i < 9; i++) {
       partitionDataWriter.write(generateDataWithHeader(128));

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase1.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase1.scala
@@ -99,6 +99,7 @@ class StoragePolicyCase1 extends CelebornFunSuite {
 
   test("test create file order case1") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(memoryHintPartitionLocation)
+    when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     val conf = new CelebornConf()
     val flushLock = new AnyRef
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "MEMORY,SSD,HDD,HDFS,OSS,S3")
@@ -107,7 +108,6 @@ class StoragePolicyCase1 extends CelebornFunSuite {
     val notifier = new FlushNotifier
     val file = storagePolicy.createFileWriter(
       mockedPartitionWriterContext,
-      PartitionType.REDUCE,
       pendingWriters,
       notifier)
     assert(file.isInstanceOf[MemoryTierWriter])

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
@@ -99,6 +99,7 @@ class StoragePolicyCase2 extends CelebornFunSuite {
 
   test("test create file order case2") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(localHintPartitionLocatioin)
+    when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "SSD,HDD,HDFS,OSS,S3")
@@ -107,7 +108,6 @@ class StoragePolicyCase2 extends CelebornFunSuite {
     val notifier = new FlushNotifier
     val file = storagePolicy.createFileWriter(
       mockedPartitionWriterContext,
-      PartitionType.REDUCE,
       pendingWriters,
       notifier)
     assert(file.isInstanceOf[LocalTierWriter])

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
@@ -99,6 +99,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
 
   test("test getEvicted file case1") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(localHintPartitionLocatioin)
+    when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
     val mockedMemoryFile = mock[LocalTierWriter]
     val conf = new CelebornConf()
@@ -110,7 +111,6 @@ class StoragePolicyCase3 extends CelebornFunSuite {
     val nFile = storagePolicy.getEvictedFileWriter(
       mockedMemoryFile,
       mockedPartitionWriterContext,
-      PartitionType.REDUCE,
       pendingWriters,
       notifier)
     assert(nFile.isInstanceOf[LocalTierWriter])
@@ -118,6 +118,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
 
   test("test evict file case2") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(memoryHintPartitionLocation)
+    when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
     val mockedMemoryFile = mock[LocalTierWriter]
     val conf = new CelebornConf()
@@ -129,7 +130,6 @@ class StoragePolicyCase3 extends CelebornFunSuite {
     val nFile = storagePolicy.getEvictedFileWriter(
       mockedMemoryFile,
       mockedPartitionWriterContext,
-      PartitionType.REDUCE,
       pendingWriters,
       notifier)
     assert(nFile.isInstanceOf[LocalTierWriter])

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
@@ -100,6 +100,7 @@ class StoragePolicyCase4 extends CelebornFunSuite {
   test("test create file fallback case1") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(
       memoryDisabledHintPartitionLocation)
+    when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "MEMORY,SSD,HDD,HDFS,OSS,S3")
@@ -108,7 +109,6 @@ class StoragePolicyCase4 extends CelebornFunSuite {
     val notifier = new FlushNotifier
     val file = storagePolicy.createFileWriter(
       mockedPartitionWriterContext,
-      PartitionType.REDUCE,
       pendingWriters,
       notifier)
     assert(file.isInstanceOf[LocalTierWriter])


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove redundant `PartitionType`.

### Why are the changes needed?

`PartitionType` is included in `PartitionDataWriterContext`, therefore it is not necessary to use `PartitionType` as method parameter.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.