### PR TITLE
[CELEBORN-2133] LifecycleManager should log stack trace of Throwable for invoking appShuffleTrackerCallback

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1136,7 +1136,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
           true
         } catch {
           case t: Throwable =>
-            logError(t.toString)
+            logError("Failed to invoke appShuffleTrackerCallback.", t)
             false
         }
       case None =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

`LifecycleManager` should log stack trace of `Throwable` for invoking `appShuffleTrackerCallback`.

### Why are the changes needed?

`LifecycleManager` does not log stack trace of `Throwable` for invoking `appShuffleTrackerCallback` at present, which log is as follows:

```

ERROR LifecycleManager: java.lang.RuntimeException

```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.