### PR TITLE
[WIP] Support async response to open stream calls to avoid blocking netty threads

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -36,6 +36,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
@@ -77,6 +79,9 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
   private final ConcurrentHashMap<String, Set<String>> sortedShuffleFiles =
       JavaUtils.newConcurrentHashMap();
   private final ConcurrentHashMap<String, Set<String>> sortingShuffleFiles =
+      JavaUtils.newConcurrentHashMap();
+  // Completion signals for per-file sorting tasks (keyed by fileId "shuffleKey-fileName")
+  private final ConcurrentHashMap<String, CompletableFuture<Void>> sortCompletions =
       JavaUtils.newConcurrentHashMap();
   private final Cache<String, Map<Integer, List<ShuffleBlockInfo>>> indexCache;
   private final Map<String, Set<String>> indexCacheNames = JavaUtils.newConcurrentHashMap();
@@ -310,6 +315,112 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
           indexFilePath,
           startMapIndex,
           endMapIndex);
+    }
+  }
+
+  // Async variant: returns a future that completes with sorted FileInfo without blocking Netty threads.
+  public CompletableFuture<FileInfo> getSortedFileInfoAsync(
+      String shuffleKey,
+      String fileName,
+      FileInfo fileInfo,
+      int startMapIndex,
+      int endMapIndex) {
+    if (fileInfo instanceof MemoryFileInfo) {
+      MemoryFileInfo memoryFileInfo = ((MemoryFileInfo) fileInfo);
+      sortMemoryShuffleFile(memoryFileInfo);
+      Map<Integer, List<ShuffleBlockInfo>> indexesMap = memoryFileInfo.getSortedIndexes();
+      ReduceFileMeta reduceFileMeta =
+          new ReduceFileMeta(
+              ShuffleBlockInfoUtils.getChunkOffsetsFromShuffleBlockInfos(
+                  startMapIndex, endMapIndex, shuffleChunkSize, indexesMap, true),
+              shuffleChunkSize);
+      CompositeByteBuf targetBuffer =
+          MemoryManager.instance().getStorageByteBufAllocator().compositeBuffer(Integer.MAX_VALUE);
+      ShuffleBlockInfoUtils.sliceSortedBufferByMapRange(
+          startMapIndex,
+          endMapIndex,
+          indexesMap,
+          memoryFileInfo.getSortedBuffer(),
+          targetBuffer,
+          shuffleChunkSize);
+      FileInfo result =
+          new MemoryFileInfo(
+              memoryFileInfo.getUserIdentifier(),
+              memoryFileInfo.isPartitionSplitEnabled(),
+              reduceFileMeta,
+              targetBuffer);
+      return CompletableFuture.completedFuture(result);
+    } else {
+      DiskFileInfo diskFileInfo = ((DiskFileInfo) fileInfo);
+      String fileId = shuffleKey + "-" + fileName;
+      Set<String> sorted =
+          sortedShuffleFiles.computeIfAbsent(shuffleKey, v -> ConcurrentHashMap.newKeySet());
+      Set<String> sorting =
+          sortingShuffleFiles.computeIfAbsent(shuffleKey, v -> ConcurrentHashMap.newKeySet());
+
+      String sortedFilePath = Utils.getSortedFilePath(diskFileInfo.getFilePath());
+      String indexFilePath = Utils.getIndexFilePath(diskFileInfo.getFilePath());
+
+      synchronized (sorting) {
+        if (!sorted.contains(fileId) && !sorting.contains(fileId)) {
+          try {
+            FileSorter fileSorter = new FileSorter(diskFileInfo, fileId, shuffleKey);
+            sorting.add(fileId);
+            logger.debug(
+                "Adding sorter to sort queue (async) shuffle key {}, file name {}",
+                shuffleKey,
+                fileName);
+            shuffleSortTaskDeque.put(fileSorter);
+          } catch (InterruptedException e) {
+            CompletableFuture<FileInfo> failed = new CompletableFuture<>();
+            failed.completeExceptionally(
+                new IOException(
+                    "Sort scheduler thread is interrupted means worker is shutting down.", e));
+            return failed;
+          } catch (IOException e) {
+            CompletableFuture<FileInfo> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IOException("File sorter access DFS failed.", e));
+            return failed;
+          }
+        }
+      }
+
+      if (sorted.contains(fileId)) {
+        try {
+          return CompletableFuture.completedFuture(
+              resolve(
+                  shuffleKey,
+                  fileId,
+                  diskFileInfo.getUserIdentifier(),
+                  sortedFilePath,
+                  indexFilePath,
+                  startMapIndex,
+                  endMapIndex));
+        } catch (IOException e) {
+          CompletableFuture<FileInfo> failed = new CompletableFuture<>();
+          failed.completeExceptionally(e);
+          return failed;
+        }
+      }
+
+      CompletableFuture<Void> gate =
+          sortCompletions.computeIfAbsent(fileId, k -> new CompletableFuture<>());
+      return gate.thenApply(
+          v -> {
+            try {
+              // This part would now run on the sorter thread and not the netty thread like before, can be revisited
+              return resolve(
+                  shuffleKey,
+                  fileId,
+                  diskFileInfo.getUserIdentifier(),
+                  sortedFilePath,
+                  indexFilePath,
+                  startMapIndex,
+                  endMapIndex);
+            } catch (IOException e) {
+              throw new CompletionException(e);
+            }
+          });
     }
   }
 
