### PR TITLE
[CELEBORN-2313] Extend E2E checked zone to batch assembly point

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
@@ -221,6 +221,8 @@ public class SortBasedPusher extends MemoryConsumer {
         if (currentPartition == -1) {
           currentPartition = partition;
         } else {
+          shuffleClient.computeBatchCRC(
+              shuffleId, mapId, attemptNumber, currentPartition, dataBuf, 0, offSet);
           int bytesWritten =
               shuffleClient.mergeData(
                   shuffleId,
@@ -246,6 +248,8 @@ public class SortBasedPusher extends MemoryConsumer {
 
       if (offSet + recordSize > dataBuf.length) {
         try {
+          shuffleClient.computeBatchCRC(
+              shuffleId, mapId, attemptNumber, partition, dataBuf, 0, offSet);
           dataPusher.addTask(partition, dataBuf, offSet);
           memoryThresholdManager.updateStats(offSet, true);
         } catch (InterruptedException e) {
@@ -261,6 +265,8 @@ public class SortBasedPusher extends MemoryConsumer {
     }
     if (offSet > 0) {
       try {
+        shuffleClient.computeBatchCRC(
+            shuffleId, mapId, attemptNumber, currentPartition, dataBuf, 0, offSet);
         dataPusher.addTask(currentPartition, dataBuf, offSet);
         memoryThresholdManager.updateStats(offSet, offSet == pushBufferMaxSize);
       } catch (InterruptedException e) {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -277,6 +277,8 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
   private void pushGiantRecord(int partitionId, byte[] buffer, int numBytes) throws IOException {
     logger.debug("Push giant record for partition {}, size {}.", partitionId, numBytes);
+    shuffleClient.computeBatchCRC(
+        shuffleId, mapId, encodedAttemptId, partitionId, buffer, 0, numBytes);
     int bytesWritten =
         shuffleClient.pushData(
             shuffleId,
@@ -318,6 +320,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException, InterruptedException {
     long start = System.nanoTime();
     logger.debug("Flush buffer for partition {}, size {}.", partitionId, size);
+    shuffleClient.computeBatchCRC(shuffleId, mapId, encodedAttemptId, partitionId, buffer, 0, size);
     dataPusher.addTask(partitionId, buffer, size);
     writeMetrics.incWriteTime(System.nanoTime() - start);
   }
@@ -338,6 +341,8 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     for (int i = 0; i < sendBuffers.length; i++) {
       final int size = sendOffsets[i];
       if (size > 0) {
+        shuffleClient.computeBatchCRC(
+            shuffleId, mapId, encodedAttemptId, i, sendBuffers[i], 0, size);
         int bytesWritten =
             shuffleClient.mergeData(
                 shuffleId,

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -283,6 +283,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
   private void pushGiantRecord(int partitionId, byte[] buffer, int numBytes) throws IOException {
     logger.debug("Push giant record, size {}.", Utils.bytesToString(numBytes));
+    shuffleClient.computeBatchCRC(
+        shuffleId, mapId, encodedAttemptId, partitionId, buffer, 0, numBytes);
     int bytesWritten =
         shuffleClient.pushData(
             shuffleId,

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -278,6 +278,8 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   protected void pushGiantRecord(int partitionId, byte[] buffer, int numBytes) throws IOException {
     logger.debug("Push giant record, size {}.", numBytes);
     long start = System.nanoTime();
+    shuffleClient.computeBatchCRC(
+        shuffleId, mapId, encodedAttemptId, partitionId, buffer, 0, numBytes);
     int bytesWritten =
         shuffleClient.pushData(
             shuffleId,
@@ -321,6 +323,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException, InterruptedException {
     long start = System.nanoTime();
     if (logger.isDebugEnabled()) logger.debug("Flush buffer, size {}.", Utils.bytesToString(size));
+    shuffleClient.computeBatchCRC(shuffleId, mapId, encodedAttemptId, partitionId, buffer, 0, size);
     dataPusher.addTask(partitionId, buffer, size);
     writeMetrics.incWriteTime(System.nanoTime() - start);
   }
@@ -332,6 +335,8 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     for (int i = 0; i < numPartitions; i++) {
       final int size = sendOffsets[i];
       if (size > 0) {
+        shuffleClient.computeBatchCRC(
+            shuffleId, mapId, encodedAttemptId, i, sendBuffers[i], 0, size);
         mergeData(i, sendBuffers[i], 0, size);
       }
     }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -348,6 +348,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     if (logger.isDebugEnabled())
       logger.debug("Push giant record, size {}.", Utils.bytesToString(numBytes));
     long start = System.nanoTime();
+    shuffleClient.computeBatchCRC(
+        shuffleId, mapId, encodedAttemptId, partitionId, buffer, 0, numBytes);
     int bytesWritten =
         shuffleClient.pushData(
             shuffleId,

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -78,9 +80,11 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.client.DummyShuffleClient;
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.CommitMetadata;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.util.Utils;
+import org.apache.celeborn.common.write.PushState;
 import org.apache.celeborn.reflect.DynConstructors;
 
 public abstract class CelebornShuffleWriterSuiteBase {
@@ -211,6 +215,95 @@ public abstract class CelebornShuffleWriterSuiteBase {
     final CelebornConf conf =
         new CelebornConf().set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "128");
     check(2 << 30, conf, serializer);
+  }
+
+  @Test
+  public void testIntegrityCheckAccumulation() throws Exception {
+    final KryoSerializer serializer = new KryoSerializer(sparkConf);
+    final CelebornConf conf =
+        new CelebornConf()
+            .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "128")
+            .set("celeborn.client.shuffle.integrityCheck.enabled", "true");
+    checkWithIntegrity(10000, conf, serializer);
+  }
+
+  @Test
+  public void testIntegrityCheckAccumulationWithFastWrite() throws Exception {
+    final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
+    final CelebornConf conf =
+        new CelebornConf()
+            .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "128")
+            .set("celeborn.client.shuffle.integrityCheck.enabled", "true");
+    checkWithIntegrity(10000, conf, serializer);
+  }
+
+  private void checkWithIntegrity(
+      final int approximateSize, final CelebornConf conf, final Serializer serializer)
+      throws Exception {
+    final boolean useUnsafe = serializer instanceof UnsafeRowSerializer;
+
+    String partitionIdPassthroughClazz;
+    if (SparkVersionUtil.isGreaterThan(3, 3)) {
+      partitionIdPassthroughClazz = "org.apache.spark.PartitionIdPassthrough";
+    } else {
+      partitionIdPassthroughClazz = "org.apache.spark.sql.execution.PartitionIdPassthrough";
+    }
+    DynConstructors.Ctor<Partitioner> partitionIdPassthroughCtor =
+        DynConstructors.builder().impl(partitionIdPassthroughClazz, int.class).build();
+    final Partitioner partitioner =
+        useUnsafe
+            ? partitionIdPassthroughCtor.newInstance(numPartitions)
+            : new HashPartitioner(numPartitions);
+    Mockito.doReturn(partitioner).when(dependency).partitioner();
+    Mockito.doReturn(serializer).when(dependency).serializer();
+
+    final File tempFile = new File(tempDir, UUID.randomUUID().toString());
+    final DummyShuffleClient client = new DummyShuffleClient(conf, tempFile);
+    client.initReducePartitionMap(shuffleId, numPartitions, 1);
+
+    final CelebornShuffleHandle<Integer, String, String> handle =
+        new CelebornShuffleHandle<>(
+            appId, host, port, userIdentifier, shuffleId, false, numMaps, dependency);
+    final ShuffleWriter<Integer, String> writer =
+        createShuffleWriter(handle, taskContext, conf, client, metrics.shuffleWriteMetrics());
+
+    AtomicInteger total = new AtomicInteger(0);
+    // Use mix=true to exercise both giant and normal record paths.
+    Iterator iterator = getIterator(approximateSize, total, useUnsafe, true);
+
+    writer.write(iterator);
+    Option<MapStatus> status = writer.stop(true);
+
+    assertNotNull(status);
+    assertTrue(status.isDefined());
+
+    // mapId=0 and attemptId=0 from the mock TaskContext.
+    String mapKey = Utils.makeMapKey(shuffleId, 0, 0);
+    PushState pushState = client.getPushState(mapKey);
+
+    int[] crcPerPartition = pushState.getCRC32PerPartition(true, numPartitions);
+    long[] bytesPerPartition = pushState.getBytesWrittenPerPartition(true, numPartitions);
+
+    Map<Integer, List<byte[]>> crcData = client.getCrcDataByPartition(mapKey);
+    Map<Integer, List<byte[]>> pushData = client.getPushDataByPartition(mapKey);
+
+    for (int i = 0; i < numPartitions; i++) {
+      List<byte[]> crcBatches = crcData.getOrDefault(i, Collections.emptyList());
+      long expectedBytes = 0;
+      CommitMetadata expected = new CommitMetadata();
+      for (byte[] batch : crcBatches) {
+        expected.addDataWithOffsetAndLength(batch, 0, batch.length);
+        expectedBytes += batch.length;
+      }
+      assertEquals("Partition " + i + " bytes mismatch", expectedBytes, bytesPerPartition[i]);
+      assertEquals("Partition " + i + " CRC mismatch", expected.getChecksum(), crcPerPartition[i]);
+
+      int pushCalls = pushData.getOrDefault(i, Collections.emptyList()).size();
+      assertEquals(
+          "Partition " + i + " CRC/push call count mismatch", pushCalls, crcBatches.size());
+    }
+
+    client.shutdown();
   }
 
   private void check(

--- a/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -25,6 +25,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +49,7 @@ import org.apache.celeborn.common.protocol.PbStreamHandler;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.util.ExceptionMaker;
 import org.apache.celeborn.common.util.JavaUtils;
+import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.common.write.LocationPushFailedBatches;
 import org.apache.celeborn.common.write.PushState;
 
@@ -56,15 +59,23 @@ public class DummyShuffleClient extends ShuffleClient {
 
   private final OutputStream os;
   private final CelebornConf conf;
+  private final boolean shuffleIntegrityCheckEnabled;
 
   private final Map<Integer, ConcurrentHashMap<Integer, PartitionLocation>> reducePartitionMap =
       new HashMap<>();
+
+  // Tracking for CRC verification in tests
+  private final Map<String, PushState> pushStateMap = new ConcurrentHashMap<>();
+  private final Map<String, Map<Integer, List<byte[]>>> crcDataByMapKey = new ConcurrentHashMap<>();
+  private final Map<String, Map<Integer, List<byte[]>>> pushDataByMapKey =
+      new ConcurrentHashMap<>();
 
   public AtomicInteger fetchFailureCount = new AtomicInteger();
 
   public DummyShuffleClient(CelebornConf conf, File file) throws Exception {
     this.os = new BufferedOutputStream(new FileOutputStream(file));
     this.conf = conf;
+    this.shuffleIntegrityCheckEnabled = conf.clientShuffleIntegrityCheckEnabled();
   }
 
   @Override
@@ -88,8 +99,38 @@ public class DummyShuffleClient extends ShuffleClient {
       int numMappers,
       int numPartitions)
       throws IOException {
+    String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    Map<Integer, List<byte[]>> partitionData =
+        pushDataByMapKey.computeIfAbsent(mapKey, k -> new HashMap<>());
+    partitionData
+        .computeIfAbsent(partitionId, k -> new ArrayList<>())
+        .add(Arrays.copyOfRange(data, offset, offset + length));
+
     os.write(data, offset, length);
     return length;
+  }
+
+  @Override
+  public void computeBatchCRC(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      byte[] data,
+      int offset,
+      int length) {
+    if (!shuffleIntegrityCheckEnabled) {
+      return;
+    }
+    String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    PushState pushState = pushStateMap.computeIfAbsent(mapKey, k -> new PushState(conf));
+    pushState.addDataWithOffsetAndLength(partitionId, data, offset, length);
+
+    Map<Integer, List<byte[]>> partitionData =
+        crcDataByMapKey.computeIfAbsent(mapKey, k -> new HashMap<>());
+    partitionData
+        .computeIfAbsent(partitionId, k -> new ArrayList<>())
+        .add(Arrays.copyOfRange(data, offset, offset + length));
   }
 
   @Override
@@ -104,6 +145,13 @@ public class DummyShuffleClient extends ShuffleClient {
       int numMappers,
       int numPartitions)
       throws IOException {
+    String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    Map<Integer, List<byte[]>> partitionData =
+        pushDataByMapKey.computeIfAbsent(mapKey, k -> new HashMap<>());
+    partitionData
+        .computeIfAbsent(partitionId, k -> new ArrayList<>())
+        .add(Arrays.copyOfRange(data, offset, offset + length));
+
     os.write(data, offset, length);
     return length;
   }
@@ -188,7 +236,15 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public PushState getPushState(String mapKey) {
-    return new PushState(conf);
+    return pushStateMap.computeIfAbsent(mapKey, k -> new PushState(conf));
+  }
+
+  public Map<Integer, List<byte[]>> getCrcDataByPartition(String mapKey) {
+    return crcDataByMapKey.getOrDefault(mapKey, Collections.emptyMap());
+  }
+
+  public Map<Integer, List<byte[]>> getPushDataByPartition(String mapKey) {
+    return pushDataByMapKey.getOrDefault(mapKey, Collections.emptyMap());
   }
 
   @Override

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -188,6 +188,20 @@ public abstract class ShuffleClient {
       int numPartitions)
       throws IOException;
 
+  /**
+   * Pre-compute CRC for a batch immediately after assembly in the writer, before the data enters
+   * the async push pipeline. This is the sole CRC accumulation path when shuffle integrity check is
+   * enabled; {@link #pushOrMergeData} does not perform CRC computation.
+   */
+  public abstract void computeBatchCRC(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      byte[] data,
+      int offset,
+      int length);
+
   public abstract int mergeData(
       int shuffleId,
       int mapId,

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1044,12 +1044,6 @@ public class ShuffleClientImpl extends ShuffleClient {
     // increment batchId
     final int nextBatchId = pushState.nextBatchId();
 
-    // Track commit metadata if shuffle compression and integrity check are enabled and this request
-    // is not for pushing metadata itself.
-    if (shuffleIntegrityCheckEnabled) {
-      pushState.addDataWithOffsetAndLength(partitionId, data, offset, length);
-    }
-
     if (shuffleCompressionEnabled && !skipCompress) {
       // compress data
       final Compressor compressor = compressorThreadLocal.get();
@@ -1402,6 +1396,26 @@ public class ShuffleClientImpl extends ShuffleClient {
         numPartitions,
         false,
         false);
+  }
+
+  @Override
+  public void computeBatchCRC(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      byte[] data,
+      int offset,
+      int length) {
+    if (!shuffleIntegrityCheckEnabled) {
+      return;
+    }
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    if (mapperEnded(shuffleId, mapId) || isStageEnded(shuffleId)) {
+      return;
+    }
+    PushState pushState = getPushState(mapKey);
+    pushState.addDataWithOffsetAndLength(partitionId, data, offset, length);
   }
 
   @Override

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -47,6 +47,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.celeborn.client.compress.Compressor;
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.CommitMetadata;
 import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.network.client.TransportClient;
@@ -61,6 +62,8 @@ import org.apache.celeborn.common.protocol.message.ControlMessages.RegisterShuff
 import org.apache.celeborn.common.protocol.message.StatusCode;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.rpc.RpcTimeoutException;
+import org.apache.celeborn.common.util.Utils;
+import org.apache.celeborn.common.write.PushState;
 
 public class ShuffleClientSuiteJ {
 
@@ -708,5 +711,99 @@ public class ShuffleClientSuiteJ {
     assertEquals(endMapIndex, capturedRequest.getEndMapIndex());
     assertEquals(crc32, capturedRequest.getCrc32());
     assertEquals(bytesWritten, capturedRequest.getBytesWritten());
+  }
+
+  @Test
+  public void testComputeBatchCRCAccumulatesCorrectly() {
+    CelebornConf conf = new CelebornConf();
+    conf.set("celeborn.client.shuffle.integrityCheck.enabled", "true");
+    shuffleClient =
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+    shuffleClient.setupLifecycleManagerRef(endpointRef);
+
+    byte[] batch0 = "hello world".getBytes(StandardCharsets.UTF_8);
+    byte[] batch1a = "foo".getBytes(StandardCharsets.UTF_8);
+    byte[] batch1b = "bar".getBytes(StandardCharsets.UTF_8);
+
+    shuffleClient.computeBatchCRC(
+        TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID, 0, batch0, 0, batch0.length);
+    shuffleClient.computeBatchCRC(
+        TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID, 1, batch1a, 0, batch1a.length);
+    shuffleClient.computeBatchCRC(
+        TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID, 1, batch1b, 0, batch1b.length);
+
+    PushState pushState =
+        shuffleClient.getPushState(Utils.makeMapKey(TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID));
+
+    int numPartitions = 2;
+    int[] crcPerPartition = pushState.getCRC32PerPartition(true, numPartitions);
+    long[] bytesPerPartition = pushState.getBytesWrittenPerPartition(true, numPartitions);
+
+    // compute expected values via CommitMetadata — same code path as production
+    CommitMetadata expected0 = new CommitMetadata();
+    expected0.addDataWithOffsetAndLength(batch0, 0, batch0.length);
+    assertEquals(expected0.getChecksum(), crcPerPartition[0]);
+    assertEquals(expected0.getBytes(), bytesPerPartition[0]);
+
+    CommitMetadata expected1 = new CommitMetadata();
+    expected1.addDataWithOffsetAndLength(batch1a, 0, batch1a.length);
+    expected1.addDataWithOffsetAndLength(batch1b, 0, batch1b.length);
+    assertEquals(expected1.getChecksum(), crcPerPartition[1]);
+    assertEquals(expected1.getBytes(), bytesPerPartition[1]);
+  }
+
+  @Test
+  public void testComputeBatchCRCDisabled() {
+    CelebornConf conf = new CelebornConf();
+    conf.set("celeborn.client.shuffle.integrityCheck.enabled", "false");
+    shuffleClient =
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+    shuffleClient.setupLifecycleManagerRef(endpointRef);
+
+    byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+    shuffleClient.computeBatchCRC(
+        TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID, 0, data, 0, data.length);
+
+    PushState pushState =
+        shuffleClient.getPushState(Utils.makeMapKey(TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID));
+
+    int numPartitions = 2;
+    // When integrity check is disabled at the client level, computeBatchCRC is a no-op,
+    // so the PushState should remain empty even though we pass true to the getter.
+    int[] crcPerPartition = pushState.getCRC32PerPartition(true, numPartitions);
+    long[] bytesPerPartition = pushState.getBytesWrittenPerPartition(true, numPartitions);
+
+    for (int i = 0; i < numPartitions; i++) {
+      assertEquals("Partition " + i + " CRC should be zero", 0, crcPerPartition[i]);
+      assertEquals("Partition " + i + " bytes should be zero", 0, bytesPerPartition[i]);
+    }
+  }
+
+  @Test
+  public void testComputeBatchCRCAttemptIdConsistency() {
+    CelebornConf conf = new CelebornConf();
+    conf.set("celeborn.client.shuffle.integrityCheck.enabled", "true");
+    shuffleClient =
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+    shuffleClient.setupLifecycleManagerRef(endpointRef);
+
+    byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+
+    // Call with attemptId=0
+    shuffleClient.computeBatchCRC(
+        TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID, 0, data, 0, data.length);
+
+    // PushState for attemptId=0 should have the data
+    PushState pushState0 =
+        shuffleClient.getPushState(Utils.makeMapKey(TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID));
+    int[] crc0 = pushState0.getCRC32PerPartition(true, 2);
+    assertTrue(crc0[0] != 0);
+
+    // PushState for attemptId=1 should be empty
+    PushState pushState1 =
+        shuffleClient.getPushState(
+            Utils.makeMapKey(TEST_SHUFFLE_ID, TEST_MAP_ID, TEST_ATTEMPT_ID + 1));
+    int[] crc1 = pushState1.getCRC32PerPartition(true, 2);
+    assertEquals(0, crc1[0]);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Celeborn's E2E integrity check computes CRC_M inside `ShuffleClientImpl.pushOrMergeData()`, which runs in the async `DataPusher` thread. This leaves the segment from batch assembly in the writer thread through the `DataPusher` queue entirely outside the checked zone — meaning any corruption that occurs in that window is invisible to the integrity check and reaches reducers silently.

This change closes that gap and enables detection of a class of correctness bugs where data corruption occurs between batch assembly and async push dispatch, including bugs involving shared buffer pool references.

Introduce `ShuffleClient.computeBatchCRC()` and call it immediately before each assembled batch enters the async push pipeline, at 7 call sites across 3 classes: `HashBasedShuffleWriter` (spark-2/3) at `flushSendBuffer()`, `pushGiantRecord()`, and the per-partition flush in `close()`; and `SortBasedPusher` at the partition-change flush, buffer-overflow flush, `pushGiantRecord()`, and final flush. The now-redundant CRC computation inside `pushOrMergeData()` is removed.

This approach is less elegant than the original design, which had a single CRC call site inside `pushOrMergeData()` — one place to reason about and maintain. The new design scatters `computeBatchCRC()` across 7 call sites, but the trade-off is justified: the checked zone now starts at batch assembly rather than at async push dispatch, covering more of the data pipeline and enabling detection of a broader class of correctness bugs.

### Why are the changes needed?

Celeborn's E2E integrity check computes CRC_M inside `ShuffleClientImpl.pushOrMergeData()`, which runs in the async `DataPusher` thread. This leaves the segment from batch assembly in the writer thread through the `DataPusher` queue entirely outside the checked zone — meaning any corruption that occurs in that window is invisible to the integrity check and reaches reducers silently.

### Does this PR resolve a correctness bug?

It could help us detect more correctness bug.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.