### PR TITLE
[CELEBORN-2150] Fix the match condition in checkIfWorkingDirCleaned

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -773,21 +773,26 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
               false
           }
         }
-
-      val dfsCleaned = hadoopFs match {
-        case dfs: FileSystem =>
-          val dfsDir = if (hasHDFSStorage) hdfsDir else if (hasOssStorage) ossDir else s3Dir
-          val dfsWorkPath = new Path(dfsDir, conf.workerWorkingDir)
-          // DFS path not exist when first time initialize
-          if (dfs.exists(dfsWorkPath)) {
-            !dfs.listFiles(dfsWorkPath, false).hasNext
-          } else {
-            true
+      val dfsCleaned = hadoopFs == null || hadoopFs.asScala.forall {
+        case (storageType, fs) =>
+          val dfsDir =
+            if (storageType == StorageInfo.Type.HDFS)
+              hdfsDir
+            else if (storageType == StorageInfo.Type.OSS) ossDir
+            else s3Dir
+          try {
+            val dfsWorkPath = new Path(dfsDir, conf.workerWorkingDir)
+            // DFS path not exist when first time initialize
+            !fs.exists(dfsWorkPath) || !fs.listFiles(dfsWorkPath, false).hasNext
+          } catch {
+            case t: Throwable =>
+              // When DFS is not accessible, assume it's cleaned
+              logError("checkIfWorkingDirCleaned failed.", t)
+              true
           }
         case _ =>
           true
       }
-
       if (localCleaned && dfsCleaned) {
         return true
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix the match condition in checkIfWorkingDirCleaned

### Why are the changes needed?

`checkIfWorkingDirCleaned` has wrong match condition, `dfsCleaned` always return true.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI