### PR TITLE
[CELEBORN-2115][CIP-14] Support PushData in cppClient

### DIFF
--- a/cpp/celeborn/network/Message.h
+++ b/cpp/celeborn/network/Message.h
@@ -238,7 +238,7 @@ class ChunkFetchFailure : public Message {
 };
 
 class PushData : public Message {
-public:
+ public:
   PushData(
       long requestId,
       uint8_t mode,
@@ -252,7 +252,7 @@ public:
     return requestId_;
   }
 
-private:
+ private:
   int internalEncodedLength() const override;
 
   void internalEncodeTo(memory::WriteOnlyByteBuffer& buffer) const override;

--- a/cpp/celeborn/network/Message.h
+++ b/cpp/celeborn/network/Message.h
@@ -236,5 +236,32 @@ class ChunkFetchFailure : public Message {
   protocol::StreamChunkSlice streamChunkSlice_;
   std::string errorString_;
 };
+
+class PushData : public Message {
+public:
+  PushData(
+      long requestId,
+      uint8_t mode,
+      const std::string& shuffleKey,
+      const std::string& partitionUniqueId,
+      std::unique_ptr<memory::ReadOnlyByteBuffer> body);
+
+  PushData(const PushData& other);
+
+  long requestId() const {
+    return requestId_;
+  }
+
+private:
+  int internalEncodedLength() const override;
+
+  void internalEncodeTo(memory::WriteOnlyByteBuffer& buffer) const override;
+
+  long requestId_;
+  // 0 for primary, 1 for replica. Ref to PartitionLocation::Mode.
+  uint8_t mode_;
+  std::string shuffleKey_;
+  std::string partitionUniqueId_;
+};
 } // namespace network
 } // namespace celeborn

--- a/cpp/celeborn/protocol/CMakeLists.txt
+++ b/cpp/celeborn/protocol/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
         PartitionLocation.cpp
         TransportMessage.cpp
         ControlMessages.cpp
+        Encoders.cpp
         CompressionCodec.cpp)
 
 target_include_directories(protocol PUBLIC ${CMAKE_BINARY_DIR})

--- a/cpp/celeborn/protocol/Encoders.cpp
+++ b/cpp/celeborn/protocol/Encoders.cpp
@@ -1,5 +1,5 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0

--- a/cpp/celeborn/protocol/Encoders.cpp
+++ b/cpp/celeborn/protocol/Encoders.cpp
@@ -1,0 +1,37 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "celeborn/protocol/Encoders.h"
+
+namespace celeborn {
+namespace protocol {
+
+int encodedLength(const std::string& msg) {
+  return sizeof(int) + msg.size();
+}
+
+void encode(memory::WriteOnlyByteBuffer& buffer, const std::string& msg) {
+  buffer.write<int>(msg.size());
+  buffer.writeFromString(msg);
+}
+
+std::string decode(memory::ReadOnlyByteBuffer& buffer) {
+  int size = buffer.read<int>();
+  return buffer.readToString(size);
+}
+} // namespace protocol
+} // namespace celeborn

--- a/cpp/celeborn/protocol/Encoders.h
+++ b/cpp/celeborn/protocol/Encoders.h
@@ -1,5 +1,5 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0

--- a/cpp/celeborn/protocol/Encoders.h
+++ b/cpp/celeborn/protocol/Encoders.h
@@ -1,0 +1,32 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "celeborn/memory/ByteBuffer.h"
+
+namespace celeborn {
+namespace protocol {
+
+int encodedLength(const std::string& msg);
+
+void encode(memory::WriteOnlyByteBuffer& buffer, const std::string& msg);
+
+std::string decode(memory::ReadOnlyByteBuffer& buffer);
+
+} // namespace protocol
+} // namespace celeborn

--- a/cpp/celeborn/protocol/tests/CMakeLists.txt
+++ b/cpp/celeborn/protocol/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ add_executable(
         celeborn_protocol_test
         PartitionLocationTest.cpp
         TransportMessageTest.cpp
-        ControlMessagesTest.cpp)
+        ControlMessagesTest.cpp
+        EncodersTest.cpp)
 
 add_test(NAME celeborn_protocol_test COMMAND celeborn_protocol_test)
 

--- a/cpp/celeborn/protocol/tests/EncodersTest.cpp
+++ b/cpp/celeborn/protocol/tests/EncodersTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celeborn/protocol/Encoders.h"
+
+using namespace celeborn;
+using namespace celeborn::protocol;
+
+TEST(EncodersTest, encodedLength) {
+  std::string testString = "test-string";
+  EXPECT_EQ(encodedLength(testString), sizeof(int) + testString.size());
+}
+
+TEST(EncodersTest, encode) {
+  std::string testString = "test-string";
+  auto writeBuffer =
+      memory::ByteBuffer::createWriteOnly(sizeof(int) + testString.size());
+  encode(*writeBuffer, testString);
+  auto readBuffer = memory::ByteBuffer::toReadOnly(std::move(writeBuffer));
+  EXPECT_EQ(readBuffer->read<int>(), testString.size());
+  EXPECT_EQ(readBuffer->readToString(testString.size()), testString);
+}
+
+TEST(EncodersTest, decode) {
+  std::string testString = "test-string";
+  auto writeBuffer =
+      memory::ByteBuffer::createWriteOnly(sizeof(int) + testString.size());
+  writeBuffer->write<int>(testString.size());
+  writeBuffer->writeFromString(testString);
+  auto readBuffer = memory::ByteBuffer::toReadOnly(std::move(writeBuffer));
+  EXPECT_EQ(decode(*readBuffer), testString);
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support PushData network message in cppClient.

### Why are the changes needed?
PushData is the network message of writing to cppClient.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
