### PR TITLE
[CLOUD DISK] Add cloud disk mounted mode for local shuffle reading

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -149,6 +149,7 @@ class CelebornShuffleReader[K, C](
     val fetchTimeoutMs = conf.clientFetchTimeoutMs
     val localFetchEnabled = conf.enableReadLocalShuffleFile
     val localHostAddress = Utils.localHostName(conf)
+    val cloudDiskMounted = conf.cloudDiskMounted
     val shuffleKey = Utils.makeShuffleKey(handle.appUniqueId, shuffleId)
     var fileGroups: ReduceFileGroups = null
     var isShuffleStageEnd: Boolean = false
@@ -231,8 +232,10 @@ class CelebornShuffleReader[K, C](
             pbOpenStreamListBuilder.addFileName(location.getFileName)
               .addStartIndex(startMapIndex)
               .addEndIndex(endMapIndex)
-            pbOpenStreamListBuilder.addReadLocalShuffle(
-              localFetchEnabled && location.getHost.equals(localHostAddress))
+            val isLocalRead =
+              localFetchEnabled && (cloudDiskMounted || location.getHost.equals(localHostAddress))
+            pbOpenStreamListBuilder.addReadLocalShuffle(isLocalRead)
+            logDebug(s"Partition ${location.getId}: isLocalRead=${isLocalRead}, cloudDiskMounted=${cloudDiskMounted}")
           case _ =>
             logDebug(s"Empty client for host ${hostPort}")
         }

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -210,6 +210,7 @@ public abstract class CelebornInputStream extends InputStream {
     private LongAdder skipCount = new LongAdder();
     private final boolean rangeReadFilter;
     private final boolean enabledReadLocalShuffle;
+    private final boolean cloudDiskMounted;
     private final String localHostAddress;
 
     private boolean shouldDecompress;
@@ -318,6 +319,7 @@ public abstract class CelebornInputStream extends InputStream {
       this.partitionLocationToChunkRange = partitionLocationToChunkRange;
       this.rangeReadFilter = conf.shuffleRangeReadFilterEnabled();
       this.enabledReadLocalShuffle = conf.enableReadLocalShuffleFile();
+      this.cloudDiskMounted = conf.cloudDiskMounted();
       this.localHostAddress = Utils.localHostName(conf);
       this.shouldDecompress =
           !conf.shuffleCompressionCodec().equals(CompressionCodec.NONE) && needDecompress;
@@ -602,9 +604,12 @@ public abstract class CelebornInputStream extends InputStream {
         case SSD:
         case MEMORY:
           if (enabledReadLocalShuffle
-              && location.getHost().equals(localHostAddress)
-              && storageInfo.getType() != StorageInfo.Type.MEMORY) {
-            logger.debug("Read local shuffle file {}", localHostAddress);
+              && storageInfo.getType() != StorageInfo.Type.MEMORY
+              && (cloudDiskMounted || location.getHost().equals(localHostAddress))) {
+            logger.debug(
+                "Read local shuffle file {}, cloudDiskMounted={}",
+                localHostAddress,
+                cloudDiskMounted);
             containLocalRead = true;
             return new LocalPartitionReader(
                 conf,

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -110,13 +110,13 @@ public class LocalPartitionReader implements PartitionReader {
                     .setFileName(location.getFileName())
                     .setStartIndex(startMapIndex)
                     .setEndIndex(endMapIndex)
-                    .setReadLocalShuffle(true)
+                    .setReadLocalShuffle(conf.enableReadLocalShuffleFile())
                     .build()
                     .toByteArray());
         ByteBuffer response = client.sendRpcSync(openStreamMsg.toByteBuffer(), fetchTimeoutMs);
         streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
       } else {
-        this.streamHandler = pbStreamHandler;
+        streamHandler = pbStreamHandler;
       }
       this.startChunkIndex = startChunkIndex == -1 ? 0 : startChunkIndex;
       this.endChunkIndex =

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1152,6 +1152,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def batchHandleReleasePartitionRequestInterval: Long =
     get(CLIENT_BATCH_HANDLED_RELEASE_PARTITION_INTERVAL)
   def enableReadLocalShuffleFile: Boolean = get(READ_LOCAL_SHUFFLE_FILE)
+  def cloudDiskMounted: Boolean = get(CLOUD_DISK_MOUNTED)
   def readLocalShuffleThreads: Int = get(READ_LOCAL_SHUFFLE_THREADS)
   def readStreamCreatorPoolThreads: Int = get(READ_STREAM_CREATOR_POOL_THREADS)
 
@@ -6105,6 +6106,17 @@ object CelebornConf extends Logging {
       .doc("Threads count for read local shuffle file.")
       .intConf
       .createWithDefault(4)
+
+  val CLOUD_DISK_MOUNTED: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.readLocalShuffleFile.cloudDiskMounted")
+      .categories("client")
+      .version("0.6.1")
+      .doc("Enable cloud disk mounted mode for local shuffle file reading. When enabled, all " +
+        "workers' data can be accessed locally via mounted cloud disk, eliminating the need for " +
+        "host address comparison. This should be used together with " +
+        "celeborn.client.readLocalShuffleFile.enabled.")
+      .booleanConf
+      .createWithDefault(false)
 
   val READ_STREAM_CREATOR_POOL_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.client.eagerlyCreateInputStream.threads")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

1. **New Configuration Parameter**: Added \`celeborn.client.readLocalShuffleFile.cloudDiskMounted\` configuration option
2. **Enhanced Local Read Logic**: Modified \`CelebornShuffleReader\` to support cloud disk mounted mode where host address comparison is no longer required

### Why are the changes needed?

The current Celeborn implementation requires network communication between client and worker even when data is stored on cloud disks that are mounted locally. This creates unnecessary overhead in cloud environments where:

- All worker data is accessible via mounted cloud disks
- Network latency between client and worker adds performance penalty
- Multi-layer IO (client -> worker -> cloud disk) is less efficient than direct file system access

**The primary goal of using cloud disks is to eliminate dependency on local disks**, providing a more scalable and cost-effective storage solution. The cloud disk mounted mode eliminates the worker layer for data access, providing direct file system access to shuffle data while removing the need for local disk storage.


### Does this PR introduce _any_ user-facing change?

Yes, this PR introduces a new configuration parameter:

- **New config**: \`celeborn.client.readLocalShuffleFile.cloudDiskMounted\` (default: false)
- **Usage**: Must be used together with \`celeborn.client.readLocalShuffleFile.enabled=true\`
- **Behavior**: When enabled, all workers' data can be accessed locally via mounted cloud disk, eliminating host address comparison requirements

This change is backward compatible and does not affect existing functionality when the new config is not enabled.

### How was this patch tested?

1. **Functional Testing**: 
   - Tested in cloud disk mounted environment

2. **Performance Testing**:
   - Compared direct cloud disk mounting vs multi-layer IO (client -> worker -> cloud disk)
   - **Results**: 5.5% overall performance improvement with direct cloud disk access