### PR TITLE
[CELEBORN-2142] DfsTierWriter should create for unavailable disks

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -133,7 +133,8 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
                 partitionDataWriterContext.isPartitionSplitEnabled)
               partitionDataWriterContext.setWorkingDir(workingDir)
               val metaHandler = getPartitionMetaHandler(diskFileInfo)
-              if ((storageInfoType == StorageInfo.Type.HDD || storageInfoType == StorageInfo.Type.SSD) && location.getStorageInfo.localDiskAvailable()) {
+              if (flusher.isInstanceOf[LocalFlusher]
+                && location.getStorageInfo.localDiskAvailable()) {
                 new LocalTierWriter(
                   conf,
                   metaHandler,
@@ -142,7 +143,7 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
                   flusher,
                   source,
                   diskFileInfo,
-                  storageInfoType,
+                  diskFileInfo.getStorageType,
                   partitionDataWriterContext,
                   storageManager)
               } else {
@@ -154,7 +155,7 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
                   flusher,
                   source,
                   diskFileInfo,
-                  storageInfoType,
+                  diskFileInfo.getStorageType,
                   partitionDataWriterContext,
                   storageManager)
               }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
@@ -56,7 +56,7 @@ class StoragePolicyCase2 extends CelebornFunSuite {
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
   val mockedDiskFile = mock[DiskFileInfo]
-  val mockedFlusher = mock[Flusher]
+  val mockedFlusher = mock[LocalFlusher]
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
@@ -101,6 +101,7 @@ class StoragePolicyCase2 extends CelebornFunSuite {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(localHintPartitionLocatioin)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.HDD)
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "SSD,HDD,HDFS,OSS,S3")
     val storagePolicy = new StoragePolicy(conf, mockedStorageManager, mockedSource)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
@@ -56,7 +56,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
   val mockedDiskFile = mock[DiskFileInfo]
-  val mockedFlusher = mock[Flusher]
+  val mockedFlusher = mock[LocalFlusher]
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
@@ -101,6 +101,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(localHintPartitionLocatioin)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.SSD)
     val mockedMemoryFile = mock[LocalTierWriter]
     val conf = new CelebornConf()
     val flushLock = new AnyRef
@@ -120,6 +121,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(memoryHintPartitionLocation)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.HDD)
     val mockedMemoryFile = mock[LocalTierWriter]
     val conf = new CelebornConf()
     val flushLock = new AnyRef

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
@@ -56,7 +56,7 @@ class StoragePolicyCase4 extends CelebornFunSuite {
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
   val mockedDiskFile = mock[DiskFileInfo]
-  val mockedFlusher = mock[Flusher]
+  val mockedFlusher = mock[LocalFlusher]
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
@@ -102,6 +102,7 @@ class StoragePolicyCase4 extends CelebornFunSuite {
       memoryDisabledHintPartitionLocation)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.SSD)
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "MEMORY,SSD,HDD,HDFS,OSS,S3")
     val storagePolicy = new StoragePolicy(conf, mockedStorageManager, mockedSource)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DfsTierWriter` should create for unavailable disks.

### Why are the changes needed?

If there is no available disk, `StorageManager#createDiskFile` returns `HdfsFlusher`, `S3Flusher`, or `OssFlusher`. Meanwhile, `LocalTierWriter` should not be created.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.