### PR TITLE
[CELEBORN-2137] Remove unused MAPGROUP PartitionType

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionType.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionType.java
@@ -19,8 +19,7 @@ package org.apache.celeborn.common.protocol;
 
 public enum PartitionType {
   REDUCE(0),
-  MAP(1),
-  MAPGROUP(2);
+  MAP(1);
 
   private final int value;
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -5039,8 +5039,7 @@ object CelebornConf extends Logging {
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(Set(
         PartitionType.REDUCE.name,
-        PartitionType.MAP.name,
-        PartitionType.MAPGROUP.name))
+        PartitionType.MAP.name))
       .createWithDefault(PartitionType.REDUCE.name)
 
   val SHUFFLE_PARTITION_SPLIT_THRESHOLD: ConfigEntry[Long] =

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -113,8 +113,6 @@ object PbSerDeUtils {
         // writer always closed as this is committed file info.
         fileMeta.setIsWriterClosed(true)
         fileMeta
-      case PartitionType.MAPGROUP =>
-        throw new NotImplementedError("Map group is not implemented")
     }
     new DiskFileInfo(
       userIdentifier,

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -1085,7 +1085,6 @@ object Utils extends Logging {
     value match {
       case 0 => PartitionType.REDUCE
       case 1 => PartitionType.MAP
-      case 2 => PartitionType.MAPGROUP
       case _ =>
         logWarning(s"invalid partitionType $value, fallback to ReducePartition")
         PartitionType.REDUCE

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -1053,8 +1053,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         new ReduceFileMeta(conf.shuffleChunkSize)
       case PartitionType.MAP =>
         new MapFileMeta()
-      case PartitionType.MAPGROUP =>
-        throw new NotImplementedError("Map group is not implemented")
     }
     val shuffleKey = Utils.makeShuffleKey(appId, shuffleId)
     val memoryFileInfo =
@@ -1229,8 +1227,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           mapFileMeta.setMountPoint(mountPoint)
         }
         mapFileMeta
-      case PartitionType.MAPGROUP =>
-        throw new NotImplementedError("Map group is not implemented")
     }
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -90,8 +90,6 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
               fileInfo.asInstanceOf[DiskFileInfo],
               notifier)
           }
-        case PartitionType.MAPGROUP =>
-          null
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove unused `MAPGROUP` `PartitionType`.

### Why are the changes needed?

`PartitionType` `MAPGROUP` is unused at present, which could be removed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.