@@ -801,9 +912,18 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         originFileInfo.getReduceFileMeta().setSorted();
         cleaner.add(this);
         logger.debug("sort complete for {} {}", shuffleKey, originFilePath);
+        // complete async future if any waiter exists
+        CompletableFuture<Void> f = sortCompletions.get(fileId);
+        if (f != null && !f.isDone()) {
+          f.complete(null);
+        }
       } catch (Exception e) {
         logger.error(
             "Sorting shuffle file for " + fileId + " " + originFilePath + " failed, detail: ", e);
+        CompletableFuture<Void> f = sortCompletions.get(fileId);
+        if (f != null && !f.isDone()) {
+          f.completeExceptionally(e);
+        }
       } finally {
         closeFiles();
         Set<String> sorting = sortingShuffleFiles.get(shuffleKey);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -20,8 +20,9 @@ package org.apache.celeborn.service.deploy.worker
 import java.io.{FileNotFoundException, IOException}
 import java.nio.charset.StandardCharsets
 import java.util
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.function.Consumer
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.function.{BiConsumer, Consumer}
+import java.util.concurrent.TimeUnit
 
 import com.google.common.base.Throwables
 import com.google.protobuf.GeneratedMessageV3
@@ -143,36 +144,74 @@ class FetchHandler(
         val startIndices = openStreamList.getStartIndexList
         val endIndices = openStreamList.getEndIndexList
         val readLocalFlags = openStreamList.getReadLocalShuffleList
-        val pbOpenStreamListResponse = PbOpenStreamListResponse.newBuilder()
         checkAuth(client, Utils.splitShuffleKey(shuffleKey)._1)
         val openStreamRequestId = Utils.makeOpenStreamRequestId(
           shuffleKey,
           client.getChannel.id().toString,
           rpcRequest.requestId)
         workerSource.startTimer(WorkerSource.OPEN_STREAM_TIME, openStreamRequestId)
-        try {
-          0 until files.size() foreach { idx =>
-            val pbStreamHandlerOpt = handleReduceOpenStreamInternal(
+        val asyncOpen = conf.getBoolean("celeborn.worker.async.openStream.enabled", false)
+        if (asyncOpen) {
+          val total = files.size()
+          val results = new Array[PbStreamHandlerOpt](total)
+          val completed = new AtomicInteger(0)
+          0 until total foreach { idx =>
+            handleReduceOpenStreamInternalAsync(
               client,
               shuffleKey,
               files.get(idx),
               startIndices.get(idx),
               endIndices.get(idx),
-              readLocalFlags.get(idx))
-            if (pbStreamHandlerOpt.getStatus != StatusCode.SUCCESS.getValue) {
-              workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
-            }
-            pbOpenStreamListResponse.addStreamHandlerOpt(pbStreamHandlerOpt)
-          }
-        } finally {
-          workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, openStreamRequestId)
-        }
+              readLocalFlags.get(idx),
+              (res: PbStreamHandlerOpt) => {
+                if (res.getStatus != StatusCode.SUCCESS.getValue) {
+                  workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
+                }
+                results(idx) = res
 
-        client.getChannel.writeAndFlush(new RpcResponse(
-          rpcRequest.requestId,
-          new NioManagedBuffer(new TransportMessage(
-            MessageType.BATCH_OPEN_STREAM_RESPONSE,
-            pbOpenStreamListResponse.build().toByteArray).toByteBuffer)))
+                // TODO ideally because this is running on the same eventloop thread,
+                //  we can getaway with a non atomic counter too
+                if (completed.incrementAndGet() == total) {
+                  // all done, reply once
+                  val pbOpenStreamListResponse = PbOpenStreamListResponse.newBuilder()
+                  0 until total foreach { i => pbOpenStreamListResponse.addStreamHandlerOpt(results(i)) }
+                  client.getChannel.writeAndFlush(new RpcResponse(
+                    rpcRequest.requestId,
+                    new NioManagedBuffer(new TransportMessage(
+                      MessageType.BATCH_OPEN_STREAM_RESPONSE,
+                      pbOpenStreamListResponse.build().toByteArray).toByteBuffer)))
+                  workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, openStreamRequestId)
+                }
+              })
+          }
+        } else {
+          val pbOpenStreamListResponse = PbOpenStreamListResponse.newBuilder()
+          try {
+            0 until files.size() foreach { idx =>
+              val pbStreamHandlerOpt = handleReduceOpenStreamInternalSync(
+                client,
+                shuffleKey,
+                files.get(idx),
+                startIndices.get(idx),
+                endIndices.get(idx),
+                readLocalFlags.get(idx),
+                (pbStreamHandlerOpt: PbStreamHandlerOpt) => {
+                  if (pbStreamHandlerOpt.getStatus != StatusCode.SUCCESS.getValue) {
+                    workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
+                  }
+                  pbOpenStreamListResponse.addStreamHandlerOpt(pbStreamHandlerOpt)
+                }
+              )
+            }
+          } finally {
+            workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, openStreamRequestId)
+          }
+          client.getChannel.writeAndFlush(new RpcResponse(
+            rpcRequest.requestId,
+            new NioManagedBuffer(new TransportMessage(
+              MessageType.BATCH_OPEN_STREAM_RESPONSE,
+              pbOpenStreamListResponse.build().toByteArray).toByteBuffer)))
+        }
       case bufferStreamEnd: PbBufferStreamEnd =>
         handleEndStreamFromClient(
           client,
@@ -245,13 +284,14 @@ class FetchHandler(
 
   }
 
-  private def handleReduceOpenStreamInternal(
+  private def handleReduceOpenStreamInternalSync(
       client: TransportClient,
       shuffleKey: String,
       fileName: String,
       startIndex: Int,
       endIndex: Int,
-      readLocalShuffle: Boolean = false): PbStreamHandlerOpt = {
+      readLocalShuffle: Boolean = false,
+      callback: PbStreamHandlerOpt => Unit): Unit = {
     try {
       logDebug(s"Received open stream request $shuffleKey $fileName $startIndex " +
         s"$endIndex get file name $fileName from client channel " +
@@ -272,73 +312,18 @@ class FetchHandler(
           startIndex,
           endIndex)
       }
-      val meta = fileInfo.getReduceFileMeta
-      val streamHandler =
-        if (readLocalShuffle && !fileInfo.isInstanceOf[MemoryFileInfo]) {
-          chunkStreamManager.registerStream(
-            streamId,
-            shuffleKey,
-            fileName)
-          makeStreamHandler(
-            streamId,
-            meta.getNumChunks,
-            meta.getChunkOffsets,
-            fileInfo.asInstanceOf[DiskFileInfo].getFilePath)
-        } else fileInfo match {
-          case info: DiskFileInfo if info.isHdfs =>
-            chunkStreamManager.registerStream(
-              streamId,
-              shuffleKey,
-              fileName)
-            makeStreamHandler(streamId, numChunks = 0)
-          case info: DiskFileInfo if info.isS3 =>
-            chunkStreamManager.registerStream(
-              streamId,
-              shuffleKey,
-              fileName)
-            makeStreamHandler(streamId, numChunks = 0)
-          case info: DiskFileInfo if info.isOSS =>
-            chunkStreamManager.registerStream(
-              streamId,
-              shuffleKey,
-              fileName)
-            makeStreamHandler(streamId, numChunks = 0)
-          case _ =>
-            val managedBuffer = fileInfo match {
-              case df: DiskFileInfo =>
-                new FileChunkBuffers(df, transportConf)
-              case mf: MemoryFileInfo =>
-                new MemoryChunkBuffers(mf)
-            }
-            val fetchTimeMetric =
-              fileInfo match {
-                case info: DiskFileInfo =>
-                  storageManager.getFetchTimeMetric(info.getFile)
-                case _ =>
-                  null
-              }
-            chunkStreamManager.registerStream(
-              streamId,
-              shuffleKey,
-              managedBuffer,
-              fileName,
-              fetchTimeMetric)
-            if (meta.getNumChunks == 0)
-              logDebug(s"StreamId $streamId, fileName $fileName, mapRange " +
-                s"[$startIndex-$endIndex] is empty. Received from client channel " +
-                s"${NettyUtils.getRemoteAddress(client.getChannel)}")
-            else logDebug(
-              s"StreamId $streamId, fileName $fileName, numChunks ${meta.getNumChunks}, " +
-                s"mapRange [$startIndex-$endIndex]. Received from client channel " +
-                s"${NettyUtils.getRemoteAddress(client.getChannel)}")
-            makeStreamHandler(
-              streamId,
-              meta.getNumChunks)
-        }
-      workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
-      PbStreamHandlerOpt.newBuilder().setStreamHandler(streamHandler)
-        .setStatus(StatusCode.SUCCESS.getValue)
-        .build()
+
+      buildAndCompleteStreamHandler(
+        client,
+        shuffleKey,
+        fileName,
+        startIndex,
+        endIndex,
+        readLocalShuffle,
+        streamId,
+        fileInfo,
+        callback
+      )
     } catch {
       case e: IOException =>
         val msg =
@@ -371,19 +356,61 @@ class FetchHandler(
       val fileInfo = getRawFileInfo(shuffleKey, fileName)
       fileInfo.getFileMeta match {
         case _: ReduceFileMeta =>
-          val pbStreamHandlerOpt =
-            handleReduceOpenStreamInternal(
+          val asyncOpen = conf.getBoolean("celeborn.worker.async.openStream.enabled", false)
+          if (asyncOpen) {
+            // Async path: schedule potential sorting and reply later
+            handleReduceOpenStreamInternalAsync(
               client,
               shuffleKey,
               fileName,
               startIndex,
               endIndex,
-              readLocalShuffle)
-
-          if (pbStreamHandlerOpt.getStatus != StatusCode.SUCCESS.getValue) {
-            throw new CelebornIOException(pbStreamHandlerOpt.getErrorMsg)
+              readLocalShuffle,
+              (res: PbStreamHandlerOpt) => {
+                if (res.getStatus != StatusCode.SUCCESS.getValue) {
+                  workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
+                  handleRpcIOException(
+                    client,
+                    rpcRequestId,
+                    shuffleKey,
+                    fileName,
+                    new IOException(res.getErrorMsg),
+                    callback)
+                } else {
+                  replyStreamHandler(client, rpcRequestId, res.getStreamHandler, isLegacy)
+                  workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
+                }
+                workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, requestId)
+              })
+            // return immediately; response will be sent in callback
+            return
+          } else {
+            // Original synchronous path
+            val pbStreamHandlerOpt =
+              handleReduceOpenStreamInternalSync(
+                client,
+                shuffleKey,
+                fileName,
+                startIndex,
+                endIndex,
+                readLocalShuffle,
+                (res: PbStreamHandlerOpt) => {
+                  if (res.getStatus != StatusCode.SUCCESS.getValue) {
+                    workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
+                    handleRpcIOException(
+                      client,
+                      rpcRequestId,
+                      shuffleKey,
+                      fileName,
+                      new IOException(res.getErrorMsg),
+                      callback)
+                  } else {
+                    replyStreamHandler(client, rpcRequestId, res.getStreamHandler, isLegacy)
+                    workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
+                  }
+                  workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, requestId)
+                })
           }
-          replyStreamHandler(client, rpcRequestId, pbStreamHandlerOpt.getStreamHandler, isLegacy)
         case _: MapFileMeta =>
           val creditStreamHandler =
             new Consumer[java.lang.Long] {
@@ -404,15 +431,192 @@ class FetchHandler(
             startIndex,
             endIndex,
             fileInfo.asInstanceOf[DiskFileInfo])
+          workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
+          workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, requestId)
       }
-      workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
     } catch {
       case e: IOException =>
         workerSource.incCounter(WorkerSource.OPEN_STREAM_FAIL_COUNT)
         handleRpcIOException(client, rpcRequestId, shuffleKey, fileName, e, callback)
-    } finally {
-      workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, requestId)
+        workerSource.stopTimer(WorkerSource.OPEN_STREAM_TIME, requestId)
     }
+  }
+
+  // New async variant: schedule sorting in background and invoke callback when ready
+  private def handleReduceOpenStreamInternalAsync(
+      client: TransportClient,
+      shuffleKey: String,
+      fileName: String,
+      startIndex: Int,
+      endIndex: Int,
+      readLocalShuffle: Boolean = false,
+      onComplete: PbStreamHandlerOpt => Unit): Unit = {
+    try {
+      logDebug(s"Received open stream request $shuffleKey $fileName $startIndex " +
+        s"$endIndex get file name $fileName from client channel " +
+        s"${NettyUtils.getRemoteAddress(client.getChannel)}")
+
+      var fileInfo = getRawFileInfo(shuffleKey, fileName)
+      val streamId = chunkStreamManager.nextStreamId()
+      val needSorted =
+        (endIndex != Int.MaxValue && endIndex != -1 && endIndex >= startIndex) ||
+          (endIndex == Int.MaxValue && !fileInfo.addStream(streamId))
+
+      if (needSorted) {
+        val responded = new java.util.concurrent.atomic.AtomicBoolean(false)
+        var timeoutTask: java.util.concurrent.ScheduledFuture[_] = null
+        // If sorting takes more than conf.workerPartitionSorterSortPartitionTimeout,
+        // error out and fail. Status quo with sync flow
+        // This part runs on eventloop thread
+        timeoutTask = client.getChannel.eventLoop().schedule(new Runnable {
+          override def run(): Unit = {
+            if (responded.compareAndSet(false, true)) {
+              val msg = String.format(
+                "Sorting file %s path %s length %s timeout after %dms",
+                s"$shuffleKey-$fileName",
+                fileInfo.getFilePath,
+                java.lang.Long.valueOf(fileInfo.getFileLength),
+                java.lang.Long.valueOf(conf.workerPartitionSorterSortPartitionTimeout))
+              onComplete(PbStreamHandlerOpt.newBuilder()
+                .setStatus(StatusCode.OPEN_STREAM_FAILED.getValue)
+                .setErrorMsg(msg).build())
+            }
+          }
+        }, conf.workerPartitionSorterSortPartitionTimeout, TimeUnit.MILLISECONDS)
+
+        // async wait for sorted file
+        partitionsSorter
+          .getSortedFileInfoAsync(shuffleKey, fileName, fileInfo, startIndex, endIndex)
+          .whenCompleteAsync(
+            new BiConsumer[FileInfo, Throwable] {
+              override def accept(sortedOrOriginal: FileInfo, error: Throwable): Unit = {
+                // ensure only one response path wins (timeout vs completion), and cancel timeout
+                val proceed =
+                  if (fileInfo.isInstanceOf[DiskFileInfo]) responded.compareAndSet(false, true)
+                  else true
+                if (!proceed) return
+                if (timeoutTask != null) {
+                  // If we reach here, sorting finished before timeout,
+                  // cancel timeout task to save resource
+                  timeoutTask.cancel(false)
+                }
+                if (error != null) {
+                  val msg =
+                    s"Read file: $fileName with shuffleKey: $shuffleKey error from ${NettyUtils.getRemoteAddress(client.getChannel)}, Exception: ${error.getMessage}"
+                  onComplete(PbStreamHandlerOpt.newBuilder()
+                    .setStatus(StatusCode.OPEN_STREAM_FAILED.getValue)
+                    .setErrorMsg(msg).build())
+                  return
+                }
+                buildAndCompleteStreamHandler(client, shuffleKey, fileName, startIndex, endIndex,
+                  readLocalShuffle, streamId, sortedOrOriginal, onComplete)
+              }
+            },
+
+            // This ensures we run the callback on the same eventloop thread,
+            // maintains status quo with handleReduceOpenStreamInternalSync
+            client.getChannel.eventLoop()
+          )
+      } else {
+        // no sorting needed, this will run on eventloop thread by default
+        buildAndCompleteStreamHandler(
+          client,
+          shuffleKey,
+          fileName,
+          startIndex,
+          endIndex,
+          readLocalShuffle,
+          streamId,
+          fileInfo,
+          onComplete)
+      }
+    } catch {
+      case e: IOException =>
+        val msg =
+          s"Read file: $fileName with shuffleKey: $shuffleKey error from ${NettyUtils.getRemoteAddress(client.getChannel)}, Exception: ${e.getMessage}"
+        onComplete(PbStreamHandlerOpt.newBuilder()
+          .setStatus(StatusCode.OPEN_STREAM_FAILED.getValue)
+          .setErrorMsg(msg).build())
+    }
+  }
+
+  private def buildAndCompleteStreamHandler(
+      client: TransportClient,
+      shuffleKey: String,
+      fileName: String,
+      startIndex: Int,
+      endIndex: Int,
+      readLocalShuffle: Boolean,
+      streamId: Long,
+      fileInfo: FileInfo,
+      onComplete: PbStreamHandlerOpt => Unit): Unit = {
+    val meta = fileInfo.getReduceFileMeta
+    val streamHandler =
+      if (readLocalShuffle && !fileInfo.isInstanceOf[MemoryFileInfo]) {
+        chunkStreamManager.registerStream(
+          streamId,
+          shuffleKey,
+          fileName)
+        makeStreamHandler(
+          streamId,
+          meta.getNumChunks,
+          meta.getChunkOffsets,
+          fileInfo.asInstanceOf[DiskFileInfo].getFilePath)
+      } else fileInfo match {
+        case info: DiskFileInfo if info.isHdfs =>
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            fileName)
+          makeStreamHandler(streamId, numChunks = 0)
+        case info: DiskFileInfo if info.isS3 =>
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            fileName)
+          makeStreamHandler(streamId, numChunks = 0)
+        case info: DiskFileInfo if info.isOSS =>
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            fileName)
+          makeStreamHandler(streamId, numChunks = 0)
+        case _ =>
+          val managedBuffer = fileInfo match {
+            case df: DiskFileInfo =>
+              new FileChunkBuffers(df, transportConf)
+            case mf: MemoryFileInfo =>
+              new MemoryChunkBuffers(mf)
+          }
+          val fetchTimeMetric =
+            fileInfo match {
+              case info: DiskFileInfo =>
+                storageManager.getFetchTimeMetric(info.getFile)
+              case _ =>
+                null
+            }
+          chunkStreamManager.registerStream(
+            streamId,
+            shuffleKey,
+            managedBuffer,
+            fileName,
+            fetchTimeMetric)
+          if (meta.getNumChunks == 0)
+            logDebug(s"StreamId $streamId, fileName $fileName, mapRange " +
+              s"[$startIndex-$endIndex] is empty. Received from client channel " +
+              s"${NettyUtils.getRemoteAddress(client.getChannel)}")
+          else logDebug(
+            s"StreamId $streamId, fileName $fileName, numChunks ${meta.getNumChunks}, " +
+              s"mapRange [$startIndex-$endIndex]. Received from client channel " +
+              s"${NettyUtils.getRemoteAddress(client.getChannel)}")
+          makeStreamHandler(
+            streamId,
+            meta.getNumChunks)
+      }
+    workerSource.incCounter(WorkerSource.OPEN_STREAM_SUCCESS_COUNT)
+    onComplete(PbStreamHandlerOpt.newBuilder().setStreamHandler(streamHandler)
+      .setStatus(StatusCode.SUCCESS.getValue)
+      .build())
   }
 
   private def makeStreamHandler(


### PR DESCRIPTION

### What changes were proposed in this pull request?
During openStream calls to workers, the worker netty threads can get blocked for `sortTimeout` milliseconds. This could degrade other worker RPC calls. Ideally, if we introduce an async reply mechanism, we can free the netty threads thereby ensuring other RPC calls are not impacted.

Eg: On a 48 core VM, if > (48 * 2) OpenStream calls with AQE are made requesting the same partition file, all the netty threads will get blocked. Even if a non AQE OpenStream call is then received, we'll not have free netty threads to respond


### Why are the changes needed?
Avoid blocking worker netty threads during heavy sorting openStream calls.

### Does this PR resolve a correctness bug?
No

### Does this PR introduce _any_ user-facing change?
Set worker config "celeborn.worker.async.openStream.enabled" to move to async reply mechanism for openStream calls.



### How was this patch tested?
TODO
