### PR TITLE
[CELEBORN-2306] Master adds shutdown hook for ratis stepdown

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2766,7 +2766,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.master.ha.gracefulShutdown.enabled")
       .categories("ha")
       .version("0.7.0")
-      .doc("When true, the master will run a shutdown hook and" +
+      .doc("When true, the master will run a shutdown hook and " +
         "transfer Raft leadership before shutting down. " +
         "This reduces chances of client side failures by avoiding " +
         "the Raft election window where no leader is available.")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2763,7 +2763,7 @@ object CelebornConf extends Logging {
       .createWithDefault(false)
 
   val HA_MASTER_GRACEFUL_SHUTDOWN_ENABLED: ConfigEntry[Boolean] =
-    buildConf("celeborn.master.ha.gracefulShutdown.enabled")
+    buildConf("celeborn.master.ha.graceful.shutdown.enabled")
       .categories("ha")
       .version("0.7.0")
       .doc("When true, the master will transfer Raft leadership " +

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -730,6 +730,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def masterHttpIdleTimeout: Long = get(MASTER_HTTP_IDLE_TIMEOUT)
 
   def haEnabled: Boolean = get(HA_ENABLED)
+  def haMasterGracefulShutdownEnabled: Boolean = get(HA_MASTER_GRACEFUL_SHUTDOWN_ENABLED)
 
   def haMasterNodeId: Option[String] = get(HA_MASTER_NODE_ID)
 
@@ -2758,6 +2759,17 @@ object CelebornConf extends Logging {
       .categories("ha")
       .version("0.3.0")
       .doc("When true, master nodes run as Raft cluster mode.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val HA_MASTER_GRACEFUL_SHUTDOWN_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.master.ha.gracefulShutdown.enabled")
+      .categories("ha")
+      .version("0.7.0")
+      .doc("When true, the master will run a shutdown hook and" +
+        "transfer Raft leadership before shutting down. " +
+        "This reduces chances of client side failures by avoiding " +
+        "the Raft election window where no leader is available.")
       .booleanConf
       .createWithDefault(false)
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -731,6 +731,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
 
   def haEnabled: Boolean = get(HA_ENABLED)
   def haMasterGracefulShutdownEnabled: Boolean = get(HA_MASTER_GRACEFUL_SHUTDOWN_ENABLED)
+  def haMasterGracefulShutdownTimeoutMs: Long = get(HA_MASTER_GRACEFUL_SHUTDOWN_TIMEOUT)
 
   def haMasterNodeId: Option[String] = get(HA_MASTER_NODE_ID)
 
@@ -2772,6 +2773,16 @@ object CelebornConf extends Logging {
         "where no leader is available.")
       .booleanConf
       .createWithDefault(false)
+
+  val HA_MASTER_GRACEFUL_SHUTDOWN_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.master.ha.graceful.shutdown.timeout")
+      .categories("ha")
+      .version("0.7.0")
+      .doc("Timeout for the master graceful shutdown process including " +
+        "Raft leadership transfer. Used as the shutdown hook timeout " +
+        "and the transfer-leadership request timeout.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
 
   val HA_MASTER_NODE_ID: OptionalConfigEntry[String] =
     buildConf("celeborn.master.ha.node.id")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2766,10 +2766,10 @@ object CelebornConf extends Logging {
     buildConf("celeborn.master.ha.gracefulShutdown.enabled")
       .categories("ha")
       .version("0.7.0")
-      .doc("When true, the master will run a shutdown hook and " +
-        "transfer Raft leadership before shutting down. " +
-        "This reduces chances of client side failures by avoiding " +
-        "the Raft election window where no leader is available.")
+      .doc("When true, the master will transfer Raft leadership " +
+        "before shutting down gracefully. This reduces chances of " +
+        "client side failures by avoiding the Raft election window " +
+        "where no leader is available.")
       .booleanConf
       .createWithDefault(false)
 

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -20,7 +20,7 @@ license: |
 | Key | Default | isDynamic | Description | Since | Deprecated |
 | --- | ------- | --------- | ----------- | ----- | ---------- |
 | celeborn.master.ha.enabled | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
-| celeborn.master.ha.gracefulShutdown.enabled | false | false | When true, the master will run a shutdown hook and transfer Raft leadership before shutting down. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
+| celeborn.master.ha.gracefulShutdown.enabled | false | false | When true, the master will transfer Raft leadership before shutting down gracefully. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.host | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
 | celeborn.master.ha.node.&lt;id&gt;.internal.port | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -17,15 +17,15 @@ license: |
 ---
 
 <!--begin-include-->
-| Key                                                         | Default | isDynamic | Description | Since | Deprecated |
-|-------------------------------------------------------------| ------- | --------- | ----------- | ----- | ---------- |
-| celeborn.master.ha.enabled                                  | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
-| celeborn.master.ha.graceful.shutdown.enabled                | false | false | When true, the master will transfer Raft leadership before shutting down gracefully. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
-| celeborn.master.ha.node.&lt;id&gt;.host                     | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
-| celeborn.master.ha.node.&lt;id&gt;.internal.port            | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
-| celeborn.master.ha.node.&lt;id&gt;.port                     | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 
-| celeborn.master.ha.node.&lt;id&gt;.ratis.port               | 9872 | false | Ratis port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.ratis.port | 
-| celeborn.master.ha.ratis.raft.rpc.type                      | netty | false | RPC type for Ratis, available options: netty, grpc. | 0.3.0 | celeborn.ha.master.ratis.raft.rpc.type | 
-| celeborn.master.ha.ratis.raft.server.storage.dir            | /tmp/ratis | false | Root storage directory to hold RaftServer data. | 0.3.0 | celeborn.ha.master.ratis.raft.server.storage.dir | 
+| Key | Default | isDynamic | Description | Since | Deprecated |
+| --- | ------- | --------- | ----------- | ----- | ---------- |
+| celeborn.master.ha.enabled | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
+| celeborn.master.ha.graceful.shutdown.enabled | false | false | When true, the master will transfer Raft leadership before shutting down gracefully. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
+| celeborn.master.ha.node.&lt;id&gt;.host | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
+| celeborn.master.ha.node.&lt;id&gt;.internal.port | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
+| celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 
+| celeborn.master.ha.node.&lt;id&gt;.ratis.port | 9872 | false | Ratis port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.ratis.port | 
+| celeborn.master.ha.ratis.raft.rpc.type | netty | false | RPC type for Ratis, available options: netty, grpc. | 0.3.0 | celeborn.ha.master.ratis.raft.rpc.type | 
+| celeborn.master.ha.ratis.raft.server.storage.dir | /tmp/ratis | false | Root storage directory to hold RaftServer data. | 0.3.0 | celeborn.ha.master.ratis.raft.server.storage.dir | 
 | celeborn.master.ha.ratis.raft.server.storage.startup.option | RECOVER | false | Startup option of RaftServer storage. Available options: RECOVER, FORMAT. | 0.5.0 |  | 
 <!--end-include-->

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -20,6 +20,7 @@ license: |
 | Key | Default | isDynamic | Description | Since | Deprecated |
 | --- | ------- | --------- | ----------- | ----- | ---------- |
 | celeborn.master.ha.enabled | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
+| celeborn.master.ha.gracefulShutdown.enabled | false | false | When true, the master will run a shutdown hook andtransfer Raft leadership before shutting down. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.host | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
 | celeborn.master.ha.node.&lt;id&gt;.internal.port | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -20,7 +20,7 @@ license: |
 | Key | Default | isDynamic | Description | Since | Deprecated |
 | --- | ------- | --------- | ----------- | ----- | ---------- |
 | celeborn.master.ha.enabled | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
-| celeborn.master.ha.gracefulShutdown.enabled | false | false | When true, the master will run a shutdown hook andtransfer Raft leadership before shutting down. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
+| celeborn.master.ha.gracefulShutdown.enabled | false | false | When true, the master will run a shutdown hook and transfer Raft leadership before shutting down. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.host | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
 | celeborn.master.ha.node.&lt;id&gt;.internal.port | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -21,6 +21,7 @@ license: |
 | --- | ------- | --------- | ----------- | ----- | ---------- |
 | celeborn.master.ha.enabled | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
 | celeborn.master.ha.graceful.shutdown.enabled | false | false | When true, the master will transfer Raft leadership before shutting down gracefully. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
+| celeborn.master.ha.graceful.shutdown.timeout | 30s | false | Timeout for the master graceful shutdown process including Raft leadership transfer. Used as the shutdown hook timeout and the transfer-leadership request timeout. | 0.7.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.host | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
 | celeborn.master.ha.node.&lt;id&gt;.internal.port | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
 | celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -17,15 +17,15 @@ license: |
 ---
 
 <!--begin-include-->
-| Key | Default | isDynamic | Description | Since | Deprecated |
-| --- | ------- | --------- | ----------- | ----- | ---------- |
-| celeborn.master.ha.enabled | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
-| celeborn.master.ha.gracefulShutdown.enabled | false | false | When true, the master will transfer Raft leadership before shutting down gracefully. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
-| celeborn.master.ha.node.&lt;id&gt;.host | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
-| celeborn.master.ha.node.&lt;id&gt;.internal.port | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
-| celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 
-| celeborn.master.ha.node.&lt;id&gt;.ratis.port | 9872 | false | Ratis port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.ratis.port | 
-| celeborn.master.ha.ratis.raft.rpc.type | netty | false | RPC type for Ratis, available options: netty, grpc. | 0.3.0 | celeborn.ha.master.ratis.raft.rpc.type | 
-| celeborn.master.ha.ratis.raft.server.storage.dir | /tmp/ratis | false | Root storage directory to hold RaftServer data. | 0.3.0 | celeborn.ha.master.ratis.raft.server.storage.dir | 
+| Key                                                         | Default | isDynamic | Description | Since | Deprecated |
+|-------------------------------------------------------------| ------- | --------- | ----------- | ----- | ---------- |
+| celeborn.master.ha.enabled                                  | false | false | When true, master nodes run as Raft cluster mode. | 0.3.0 | celeborn.ha.enabled | 
+| celeborn.master.ha.graceful.shutdown.enabled                | false | false | When true, the master will transfer Raft leadership before shutting down gracefully. This reduces chances of client side failures by avoiding the Raft election window where no leader is available. | 0.7.0 |  | 
+| celeborn.master.ha.node.&lt;id&gt;.host                     | &lt;required&gt; | false | Host to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.host | 
+| celeborn.master.ha.node.&lt;id&gt;.internal.port            | 8097 | false | Internal port for the workers and other masters to bind to a master node <id> in HA mode. | 0.5.0 |  | 
+| celeborn.master.ha.node.&lt;id&gt;.port                     | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 
+| celeborn.master.ha.node.&lt;id&gt;.ratis.port               | 9872 | false | Ratis port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.ratis.port | 
+| celeborn.master.ha.ratis.raft.rpc.type                      | netty | false | RPC type for Ratis, available options: netty, grpc. | 0.3.0 | celeborn.ha.master.ratis.raft.rpc.type | 
+| celeborn.master.ha.ratis.raft.server.storage.dir            | /tmp/ratis | false | Root storage directory to hold RaftServer data. | 0.3.0 | celeborn.ha.master.ratis.raft.server.storage.dir | 
 | celeborn.master.ha.ratis.raft.server.storage.startup.option | RECOVER | false | Startup option of RaftServer storage. Available options: RECOVER, FORMAT. | 0.5.0 |  | 
 <!--end-include-->

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -647,6 +647,7 @@ public class HARaftServer {
   }
 
   boolean stepDown() {
+    long timeoutMs = conf.haMasterGracefulShutdownTimeoutMs();
     try {
       TransferLeadershipRequest request =
           new TransferLeadershipRequest(
@@ -655,7 +656,7 @@ public class HARaftServer {
               raftGroup.getGroupId(),
               CallId.getAndIncrement(),
               null,
-              REQUEST_TIMEOUT_MS);
+              timeoutMs);
       RaftClientReply reply = server.transferLeadership(request);
       if (reply.isSuccess()) {
         return true;

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.net.ssl.KeyManager;
@@ -99,6 +100,7 @@ public class HARaftServer {
   private Optional<LeaderPeerEndpoints> cachedLeaderPeerRpcEndpoints = Optional.empty();
 
   private final CelebornConf conf;
+  private final AtomicBoolean stopped = new AtomicBoolean(false);
   private long workerTimeoutDeadline;
   private long appTimeoutDeadline;
 
@@ -274,8 +276,16 @@ public class HARaftServer {
   }
 
   public void stop() {
+    stop(false);
+  }
+
+  public void stop(boolean transferLeadership) {
+    if (!stopped.compareAndSet(false, true)) {
+      LOG.info("Raft server {} already stopped.", server.getId());
+      return;
+    }
     try {
-      if (isLeader()) {
+      if (transferLeadership && isLeader()) {
         LOG.info(
             "This node {} is the Raft leader. Transferring leadership before shutdown.",
             server.getId());
@@ -647,16 +657,13 @@ public class HARaftServer {
               REQUEST_TIMEOUT_MS);
       RaftClientReply reply = server.transferLeadership(request);
       if (reply.isSuccess()) {
-        LOG.info("Successfully step down leader {}.", server.getId());
         return true;
-      } else {
-        LOG.warn("Step down leader failed!");
-        return false;
       }
+      LOG.warn("Step down leader {} failed.", server.getId());
     } catch (Exception e) {
-      LOG.warn("Step down leader failed!", e);
-      return false;
+      LOG.warn("Step down leader {} failed.", server.getId(), e);
     }
+    return false;
   }
 
   public void setDeadlineTime(long increaseWorkerTime, long increaseAppTime) {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -275,8 +275,27 @@ public class HARaftServer {
 
   public void stop() {
     try {
+      if (isLeader()) {
+        LOG.info(
+            "This node {} is the Raft leader. Transferring leadership before shutdown.",
+            server.getId());
+        long startTime = System.currentTimeMillis();
+        boolean success = stepDown();
+        long elapsed = System.currentTimeMillis() - startTime;
+        if (success) {
+          LOG.info("Successfully transferred leadership from {} in {}ms.", server.getId(), elapsed);
+        } else {
+          LOG.warn(
+              "Leadership transfer from {} failed after {}ms. "
+                  + "Proceeding with shutdown anyway.",
+              server.getId(),
+              elapsed);
+        }
+      }
       server.close();
+      LOG.info("Raft server {} closed.", server.getId());
     } catch (IOException e) {
+      LOG.error("Error while stopping Raft server {}.", server.getId(), e);
       throw new RuntimeException(e);
     }
   }
@@ -616,7 +635,7 @@ public class HARaftServer {
     return this.internalRpcEndpoint;
   }
 
-  void stepDown() {
+  boolean stepDown() {
     try {
       TransferLeadershipRequest request =
           new TransferLeadershipRequest(
@@ -629,11 +648,14 @@ public class HARaftServer {
       RaftClientReply reply = server.transferLeadership(request);
       if (reply.isSuccess()) {
         LOG.info("Successfully step down leader {}.", server.getId());
+        return true;
       } else {
         LOG.warn("Step down leader failed!");
+        return false;
       }
     } catch (Exception e) {
       LOG.warn("Step down leader failed!", e);
+      return false;
     }
   }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -305,6 +305,7 @@ public class HARaftServer {
       server.close();
       LOG.info("Raft server {} closed.", server.getId());
     } catch (IOException e) {
+      stopped.set(false);
       LOG.error("Error while stopping Raft server {}.", server.getId(), e);
       throw new RuntimeException(e);
     }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -378,26 +378,6 @@ private[celeborn] class Master(
     }
     logInfo("Stopping Celeborn Master.")
 
-    // Transfer Raft leadership before shutting down so other masters can
-    // immediately take over without waiting for heartbeat timeout
-    if (conf.haMasterGracefulShutdownEnabled) {
-      statusSystem match {
-        case ha: HAMasterMetaManager =>
-          val ratisServer = ha.getRatisServer
-          if (ratisServer != null) {
-            logInfo("HA graceful shutdown enabled. Stopping Raft server (will transfer leadership if leader).")
-            try {
-              ratisServer.stop()
-            } catch {
-              case e: Exception =>
-                logError("Failed to stop Raft server during Master shutdown.", e)
-            }
-          }
-        case _ =>
-          logInfo("Single-master mode, skipping Raft shutdown.")
-      }
-    }
-
     Option(checkForWorkerTimeoutTask).foreach(_.cancel(true))
     Option(checkForUnavailableWorkerTimeOutTask).foreach(_.cancel(true))
     Option(checkForApplicationTimeOutTask).foreach(_.cancel(true))
@@ -1607,6 +1587,22 @@ private[celeborn] class Master(
   override def stop(exitKind: Int): Unit = synchronized {
     if (!stopped) {
       logInfo("Stopping Master")
+      // Transfer Raft leadership before shutting down so other masters can
+      // immediately take over without waiting for heartbeat timeout.
+      val transferLeadership = conf.haMasterGracefulShutdownEnabled
+      statusSystem match {
+        case ha: HAMasterMetaManager =>
+          val ratisServer = ha.getRatisServer
+          if (ratisServer != null) {
+            try {
+              ratisServer.stop(transferLeadership)
+            } catch {
+              case e: Exception =>
+                logError("Failed to stop Raft server during Master shutdown.", e)
+            }
+          }
+        case _ => // single-master mode, no Raft server to stop
+      }
       rpcEnv.stop(self)
       if (conf.internalPortEnabled) {
         internalRpcEnvInUse.stop(internalRpcEndpointRef)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -51,7 +51,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.rpc.{RpcSecurityContextBuilder, ServerSaslContextBuilder}
-import org.apache.celeborn.common.util.{CelebornHadoopUtils, JavaUtils, PbSerDeUtils, SignalUtils, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{CelebornExitKind, CelebornHadoopUtils, JavaUtils, PbSerDeUtils, ShutdownHookManager, SignalUtils, ThreadUtils, Utils}
 import org.apache.celeborn.server.common.{HttpService, Service}
 import org.apache.celeborn.service.deploy.master.audit.ShuffleAuditLogger
 import org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager
@@ -377,6 +377,27 @@ private[celeborn] class Master(
       return
     }
     logInfo("Stopping Celeborn Master.")
+
+    // Transfer Raft leadership before shutting down so other masters can
+    // immediately take over without waiting for heartbeat timeout
+    if (conf.haMasterGracefulShutdownEnabled) {
+      statusSystem match {
+        case ha: HAMasterMetaManager =>
+          val ratisServer = ha.getRatisServer
+          if (ratisServer != null) {
+            logInfo("HA graceful shutdown enabled. Stopping Raft server (will transfer leadership if leader).")
+            try {
+              ratisServer.stop()
+            } catch {
+              case e: Exception =>
+                logError("Failed to stop Raft server during Master shutdown.", e)
+            }
+          }
+        case _ =>
+          logInfo("Single-master mode, skipping Raft shutdown.")
+      }
+    }
+
     Option(checkForWorkerTimeoutTask).foreach(_.cancel(true))
     Option(checkForUnavailableWorkerTimeOutTask).foreach(_.cancel(true))
     Option(checkForApplicationTimeOutTask).foreach(_.cancel(true))
@@ -1564,6 +1585,19 @@ private[celeborn] class Master(
   override def initialize(): Unit = {
     super.initialize()
     logInfo("Master started.")
+
+    // Register a shutdown hook so that SIGTERM triggers a graceful stop.
+    ShutdownHookManager.get().addShutdownHook(
+      ThreadUtils.newThread(
+        new Runnable {
+          override def run(): Unit = {
+            logInfo("Shutdown hook called for Master.")
+            stop(CelebornExitKind.EXIT_IMMEDIATELY)
+          }
+        },
+        "master-shutdown-hook-thread"),
+      100)
+
     rpcEnv.awaitTermination()
     if (conf.internalPortEnabled) {
       internalRpcEnvInUse.awaitTermination()

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1566,7 +1566,9 @@ private[celeborn] class Master(
     super.initialize()
     logInfo("Master started.")
 
-    // Register a shutdown hook so that SIGTERM triggers a graceful stop.
+    // SIGTERM triggers leadership transfer (in stop()) then immediate HTTP/RPC teardown.
+    // EXIT_IMMEDIATELY is intentional: once Raft leadership is transferred and RPC is
+    // stopped, there is no need to drain HTTP connections.
     ShutdownHookManager.get().addShutdownHook(
       ThreadUtils.newThread(
         new Runnable {
@@ -1576,7 +1578,9 @@ private[celeborn] class Master(
           }
         },
         "master-shutdown-hook-thread"),
-      100)
+      100,
+      conf.haMasterGracefulShutdownTimeoutMs,
+      java.util.concurrent.TimeUnit.MILLISECONDS)
 
     rpcEnv.awaitTermination()
     if (conf.internalPortEnabled) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1899,19 +1899,32 @@ public class RatisMasterStatusSystemSuiteJ {
         "CLOSED",
         leader.getServer().getLifeCycleState().name());
 
-    // Wait until the cluster has a leader again, so subsequent tests can proceed.
+    // Wait until the cluster has a ready leader again, so subsequent tests can proceed.
     // Any of the three peers may win the ensuing election (including the one that
     // just stepped down, since TransferLeadershipRequest with a null target just
     // demotes the leader to follower and lets the normal election protocol run).
-    boolean leaderElected = false;
+    // We require isLeaderReady(), not just isLeader(): a newly elected leader rejects
+    // writes with LeaderNotReadyException until its no-op log entry for the new term
+    // has been committed.
+    boolean leaderReady = false;
     for (int i = 0; i < 60; i++) {
       for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {
         if (server.isLeader()) {
-          leaderElected = true;
-          break;
+          try {
+            if (server
+                .getServer()
+                .getDivision(server.getGroupId())
+                .getInfo()
+                .isLeaderReady()) {
+              leaderReady = true;
+              break;
+            }
+          } catch (IOException e) {
+            // Division not available yet; keep polling.
+          }
         }
       }
-      if (leaderElected) break;
+      if (leaderReady) break;
       try {
         Thread.sleep(1000);
       } catch (InterruptedException e) {
@@ -1919,7 +1932,8 @@ public class RatisMasterStatusSystemSuiteJ {
         break;
       }
     }
-    Assert.assertTrue("A leader should be elected after step down", leaderElected);
+    Assert.assertTrue(
+        "A ready leader should be elected after step down so later tests can run", leaderReady);
   }
 
   @AfterClass

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1911,11 +1911,7 @@ public class RatisMasterStatusSystemSuiteJ {
       for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {
         if (server.isLeader()) {
           try {
-            if (server
-                .getServer()
-                .getDivision(server.getGroupId())
-                .getInfo()
-                .isLeaderReady()) {
+            if (server.getServer().getDivision(server.getGroupId()).getInfo().isLeaderReady()) {
               leaderReady = true;
               break;
             }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1899,16 +1899,19 @@ public class RatisMasterStatusSystemSuiteJ {
         "CLOSED",
         leader.getServer().getLifeCycleState().name());
 
-    // Wait for a new leader to be elected so subsequent tests are not affected.
-    boolean newLeaderElected = false;
-    for (int i = 0; i < 30; i++) {
+    // Wait until the cluster has a leader again, so subsequent tests can proceed.
+    // Any of the three peers may win the ensuing election (including the one that
+    // just stepped down, since TransferLeadershipRequest with a null target just
+    // demotes the leader to follower and lets the normal election protocol run).
+    boolean leaderElected = false;
+    for (int i = 0; i < 60; i++) {
       for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {
-        if (server != leader && server.isLeader()) {
-          newLeaderElected = true;
+        if (server.isLeader()) {
+          leaderElected = true;
           break;
         }
       }
-      if (newLeaderElected) break;
+      if (leaderElected) break;
       try {
         Thread.sleep(1000);
       } catch (InterruptedException e) {
@@ -1916,7 +1919,7 @@ public class RatisMasterStatusSystemSuiteJ {
         break;
       }
     }
-    Assert.assertTrue("A new leader should be elected after step down", newLeaderElected);
+    Assert.assertTrue("A leader should be elected after step down", leaderElected);
   }
 
   @AfterClass

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1896,8 +1896,8 @@ public class RatisMasterStatusSystemSuiteJ {
         "Leader should step down without closing the shared server", leader.isLeader());
     Assert.assertNotEquals(
         "Raft server should remain available to the rest of the suite",
-        "CLOSED",
-        leader.getServer().getLifeCycleState().name());
+        org.apache.ratis.util.LifeCycle.State.CLOSED,
+        leader.getServer().getLifeCycleState());
 
     // Wait until the cluster has a ready leader again, so subsequent tests can proceed.
     // Any of the three peers may win the ensuing election (including the one that

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1883,13 +1883,15 @@ public class RatisMasterStatusSystemSuiteJ {
       }
     }
     Assert.assertNotNull("A leader should exist before the test", leader);
+    Assert.assertTrue("Leader node should report isLeader=true", leader.isLeader());
 
-    // Stop the leader — this calls stepDown() before closing the Raft server.
-    // We only verify that stop() completes without error; the actual new
-    // leader election depends on Raft heartbeat timeout and is non-deterministic.
-    // stop() should complete without throwing — it calls stepDown() internally
-    // before closing the Raft server.
+    // stop() calls stepDown() then closes the Raft server.
+    // Verify it completes and the underlying server is actually closed.
     leader.stop();
+    Assert.assertEquals(
+        "Raft server should be CLOSED after stop()",
+        "CLOSED",
+        leader.getServer().getLifeCycleState().name());
   }
 
   @AfterClass

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1872,6 +1872,26 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(STATUSSYSTEM3.registeredShuffleCount(), 8);
   }
 
+  @Test
+  public void testGracefulLeaderShutdownStepDown() {
+    // Identify the current leader
+    HARaftServer leader = null;
+    for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {
+      if (server.isLeader()) {
+        leader = server;
+        break;
+      }
+    }
+    Assert.assertNotNull("A leader should exist before the test", leader);
+
+    // Stop the leader — this calls stepDown() before closing the Raft server.
+    // We only verify that stop() completes without error; the actual new
+    // leader election depends on Raft heartbeat timeout and is non-deterministic.
+    // stop() should complete without throwing — it calls stepDown() internally
+    // before closing the Raft server.
+    leader.stop();
+  }
+
   @AfterClass
   public static void testNotifyLogFailed() {
     List<HARaftServer> list = Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3);

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1873,7 +1873,7 @@ public class RatisMasterStatusSystemSuiteJ {
   }
 
   @Test
-  public void testGracefulLeaderShutdownStepDown() {
+  public void testLeaderStepDownOnLogFailed() {
     // Identify the current leader
     HARaftServer leader = null;
     for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1892,11 +1892,31 @@ public class RatisMasterStatusSystemSuiteJ {
         .getMasterStateMachine()
         .notifyLogFailed(new Exception("test leader graceful step down"), null);
 
-    Assert.assertFalse("Leader should step down without closing the shared server", leader.isLeader());
+    Assert.assertFalse(
+        "Leader should step down without closing the shared server", leader.isLeader());
     Assert.assertNotEquals(
         "Raft server should remain available to the rest of the suite",
         "CLOSED",
         leader.getServer().getLifeCycleState().name());
+
+    // Wait for a new leader to be elected so subsequent tests are not affected.
+    boolean newLeaderElected = false;
+    for (int i = 0; i < 30; i++) {
+      for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {
+        if (server != leader && server.isLeader()) {
+          newLeaderElected = true;
+          break;
+        }
+      }
+      if (newLeaderElected) break;
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
+    Assert.assertTrue("A new leader should be elected after step down", newLeaderElected);
   }
 
   @AfterClass

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -1885,11 +1885,16 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertNotNull("A leader should exist before the test", leader);
     Assert.assertTrue("Leader node should report isLeader=true", leader.isLeader());
 
-    // stop() calls stepDown() then closes the Raft server.
-    // Verify it completes and the underlying server is actually closed.
-    leader.stop();
-    Assert.assertEquals(
-        "Raft server should be CLOSED after stop()",
+    // Do not stop() the shared static server used by the suite, since that permanently
+    // closes one of RATISSERVER1/2/3 and can break later tests depending on execution order.
+    // Instead, trigger the leader to step down without closing the underlying server.
+    leader
+        .getMasterStateMachine()
+        .notifyLogFailed(new Exception("test leader graceful step down"), null);
+
+    Assert.assertFalse("Leader should step down without closing the shared server", leader.isLeader());
+    Assert.assertNotEquals(
+        "Raft server should remain available to the rest of the suite",
         "CLOSED",
         leader.getServer().getLifeCycleState().name());
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Adds master shutdown hook
- Updates RAFT stepdown to return bool
- Calls RAFT stepdown on manager shutdown to do graceful stepdown

### Why are the changes needed?

- Manager.stop() isnt being called from anywhere, it emmits some logs as well for "Stopping manager" but since there is no shutdown hook defined, none of them are logged or the function is called at all
- We faced a certain issue where the leader got removed from service mesh before shutdown and followers redirected to it because it was still running (able to send requests but not receive) for a brief period. This method adds a graceful shutdown option to do a RATIS stepdown before shutting down. 

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

Yes, adds an additional config.


### How was this patch tested?

Added a tests and validated that.