### PR TITLE
[CELEBORN-2124][CIP-14] Support PushData network interfaces in cppClient

### DIFF
--- a/cpp/celeborn/network/Message.h
+++ b/cpp/celeborn/network/Message.h
@@ -252,6 +252,18 @@ class PushData : public Message {
     return requestId_;
   }
 
+  uint8_t mode() const {
+    return mode_;
+  }
+
+  std::string shuffleKey() const {
+    return shuffleKey_;
+  }
+
+  std::string partitionUniqueId() const {
+    return partitionUniqueId_;
+  }
+
  private:
   int internalEncodedLength() const override;
 

--- a/cpp/celeborn/network/MessageDispatcher.cpp
+++ b/cpp/celeborn/network/MessageDispatcher.cpp
@@ -129,14 +129,30 @@ void MessageDispatcher::read(Context*, std::unique_ptr<Message> toRecvMsg) {
 folly::Future<std::unique_ptr<Message>> MessageDispatcher::operator()(
     std::unique_ptr<Message> toSendMsg) {
   CELEBORN_CHECK(!closed_);
-  CELEBORN_CHECK(toSendMsg->type() == Message::RPC_REQUEST);
-  RpcRequest* request = reinterpret_cast<RpcRequest*>(toSendMsg.get());
+  auto currTime = std::chrono::system_clock::now();
+  long requestId;
+  switch (toSendMsg->type()) {
+    case Message::RPC_REQUEST: {
+      RpcRequest* request = reinterpret_cast<RpcRequest*>(toSendMsg.get());
+      requestId = request->requestId();
+      break;
+    }
+    case Message::PUSH_DATA: {
+      PushData* pushData = reinterpret_cast<PushData*>(toSendMsg.get());
+      requestId = pushData->requestId();
+      break;
+    }
+    default: {
+      CELEBORN_FAIL("unsupported type");
+    }
+  }
+
   auto f = requestIdRegistry_.withLock(
       [&](auto& registry) -> folly::Future<std::unique_ptr<Message>> {
-        auto& holder = registry[request->requestId()];
-        holder.requestTime = std::chrono::system_clock::now();
+        auto& holder = registry[requestId];
+        holder.requestTime = currTime;
         auto& p = holder.msgPromise;
-        p.setInterruptHandler([requestId = request->requestId(),
+        p.setInterruptHandler([requestId,
                                this](const folly::exception_wrapper&) {
           this->requestIdRegistry_.lock()->erase(requestId);
           LOG(WARNING) << "rpc request interrupted, requestId: " << requestId;
@@ -148,6 +164,11 @@ folly::Future<std::unique_ptr<Message>> MessageDispatcher::operator()(
 
   CELEBORN_CHECK(!closed_);
   return f;
+}
+
+folly::Future<std::unique_ptr<Message>>
+MessageDispatcher::sendPushDataRequest(std::unique_ptr<Message> toSendMsg) {
+  return (*this)(std::move(toSendMsg));
 }
 
 folly::Future<std::unique_ptr<Message>>

--- a/cpp/celeborn/network/MessageDispatcher.cpp
+++ b/cpp/celeborn/network/MessageDispatcher.cpp
@@ -166,8 +166,8 @@ folly::Future<std::unique_ptr<Message>> MessageDispatcher::operator()(
   return f;
 }
 
-folly::Future<std::unique_ptr<Message>>
-MessageDispatcher::sendPushDataRequest(std::unique_ptr<Message> toSendMsg) {
+folly::Future<std::unique_ptr<Message>> MessageDispatcher::sendPushDataRequest(
+    std::unique_ptr<Message> toSendMsg) {
   return (*this)(std::move(toSendMsg));
 }
 

--- a/cpp/celeborn/network/MessageDispatcher.h
+++ b/cpp/celeborn/network/MessageDispatcher.h
@@ -61,7 +61,7 @@ class MessageDispatcher : public wangle::ClientDispatcherBase<
   }
 
   virtual folly::Future<std::unique_ptr<Message>> sendPushDataRequest(
-        std::unique_ptr<Message> toSendMsg);
+      std::unique_ptr<Message> toSendMsg);
 
   virtual folly::Future<std::unique_ptr<Message>> sendFetchChunkRequest(
       const protocol::StreamChunkSlice& streamChunkSlice,

--- a/cpp/celeborn/network/MessageDispatcher.h
+++ b/cpp/celeborn/network/MessageDispatcher.h
@@ -60,6 +60,9 @@ class MessageDispatcher : public wangle::ClientDispatcherBase<
     return operator()(std::move(toSendMsg));
   }
 
+  virtual folly::Future<std::unique_ptr<Message>> sendPushDataRequest(
+        std::unique_ptr<Message> toSendMsg);
+
   virtual folly::Future<std::unique_ptr<Message>> sendFetchChunkRequest(
       const protocol::StreamChunkSlice& streamChunkSlice,
       std::unique_ptr<Message> toSendMsg);

--- a/cpp/celeborn/network/TransportClient.cpp
+++ b/cpp/celeborn/network/TransportClient.cpp
@@ -95,9 +95,8 @@ void TransportClient::pushDataAsync(
                     reinterpret_cast<RpcResponse*>(responseMsg.get());
                 _callback->onSuccess(rpcResponse->body());
               } else {
-                _callback->onFailure(
-                    std::make_unique<std::runtime_error>(
-                        "pushData return value type is not rpcResponse"));
+                _callback->onFailure(std::make_unique<std::runtime_error>(
+                    "pushData return value type is not rpcResponse"));
               }
             })
         .thenError([_callback = callback](const folly::exception_wrapper& e) {

--- a/cpp/celeborn/network/TransportClient.cpp
+++ b/cpp/celeborn/network/TransportClient.cpp
@@ -105,7 +105,12 @@ void TransportClient::pushDataAsync(
         });
 
   } catch (std::exception& e) {
-    auto errorMsg = fmt::format("pushData failed: {}", e.what());
+    auto errorMsg = fmt::format(
+        "PushData failed. shuffleKey: {}, partitionUniqueId: {}, mode: {}, error message: {}",
+        pushData.shuffleKey(),
+        pushData.partitionUniqueId(),
+        pushData.mode(),
+        e.what());
     LOG(ERROR) << errorMsg;
     callback->onFailure(std::make_unique<std::runtime_error>(errorMsg));
   }

--- a/cpp/celeborn/network/TransportClient.cpp
+++ b/cpp/celeborn/network/TransportClient.cpp
@@ -79,6 +79,39 @@ void TransportClient::sendRpcRequestWithoutResponse(const RpcRequest& request) {
   }
 }
 
+void TransportClient::pushDataAsync(
+    const PushData& pushData,
+    Timeout timeout,
+    std::shared_ptr<RpcResponseCallback> callback) {
+  try {
+    auto requestMsg = std::make_unique<PushData>(pushData);
+    auto future = dispatcher_->sendPushDataRequest(std::move(requestMsg));
+    std::move(future)
+        .within(timeout)
+        .thenValue(
+            [_callback = callback](std::unique_ptr<Message> responseMsg) {
+              if (responseMsg->type() == Message::RPC_RESPONSE) {
+                auto rpcResponse =
+                    reinterpret_cast<RpcResponse*>(responseMsg.get());
+                _callback->onSuccess(rpcResponse->body());
+              } else {
+                _callback->onFailure(
+                    std::make_unique<std::runtime_error>(
+                        "pushData return value type is not rpcResponse"));
+              }
+            })
+        .thenError([_callback = callback](const folly::exception_wrapper& e) {
+          _callback->onFailure(
+              std::make_unique<std::runtime_error>(e.what().toStdString()));
+        });
+
+  } catch (std::exception& e) {
+    auto errorMsg = fmt::format("pushData failed: {}", e.what());
+    LOG(ERROR) << errorMsg;
+    callback->onFailure(std::make_unique<std::runtime_error>(errorMsg));
+  }
+}
+
 void TransportClient::fetchChunkAsync(
     const protocol::StreamChunkSlice& streamChunkSlice,
     const RpcRequest& request,

--- a/cpp/celeborn/network/TransportClient.h
+++ b/cpp/celeborn/network/TransportClient.h
@@ -54,6 +54,17 @@ using FetchChunkSuccessCallback = std::function<void(
 using FetchChunkFailureCallback = std::function<
     void(protocol::StreamChunkSlice, std::unique_ptr<std::exception>)>;
 
+class RpcResponseCallback {
+ public:
+  RpcResponseCallback() = default;
+
+  virtual ~RpcResponseCallback() = default;
+
+  virtual void onSuccess(std::unique_ptr<memory::ReadOnlyByteBuffer>) = 0;
+
+  virtual void onFailure(std::unique_ptr<std::exception> exception) = 0;
+};
+
 /**
  * TransportClient sends the messages to the network layer, and handles
  * the message callback, timeout, error handling, etc.
@@ -75,6 +86,11 @@ class TransportClient {
 
   // Ignore the response, return immediately.
   virtual void sendRpcRequestWithoutResponse(const RpcRequest& request);
+
+  virtual void pushDataAsync(
+      const PushData& pushData,
+      Timeout timeout,
+      std::shared_ptr<RpcResponseCallback> callback);
 
   virtual void fetchChunkAsync(
       const protocol::StreamChunkSlice& streamChunkSlice,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support PushData network interfaces in cppClient.

### Why are the changes needed?
PushData network interfaces are used when writing data to Worker node via cppClient.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
