### PR TITLE
[CELEBORN-2127] When fileWriter is closed, it should return HARD_SPLIT StatusCode

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -265,7 +265,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       logWarning(
         s"[handlePushData] FileWriter is already closed! File path ${fileInfo.getFilePath} " +
           s"length ${fileInfo.getFileLength}")
-      callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
+      callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
       fileWriter.decrementPendingWrites()
       return
     }


### PR DESCRIPTION
…T StatusCode

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

When fileWriter is closed, it should return HARD_SPLIT StatusCode

### Why are the changes needed?

When fileWriter is closed, it should return HARD_SPLIT StatusCode

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI