### PR TITLE
[CELEBORN-2121] Support Zstd Compression in CppClient

### DIFF
--- a/cpp/celeborn/client/CMakeLists.txt
+++ b/cpp/celeborn/client/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(
         compress/Lz4Decompressor.cpp
         compress/ZstdDecompressor.cpp
         compress/Compressor.cpp
-        compress/Lz4Compressor.cpp)
+        compress/Lz4Compressor.cpp
+        compress/ZstdCompressor.cpp)
 
 target_include_directories(client PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/cpp/celeborn/client/compress/Compressor.cpp
+++ b/cpp/celeborn/client/compress/Compressor.cpp
@@ -31,7 +31,8 @@ std::unique_ptr<Compressor> Compressor::createCompressor(
     case protocol::CompressionCodec::LZ4:
       return std::make_unique<Lz4Compressor>();
     case protocol::CompressionCodec::ZSTD:
-      return std::make_unique<ZstdCompressor>(conf.shuffleCompressionZstdCompressLevel());
+       return std::make_unique<ZstdCompressor>(
+           conf.shuffleCompressionZstdCompressLevel());
     default:
       CELEBORN_FAIL("Unknown compression codec.");
   }

--- a/cpp/celeborn/client/compress/ZstdCompressor.cpp
+++ b/cpp/celeborn/client/compress/ZstdCompressor.cpp
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <zstd.h>
+#include <zlib.h>
+
+#include "celeborn/client/compress/ZstdCompressor.h"
+#include "celeborn/conf/CelebornConf.h"
+#include "celeborn/utils/Exceptions.h"
+
+namespace celeborn {
+namespace client {
+namespace compress {
+
+ZstdCompressor::ZstdCompressor() {
+  compressionLevel_ = ZSTD_CLEVEL_DEFAULT;
+}
+
+ZstdCompressor::ZstdCompressor(int compressionLevel) : compressionLevel_(compressionLevel) {}
+
+ZstdCompressor::~ZstdCompressor() = default;
+
+size_t ZstdCompressor::compress(
+    const uint8_t* src,
+    int srcOffset,
+    int srcLength,
+    uint8_t* dst,
+    int dstOffset) {
+  const auto srcPtr = src + srcOffset;
+  const auto dstPtr = dst + dstOffset;
+  const auto dstDataPtr = dstPtr + kHeaderLength;
+
+  uLong check = crc32(0L, Z_NULL, 0);
+  check = crc32(check, srcPtr, srcLength);
+
+  std::copy_n(kMagic, kMagicLength, dstPtr);
+
+  size_t compressedLength = ZSTD_compress(
+      dstDataPtr,
+      ZSTD_compressBound(srcLength),
+      srcPtr,
+      srcLength,
+      compressionLevel_);
+
+  int compressionMethod;
+  if (ZSTD_isError(compressedLength) || compressedLength >= static_cast<size_t>(srcLength)) {
+    compressionMethod = kCompressionMethodRaw;
+    compressedLength = srcLength;
+    std::copy_n(srcPtr, srcLength, dstDataPtr);
+  } else {
+    compressionMethod = kCompressionMethodZstd;
+  }
+
+  dstPtr[kMagicLength] = static_cast<uint8_t>(compressionMethod);
+  writeIntLE(static_cast<int>(compressedLength), dstPtr, kMagicLength + 1);
+  writeIntLE(srcLength, dstPtr, kMagicLength + 5);
+  writeIntLE(static_cast<int>(check), dstPtr, kMagicLength + 9);
+
+  return kHeaderLength + compressedLength;
+}
+
+size_t ZstdCompressor::getDstCapacity(int length) {
+  return ZSTD_compressBound(length) + kHeaderLength;
+}
+
+} // namespace compress
+} // namespace client
+} // namespace celeborn

--- a/cpp/celeborn/client/compress/ZstdCompressor.h
+++ b/cpp/celeborn/client/compress/ZstdCompressor.h
@@ -15,27 +15,36 @@
  * limitations under the License.
  */
 
-#include <stdexcept>
+#pragma once
 
-#include "celeborn/client/compress/Lz4Compressor.h"
-#include "celeborn/utils/Exceptions.h"
+#include "celeborn/client/compress/Compressor.h"
+#include "celeborn/client/compress/ZstdTrait.h"
 
 namespace celeborn {
 namespace client {
 namespace compress {
 
-std::unique_ptr<Compressor> Compressor::createCompressor(
-    const conf::CelebornConf& conf) {
-  const auto codec = conf.shuffleCompressionCodec();
-  switch (codec) {
-    case protocol::CompressionCodec::LZ4:
-      return std::make_unique<Lz4Compressor>();
-    case protocol::CompressionCodec::ZSTD:
-      return std::make_unique<ZstdCompressor>(conf.shuffleCompressionZstdCompressLevel());
-    default:
-      CELEBORN_FAIL("Unknown compression codec.");
-  }
-}
+class ZstdCompressor final : public Compressor, ZstdTrait {
+ public:
+  ZstdCompressor();
+  explicit ZstdCompressor(int compressionLevel);
+  ~ZstdCompressor() override;
+
+  size_t compress(
+      const uint8_t* src,
+      int srcOffset,
+      int srcLength,
+      uint8_t* dst,
+      int dstOffset) override;
+
+  size_t getDstCapacity(int length) override;
+
+  ZstdCompressor(const ZstdCompressor&) = delete;
+  ZstdCompressor& operator=(const ZstdCompressor&) = delete;
+
+ private:
+  int compressionLevel_;
+};
 
 } // namespace compress
 } // namespace client

--- a/cpp/celeborn/client/tests/CMakeLists.txt
+++ b/cpp/celeborn/client/tests/CMakeLists.txt
@@ -18,7 +18,8 @@ add_executable(
         WorkerPartitionReaderTest.cpp
         Lz4DecompressorTest.cpp
         ZstdDecompressorTest.cpp
-        Lz4CompressorTest.cpp)
+        Lz4CompressorTest.cpp
+        ZstdCompressorTest.cpp)
 
 add_test(NAME celeborn_client_test COMMAND celeborn_client_test)
 

--- a/cpp/celeborn/client/tests/ZstdCompressorTest.cpp
+++ b/cpp/celeborn/client/tests/ZstdCompressorTest.cpp
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celeborn/client/compress/ZstdCompressor.h"
+#include "celeborn/client/compress/ZstdDecompressor.h"
+
+using namespace celeborn;
+using namespace celeborn::client;
+using namespace celeborn::protocol;
+
+TEST(ZstdCompressorTest, CompressWithZstd) {
+  compress::ZstdCompressor compressor;
+  const std::string toCompressData = "Helloooooooooooo Celeborn!!!!!!!!!!!!!!";
+
+  const auto maxLength = compressor.getDstCapacity(toCompressData.size());
+  std::vector<uint8_t> compressedData(maxLength);
+  compressor.compress(
+      reinterpret_cast<const uint8_t*>(toCompressData.data()),
+      0,
+      toCompressData.size(),
+      compressedData.data(),
+      0);
+
+  compress::ZstdDecompressor decompressor;
+
+  const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+  std::vector<uint8_t> decompressedData(originalLen + 1);
+  decompressedData[originalLen] = '\0';
+
+  const int decompressedLen = decompressor.decompress(
+      compressedData.data(), decompressedData.data(), 0);
+
+  EXPECT_GT(decompressedLen, 0);
+  EXPECT_EQ(reinterpret_cast<char*>(decompressedData.data()), toCompressData);
+}
+
+TEST(ZstdCompressorTest, CompressWithRaw) {
+  compress::ZstdCompressor compressor(-5); // Very low compression level may result in raw data
+  const std::string toCompressData = "Hello Celeborn!";
+
+  const auto maxLength = compressor.getDstCapacity(toCompressData.size());
+  std::vector<uint8_t> compressedData(maxLength);
+  compressor.compress(
+      reinterpret_cast<const uint8_t*>(toCompressData.data()),
+      0,
+      toCompressData.size(),
+      compressedData.data(),
+      0);
+
+  compress::ZstdDecompressor decompressor;
+
+  const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+  std::vector<uint8_t> decompressedData(originalLen + 1);
+  decompressedData[originalLen] = '\0';
+
+  const int decompressedLen = decompressor.decompress(
+      compressedData.data(), decompressedData.data(), 0);
+
+  EXPECT_GT(decompressedLen, 0);
+  EXPECT_EQ(reinterpret_cast<char*>(decompressedData.data()), toCompressData);
+}
+
+TEST(ZstdCompressorTest, CompressWithDifferentLevels) {
+  const std::string toCompressData = "This is a test string for checking different compression levels in ZSTD.";
+
+  for (int level = -5; level <= 5; level += 5) {
+    compress::ZstdCompressor compressor(level);
+
+    const auto maxLength = compressor.getDstCapacity(toCompressData.size());
+    std::vector<uint8_t> compressedData(maxLength);
+    compressor.compress(
+        reinterpret_cast<const uint8_t*>(toCompressData.data()),
+        0,
+        toCompressData.size(),
+        compressedData.data(),
+        0);
+
+    compress::ZstdDecompressor decompressor;
+
+    const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+    std::vector<uint8_t> decompressedData(originalLen + 1);
+    decompressedData[originalLen] = '\0';
+
+    const int decompressedLen = decompressor.decompress(
+        compressedData.data(), decompressedData.data(), 0);
+
+    EXPECT_GT(decompressedLen, 0);
+    EXPECT_EQ(reinterpret_cast<char*>(decompressedData.data()), toCompressData);
+  }
+}

--- a/cpp/celeborn/client/tests/ZstdCompressorTest.cpp
+++ b/cpp/celeborn/client/tests/ZstdCompressorTest.cpp
@@ -24,65 +24,10 @@ using namespace celeborn;
 using namespace celeborn::client;
 using namespace celeborn::protocol;
 
-TEST(ZstdCompressorTest, CompressWithZstd) {
-  compress::ZstdCompressor compressor;
-  const std::string toCompressData = "Helloooooooooooo Celeborn!!!!!!!!!!!!!!";
-
-  const auto maxLength = compressor.getDstCapacity(toCompressData.size());
-  std::vector<uint8_t> compressedData(maxLength);
-  compressor.compress(
-      reinterpret_cast<const uint8_t*>(toCompressData.data()),
-      0,
-      toCompressData.size(),
-      compressedData.data(),
-      0);
-
-  compress::ZstdDecompressor decompressor;
-
-  const int originalLen = decompressor.getOriginalLen(compressedData.data());
-
-  std::vector<uint8_t> decompressedData(originalLen + 1);
-  decompressedData[originalLen] = '\0';
-
-  const int decompressedLen = decompressor.decompress(
-      compressedData.data(), decompressedData.data(), 0);
-
-  EXPECT_GT(decompressedLen, 0);
-  EXPECT_EQ(reinterpret_cast<char*>(decompressedData.data()), toCompressData);
-}
-
-TEST(ZstdCompressorTest, CompressWithRaw) {
-  compress::ZstdCompressor compressor(-5); // Very low compression level may result in raw data
-  const std::string toCompressData = "Hello Celeborn!";
-
-  const auto maxLength = compressor.getDstCapacity(toCompressData.size());
-  std::vector<uint8_t> compressedData(maxLength);
-  compressor.compress(
-      reinterpret_cast<const uint8_t*>(toCompressData.data()),
-      0,
-      toCompressData.size(),
-      compressedData.data(),
-      0);
-
-  compress::ZstdDecompressor decompressor;
-
-  const int originalLen = decompressor.getOriginalLen(compressedData.data());
-
-  std::vector<uint8_t> decompressedData(originalLen + 1);
-  decompressedData[originalLen] = '\0';
-
-  const int decompressedLen = decompressor.decompress(
-      compressedData.data(), decompressedData.data(), 0);
-
-  EXPECT_GT(decompressedLen, 0);
-  EXPECT_EQ(reinterpret_cast<char*>(decompressedData.data()), toCompressData);
-}
-
-TEST(ZstdCompressorTest, CompressWithDifferentLevels) {
-  const std::string toCompressData = "This is a test string for checking different compression levels in ZSTD.";
-
-  for (int level = -5; level <= 5; level += 5) {
-    compress::ZstdCompressor compressor(level);
+TEST(ZstdCompressorTest, CompressWithZstd)
+{
+    compress::ZstdCompressor compressor;
+    const std::string toCompressData = "Helloooooooooooo Celeborn!!!!!!!!!!!!!!";
 
     const auto maxLength = compressor.getDstCapacity(toCompressData.size());
     std::vector<uint8_t> compressedData(maxLength);
@@ -101,9 +46,80 @@ TEST(ZstdCompressorTest, CompressWithDifferentLevels) {
     decompressedData[originalLen] = '\0';
 
     const int decompressedLen = decompressor.decompress(
-        compressedData.data(), decompressedData.data(), 0);
+        compressedData.data(),
+        decompressedData.data(),
+        0);
 
     EXPECT_GT(decompressedLen, 0);
-    EXPECT_EQ(reinterpret_cast<char*>(decompressedData.data()), toCompressData);
-  }
+    EXPECT_EQ(
+        reinterpret_cast<char*>(decompressedData.data()),
+        toCompressData);
+}
+
+TEST(ZstdCompressorTest, CompressWithRaw)
+{
+    compress::ZstdCompressor compressor(-5); // Very low compression level may result in raw data
+    const std::string toCompressData = "Hello Celeborn!";
+
+    const auto maxLength = compressor.getDstCapacity(toCompressData.size());
+    std::vector<uint8_t> compressedData(maxLength);
+    compressor.compress(
+        reinterpret_cast<const uint8_t*>(toCompressData.data()),
+        0,
+        toCompressData.size(),
+        compressedData.data(),
+        0);
+
+    compress::ZstdDecompressor decompressor;
+
+    const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+    std::vector<uint8_t> decompressedData(originalLen + 1);
+    decompressedData[originalLen] = '\0';
+
+    const int decompressedLen = decompressor.decompress(
+        compressedData.data(),
+        decompressedData.data(),
+        0);
+
+    EXPECT_GT(decompressedLen, 0);
+    EXPECT_EQ(
+        reinterpret_cast<char*>(decompressedData.data()),
+        toCompressData);
+}
+
+TEST(ZstdCompressorTest, CompressWithDifferentLevels)
+{
+    const std::string toCompressData =
+        "This is a test string for checking different compression levels in ZSTD.";
+
+    for (int level = -5; level <= 5; level += 5) {
+        compress::ZstdCompressor compressor(level);
+
+        const auto maxLength = compressor.getDstCapacity(toCompressData.size());
+        std::vector<uint8_t> compressedData(maxLength);
+        compressor.compress(
+            reinterpret_cast<const uint8_t*>(toCompressData.data()),
+            0,
+            toCompressData.size(),
+            compressedData.data(),
+            0);
+
+        compress::ZstdDecompressor decompressor;
+
+        const int originalLen = decompressor.getOriginalLen(compressedData.data());
+
+        std::vector<uint8_t> decompressedData(originalLen + 1);
+        decompressedData[originalLen] = '\0';
+
+        const int decompressedLen = decompressor.decompress(
+            compressedData.data(),
+            decompressedData.data(),
+            0);
+
+        EXPECT_GT(decompressedLen, 0);
+        EXPECT_EQ(
+            reinterpret_cast<char*>(decompressedData.data()),
+            toCompressData);
+    }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Support Zstd Compression in CppClient

### Why are the changes needed?

Support Zstd Compression in CppClient

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI & unit test
