### PR TITLE
[CELEBORN-2117] Use git submodules for Chart Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           version: v3.10.0
       - name: Setup chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           version: v3.10.0
       - name: Setup chart-testing
-        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1
+        uses: ./.github/actions/chart-testing-action
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          submodules: recursive
       - uses: actions/setup-java@v4
         name: Setup JDK with Maven
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           version: v3.10.0
       - name: Setup chart-testing
-        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".github/actions/chart-testing-action"]
+	path = .github/actions/chart-testing-action
+	url = https://github.com/helm/chart-testing-action


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?

> The action helm/chart-testing-action@v2.6.1 is not allowed in apache/celeborn because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace

https://github.com/apache/celeborn/actions/runs/17004559972

---

Refer to this PR implementation

https://github.com/apache/ozone-helm-charts/pull/6

```bash
git submodule add --force https://github.com/helm/chart-testing-action .github/actions/chart-testing-action
git -C .github/actions/chart-testing-action checkout e6669bcd63d7cb57cb4380c33043eebe5d111992
```




### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
https://github.com/apache/celeborn/actions/runs/17037324387/job/48292733845?pr=3431
