### PR TITLE
[CELEBORN-2310] Reject RESERVE_SLOTS when disks are full

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -88,6 +88,10 @@ class DiskInfo(
   lazy val shuffleAllocations = new util.HashMap[String, Integer]()
   lazy val applicationAllocations = new util.HashMap[String, Integer]()
 
+  def isHealthy: Boolean = {
+    DiskStatus.HEALTHY.equals(status) && actualUsableSpace > 0
+  }
+
   def setStorageType(storageType: StorageInfo.Type) = {
     this.storageType = storageType
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -1146,6 +1146,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         } else {
           if (suggestedMountPoint.isEmpty) {
             logDebug(s"Location suggestedMountPoint is not set, return all healthy working dirs.")
+          } else if (diskInfo == null) {
+            logInfo(s"Disk info not found for suggestedMountPoint $suggestedMountPoint, return all healthy " +
+              s"working dirs.")
           } else {
             logInfo(s"Disk(${diskInfo.mountPoint}) unavailable for $suggestedMountPoint, return all healthy" +
               s" working dirs.")

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -113,7 +113,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   def healthyWorkingDirs(): List[File] =
     disksSnapshot()
       .filter(diskInfo =>
-        (diskInfo.status == DiskStatus.HEALTHY) && (diskInfo.actualUsableSpace >= 0))
+        (diskInfo.status == DiskStatus.HEALTHY) && (diskInfo.actualUsableSpace > 0))
       .flatMap(_.dirs)
 
   private val diskOperators: ConcurrentHashMap[String, ThreadPoolExecutor] = {
@@ -1143,7 +1143,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       val diskInfo = diskInfos.get(suggestedMountPoint)
       val dirs =
         if (diskInfo != null && diskInfo.status.equals(
-            DiskStatus.HEALTHY) && diskInfo.actualUsableSpace >= 0) {
+            DiskStatus.HEALTHY) && diskInfo.actualUsableSpace > 0) {
           diskInfo.dirs
         } else {
           if (suggestedMountPoint.isEmpty) {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -112,8 +112,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
 
   def healthyWorkingDirs(): List[File] =
     disksSnapshot()
-      .filter(diskInfo =>
-        (diskInfo.status == DiskStatus.HEALTHY) && (diskInfo.actualUsableSpace > 0))
+      .filter(_.isHealthy)
       .flatMap(_.dirs)
 
   private val diskOperators: ConcurrentHashMap[String, ThreadPoolExecutor] = {
@@ -1142,8 +1141,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     while (retryCount < conf.workerCreateWriterMaxAttempts) {
       val diskInfo = diskInfos.get(suggestedMountPoint)
       val dirs =
-        if (diskInfo != null && diskInfo.status.equals(
-            DiskStatus.HEALTHY) && diskInfo.actualUsableSpace > 0) {
+        if (diskInfo != null && diskInfo.isHealthy) {
           diskInfo.dirs
         } else {
           if (suggestedMountPoint.isEmpty) {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -111,7 +111,10 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   def healthyWorkingDirs(): List[File] =
-    disksSnapshot().filter(_.status == DiskStatus.HEALTHY).flatMap(_.dirs)
+    disksSnapshot()
+      .filter(diskInfo =>
+        (diskInfo.status == DiskStatus.HEALTHY) && (diskInfo.actualUsableSpace >= 0))
+      .flatMap(_.dirs)
 
   private val diskOperators: ConcurrentHashMap[String, ThreadPoolExecutor] = {
     val cleaners = JavaUtils.newConcurrentHashMap[String, ThreadPoolExecutor]()
@@ -1139,7 +1142,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     while (retryCount < conf.workerCreateWriterMaxAttempts) {
       val diskInfo = diskInfos.get(suggestedMountPoint)
       val dirs =
-        if (diskInfo != null && diskInfo.status.equals(DiskStatus.HEALTHY)) {
+        if (diskInfo != null && diskInfo.status.equals(
+            DiskStatus.HEALTHY) && diskInfo.actualUsableSpace >= 0) {
           diskInfo.dirs
         } else {
           if (suggestedMountPoint.isEmpty) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
@@ -124,7 +124,7 @@ class StorageManagerSuite extends CelebornFunSuite with MockitoHelper {
     diskInfo.setUsableSpace(-1L)
     // Should fail even if the status is HEALTHY
     diskInfo.setStatus(DiskStatus.HEALTHY)
-    doReturn(List(diskInfo)).when(spyStorageManager).disksSnapshot()
+    doReturn(List(diskInfo)).when(spyStorageManager).localDisksSnapshot()
 
     val partitionLocation = genPartitionLocation(0, Array(0L))
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.service.deploy.worker.storage
 
+import java.io.IOException
+import java.util
+
 import org.mockito.{Mockito, MockitoSugar}
 import org.mockito.ArgumentMatchersSugar.any
 import org.mockito.stubbing.Stubber
@@ -24,7 +27,9 @@ import org.mockito.stubbing.Stubber
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.{WORKER_DISK_RESERVE_SIZE, WORKER_GRACEFUL_SHUTDOWN_ENABLED, WORKER_GRACEFUL_SHUTDOWN_RECOVER_PATH}
-import org.apache.celeborn.common.meta.DiskInfo
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.meta.{DiskInfo, DiskStatus}
+import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType, StorageInfo}
 import org.apache.celeborn.common.util.Utils
 import org.apache.celeborn.service.deploy.worker.WorkerSource
 
@@ -107,5 +112,52 @@ class StorageManagerSuite extends CelebornFunSuite with MockitoHelper {
     diskInfo.setUsableSpace(-1L)
     spyStorageManager.updateDiskInfos()
     assert(diskInfo.actualUsableSpace == 0L)
+  }
+
+  test("[CELEBORN-2310] Ensure createFile rejected with disks are full, but status is HEALTHY") {
+    val conf = new CelebornConf().set(WORKER_DISK_RESERVE_SIZE, Utils.byteStringAsBytes("5g"))
+    val storageManager = new StorageManager(conf, new WorkerSource(conf))
+    val spyStorageManager = spy(storageManager)
+
+    val diskInfo = new DiskInfo("mountPoint", List.empty, null, conf)
+    diskInfo.setUsableSpace(-1L)
+    // Should fail even if the status is HEALTHY
+    diskInfo.setStatus(DiskStatus.HEALTHY)
+    doReturn(List(diskInfo)).when(spyStorageManager).disksSnapshot()
+
+    val partitionLocation = genPartitionLocation(0, Array(0L))
+
+    try {
+      val file = storageManager.createDiskFile(
+        partitionLocation,
+        "myAppId",
+        0,
+        "myFile",
+        new UserIdentifier("t1", "u1"),
+        PartitionType.REDUCE,
+        partitionSplitEnabled = false)
+      fail("Should throw IOException when disks are full")
+    } catch {
+      case e: IOException =>
+        assert(e.getMessage.equals(
+          s"No available disks! suggested mountPoint ${partitionLocation.getStorageInfo.getMountPoint}"))
+      case e: Throwable =>
+        fail(s"Should throw IOException, but got ${e.getClass.getSimpleName}")
+    }
+  }
+
+  private def genPartitionLocation(epoch: Int, offsets: Array[Long]): PartitionLocation = {
+    val location: PartitionLocation =
+      new PartitionLocation(0, epoch, "localhost", 0, 0, 0, 0, PartitionLocation.Mode.PRIMARY)
+    val storageInfo: StorageInfo = new StorageInfo(
+      StorageInfo.Type.HDD,
+      "mountPoint",
+      false,
+      "filePath",
+      StorageInfo.LOCAL_DISK_MASK,
+      offsets(offsets.length - 1),
+      util.Arrays.asList(offsets))
+    location.setStorageInfo(storageInfo)
+    location
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.celeborn.service.deploy.worker.storage
 
+import java.{lang, util}
 import java.io.IOException
-import java.util
 
 import org.mockito.{Mockito, MockitoSugar}
 import org.mockito.ArgumentMatchersSugar.any
@@ -154,9 +154,9 @@ class StorageManagerSuite extends CelebornFunSuite with MockitoHelper {
       "mountPoint",
       false,
       "filePath",
-      StorageInfo.LOCAL_DISK_MASK,
+      StorageInfo.ALL_TYPES_AVAILABLE_MASK,
       offsets(offsets.length - 1),
-      util.Arrays.asList(offsets))
+      new util.ArrayList[lang.Long]())
     location.setStorageInfo(storageInfo)
     location
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManagerSuite.scala
@@ -26,7 +26,7 @@ import org.mockito.stubbing.Stubber
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.CelebornConf.{WORKER_DISK_RESERVE_SIZE, WORKER_GRACEFUL_SHUTDOWN_ENABLED, WORKER_GRACEFUL_SHUTDOWN_RECOVER_PATH}
+import org.apache.celeborn.common.CelebornConf.{WORKER_DISK_RESERVE_SIZE, WORKER_GRACEFUL_SHUTDOWN_ENABLED, WORKER_GRACEFUL_SHUTDOWN_RECOVER_PATH, WORKER_STORAGE_DIRS}
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.meta.{DiskInfo, DiskStatus}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType, StorageInfo}
@@ -115,11 +115,12 @@ class StorageManagerSuite extends CelebornFunSuite with MockitoHelper {
   }
 
   test("[CELEBORN-2310] Ensure createFile rejected with disks are full, but status is HEALTHY") {
-    val conf = new CelebornConf().set(WORKER_DISK_RESERVE_SIZE, Utils.byteStringAsBytes("5g"))
+    val conf = new CelebornConf().set(WORKER_DISK_RESERVE_SIZE, Utils.byteStringAsBytes("5g")).set(
+      WORKER_STORAGE_DIRS,
+      Seq("/"))
     val storageManager = new StorageManager(conf, new WorkerSource(conf))
     val spyStorageManager = spy(storageManager)
-
-    val diskInfo = new DiskInfo("mountPoint", List.empty, null, conf)
+    val diskInfo = new DiskInfo("/", List.empty, null, conf)
     diskInfo.setUsableSpace(-1L)
     // Should fail even if the status is HEALTHY
     diskInfo.setStatus(DiskStatus.HEALTHY)
@@ -142,7 +143,7 @@ class StorageManagerSuite extends CelebornFunSuite with MockitoHelper {
         assert(e.getMessage.equals(
           s"No available disks! suggested mountPoint ${partitionLocation.getStorageInfo.getMountPoint}"))
       case e: Throwable =>
-        fail(s"Should throw IOException, but got ${e.getClass.getSimpleName}")
+        fail(s"Should throw IOException, but got ${e.getClass.getSimpleName}", e)
     }
   }
 
@@ -151,7 +152,7 @@ class StorageManagerSuite extends CelebornFunSuite with MockitoHelper {
       new PartitionLocation(0, epoch, "localhost", 0, 0, 0, 0, PartitionLocation.Mode.PRIMARY)
     val storageInfo: StorageInfo = new StorageInfo(
       StorageInfo.Type.HDD,
-      "mountPoint",
+      "/",
       false,
       "filePath",
       StorageInfo.ALL_TYPES_AVAILABLE_MASK,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disk full only lead to HARD_SPLITs as a response to writes. However, doesn't lead to reserve slot rejections. This means too many write retries (due to HARD_SPLITs on each write attempt) leads to wasted network I/O. We can reject RESERVE_SLOT during disk full to avoid the wasted data write network IO.

### Why are the changes needed?

Reject reserve slots during disk full, avoid unnecessary network IO.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added UTs, CI.