### PR TITLE
[CELEBORN-2132] Enhance ratis peer add operation to support clientAddress & adminAddress

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/http/api/v1/RatisResource.scala
@@ -127,11 +127,19 @@ class RatisResource extends ApiRequestContext with Logging {
           throw new IllegalArgumentException(
             s"Peer $peer with same id or address already exists in group $groupInfo.")
         }
-        RaftPeer.newBuilder()
+        val builder = RaftPeer.newBuilder()
           .setId(peer.getId)
           .setAddress(peer.getAddress)
           .setPriority(0)
-          .build()
+
+        if (peer.getClientAddress.nonEmpty) {
+          builder.setClientAddress(peer.getClientAddress)
+        }
+        if (peer.getAdminAddress.nonEmpty) {
+          builder.setAdminAddress(peer.getAdminAddress)
+        }
+
+        builder.build()
       }
 
       val peers = (remaining ++ adding).distinct

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RatisPeer.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/RatisPeer.java
@@ -33,7 +33,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @JsonPropertyOrder({
   RatisPeer.JSON_PROPERTY_ID,
-  RatisPeer.JSON_PROPERTY_ADDRESS
+  RatisPeer.JSON_PROPERTY_ADDRESS,
+  RatisPeer.JSON_PROPERTY_CLIENT_ADDRESS,
+  RatisPeer.JSON_PROPERTY_ADMIN_ADDRESS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
 public class RatisPeer {
@@ -42,6 +44,12 @@ public class RatisPeer {
 
   public static final String JSON_PROPERTY_ADDRESS = "address";
   private String address;
+
+  public static final String JSON_PROPERTY_CLIENT_ADDRESS = "clientAddress";
+  private String clientAddress;
+
+  public static final String JSON_PROPERTY_ADMIN_ADDRESS = "adminAddress";
+  private String adminAddress;
 
   public RatisPeer() {
   }
@@ -96,6 +104,56 @@ public class RatisPeer {
     this.address = address;
   }
 
+  public RatisPeer clientAddress(String clientAddress) {
+    
+    this.clientAddress = clientAddress;
+    return this;
+  }
+
+  /**
+   * The address of the peer for client RPC communication.
+   * @return clientAddress
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CLIENT_ADDRESS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getClientAddress() {
+    return clientAddress;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CLIENT_ADDRESS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setClientAddress(String clientAddress) {
+    this.clientAddress = clientAddress;
+  }
+
+  public RatisPeer adminAddress(String adminAddress) {
+    
+    this.adminAddress = adminAddress;
+    return this;
+  }
+
+  /**
+   * The address of the peer for internal RPC communication.
+   * @return adminAddress
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ADMIN_ADDRESS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getAdminAddress() {
+    return adminAddress;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ADMIN_ADDRESS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setAdminAddress(String adminAddress) {
+    this.adminAddress = adminAddress;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -106,12 +164,14 @@ public class RatisPeer {
     }
     RatisPeer ratisPeer = (RatisPeer) o;
     return Objects.equals(this.id, ratisPeer.id) &&
-        Objects.equals(this.address, ratisPeer.address);
+        Objects.equals(this.address, ratisPeer.address) &&
+        Objects.equals(this.clientAddress, ratisPeer.clientAddress) &&
+        Objects.equals(this.adminAddress, ratisPeer.adminAddress);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, address);
+    return Objects.hash(id, address, clientAddress, adminAddress);
   }
 
   @Override
@@ -120,6 +180,8 @@ public class RatisPeer {
     sb.append("class RatisPeer {\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    address: ").append(toIndentedString(address)).append("\n");
+    sb.append("    clientAddress: ").append(toIndentedString(clientAddress)).append("\n");
+    sb.append("    adminAddress: ").append(toIndentedString(adminAddress)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -1232,6 +1232,12 @@ components:
         address:
           type: string
           description: The address of the peer.
+        clientAddress:
+          type: string
+          description: The address of the peer for client RPC communication.
+        adminAddress:
+          type: string
+          description: The address of the peer for internal RPC communication.
       required:
         - id
         - address


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances the Ratis peer add operation to support clientAddress and adminAddress parameters with RESTful api, allowing these critical RPC endpoints to be properly configured when adding new peers to the Celeborn master cluster.

### Why are the changes needed?

Currently, when expanding the Celeborn master cluster using the ratis peer add operation, newly added peers lack clientAddress and adminAddress settings. If a newly added peer becomes the Leader, all Followers will return empty addresses to clients, causing them to attempt connections to an incorrect Leader address (127.0.0.1:0). This change ensures proper client request routing in expanded clusters.

### Does this PR introduce _any_ user-facing change?

Yes, this PR extends the API for adding Ratis peers by adding support for clientAddress and adminAddress parameters. Users will now be able to specify these addresses when adding new peers to the cluster.

### How was this patch tested?

Manual testing of cluster expansion scenarios to ensure clients can correctly connect to the Leader regardless of which peer holds leadership

```
➜ curl -sX  POST zw06-data-k8s-sparktest-node007.mt:9098/api/v1/ratis/peer/add \
  -H "Content-Type: application/json" \
  -d '{ "peers": [{"id": "2", "address": "zw06-data-k8s-sparktest-node009.mt:9872", "clientAddress": "zw06-data-k8s-sparktest-node009.mt:9097", "adminAddress":  "zw06-data-k8s-sparktest-node009.mt:9097" }] }' | jq

{
  "success": true,
  "message": "Successfully added peers ArrayBuffer(2|zw06-data-k8s-sparktest-node009.mt:9872) to group GroupInfoReply:client-3E7C9CE679B2->0@group-47BEDE733167, cid=1031, SUCCESS, logIndex=0, commits[0:c224, 1:c224]."
}

➜ curl -s zw06-data-k8s-sparktest-node009.mt:9098/masterGroupInfo
====================== Master Group INFO ==============================
group id: c5196f6d-2c34-3ed3-8b8a-47bede733167
leader info: 0(zw06-data-k8s-sparktest-node007.mt:9872)

[server {
  id: "2"
  address: "zw06-data-k8s-sparktest-node009.mt:9872"
  clientAddress: "zw06-data-k8s-sparktest-node009.mt:9097"
  adminAddress: "zw06-data-k8s-sparktest-node009.mt:9097"
  startupRole: FOLLOWER
}
commitIndex: 228
, server {
  id: "0"
  address: "zw06-data-k8s-sparktest-node007.mt:9872"
  clientAddress: "zw06-data-k8s-sparktest-node007.mt:9097"
  adminAddress: "zw06-data-k8s-sparktest-node007.mt:9097"
  startupRole: FOLLOWER
}
commitIndex: 228
, server {
  id: "1"
  address: "zw06-data-k8s-sparktest-node008.mt:9872"
  clientAddress: "zw06-data-k8s-sparktest-node008.mt:9097"
  adminAddress: "zw06-data-k8s-sparktest-node008.mt:9097"
  startupRole: FOLLOWER
}
commitIndex: 228
]

```
