### PR TITLE
[CELEBORN-2154] Optimize the exception handling of DFS read to avoid tasks from getting stuck

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/PartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/PartitionReader.java
@@ -17,7 +17,6 @@
 
 package org.apache.celeborn.client.read;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import io.netty.buffer.ByteBuf;
@@ -28,7 +27,7 @@ import org.apache.celeborn.common.protocol.PartitionLocation;
 public interface PartitionReader {
   boolean hasNext();
 
-  ByteBuf next() throws IOException, InterruptedException;
+  ByteBuf next() throws Exception;
 
   void close();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize the exception handling of DFS read to avoid tasks from getting stuck.

### Why are the changes needed?

Optimize the exception handling of DFS read to avoid tasks from getting stuck.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.