### PR TITLE
[CELEBORN-2230] SparkUtils#shouldReportShuffleFetchFailure method should retrieve the number of task failures from TaskSetManager

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -421,15 +421,33 @@ public class SparkUtils {
         // Note: previousFailureCount does NOT include the current failure,
         //       so (previousFailureCount + 1) represents the total failure count.
         int previousFailureCount = getTaskFailureCount(taskSetManager, taskInfo.index());
+        // If failure count cannot be determined, fall back to attempt status based
+        // behavior instead of aggressively reporting FetchFailed. This avoids
+        // premature stage reruns when reflective access to failure counts is
+        // unavailable, while still reporting the failure when no other attempt is
+        // running.
         if (previousFailureCount < 0) {
-          logger.warn(
-              "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
-                  + "previous failure count, conservatively report shuffle fetch failure.",
-              stageId,
-              taskInfo.index(),
-              taskId,
-              taskInfo.attemptNumber());
-          return true;
+          if (!hasRunningAttempt) {
+            LOG.warn(
+                "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
+                    + "previous failure count, and no other running attempt exists. "
+                    + "Reporting shuffle fetch failure.",
+                stageId,
+                taskInfo.index(),
+                taskId,
+                taskInfo.attemptNumber());
+            return true;
+          } else {
+            LOG.warn(
+                "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
+                    + "previous failure count, but another attempt is still running. "
+                    + "Deferring shuffle fetch failure report.",
+                stageId,
+                taskInfo.index(),
+                taskId,
+                taskInfo.attemptNumber());
+            return false;
+          }
         }
         if (previousFailureCount + 1 >= maxTaskFails || !hasRunningAttempt) {
           logger.warn(

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -247,6 +247,11 @@ public class SparkUtils {
               .hiddenImpl(TaskSetManager.class, "taskInfos")
               .defaultAlwaysNull()
               .build();
+  private static final DynFields.UnboundField<int[]> TASK_FAILURES =
+      DynFields.builder()
+          .hiddenImpl(TaskSetManager.class, "numFailures")
+          .defaultAlwaysNull()
+          .build();
 
   /**
    * TaskSetManager - it is not designed to be used outside the spark scheduler. Please be careful.
@@ -282,6 +287,39 @@ public class SparkUtils {
       logger.error("Can not get TaskSetManager for taskId: {}", taskId);
       return null;
     }
+  }
+
+  /**
+   * Gets the number of task attempts that have already failed for the given task index. Note: This
+   * count does NOT include the current failure. To get the total failure count including the
+   * current attempt, you need to add 1 to the returned value.
+   *
+   * @param taskSetManager the TaskSetManager to query
+   * @param index the task index
+   * @return the number of previous failed attempts, or -1 if an error occurs
+   */
+  @VisibleForTesting
+  protected static int getTaskFailureCount(TaskSetManager taskSetManager, int index) {
+    if (taskSetManager == null) {
+      logger.error("TaskSetManager is null for task index: {}", index);
+      return -1;
+    }
+
+    int[] numFailures = TASK_FAILURES.bind(taskSetManager).get();
+    if (numFailures == null) {
+      logger.error("Failed to get numFailures array from TaskSetManager for task index: {}", index);
+      return -1;
+    }
+
+    if (index < 0 || index >= numFailures.length) {
+      logger.error(
+          "Task index {} is out of bounds for numFailures array (length: {})",
+          index,
+          numFailures.length);
+      return -1;
+    }
+
+    return numFailures[index];
   }
 
   protected static Map<String, Set<Long>> reportedStageShuffleFetchFailureTaskIds =
@@ -344,7 +382,6 @@ public class SparkUtils {
         if (taskAttempts == null) return true;
 
         TaskInfo taskInfo = taskAttempts._1();
-        int failedTaskAttempts = 1;
         boolean hasRunningAttempt = false;
         for (TaskInfo ti : taskAttempts._2()) {
           if (ti.taskId() != taskId) {
@@ -356,7 +393,6 @@ public class SparkUtils {
                   taskId,
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
-              failedTaskAttempts += 1;
             } else if (ti.successful()) {
               logger.info(
                   "StageId={} index={} taskId={} attempt={} another attempt {} is successful.",
@@ -375,36 +411,32 @@ public class SparkUtils {
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
               hasRunningAttempt = true;
-            } else if ("FAILED".equals(ti.status()) || "UNKNOWN".equals(ti.status())) {
-              // For KILLED state task, Spark does not count the number of failures
-              // For UNKNOWN state task, Spark does count the number of failures
-              // For FAILED state task, Spark decides whether to count the failure based on the
-              // different failure reasons. Since we cannot obtain the failure
-              // reason here, we will count all tasks in FAILED state.
-              logger.info(
-                  "StageId={} index={} taskId={} attempt={} another attempt {} status={}.",
-                  stageId,
-                  taskInfo.index(),
-                  taskId,
-                  taskInfo.attemptNumber(),
-                  ti.attemptNumber(),
-                  ti.status());
-              failedTaskAttempts += 1;
             }
           }
         }
         // The following situations should trigger a FetchFailed exception:
-        //  1. If failedTaskAttempts >= maxTaskFails
-        //  2. If no other taskAttempts are running
-        if (failedTaskAttempts >= maxTaskFails || !hasRunningAttempt) {
+        //  1. If total failures (previous failures + current failure) >= maxTaskFails
+        //  2. If no other taskAttempts are running, trigger a FetchFailed exception
+        //  to keep the same behavior as Spark.
+        // Note: previousFailureCount does NOT include the current failure,
+        //       so (previousFailureCount + 1) represents the total failure count.
+        int previousFailureCount = getTaskFailureCount(taskSetManager, taskInfo.index());
+        // Fail-safe: if failure count cannot be determined, conservatively trigger
+        // FetchFailed to avoid silently swallowing the error.
+        if (previousFailureCount < 0) {
+          return true;
+        }
+        if (previousFailureCount + 1 >= maxTaskFails || !hasRunningAttempt) {
           logger.warn(
-              "StageId={}, index={}, taskId={}, attemptNumber={}: Task failure count {} reached "
-                  + "maximum allowed failures {} or no running attempt exists.",
+              "StageId={}, index={}, taskId={}, attemptNumber={}: Previous failure count {} "
+                  + "(total with current: {}) reached maximum allowed failures {} "
+                  + "or no running attempt exists.",
               stageId,
               taskInfo.index(),
               taskId,
               taskInfo.attemptNumber(),
-              failedTaskAttempts,
+              previousFailureCount,
+              previousFailureCount + 1,
               maxTaskFails);
           return true;
         } else {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -421,9 +421,14 @@ public class SparkUtils {
         // Note: previousFailureCount does NOT include the current failure,
         //       so (previousFailureCount + 1) represents the total failure count.
         int previousFailureCount = getTaskFailureCount(taskSetManager, taskInfo.index());
-        // Fail-safe: if failure count cannot be determined, conservatively trigger
-        // FetchFailed to avoid silently swallowing the error.
         if (previousFailureCount < 0) {
+          logger.warn(
+              "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
+                  + "previous failure count, conservatively report shuffle fetch failure.",
+              stageId,
+              taskInfo.index(),
+              taskId,
+              taskInfo.attemptNumber());
           return true;
         }
         if (previousFailureCount + 1 >= maxTaskFails || !hasRunningAttempt) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -557,15 +557,33 @@ public class SparkUtils {
         // Note: previousFailureCount does NOT include the current failure,
         //       so (previousFailureCount + 1) represents the total failure count.
         int previousFailureCount = getTaskFailureCount(taskSetManager, taskInfo.index());
+        // If failure count cannot be determined, fall back to attempt status based
+        // behavior instead of aggressively reporting FetchFailed. This avoids
+        // premature stage reruns when reflective access to failure counts is
+        // unavailable, while still reporting the failure when no other attempt is
+        // running.
         if (previousFailureCount < 0) {
-          LOG.warn(
-              "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
-                  + "previous failure count, conservatively report shuffle fetch failure.",
-              stageId,
-              taskInfo.index(),
-              taskId,
-              taskInfo.attemptNumber());
-          return true;
+          if (!hasRunningAttempt) {
+            LOG.warn(
+                "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
+                    + "previous failure count, and no other running attempt exists. "
+                    + "Reporting shuffle fetch failure.",
+                stageId,
+                taskInfo.index(),
+                taskId,
+                taskInfo.attemptNumber());
+            return true;
+          } else {
+            LOG.warn(
+                "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
+                    + "previous failure count, but another attempt is still running. "
+                    + "Deferring shuffle fetch failure report.",
+                stageId,
+                taskInfo.index(),
+                taskId,
+                taskInfo.attemptNumber());
+            return false;
+          }
         }
         if (previousFailureCount + 1 >= maxTaskFails || !hasRunningAttempt) {
           LOG.warn(

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -557,9 +557,14 @@ public class SparkUtils {
         // Note: previousFailureCount does NOT include the current failure,
         //       so (previousFailureCount + 1) represents the total failure count.
         int previousFailureCount = getTaskFailureCount(taskSetManager, taskInfo.index());
-        // Fail-safe: if failure count cannot be determined, conservatively trigger
-        // FetchFailed to avoid silently swallowing the error.
         if (previousFailureCount < 0) {
+          LOG.warn(
+              "StageId={}, index={}, taskId={}, attemptNumber={}: Unable to determine "
+                  + "previous failure count, conservatively report shuffle fetch failure.",
+              stageId,
+              taskInfo.index(),
+              taskId,
+              taskInfo.attemptNumber());
           return true;
         }
         if (previousFailureCount + 1 >= maxTaskFails || !hasRunningAttempt) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -383,6 +383,11 @@ public class SparkUtils {
               .hiddenImpl(TaskSetManager.class, "taskInfos")
               .defaultAlwaysNull()
               .build();
+  private static final DynFields.UnboundField<int[]> TASK_FAILURES =
+      DynFields.builder()
+          .hiddenImpl(TaskSetManager.class, "numFailures")
+          .defaultAlwaysNull()
+          .build();
 
   /**
    * TaskSetManager - it is not designed to be used outside the spark scheduler. Please be careful.
@@ -418,6 +423,39 @@ public class SparkUtils {
       LOG.error("Can not get TaskSetManager for taskId: {}", taskId);
       return null;
     }
+  }
+
+  /**
+   * Gets the number of task attempts that have already failed for the given task index. Note: This
+   * count does NOT include the current failure. To get the total failure count including the
+   * current attempt, you need to add 1 to the returned value.
+   *
+   * @param taskSetManager the TaskSetManager to query
+   * @param index the task index
+   * @return the number of previous failed attempts, or -1 if an error occurs
+   */
+  @VisibleForTesting
+  protected static int getTaskFailureCount(TaskSetManager taskSetManager, int index) {
+    if (taskSetManager == null) {
+      LOG.error("TaskSetManager is null for task index: {}", index);
+      return -1;
+    }
+
+    int[] numFailures = TASK_FAILURES.bind(taskSetManager).get();
+    if (numFailures == null) {
+      LOG.error("Failed to get numFailures array from TaskSetManager for task index: {}", index);
+      return -1;
+    }
+
+    if (index < 0 || index >= numFailures.length) {
+      LOG.error(
+          "Task index {} is out of bounds for numFailures array (length: {})",
+          index,
+          numFailures.length);
+      return -1;
+    }
+
+    return numFailures[index];
   }
 
   protected static Map<String, Set<Long>> reportedStageShuffleFetchFailureTaskIds =
@@ -480,7 +518,6 @@ public class SparkUtils {
         if (taskAttempts == null) return true;
 
         TaskInfo taskInfo = taskAttempts._1();
-        int failedTaskAttempts = 1;
         boolean hasRunningAttempt = false;
         for (TaskInfo ti : taskAttempts._2()) {
           if (ti.taskId() != taskId) {
@@ -492,7 +529,6 @@ public class SparkUtils {
                   taskId,
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
-              failedTaskAttempts += 1;
             } else if (ti.successful()) {
               LOG.info(
                   "StageId={} index={} taskId={} attempt={} another attempt {} is successful.",
@@ -511,36 +547,32 @@ public class SparkUtils {
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
               hasRunningAttempt = true;
-            } else if ("FAILED".equals(ti.status()) || "UNKNOWN".equals(ti.status())) {
-              // For KILLED state task, Spark does not count the number of failures
-              // For UNKNOWN state task, Spark does count the number of failures
-              // For FAILED state task, Spark decides whether to count the failure based on the
-              // different failure reasons. Since we cannot obtain the failure
-              // reason here, we will count all tasks in FAILED state.
-              LOG.info(
-                  "StageId={} index={} taskId={} attempt={} another attempt {} status={}.",
-                  stageId,
-                  taskInfo.index(),
-                  taskId,
-                  taskInfo.attemptNumber(),
-                  ti.attemptNumber(),
-                  ti.status());
-              failedTaskAttempts += 1;
             }
           }
         }
         // The following situations should trigger a FetchFailed exception:
-        //  1. If failedTaskAttempts >= maxTaskFails
-        //  2. If no other taskAttempts are running
-        if (failedTaskAttempts >= maxTaskFails || !hasRunningAttempt) {
+        //  1. If total failures (previous failures + current failure) >= maxTaskFails
+        //  2. If no other taskAttempts are running, trigger a FetchFailed exception
+        //  to keep the same behavior as Spark.
+        // Note: previousFailureCount does NOT include the current failure,
+        //       so (previousFailureCount + 1) represents the total failure count.
+        int previousFailureCount = getTaskFailureCount(taskSetManager, taskInfo.index());
+        // Fail-safe: if failure count cannot be determined, conservatively trigger
+        // FetchFailed to avoid silently swallowing the error.
+        if (previousFailureCount < 0) {
+          return true;
+        }
+        if (previousFailureCount + 1 >= maxTaskFails || !hasRunningAttempt) {
           LOG.warn(
-              "StageId={}, index={}, taskId={}, attemptNumber={}: Task failure count {} reached "
-                  + "maximum allowed failures {} or no running attempt exists.",
+              "StageId={}, index={}, taskId={}, attemptNumber={}: Previous failure count {} "
+                  + "(total with current: {}) reached maximum allowed failures {} "
+                  + "or no running attempt exists.",
               stageId,
               taskInfo.index(),
               taskId,
               taskInfo.attemptNumber(),
-              failedTaskAttempts,
+              previousFailureCount,
+              previousFailureCount + 1,
               maxTaskFails);
           return true;
         } else {

--- a/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
@@ -283,17 +283,14 @@ class SparkUtilsSuite extends AnyFunSuite
 
       try {
         val sc = sparkSession.sparkContext
-        SparkUtilsSuite.survivingTaskAttemptId.set(-1)
 
         val jobThread = new Thread {
           override def run(): Unit = {
             try {
               sc.parallelize(1 to 10, 1).mapPartitions { iter =>
-                val ctx = TaskContext.get()
-                if (ctx.attemptNumber() < 2) {
+                if (TaskContext.get().attemptNumber() < 2) {
                   throw new RuntimeException("Simulated task failure")
                 }
-                SparkUtilsSuite.survivingTaskAttemptId.set(ctx.taskAttemptId())
                 Thread.sleep(10000)
                 iter
               }.collect()
@@ -306,9 +303,8 @@ class SparkUtilsSuite extends AnyFunSuite
 
         val taskScheduler = sc.taskScheduler.asInstanceOf[TaskSchedulerImpl]
         eventually(timeout(10.seconds), interval(100.milliseconds)) {
-          val runningTaskId = SparkUtilsSuite.survivingTaskAttemptId.get()
-          assert(runningTaskId >= 0)
-          val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, runningTaskId)
+          // taskId 0,1 failed and removed; taskId 2 is the surviving 3rd attempt
+          val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, 2)
           assert(taskSetManager != null)
           assert(SparkUtils.getTaskFailureCount(taskSetManager, 0) == 2)
         }
@@ -377,8 +373,4 @@ class SparkUtilsSuite extends AnyFunSuite
       SparkUtils.getReducerFileGroupResponseBroadcastNum.set(0)
     }
   }
-}
-
-object SparkUtilsSuite {
-  val survivingTaskAttemptId = new java.util.concurrent.atomic.AtomicLong(-1)
 }

--- a/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
@@ -216,6 +216,57 @@ class SparkUtilsSuite extends AnyFunSuite
     }
   }
 
+  test("getTaskFailureCount") {
+    assert(SparkUtils.getTaskFailureCount(null, 0) == -1)
+
+    if (Spark3OrNewer) {
+      val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[2,3]")
+      val sparkSession = SparkSession.builder()
+        .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
+        .config("spark.sql.shuffle.partitions", 2)
+        .config("spark.celeborn.shuffle.forceFallback.partition.enabled", false)
+        .config("spark.celeborn.client.spark.stageRerun.enabled", "true")
+        .config(
+          "spark.shuffle.manager",
+          "org.apache.spark.shuffle.celeborn.TestCelebornShuffleManager")
+        .getOrCreate()
+
+      try {
+        val sc = sparkSession.sparkContext
+        val jobThread = new Thread {
+          override def run(): Unit = {
+            try {
+              sc.parallelize(1 to 100, 2)
+                .repartition(1)
+                .mapPartitions { iter =>
+                  Thread.sleep(3000)
+                  iter
+                }.collect()
+            } catch {
+              case _: InterruptedException =>
+            }
+          }
+        }
+        jobThread.start()
+
+        val taskScheduler = sc.taskScheduler.asInstanceOf[TaskSchedulerImpl]
+        eventually(timeout(3.seconds), interval(100.milliseconds)) {
+          val taskId = 0
+          val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, taskId)
+          assert(taskSetManager != null)
+          assert(SparkUtils.getTaskFailureCount(taskSetManager, 0) == 0)
+          assert(SparkUtils.getTaskFailureCount(taskSetManager, -1) == -1)
+          assert(SparkUtils.getTaskFailureCount(taskSetManager, Int.MaxValue) == -1)
+        }
+
+        sparkSession.sparkContext.cancelAllJobs()
+        jobThread.interrupt()
+      } finally {
+        sparkSession.stop()
+      }
+    }
+  }
+
   test("serialize/deserialize GetReducerFileGroupResponse with broadcast") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[2,3]")
     val sparkSession = SparkSession.builder()

--- a/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.shuffle.celeborn
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, TaskContext}
 import org.apache.spark.scheduler.{TaskSchedulerImpl, TaskSetManager}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.BeforeAndAfterEach
@@ -267,6 +267,60 @@ class SparkUtilsSuite extends AnyFunSuite
     }
   }
 
+  test("getTaskFailureCount after real task failures") {
+    if (Spark3OrNewer) {
+      // local[1,4]: 1 core (sequential execution), max 4 task failures before stage abort
+      val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[1,4]")
+      val sparkSession = SparkSession.builder()
+        .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
+        .config("spark.sql.shuffle.partitions", 2)
+        .config("spark.celeborn.shuffle.forceFallback.partition.enabled", false)
+        .config("spark.celeborn.client.spark.stageRerun.enabled", "true")
+        .config(
+          "spark.shuffle.manager",
+          "org.apache.spark.shuffle.celeborn.TestCelebornShuffleManager")
+        .getOrCreate()
+
+      try {
+        val sc = sparkSession.sparkContext
+        SparkUtilsSuite.survivingTaskAttemptId.set(-1)
+
+        val jobThread = new Thread {
+          override def run(): Unit = {
+            try {
+              sc.parallelize(1 to 10, 1).mapPartitions { iter =>
+                val ctx = TaskContext.get()
+                if (ctx.attemptNumber() < 2) {
+                  throw new RuntimeException("Simulated task failure")
+                }
+                SparkUtilsSuite.survivingTaskAttemptId.set(ctx.taskAttemptId())
+                Thread.sleep(10000)
+                iter
+              }.collect()
+            } catch {
+              case _: Exception =>
+            }
+          }
+        }
+        jobThread.start()
+
+        val taskScheduler = sc.taskScheduler.asInstanceOf[TaskSchedulerImpl]
+        eventually(timeout(10.seconds), interval(100.milliseconds)) {
+          val runningTaskId = SparkUtilsSuite.survivingTaskAttemptId.get()
+          assert(runningTaskId >= 0)
+          val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, runningTaskId)
+          assert(taskSetManager != null)
+          assert(SparkUtils.getTaskFailureCount(taskSetManager, 0) == 2)
+        }
+
+        sparkSession.sparkContext.cancelAllJobs()
+        jobThread.interrupt()
+      } finally {
+        sparkSession.stop()
+      }
+    }
+  }
+
   test("serialize/deserialize GetReducerFileGroupResponse with broadcast") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[2,3]")
     val sparkSession = SparkSession.builder()
@@ -323,4 +377,8 @@ class SparkUtilsSuite extends AnyFunSuite
       SparkUtils.getReducerFileGroupResponseBroadcastNum.set(0)
     }
   }
+}
+
+object SparkUtilsSuite {
+  val survivingTaskAttemptId = new java.util.concurrent.atomic.AtomicLong(-1)
 }

--- a/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/spark/shuffle/celeborn/SparkUtilsSuite.scala
@@ -303,8 +303,10 @@ class SparkUtilsSuite extends AnyFunSuite
 
         val taskScheduler = sc.taskScheduler.asInstanceOf[TaskSchedulerImpl]
         eventually(timeout(10.seconds), interval(100.milliseconds)) {
-          // taskId 0,1 failed and removed; taskId 2 is the surviving 3rd attempt
-          val taskSetManager = SparkUtils.getTaskSetManager(taskScheduler, 2)
+          // Task IDs are globally assigned; find the active TaskSetManager dynamically
+          // rather than assuming a specific taskId.
+          val taskSetManager = (0L to 10L).map(id =>
+            SparkUtils.getTaskSetManager(taskScheduler, id)).find(_ != null).orNull
           assert(taskSetManager != null)
           assert(SparkUtils.getTaskFailureCount(taskSetManager, 0) == 2)
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reopen from https://github.com/apache/celeborn/pull/3556, retrieve the number of task failures from TaskSetManager in SparkUtils#shouldReportShuffleFetchFailure method




### Why are the changes needed?
https://github.com/apache/celeborn/blob/main/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java#L514 We record the failure counts for task attempts in the "UNKNOWN" and "FAILED" states, but spark might not record the failure counts for task attempts in the FAILED state. This is a common occurrence in our production environment where task attempts fail due to container preemption. This situation happens frequently and failure counts should not be recorded, as existing code logic makes it easier for stageRerun to be triggered prematurely. Therefore, obtaining the failure counts for task attempts from the taskSetManager would be more accurate.


### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UTs.
