### PR TITLE
[CELEBORN-2125] Imporve PartitionFilesSorter sort timeout log

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -271,9 +271,15 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
             try {
               Thread.sleep(50);
               if (System.currentTimeMillis() - sortStartTime > sortTimeout) {
-                logger.error("Sorting file {} timeout after {}ms", fileId, sortTimeout);
-                throw new IOException(
-                    "Sort file " + diskFileInfo.getFilePath() + " timeout after " + sortTimeout);
+                String msg =
+                    String.format(
+                        "Sorting file %s path %s length %s timeout after %dms",
+                        fileId,
+                        diskFileInfo.getFilePath(),
+                        diskFileInfo.getFileLength(),
+                        sortTimeout);
+                logger.error(msg);
+                throw new IOException(msg);
               }
             } catch (InterruptedException e) {
               logger.error(


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
log only outputs fileid, exception only has file path, and no file length.



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

```
25/08/25 18:06:37,083 ERROR [pool-1-thread-1] PartitionFilesSorter: Sorting file application-1-/var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/Celeborn1344631182030527062sort-suite path /var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/Celeborn1344631182030527062sort-suite length 2453444321 timeout after 1ms
```
