### PR TITLE
[CELEBORN-2047] Reuse FileChannel/FSDataInputStream in PartitionDataReader

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/DfsPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/DfsPartitionDataReader.java
@@ -35,7 +35,12 @@ public class DfsPartitionDataReader extends PartitionDataReader {
   private final FSDataInputStream indexInputStream;
 
   public DfsPartitionDataReader(
-      DiskFileInfo fileInfo, ByteBuffer headerBuffer, ByteBuffer indexBuffer) throws IOException {
+      DiskFileInfo fileInfo,
+      FSDataInputStream dataInputStream,
+      FSDataInputStream indexInputStream,
+      ByteBuffer headerBuffer,
+      ByteBuffer indexBuffer)
+      throws IOException {
     super(fileInfo, headerBuffer, indexBuffer);
     FileSystem fileSystem =
         StorageManager.hadoopFs()
@@ -43,8 +48,8 @@ public class DfsPartitionDataReader extends PartitionDataReader {
                 fileInfo.isHdfs()
                     ? StorageInfo.Type.HDFS
                     : fileInfo.isS3() ? StorageInfo.Type.S3 : StorageInfo.Type.OSS);
-    this.dataInputStream = fileSystem.open(fileInfo.getDfsPath());
-    this.indexInputStream = fileSystem.open(fileInfo.getDfsIndexPath());
+    this.dataInputStream = dataInputStream;
+    this.indexInputStream = indexInputStream;
     this.dataFileSize = fileSystem.getFileStatus(fileInfo.getDfsPath()).getLen();
     this.indexFileSize = fileSystem.getFileStatus(fileInfo.getDfsIndexPath()).getLen();
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/LocalPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/LocalPartitionDataReader.java
@@ -25,7 +25,6 @@ import io.netty.buffer.ByteBuf;
 import org.apache.commons.io.IOUtils;
 
 import org.apache.celeborn.common.meta.DiskFileInfo;
-import org.apache.celeborn.common.util.FileChannelUtils;
 import org.apache.celeborn.common.util.Utils;
 
 public class LocalPartitionDataReader extends PartitionDataReader {
@@ -34,10 +33,15 @@ public class LocalPartitionDataReader extends PartitionDataReader {
   private final FileChannel indexFileChannel;
 
   public LocalPartitionDataReader(
-      DiskFileInfo fileInfo, ByteBuffer headerBuffer, ByteBuffer indexBuffer) throws IOException {
+      DiskFileInfo fileInfo,
+      FileChannel dataFileChannel,
+      FileChannel indexFileChannel,
+      ByteBuffer headerBuffer,
+      ByteBuffer indexBuffer)
+      throws IOException {
     super(fileInfo, headerBuffer, indexBuffer);
-    this.dataFileChanel = FileChannelUtils.openReadableFileChannel(fileInfo.getFilePath());
-    this.indexFileChannel = FileChannelUtils.openReadableFileChannel(fileInfo.getIndexPath());
+    this.dataFileChanel = dataFileChannel;
+    this.indexFileChannel = indexFileChannel;
     this.dataFileSize = dataFileChanel.size();
     this.indexFileSize = indexFileChannel.size();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reuse FileChannel/FSDataInputStream in PartitionDataReader to avoid  open too many files.

### Why are the changes needed?

In previous implementations, different PartitionDataReader reused the same FileChannel/FSDataInputStream,but in #3349 
changed this logic, so we need to maintain logical consistency

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manual test.