### PR TITLE
CELEBORN-2130: Add support for redirection application registration to the leader

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -57,8 +57,13 @@ public class MasterNotLeaderException extends IOException {
             currentPeer.equals(suggestedLeaderPeer._1)
                 ? StringUtils.EMPTY
                 : String.format(
-                    " Suggested leader is Master:%s (%s).",
-                    suggestedLeaderPeer, suggestedInternalLeaderPeer),
+                    // both (host and ip) point to the preferred address configured by bindPreferIp
+                    // preserve the earlier format of Tuple._2
+                    " Suggested leader is Master:(%s,%s) ((%s,%s)).",
+                    bindPreferIp ? suggestedLeaderPeer._1 : suggestedLeaderPeer._2,
+                    bindPreferIp ? suggestedLeaderPeer._1 : suggestedLeaderPeer._2,
+                    bindPreferIp ? suggestedInternalLeaderPeer._1 : suggestedInternalLeaderPeer._2,
+                    bindPreferIp ? suggestedInternalLeaderPeer._1 : suggestedInternalLeaderPeer._2),
             cause == null
                 ? StringUtils.EMPTY
                 : String.format(" Exception:%s.", cause.getMessage())),

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SecretRegistry.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SecretRegistry.java
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.common.network.sasl;
 
+import java.io.IOException;
+
+
 /** Interface for getting a secret key associated with some application. */
 public interface SecretRegistry {
 
@@ -28,4 +31,12 @@ public interface SecretRegistry {
   void register(String appId, String secret);
 
   void unregister(String appId);
+
+  /**
+   * Checks if the SecretRegistry can register the application. If it cant register (for example,
+   * not the current leader when running in HA), then throws an exception
+   */
+  default void ensureRegistrationAllowed() throws IOException {
+    // by default, can register
+  }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/registration/RegistrationRpcHandler.java
@@ -179,6 +179,8 @@ public class RegistrationRpcHandler extends BaseMessageHandler {
         PbRegisterApplicationRequest registerApplicationRequest = pbMsg.getParsedPayload();
         checkRequestAllowed(RegistrationState.AUTHENTICATED);
         LOG.trace("Application registration started {}", registerApplicationRequest.getId());
+        // throws exception if not allowed - like not leader in HA mode
+        secretRegistry.ensureRegistrationAllowed();
         processRegisterApplicationRequest(registerApplicationRequest, callback);
         registrationState = RegistrationState.REGISTERED;
         client.setClientId(registerApplicationRequest.getId());

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/SaslTestBase.java
@@ -59,7 +59,7 @@ public class SaslTestBase {
   static final String TEST_SECRET = "secret";
 
   @SuppressWarnings("Finally")
-  void authHelper(
+  public static void authHelper(
       TransportConf conf,
       TransportServerBootstrap serverBootstrap,
       TransportClientBootstrap clientBootstrap)

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/registration/RegistrationClientBootstrapSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/registration/RegistrationClientBootstrapSuiteJ.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl.registration;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import org.apache.celeborn.common.client.MasterNotLeaderException;
+import org.apache.celeborn.common.exception.CelebornException;
+
+public class RegistrationClientBootstrapSuiteJ {
+
+  @Test
+  public void testProcessMasterNotLeaderException() {
+    testProcessMasterNotLeaderExceptionImpl(
+        new CelebornException(
+            "Exception thrown in awaitResult",
+            new MasterNotLeaderException("foo.linkedin.com:1234", "leader is not present", null)),
+        true);
+    testProcessMasterNotLeaderExceptionImpl(
+        new CelebornException(
+            "Exception thrown in awaitResult",
+            new MasterNotLeaderException("abc.linkedin.com:1234", "abc.linkedin.com:567", null)),
+        true);
+    testProcessMasterNotLeaderExceptionImpl(
+        new CelebornException(
+            "Exception thrown in awaitResult",
+            new MasterNotLeaderException(
+                "abc.linkedin.com:1234", "abc.linkedin.com:567", new Exception("dummy"))),
+        true);
+    testProcessMasterNotLeaderExceptionImpl(
+        new CelebornException(
+            "Exception thrown in awaitResult, not MasterNotLeaderException",
+            new Exception("Nested")),
+        false);
+  }
+
+  private void testProcessMasterNotLeaderExceptionImpl(Exception ex, boolean shouldMatch) {
+    boolean matched =
+        RegistrationClientBootstrap.processMasterNotLeaderException(ex)
+            instanceof MasterNotLeaderException;
+
+    assertEquals(shouldMatch, matched);
+  }
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -83,7 +83,7 @@ private[celeborn] class Master(
   private val bindPreferIP: Boolean = conf.bindPreferIP
   private val authEnabled = conf.authEnabled
   private val haEnabled = conf.haEnabled
-  private val secretRegistry = new MasterSecretRegistryImpl()
+  private val secretRegistry = new MasterSecretRegistryImpl(bindPreferIP)
   private val sendApplicationMetaThreads = conf.masterSendApplicationMetaThreads
   // Send ApplicationMeta to workers
   private var sendApplicationMetaExecutor: ExecutorService = _
@@ -395,7 +395,11 @@ private[celeborn] class Master(
         f
       } catch {
         case e: Exception =>
-          HAHelper.sendFailure(context, HAHelper.getRatisServer(statusSystem), e, bindPreferIP)
+          HAHelper.sendFailure(
+            if (null != context) context.sendFailure _ else null,
+            HAHelper.getRatisServer(statusSystem),
+            e,
+            bindPreferIP)
       }
     }
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -17,15 +17,26 @@
 
 package org.apache.celeborn.service.deploy.master.clustermeta.ha;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.celeborn.common.client.MasterNotLeaderException;
+import org.apache.celeborn.common.network.sasl.SaslCredentials;
+import org.apache.celeborn.common.network.sasl.SaslTestBase;
+import org.apache.celeborn.common.network.sasl.SecretRegistry;
+import org.apache.celeborn.common.network.sasl.registration.RegistrationClientBootstrap;
+import org.apache.celeborn.common.network.sasl.registration.RegistrationInfo;
+import org.apache.celeborn.common.network.sasl.registration.RegistrationServerBootstrap;
+import org.apache.celeborn.common.network.util.TransportConf;
+import org.apache.celeborn.common.rpc.RpcAddress;
+import org.apache.celeborn.service.deploy.master.MasterSecretRegistryImpl;
 import scala.Tuple2;
 
 import com.google.common.collect.Lists;
@@ -302,7 +313,7 @@ public class RatisMasterStatusSystemSuiteJ {
           disks1,
           userResourceConsumption1,
           getNewReqeustId());
-      Assert.fail();
+      fail();
     } catch (CelebornRuntimeException e) {
       Assert.assertTrue(true);
     } finally {
@@ -1399,7 +1410,7 @@ public class RatisMasterStatusSystemSuiteJ {
       Assert.assertEquals(1, STATUSSYSTEM2.availableWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM3.availableWorkers.size());
     } catch (Exception e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     } finally {
       resetRaftServer(
           configureServerConf(new CelebornConf(), 1),
@@ -1937,6 +1948,66 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM1.availableWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM2.availableWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
+  }
+
+  @Test
+  public void testRedirectToLeaderForRegistration() throws Throwable {
+    CelebornConf celebornConf = new CelebornConf();
+    celebornConf.set("celeborn.shuffle.io.maxRetries", "1");
+    celebornConf.set("celeborn.network.bind.preferIpAddress", "false");
+    TransportConf conf = new TransportConf("shuffle", celebornConf);
+
+    // if server1 is the leader, pick server2, else server1 - so that it is always a follower
+    AbstractMetaManager followerStatusSystem =
+        RATISSERVER1.isLeader() ? STATUSSYSTEM2 : STATUSSYSTEM1;
+
+    SecretRegistry registry =
+        new SecretRegistry() {
+          // Only canRegisterElseReturnFailure is relevant for this test, rest dont matter
+          public String getSecretKey(String appId) {
+            return null;
+          }
+
+          public boolean isRegistered(String appId) {
+            return false;
+          }
+
+          public void register(String appId, String secret) {}
+
+          public void unregister(String appId) {}
+
+          public void ensureRegistrationAllowed() throws IOException {
+            // what MasterSecretRegistryImpl does - except we purposefully pick a follower
+            MasterSecretRegistryImpl.ensureRegistrationAllowedImpl(followerStatusSystem, false);
+          }
+        };
+
+    RegistrationServerBootstrap serverBootstrap = new RegistrationServerBootstrap(conf, registry);
+    RegistrationClientBootstrap clientBootstrap =
+        new RegistrationClientBootstrap(
+            conf, "app", new SaslCredentials("user", "password"), new RegistrationInfo());
+    try {
+      SaslTestBase.authHelper(conf, serverBootstrap, clientBootstrap);
+      fail("Should have redirected to leader");
+    } catch (Exception e) {
+      assertTrue(e.getCause() instanceof MasterNotLeaderException);
+      MasterNotLeaderException notLeaderException = (MasterNotLeaderException) e.getCause();
+
+      HARaftServer leader =
+          RATISSERVER1.isLeader()
+              ? RATISSERVER1
+              : RATISSERVER2.isLeader() ? RATISSERVER2 : RATISSERVER3;
+
+      // By default, prefer ip is true - which is used while the config above returns hostnames.
+      // Resolve the host in order to match
+      RpcAddress leaderEndpointAddress = RpcAddress.fromHostAndPort(leader.getRpcEndpoint());
+      RpcAddress suggestedEndpointAddress =
+          RpcAddress.fromHostAndPort(notLeaderException.getSuggestedLeaderAddress());
+
+      assertEquals(
+          new InetSocketAddress(leaderEndpointAddress.host(), leaderEndpointAddress.port()),
+          new InetSocketAddress(suggestedEndpointAddress.host(), suggestedEndpointAddress.port()));
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
-Detect if celeborn coordinator is a follower during registration and notify application proactively to reconnect to the right leader.
- Reconstruct MasterNotLeaderException based on the rpc failure stringified exception when .
The goal here is to ensure there are no breaking backwards compatibility changes.

Merging this internally, instead of OSS - given the nontrivial changes that have gone in for C++ support in the Apache main branch. I will create a PR based on this once we have validated it in prod.



### Why are the changes needed?
see above


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added UTs
