### PR TITLE
[CELEBORN-2152] Support merge buffers on the worker side to improve memory utilization

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1416,6 +1416,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(WORKER_MEMORY_FILE_STORAGE_EVICT_AGGRESSIVE_MODE_ENABLED)
   def workerMemoryFileStorageEvictRatio: Double =
     get(WORKER_MEMORY_FILE_STORAGE_EVICT_RATIO)
+  def workerPushDataMergeBufferEnabled: Boolean = get(WORKER_PUSH_DATA_MERGE_BUFFER_ENABLED)
 
   // //////////////////////////////////////////////////////
   //                  Rate Limit controller              //
@@ -4172,6 +4173,14 @@ object CelebornConf extends Logging {
       .version("0.5.1")
       .doubleConf
       .createWithDefault(0.5)
+
+  val WORKER_PUSH_DATA_MERGE_BUFFER_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.pushdata.mergeBuffer.enabled")
+      .categories("worker")
+      .version("0.5.1")
+      .doc("enable merge low utilization push data's body buffer before write")
+      .booleanConf
+      .createWithDefault(true)
 
   val WORKER_CONGESTION_CONTROL_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.congestionControl.enabled")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -161,6 +161,7 @@ license: |
 | celeborn.worker.push.heartbeat.enabled | false | false | enable the heartbeat from worker to client when pushing data | 0.3.0 |  | 
 | celeborn.worker.push.io.threads | &lt;undefined&gt; | false | Netty IO thread number of worker to handle client push data. The default threads number is the number of flush thread. | 0.2.0 |  | 
 | celeborn.worker.push.port | 0 | false | Server port for Worker to receive push data request from ShuffleClient. | 0.2.0 |  | 
+| celeborn.worker.pushdata.mergeBuffer.enabled | true | false | enable merge low utilization push data's body buffer before write | 0.5.1 |  | 
 | celeborn.worker.readBuffer.allocationWait | 50ms | false | The time to wait when buffer dispatcher can not allocate a buffer. | 0.3.0 |  | 
 | celeborn.worker.readBuffer.target.changeThreshold | 1mb | false | The target ratio for pre read memory usage. | 0.3.0 |  | 
 | celeborn.worker.readBuffer.target.ratio | 0.9 | false | The target ratio for read ahead buffer's memory usage. | 0.3.0 |  | 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -64,6 +64,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
   private var storageManager: StorageManager = _
   private var workerPartitionSplitEnabled: Boolean = _
   private var workerReplicateRandomConnectionEnabled: Boolean = _
+  private var workerPushDataMergeBufferEnabled: Boolean = _
 
   private var testPushPrimaryDataTimeout: Boolean = _
   private var testPushReplicaDataTimeout: Boolean = _
@@ -83,7 +84,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     shutdown = worker.shutdown
     workerPartitionSplitEnabled = worker.conf.workerPartitionSplitEnabled
     workerReplicateRandomConnectionEnabled = worker.conf.workerReplicateRandomConnectionEnabled
-
+    workerPushDataMergeBufferEnabled = worker.conf.workerPushDataMergeBufferEnabled
     testPushPrimaryDataTimeout = worker.conf.testPushPrimaryDataTimeout
     testPushReplicaDataTimeout = worker.conf.testPushReplicaDataTimeout
     registered = Some(worker.registered)
@@ -1514,6 +1515,25 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       hardSplitIndexes: Array[Int] = Array.empty[Int]): Unit = {
     val length = fileWriters.length
     val result = new Array[StatusCode](length)
+
+    var finalBody: ByteBuf = body
+    var copyBody: ByteBuf = null
+    if (workerPushDataMergeBufferEnabled) {
+      val numBytes = body.readableBytes()
+      try {
+        copyBody = body.alloc.directBuffer(numBytes)
+        // this method do not increase the readerIndex of source buffer, when oom
+        // happens, we can fall back to the original buffer
+        copyBody.writeBytes(body, body.readerIndex, numBytes)
+        finalBody = copyBody
+      } catch {
+        case e: OutOfMemoryError =>
+          logError(s"caught oom when consolidate data failed, size: $numBytes", e)
+        case e: Throwable =>
+          logError(s"consolidate data failed, size: $numBytes", e)
+      }
+    }
+
     def writeData(
         fileWriter: PartitionDataWriter,
         body: ByteBuf,
@@ -1561,14 +1581,14 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           } else {
             fileWriter = fileWriters(index)
             if (!writePromise.isCompleted) {
-              val offset = body.readerIndex() + batchOffsets(index)
+              val offset = finalBody.readerIndex() + batchOffsets(index)
               val length =
                 if (index == fileWriters.length - 1) {
-                  body.readableBytes() - batchOffsets(index)
+                  finalBody.readableBytes() - batchOffsets(index)
                 } else {
                   batchOffsets(index + 1) - batchOffsets(index)
                 }
-              val batchBody = body.slice(offset, length)
+              val batchBody = finalBody.slice(offset, length)
               writeData(fileWriter, batchBody, shuffleKey, index)
             } else {
               fileWriter.decrementPendingWrites()
@@ -1577,11 +1597,15 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           index += 1
         }
       case _ =>
-        writeData(fileWriters.head, body, shuffleKey, 0)
+        writeData(fileWriters.head, finalBody, shuffleKey, 0)
     }
     if (!writePromise.isCompleted) {
       workerSource.incCounter(WorkerSource.WRITE_DATA_SUCCESS_COUNT)
       writePromise.success(result)
+    }
+    // manually release copyBody to avoid memory leak
+    if (copyBody != null) {
+      copyBody.release()
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provides a configuration item that can copy the body buffer in pushdata to a newly requested buffer before writing on the worker, achieving 100% buffer internal space utilization, and ultimately significantly improving the overall utilization of NettyMemory.

### Why are the changes needed?
In the worker, Netty uses AdaptiveRecvByteBufAllocator to determine the buffer size to allocate in advance when reading data from the socket. However, in certain network environments, there can be a significant discrepancy between the buffer size predicted and allocated by AdaptiveRecvByteBufAllocator and the actual data size read from the socket. This can result in a large buffer being allocated but only a small amount of data being read, ultimately leading to very low overall memory utilization in the worker. A clear metric is that NettyMemory is large but DiskBuffer is very small. This means that the worker may receive a small amount of data but quickly enter the Pause state due to excessive NettyMemory usage.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

cluster test

### Performance Test
<img width="1697" height="700" alt="image" src="https://github.com/user-attachments/assets/56495d08-6da7-4d43-8e8a-da87a33ccf90" />

