### PR TITLE
[CELEBORN-2174] Remove partitionSplitEnabled from ReserveSlots and FileInfo

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1320,7 +1320,6 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             rangeReadFilter,
             userIdentifier,
             conf.pushDataTimeoutMs,
-            partitionSplitEnabled = true,
             isSegmentGranularityVisible = isSegmentGranularityVisible))
         futures.add((future, workerInfo))
       }(ec)

--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
@@ -19,7 +19,7 @@ package org.apache.celeborn.common.meta;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.FileSystem;
@@ -42,11 +42,10 @@ public class DiskFileInfo extends FileInfo {
 
   public DiskFileInfo(
       UserIdentifier userIdentifier,
-      boolean partitionSplitEnabled,
       FileMeta fileMeta,
       String filePath,
       StorageInfo.Type storageType) {
-    super(userIdentifier, partitionSplitEnabled, fileMeta);
+    super(userIdentifier, fileMeta);
     this.filePath = filePath;
     this.storageType = storageType;
   }
@@ -54,12 +53,11 @@ public class DiskFileInfo extends FileInfo {
   // only called when restore from pb or in UT
   public DiskFileInfo(
       UserIdentifier userIdentifier,
-      boolean partitionSplitEnabled,
       FileMeta fileMeta,
       String filePath,
       StorageInfo.Type storageType,
       long bytesFlushed) {
-    super(userIdentifier, partitionSplitEnabled, fileMeta);
+    super(userIdentifier, fileMeta);
     this.filePath = filePath;
     if (storageType != null) {
       this.storageType = storageType;
@@ -73,14 +71,13 @@ public class DiskFileInfo extends FileInfo {
   public DiskFileInfo(File file, UserIdentifier userIdentifier, CelebornConf conf) {
     this(
         userIdentifier,
-        true,
-        new ReduceFileMeta(new ArrayList<>(Arrays.asList(0L)), conf.shuffleChunkSize()),
+        new ReduceFileMeta(new ArrayList<>(Collections.singletonList(0L)), conf.shuffleChunkSize()),
         file.getAbsolutePath(),
         StorageInfo.Type.HDD);
   }
 
   public DiskFileInfo(UserIdentifier userIdentifier, FileMeta fileMeta, String filePath) {
-    super(userIdentifier, true, fileMeta);
+    super(userIdentifier, fileMeta);
     this.filePath = filePath;
     this.storageType = StorageInfo.Type.HDD;
   }

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -24,17 +24,13 @@ import org.apache.celeborn.common.identity.UserIdentifier;
 
 public abstract class FileInfo {
   private final UserIdentifier userIdentifier;
-  // whether to split is decided by client side.
-  // now it's just used for mappartition to compatible with old client which can't support split
-  private boolean partitionSplitEnabled;
   protected FileMeta fileMeta;
   protected final Set<Long> streams = ConcurrentHashMap.newKeySet();
   protected volatile long bytesFlushed;
   private boolean isReduceFileMeta;
 
-  public FileInfo(UserIdentifier userIdentifier, boolean partitionSplitEnabled, FileMeta fileMeta) {
+  public FileInfo(UserIdentifier userIdentifier, FileMeta fileMeta) {
     this.userIdentifier = userIdentifier;
-    this.partitionSplitEnabled = partitionSplitEnabled;
     this.fileMeta = fileMeta;
     this.isReduceFileMeta = fileMeta instanceof ReduceFileMeta;
   }
@@ -65,14 +61,6 @@ public abstract class FileInfo {
 
   public UserIdentifier getUserIdentifier() {
     return userIdentifier;
-  }
-
-  public boolean isPartitionSplitEnabled() {
-    return partitionSplitEnabled;
-  }
-
-  public void setPartitionSplitEnabled(boolean partitionSplitEnabled) {
-    this.partitionSplitEnabled = partitionSplitEnabled;
   }
 
   public boolean addStream(long streamId) {

--- a/common/src/main/java/org/apache/celeborn/common/meta/MemoryFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MemoryFileInfo.java
@@ -32,18 +32,13 @@ public class MemoryFileInfo extends FileInfo {
   private CompositeByteBuf sortedBuffer;
   private Map<Integer, List<ShuffleBlockInfo>> sortedIndexes;
 
-  public MemoryFileInfo(
-      UserIdentifier userIdentifier, boolean partitionSplitEnabled, FileMeta fileMeta) {
-    super(userIdentifier, partitionSplitEnabled, fileMeta);
+  public MemoryFileInfo(UserIdentifier userIdentifier, FileMeta fileMeta) {
+    super(userIdentifier, fileMeta);
   }
 
   // This constructor is only used in partition sorter for temp new memory file
-  public MemoryFileInfo(
-      UserIdentifier userIdentifier,
-      boolean partitionSplitEnabled,
-      FileMeta fileMeta,
-      CompositeByteBuf buffer) {
-    super(userIdentifier, partitionSplitEnabled, fileMeta);
+  public MemoryFileInfo(UserIdentifier userIdentifier, FileMeta fileMeta, CompositeByteBuf buffer) {
+    super(userIdentifier, fileMeta);
     this.buffer = buffer;
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -481,7 +481,6 @@ object ControlMessages extends Logging {
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
       pushDataTimeout: Long,
-      partitionSplitEnabled: Boolean = false,
       isSegmentGranularityVisible: Boolean = false)
     extends WorkerMessage
 
@@ -960,7 +959,6 @@ object ControlMessages extends Logging {
           rangeReadFilter,
           userIdentifier,
           pushDataTimeout,
-          partitionSplitEnabled,
           isSegmentGranularityVisible) =>
       val payload = PbReserveSlots.newBuilder()
         .setApplicationId(applicationId)
@@ -973,7 +971,6 @@ object ControlMessages extends Logging {
         .setRangeReadFilter(rangeReadFilter)
         .setUserIdentifier(PbSerDeUtils.toPbUserIdentifier(userIdentifier))
         .setPushDataTimeout(pushDataTimeout)
-        .setPartitionSplitEnabled(partitionSplitEnabled)
         .setIsSegmentGranularityVisible(isSegmentGranularityVisible)
         .build().toByteArray
       new TransportMessage(MessageType.RESERVE_SLOTS, payload)
@@ -1438,7 +1435,6 @@ object ControlMessages extends Logging {
           pbReserveSlots.getRangeReadFilter,
           userIdentifier,
           pbReserveSlots.getPushDataTimeout,
-          pbReserveSlots.getPartitionSplitEnabled,
           pbReserveSlots.getIsSegmentGranularityVisible)
 
       case RESERVE_SLOTS_RESPONSE_VALUE =>

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -77,42 +77,36 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
 
   val fileInfo1 = new DiskFileInfo(
     userIdentifier1,
-    true,
     new ReduceFileMeta(chunkOffsets1, 123),
     file1.getAbsolutePath,
     StorageInfo.Type.HDD,
     3000L)
   val fileInfo2 = new DiskFileInfo(
     userIdentifier2,
-    true,
     new ReduceFileMeta(chunkOffsets2, 123),
     file2.getAbsolutePath,
     StorageInfo.Type.SSD,
     6000L)
   val fileInfo3 = new DiskFileInfo(
     userIdentifier3,
-    true,
     new ReduceFileMeta(chunkOffsets3, 123),
     file3,
     StorageInfo.Type.HDFS,
     6000L)
   val fileInfo4 = new DiskFileInfo(
     userIdentifier3,
-    true,
     new ReduceFileMeta(chunkOffsets3, 123),
     file4,
     StorageInfo.Type.OSS,
     6000L)
   val fileInfo5 = new DiskFileInfo(
     userIdentifier3,
-    true,
     new ReduceFileMeta(chunkOffsets3, 123),
     file5,
     StorageInfo.Type.S3,
     6000L)
   val fileInfo6 = new DiskFileInfo(
     userIdentifier3,
-    true,
     new ReduceFileMeta(chunkOffsets3, 123),
     file6,
     StorageInfo.Type.S3,
@@ -120,14 +114,12 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
 
   val mapFileInfo1 = new DiskFileInfo(
     userIdentifier1,
-    true,
     new MapFileMeta(1024, 10),
     file1.getAbsolutePath,
     StorageInfo.Type.HDD,
     6000L)
   val mapFileInfo2 = new DiskFileInfo(
     userIdentifier2,
-    true,
     new MapFileMeta(1024, 10),
     file2.getAbsolutePath,
     StorageInfo.Type.SSD,
@@ -376,7 +368,6 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
       .setFilePath(diskFileInfo.getFilePath)
       .setUserIdentifier(toPbUserIdentifier(diskFileInfo.getUserIdentifier))
       .setBytesFlushed(diskFileInfo.getFileLength)
-      .setPartitionSplitEnabled(diskFileInfo.isPartitionSplitEnabled)
     val reduceFileMeta = diskFileInfo.getFileMeta.asInstanceOf[ReduceFileMeta]
     builder.setPartitionType(PartitionType.REDUCE.getValue)
     builder.addAllChunkOffsets(reduceFileMeta.getChunkOffsets)

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
@@ -455,7 +455,7 @@ public class MapPartitionDataReader implements Comparable<MapPartitionDataReader
         logger.debug("release reader for stream {}", streamId);
         // old client can't support BufferStreamEnd, so for new client it tells client that this
         // stream is finished.
-        if (fileInfo.isPartitionSplitEnabled() && !errorNotified) {
+        if (!errorNotified) {
           associatedChannel.writeAndFlush(
               new RpcRequest(
                   TransportClient.requestId(),

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterContext.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterContext.java
@@ -33,7 +33,6 @@ public class PartitionDataWriterContext {
   private final String appId;
   private final int shuffleId;
   private final UserIdentifier userIdentifier;
-  private final boolean partitionSplitEnabled;
   private final String shuffleKey;
   private final PartitionType partitionType;
   private final boolean isSegmentGranularityVisible;
@@ -51,7 +50,6 @@ public class PartitionDataWriterContext {
       int shuffleId,
       UserIdentifier userIdentifier,
       PartitionType partitionType,
-      boolean partitionSplitEnabled,
       boolean isSegmentGranularityVisible) {
     this.splitThreshold = splitThreshold;
     this.partitionSplitMode = partitionSplitMode;
@@ -60,7 +58,6 @@ public class PartitionDataWriterContext {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.userIdentifier = userIdentifier;
-    this.partitionSplitEnabled = partitionSplitEnabled;
     this.partitionType = partitionType;
     this.shuffleKey = Utils.makeShuffleKey(appId, shuffleId);
     this.isSegmentGranularityVisible = isSegmentGranularityVisible;
@@ -92,10 +89,6 @@ public class PartitionDataWriterContext {
 
   public UserIdentifier getUserIdentifier() {
     return userIdentifier;
-  }
-
-  public boolean isPartitionSplitEnabled() {
-    return partitionSplitEnabled;
   }
 
   public String getShuffleKey() {
@@ -152,8 +145,6 @@ public class PartitionDataWriterContext {
         + shuffleId
         + ", userIdentifier="
         + userIdentifier
-        + ", partitionSplitEnabled="
-        + partitionSplitEnabled
         + ", shuffleKey='"
         + shuffleKey
         + '\''

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -227,11 +227,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
           memoryFileInfo.getSortedBuffer(),
           targetBuffer,
           shuffleChunkSize);
-      return new MemoryFileInfo(
-          memoryFileInfo.getUserIdentifier(),
-          memoryFileInfo.isPartitionSplitEnabled(),
-          reduceFileMeta,
-          targetBuffer);
+      return new MemoryFileInfo(memoryFileInfo.getUserIdentifier(), reduceFileMeta, targetBuffer);
     } else {
       DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);
       String fileId = shuffleKey + "-" + fileName;

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -113,7 +113,6 @@ private[deploy] class Controller(
           rangeReadFilter,
           userIdentifier,
           pushDataTimeout,
-          partitionSplitEnabled,
           isSegmentGranularityVisible) =>
       checkAuth(context, applicationId)
       val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
@@ -133,7 +132,6 @@ private[deploy] class Controller(
           rangeReadFilter,
           userIdentifier,
           pushDataTimeout,
-          partitionSplitEnabled,
           isSegmentGranularityVisible)
         logDebug(s"ReserveSlots for $shuffleKey finished.")
       }
@@ -180,7 +178,6 @@ private[deploy] class Controller(
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
       pushDataTimeout: Long,
-      partitionSplitEnabled: Boolean,
       isSegmentGranularityVisible: Boolean): Unit = {
     val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
     if (shutdown.get()) {
@@ -211,7 +208,6 @@ private[deploy] class Controller(
       partitionType,
       rangeReadFilter,
       userIdentifier,
-      partitionSplitEnabled,
       isSegmentGranularityVisible,
       isPrimary = true)
     if (primaryLocs.size() < requestPrimaryLocs.size()) {
@@ -232,7 +228,6 @@ private[deploy] class Controller(
       partitionType,
       rangeReadFilter,
       userIdentifier,
-      partitionSplitEnabled,
       isSegmentGranularityVisible,
       isPrimary = false)
     if (replicaLocs.size() < requestReplicaLocs.size()) {
@@ -275,7 +270,6 @@ private[deploy] class Controller(
       partitionType: PartitionType,
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
-      partitionSplitEnabled: Boolean,
       isSegmentGranularityVisible: Boolean,
       isPrimary: Boolean): jList[PartitionLocation] = {
     val partitionLocations = new jArrayList[PartitionLocation]()
@@ -291,7 +285,6 @@ private[deploy] class Controller(
           partitionType,
           rangeReadFilter,
           userIdentifier,
-          partitionSplitEnabled,
           isSegmentGranularityVisible,
           isPrimary)
       }
@@ -321,7 +314,6 @@ private[deploy] class Controller(
       partitionType: PartitionType,
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
-      partitionSplitEnabled: Boolean,
       isSegmentGranularityVisible: Boolean,
       isPrimary: Boolean): PartitionLocation = {
     try {
@@ -346,7 +338,6 @@ private[deploy] class Controller(
           partitionType,
           rangeReadFilter,
           userIdentifier,
-          partitionSplitEnabled,
           isSegmentGranularityVisible)
         new WorkingPartition(location, writer)
       } else {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -1247,17 +1247,15 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     // During worker shutdown, worker will return HARD_SPLIT for all existed partition.
     // This should before return exception to make current push request revive and retry.
-    val isPartitionSplitEnabled = fileWriter.getCurrentFileInfo.isPartitionSplitEnabled
-
     if (shutdown.get() && (messageType == Type.REGION_START || messageType ==
-        Type.PUSH_DATA_HAND_SHAKE) && isPartitionSplitEnabled) {
+        Type.PUSH_DATA_HAND_SHAKE)) {
       logInfo(s"$messageType return HARD_SPLIT for shuffle $shuffleKey since worker shutdown.")
       callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
       return
     }
 
     if (checkSplit && (messageType == Type.REGION_START || messageType ==
-        Type.PUSH_DATA_HAND_SHAKE) && isPartitionSplitEnabled && checkDiskFullAndSplit(
+        Type.PUSH_DATA_HAND_SHAKE) && checkDiskFullAndSplit(
         fileWriter,
         isPrimary) == StatusCode.HARD_SPLIT) {
       workerSource.incCounter(WorkerSource.WRITE_DATA_HARD_SPLIT_COUNT)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -434,7 +434,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       partitionType,
       rangeReadFilter,
       userIdentifier,
-      true,
       isSegmentGranularityVisible = false)
   }
 
@@ -487,7 +486,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       partitionType: PartitionType,
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
-      partitionSplitEnabled: Boolean,
       isSegmentGranularityVisible: Boolean): PartitionDataWriter = {
     if (healthyWorkingDirs().isEmpty && remoteStorageDirs.isEmpty) {
       throw new IOException("No available working dirs!")
@@ -501,7 +499,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       shuffleId,
       userIdentifier,
       partitionType,
-      partitionSplitEnabled,
       isSegmentGranularityVisible)
 
     val writer =
@@ -1066,8 +1063,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           partitionDataWriterContext.getShuffleId,
           location.getFileName,
           partitionDataWriterContext.getUserIdentifier,
-          partitionDataWriterContext.getPartitionType,
-          partitionDataWriterContext.isPartitionSplitEnabled),
+          partitionDataWriterContext.getPartitionType),
         null,
         null,
         null)
@@ -1080,8 +1076,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         partitionDataWriterContext.getShuffleId,
         location.getFileName,
         partitionDataWriterContext.getUserIdentifier,
-        partitionDataWriterContext.getPartitionType,
-        partitionDataWriterContext.isPartitionSplitEnabled)
+        partitionDataWriterContext.getPartitionType)
       (null, createDiskFileResult._1, createDiskFileResult._2, createDiskFileResult._3)
     } else {
       (null, null, null, null)
@@ -1093,8 +1088,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       shuffleId: Int,
       fileName: String,
       userIdentifier: UserIdentifier,
-      partitionType: PartitionType,
-      partitionSplitEnabled: Boolean): MemoryFileInfo = {
+      partitionType: PartitionType): MemoryFileInfo = {
     val fileMeta = partitionType match {
       case PartitionType.REDUCE =>
         new ReduceFileMeta(conf.shuffleChunkSize)
@@ -1105,7 +1099,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     val memoryFileInfo =
       new MemoryFileInfo(
         userIdentifier,
-        partitionSplitEnabled,
         fileMeta)
     logDebug(s"create memory file for ${shuffleKey} ${fileName} and put it int memoryFileInfos")
     memoryFileInfos.computeIfAbsent(shuffleKey, memoryFileInfoMapFunc).put(
@@ -1124,7 +1117,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       fileName: String,
       userIdentifier: UserIdentifier,
       partitionType: PartitionType,
-      partitionSplitEnabled: Boolean,
       overrideStorageType: StorageInfo.Type = null): (Flusher, DiskFileInfo, File) = {
     val suggestedMountPoint = location.getStorageInfo.getMountPoint
 
@@ -1164,7 +1156,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         val hdfsFilePath = new Path(shuffleDir, fileName).toString
         val hdfsFileInfo = new DiskFileInfo(
           userIdentifier,
-          partitionSplitEnabled,
           getFileMeta(partitionType, s"hdfs", conf.shuffleChunkSize),
           hdfsFilePath,
           StorageInfo.Type.HDFS)
@@ -1179,7 +1170,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         val s3FilePath = new Path(shuffleDir, fileName).toString
         val s3FileInfo = new DiskFileInfo(
           userIdentifier,
-          partitionSplitEnabled,
           new ReduceFileMeta(conf.shuffleChunkSize),
           s3FilePath,
           StorageInfo.Type.S3)
@@ -1197,7 +1187,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         val ossFilePath = new Path(shuffleDir, fileName).toString
         val ossFileInfo = new DiskFileInfo(
           userIdentifier,
-          partitionSplitEnabled,
           new ReduceFileMeta(conf.shuffleChunkSize),
           ossFilePath,
           StorageInfo.Type.OSS)
@@ -1227,7 +1216,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           val storageType = diskInfos.get(mountPoint).storageType
           val diskFileInfo = new DiskFileInfo(
             userIdentifier,
-            partitionSplitEnabled,
             fileMeta,
             filePath,
             storageType)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -105,8 +105,7 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
                 partitionDataWriterContext.getShuffleId,
                 location.getFileName,
                 partitionDataWriterContext.getUserIdentifier,
-                partitionDataWriterContext.getPartitionType,
-                partitionDataWriterContext.isPartitionSplitEnabled)
+                partitionDataWriterContext.getPartitionType)
               val metaHandler = getPartitionMetaHandler(memoryFileInfo)
               new MemoryTierWriter(
                 conf,
@@ -134,7 +133,6 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
                 location.getFileName,
                 partitionDataWriterContext.getUserIdentifier,
                 partitionDataWriterContext.getPartitionType,
-                partitionDataWriterContext.isPartitionSplitEnabled,
                 overrideType // this is different from location type, in case of eviction
               )
               partitionDataWriterContext.setWorkingDir(workingDir)

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
@@ -117,7 +117,7 @@ public class PartitionDataWriterSuiteUtils {
       AbstractSource source,
       PartitionDataWriterContext writerContext) {
     ReduceFileMeta reduceFileMeta = new ReduceFileMeta(celebornConf.shuffleChunkSize());
-    MemoryFileInfo memoryFileInfo = new MemoryFileInfo(userIdentifier, false, reduceFileMeta);
+    MemoryFileInfo memoryFileInfo = new MemoryFileInfo(userIdentifier, reduceFileMeta);
     if (!reduceMeta) {
       memoryFileInfo.replaceFileMeta(new MapFileMeta(32 * 1024, 10));
     }
@@ -164,7 +164,7 @@ public class PartitionDataWriterSuiteUtils {
       StoragePolicy storagePolicy)
       throws IOException {
     ReduceFileMeta reduceFileMeta = new ReduceFileMeta(celebornConf.shuffleChunkSize());
-    MemoryFileInfo memoryFileInfo = new MemoryFileInfo(userIdentifier, false, reduceFileMeta);
+    MemoryFileInfo memoryFileInfo = new MemoryFileInfo(userIdentifier, reduceFileMeta);
     if (!reduceMeta) {
       memoryFileInfo.replaceFileMeta(new MapFileMeta(32 * 1024, 10));
     }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskMapPartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskMapPartitionDataWriterSuiteJ.java
@@ -132,7 +132,6 @@ public class DiskMapPartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.MAP,
-            false,
             false);
     PartitionDataWriter fileWriter =
         new PartitionDataWriter(

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/local/DiskReducePartitionDataWriterSuiteJ.java
@@ -279,7 +279,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -333,7 +332,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -388,7 +386,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -458,7 +455,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -577,7 +573,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -609,7 +604,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -641,7 +635,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -672,7 +665,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -705,7 +697,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -737,7 +728,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -771,7 +761,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -804,7 +793,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -838,7 +826,6 @@ public class DiskReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryPartitionFilesSorterSuiteJ.java
@@ -57,7 +57,7 @@ public class MemoryPartitionFilesSorterSuiteJ {
   public long[] prepare(int mapCount) {
     long[] partitionSize = new long[MAX_MAP_ID];
     byte[] batchHeader = new byte[16];
-    fileInfo = new MemoryFileInfo(userIdentifier, true, new ReduceFileMeta(8 * 1024 * 1024));
+    fileInfo = new MemoryFileInfo(userIdentifier, new ReduceFileMeta(8 * 1024 * 1024));
 
     AbstractSource source = Mockito.mock(AbstractSource.class);
     ByteBufAllocator allocator =

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/memory/MemoryReducePartitionDataWriterSuiteJ.java
@@ -91,7 +91,7 @@ public class MemoryReducePartitionDataWriterSuiteJ {
       AbstractSource source,
       PartitionDataWriterContext writerContext) {
     ReduceFileMeta reduceFileMeta = new ReduceFileMeta(celebornConf.shuffleChunkSize());
-    MemoryFileInfo memoryFileInfo = new MemoryFileInfo(userIdentifier, false, reduceFileMeta);
+    MemoryFileInfo memoryFileInfo = new MemoryFileInfo(userIdentifier, reduceFileMeta);
     if (!reduceMeta) {
       memoryFileInfo.replaceFileMeta(new MapFileMeta(32 * 1024, 10));
     }
@@ -294,7 +294,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
 
     PartitionDataWriter partitionDataWriter =
@@ -349,7 +348,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -405,7 +403,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -466,7 +463,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -554,7 +550,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -684,7 +679,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     PartitionDataWriter partitionDataWriter =
         new PartitionDataWriter(
@@ -716,7 +710,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -748,7 +741,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -779,7 +771,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -812,7 +803,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -844,7 +834,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -878,7 +867,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -911,7 +899,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(
@@ -945,7 +932,6 @@ public class MemoryReducePartitionDataWriterSuiteJ {
             1,
             userIdentifier,
             PartitionType.REDUCE,
-            false,
             false);
     partitionDataWriter =
         new PartitionDataWriter(

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/PartitionMetaHandlerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/PartitionMetaHandlerSuite.scala
@@ -40,7 +40,6 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
     val notifier = new FlushNotifier()
     val diskFileInfo = new DiskFileInfo(
       UserIdentifier.apply("`a`.`b`"),
-      true,
       fileMeta,
       tmpFilePath.toString,
       StorageInfo.Type.HDD)
@@ -105,7 +104,6 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
     val fileMeta = new ReduceFileMeta(8192)
     val diskFileInfo = new DiskFileInfo(
       UserIdentifier.apply("`a`.`b`"),
-      true,
       fileMeta,
       tmpFilePath.toString,
       StorageInfo.Type.HDD)
@@ -150,7 +148,6 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
     val notifier = new FlushNotifier()
     val diskFileInfo = new DiskFileInfo(
       UserIdentifier.apply("`a`.`b`"),
-      true,
       fileMeta,
       tmpFilePath.toString,
       StorageInfo.Type.HDD)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriterSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriterSuite.scala
@@ -43,7 +43,7 @@ class TierWriterSuite extends AnyFunSuite with BeforeAndAfterEach {
     celebornConf.set("celeborn.worker.memoryFileStorage.maxFileSize", "80k")
     val reduceFileMeta = new ReduceFileMeta(celebornConf.shuffleChunkSize)
     val userIdentifier = UserIdentifier("`aa`.`bb`")
-    val memoryFileInfo = new MemoryFileInfo(userIdentifier, false, reduceFileMeta)
+    val memoryFileInfo = new MemoryFileInfo(userIdentifier, reduceFileMeta)
     val numPendingWriters = new AtomicInteger()
     val flushNotifier = new FlushNotifier()
 
@@ -68,7 +68,6 @@ class TierWriterSuite extends AnyFunSuite with BeforeAndAfterEach {
       1,
       userIdentifier,
       PartitionType.REDUCE,
-      false,
       false)
 
     val source = new WorkerSource(celebornConf)
@@ -183,7 +182,7 @@ class TierWriterSuite extends AnyFunSuite with BeforeAndAfterEach {
     val userIdentifier = UserIdentifier("`aa`.`bb`")
     val tmpFile = Files.createTempFile("celeborn", "local-test").toString
     val diskFileInfo =
-      new DiskFileInfo(userIdentifier, false, reduceFileMeta, tmpFile, StorageInfo.Type.HDD)
+      new DiskFileInfo(userIdentifier, reduceFileMeta, tmpFile, StorageInfo.Type.HDD)
     val numPendingWriters = new AtomicInteger()
     val flushNotifier = new FlushNotifier()
     val source = new WorkerSource(celebornConf)
@@ -206,7 +205,6 @@ class TierWriterSuite extends AnyFunSuite with BeforeAndAfterEach {
       1,
       userIdentifier,
       PartitionType.REDUCE,
-      false,
       false)
 
     val flusher = new LocalFlusher(

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase1.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase1.scala
@@ -51,7 +51,7 @@ class StoragePolicyCase1 extends CelebornFunSuite {
 
   val mockedCelebornMemoryFile = mock[MemoryFileInfo]
   when(
-    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any(), any())).thenAnswer(
+    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any())).thenAnswer(
     mockedCelebornMemoryFile)
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
@@ -60,7 +60,6 @@ class StoragePolicyCase1 extends CelebornFunSuite {
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
-      any(),
       any(),
       any(),
       any(),

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
@@ -51,7 +51,7 @@ class StoragePolicyCase2 extends CelebornFunSuite {
 
   val mockedCelebornMemoryFile = mock[MemoryFileInfo]
   when(
-    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any(), any())).thenAnswer(
+    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any())).thenAnswer(
     mockedCelebornMemoryFile)
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
@@ -60,7 +60,6 @@ class StoragePolicyCase2 extends CelebornFunSuite {
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
-      any(),
       any(),
       any(),
       any(),

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
@@ -51,7 +51,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
 
   val mockedCelebornMemoryFile = mock[MemoryFileInfo]
   when(
-    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any(), any())).thenAnswer(
+    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any())).thenAnswer(
     mockedCelebornMemoryFile)
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
@@ -60,7 +60,6 @@ class StoragePolicyCase3 extends CelebornFunSuite {
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
-      any(),
       any(),
       any(),
       any(),

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
@@ -51,7 +51,7 @@ class StoragePolicyCase4 extends CelebornFunSuite {
 
   val mockedCelebornMemoryFile = mock[MemoryFileInfo]
   when(
-    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any(), any())).thenAnswer(
+    mockedStorageManager.createMemoryFileInfo(any(), any(), any(), any(), any())).thenAnswer(
     mockedCelebornMemoryFile)
   when(mockedStorageManager.storageBufferAllocator).thenAnswer(UnpooledByteBufAllocator.DEFAULT)
 
@@ -60,7 +60,6 @@ class StoragePolicyCase4 extends CelebornFunSuite {
   val mockedFile = mock[File]
   when(
     mockedStorageManager.createDiskFile(
-      any(),
       any(),
       any(),
       any(),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove `partitionSplitEnabled` from `ReserveSlots` and `FileInfo`. Address comment https://github.com/apache/celeborn/pull/3492#discussion_r2427749008.

### Why are the changes needed?

Since 0.6.0, Celeborn removed `celeborn.client.shuffle.mapPartition.split.enabled` to enable shuffle partition split at default for MapPartition. Therefore, `partitionSplitEnabled` of `ReserveSlots` and `FileInfo` is unnecessary because MapPartition enables partition split by default.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.