### PR TITLE
[CELEBORN-2315] Add iterator fully-consumed validation after shuffle write

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/TaskInterruptedHelper.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/TaskInterruptedHelper.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.shuffle.celeborn;
 
+import scala.Option;
+
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskKilledException;
 
@@ -30,8 +32,17 @@ public class TaskInterruptedHelper {
    * kill reason, so here we throw the TaskKilledException.
    */
   public static void throwTaskKillException() {
-    if (TaskContext.get().getKillReason().isDefined()) {
-      throw new TaskKilledException(TaskContext.get().getKillReason().get());
+    throwTaskKillException(null);
+  }
+
+  public static void throwTaskKillException(String message) {
+    Option<String> sparkReason = TaskContext.get().getKillReason();
+    if (sparkReason.isDefined() && message != null) {
+      throw new TaskKilledException(sparkReason.get() + "; " + message);
+    } else if (sparkReason.isDefined()) {
+      throw new TaskKilledException(sparkReason.get());
+    } else if (message != null) {
+      throw new TaskKilledException(message);
     } else {
       throw new TaskKilledException();
     }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/TaskInterruptedHelper.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/TaskInterruptedHelper.java
@@ -17,8 +17,6 @@
 
 package org.apache.spark.shuffle.celeborn;
 
-import scala.Option;
-
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskKilledException;
 
@@ -32,17 +30,8 @@ public class TaskInterruptedHelper {
    * kill reason, so here we throw the TaskKilledException.
    */
   public static void throwTaskKillException() {
-    throwTaskKillException(null);
-  }
-
-  public static void throwTaskKillException(String message) {
-    Option<String> sparkReason = TaskContext.get().getKillReason();
-    if (sparkReason.isDefined() && message != null) {
-      throw new TaskKilledException(sparkReason.get() + "; " + message);
-    } else if (sparkReason.isDefined()) {
-      throw new TaskKilledException(sparkReason.get());
-    } else if (message != null) {
-      throw new TaskKilledException(message);
+    if (TaskContext.get().getKillReason().isDefined()) {
+      throw new TaskKilledException(TaskContext.get().getKillReason().get());
     } else {
       throw new TaskKilledException();
     }

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -166,18 +166,8 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   public void write(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
     boolean needCleanupPusher = true;
     try {
-      if (canUseFastWrite()) {
-        fastWrite0(records);
-      } else if (dep.mapSideCombine()) {
-        if (dep.aggregator().isEmpty()) {
-          throw new UnsupportedOperationException(
-              "When using map side combine, an aggregator must be specified.");
-        }
-        write0(dep.aggregator().get().combineValuesByKey(records, taskContext));
-      } else {
-        write0(records);
-      }
-      close();
+      boolean iteratorHasNext = doWrite(records);
+      close(iteratorHasNext);
       needCleanupPusher = false;
     } catch (InterruptedException e) {
       TaskInterruptedHelper.throwTaskKillException();
@@ -185,6 +175,26 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       if (needCleanupPusher) {
         cleanupPusher();
       }
+    }
+  }
+
+  boolean doWrite(scala.collection.Iterator<Product2<K, V>> records)
+      throws IOException, InterruptedException {
+    if (canUseFastWrite()) {
+      fastWrite0(records);
+      return records.hasNext();
+    } else if (dep.mapSideCombine()) {
+      if (dep.aggregator().isEmpty()) {
+        throw new UnsupportedOperationException(
+            "When using map side combine, an aggregator must be specified.");
+      }
+      scala.collection.Iterator<?> combinedIterator =
+          dep.aggregator().get().combineValuesByKey(records, taskContext);
+      write0(combinedIterator);
+      return combinedIterator.hasNext();
+    } else {
+      write0(records);
+      return records.hasNext();
     }
   }
 
@@ -331,7 +341,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  private void close() throws IOException, InterruptedException {
+  private void close(boolean iteratorHasNext) throws IOException, InterruptedException {
     // merge and push residual data to reduce network traffic
     // NB: since dataPusher thread have no in-flight data at this point,
     //     we now push merged data by task thread will not introduce any contention
@@ -366,6 +376,10 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     long waitStartTime = System.nanoTime();
     dataPusher.waitOnTermination();
     sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
+    // Check after releasing buffers and draining the pusher so that the TaskKilledException
+    // thrown here does not leak sendBuffers or the push task queue. The check must still come
+    // before mapperEnd so a partial map output is never committed to the shuffle service.
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
 

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -373,13 +373,16 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     sendBuffers = null;
     sendOffsets = null;
 
+    // The check must come before mapperEnd so a partial map output is never committed to the
+    // shuffle service.
+    // Check BEFORE releasing buffers and draining the pusher(the outer finally block will handle
+    // that).
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
+
     long waitStartTime = System.nanoTime();
     dataPusher.waitOnTermination();
     sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
-    // Check after releasing buffers and draining the pusher so that the TaskKilledException
-    // thrown here does not leak sendBuffers or the push task queue. The check must still come
-    // before mapperEnd so a partial map output is never committed to the shuffle service.
-    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
+
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
 

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -147,23 +147,32 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   public void write(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
     boolean needCleanupPusher = true;
     try {
-      if (canUseFastWrite()) {
-        fastWrite0(records);
-      } else if (dep.mapSideCombine()) {
-        if (dep.aggregator().isEmpty()) {
-          throw new UnsupportedOperationException(
-              "When using map side combine, an aggregator must be specified.");
-        }
-        write0(dep.aggregator().get().combineValuesByKey(records, taskContext));
-      } else {
-        write0(records);
-      }
-      close();
+      boolean iteratorHasNext = doWrite(records);
+      close(iteratorHasNext);
       needCleanupPusher = false;
     } finally {
       if (needCleanupPusher) {
         cleanupPusher();
       }
+    }
+  }
+
+  boolean doWrite(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
+    if (canUseFastWrite()) {
+      fastWrite0(records);
+      return records.hasNext();
+    } else if (dep.mapSideCombine()) {
+      if (dep.aggregator().isEmpty()) {
+        throw new UnsupportedOperationException(
+            "When using map side combine, an aggregator must be specified.");
+      }
+      scala.collection.Iterator<?> combinedIterator =
+          dep.aggregator().get().combineValuesByKey(records, taskContext);
+      write0(combinedIterator);
+      return combinedIterator.hasNext();
+    } else {
+      write0(records);
+      return records.hasNext();
     }
   }
 
@@ -304,7 +313,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  private void close() throws IOException {
+  private void close(boolean iteratorHasNext) throws IOException {
     logger.info("Memory used {}", Utils.bytesToString(pusher.getUsed()));
     long pushStartTime = System.nanoTime();
     pusher.pushData(false);
@@ -314,6 +323,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     shuffleClient.pushMergedData(shuffleId, mapId, encodedAttemptId);
 
     updateMapStatus();
+
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
 
     long waitStartTime = System.nanoTime();
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -317,14 +317,19 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     logger.info("Memory used {}", Utils.bytesToString(pusher.getUsed()));
     long pushStartTime = System.nanoTime();
     pusher.pushData(false);
+
+    // The check must come BEFORE mapperEnd so a partial map output is never committed to the
+    // shuffle service.
+    // Check BEFORE pusher.close() so if we throw here the outer finally block will handle the
+    // closing thing.
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
+
     pusher.close(true);
     writeMetrics.incWriteTime(System.nanoTime() - pushStartTime);
 
     shuffleClient.pushMergedData(shuffleId, mapId, encodedAttemptId);
 
     updateMapStatus();
-
-    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
 
     long waitStartTime = System.nanoTime();
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -543,4 +543,11 @@ public class SparkUtils {
           return null;
         });
   }
+
+  public static void assertIteratorFullyConsumed(boolean iteratorHasNext) {
+    if (iteratorHasNext) {
+      TaskInterruptedHelper.throwTaskKillException(
+          "Shuffle write task finished but iterator was not fully consumed.");
+    }
+  }
 }

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.exception.CelebornRuntimeException;
 import org.apache.celeborn.common.network.protocol.TransportMessage;
 import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse;
@@ -544,9 +545,9 @@ public class SparkUtils {
         });
   }
 
-  public static void assertIteratorFullyConsumed(boolean iteratorHasNext) {
+  public static void assertIteratorFullyConsumed(boolean iteratorHasNext) throws IOException {
     if (iteratorHasNext) {
-      TaskInterruptedHelper.throwTaskKillException(
+      throw new CelebornIOException(
           "Shuffle write task finished but iterator was not fully consumed.");
     }
   }

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -43,6 +43,8 @@ import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
+import org.apache.spark.TaskContext$;
+import org.apache.spark.TaskKilledException;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -145,6 +147,7 @@ public abstract class CelebornShuffleWriterSuiteBase {
 
     Mockito.doReturn(metrics).when(taskContext).taskMetrics();
     Mockito.doReturn(taskMemoryManager).when(taskContext).taskMemoryManager();
+    Mockito.doReturn(None$.MODULE$).when(taskContext).getKillReason();
 
     Mockito.doReturn(bmId).when(blockManager).shuffleServerId();
     Mockito.doReturn(blockManager).when(env).blockManager();
@@ -212,6 +215,24 @@ public abstract class CelebornShuffleWriterSuiteBase {
     final CelebornConf conf =
         new CelebornConf().set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "128");
     check(2 << 30, conf, serializer);
+  }
+
+  @Test
+  public void testAssertIteratorFullyConsumed() {
+    SparkUtils.assertIteratorFullyConsumed(false);
+  }
+
+  @Test
+  public void testAssertIteratorFullyConsumedThrows() {
+    TaskContext$.MODULE$.setTaskContext(taskContext);
+    try {
+      SparkUtils.assertIteratorFullyConsumed(true);
+      fail("Expected TaskKilledException when iterator is not fully consumed");
+    } catch (TaskKilledException e) {
+      assertTrue(e.reason().contains("not fully consumed"));
+    } finally {
+      TaskContext$.MODULE$.setTaskContext(null);
+    }
   }
 
   private void check(

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -44,7 +44,6 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
-import org.apache.spark.TaskKilledException;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -227,9 +226,9 @@ public abstract class CelebornShuffleWriterSuiteBase {
     TaskContext$.MODULE$.setTaskContext(taskContext);
     try {
       SparkUtils.assertIteratorFullyConsumed(true);
-      fail("Expected TaskKilledException when iterator is not fully consumed");
-    } catch (TaskKilledException e) {
-      assertTrue(e.reason().contains("not fully consumed"));
+      fail("Expected IOException when iterator is not fully consumed");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("not fully consumed"));
     } finally {
       TaskContext$.MODULE$.setTaskContext(null);
     }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -162,18 +162,8 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   public void write(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
     boolean needCleanupPusher = true;
     try {
-      if (canUseFastWrite()) {
-        fastWrite0(records);
-      } else if (dep.mapSideCombine()) {
-        if (dep.aggregator().isEmpty()) {
-          throw new UnsupportedOperationException(
-              "When using map side combine, an aggregator must be specified.");
-        }
-        write0(dep.aggregator().get().combineValuesByKey(records, taskContext));
-      } else {
-        write0(records);
-      }
-      close();
+      boolean iteratorHasNext = doWrite(records);
+      close(iteratorHasNext);
       needCleanupPusher = false;
     } catch (InterruptedException e) {
       TaskInterruptedHelper.throwTaskKillException();
@@ -181,6 +171,26 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       if (needCleanupPusher) {
         cleanupPusher();
       }
+    }
+  }
+
+  boolean doWrite(scala.collection.Iterator<Product2<K, V>> records)
+      throws IOException, InterruptedException {
+    if (canUseFastWrite()) {
+      fastWrite0(records);
+      return records.hasNext();
+    } else if (dep.mapSideCombine()) {
+      if (dep.aggregator().isEmpty()) {
+        throw new UnsupportedOperationException(
+            "When using map side combine, an aggregator must be specified.");
+      }
+      scala.collection.Iterator<?> combinedIterator =
+          dep.aggregator().get().combineValuesByKey(records, taskContext);
+      write0(combinedIterator);
+      return combinedIterator.hasNext();
+    } else {
+      write0(records);
+      return records.hasNext();
     }
   }
 
@@ -366,7 +376,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  private void close() throws IOException, InterruptedException {
+  private void close(boolean iteratorHasNext) throws IOException, InterruptedException {
     // Send the remaining data in sendBuffer
     long pushMergedDataTime = System.nanoTime();
     closeWrite();
@@ -377,6 +387,10 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     long waitStartTime = System.nanoTime();
     dataPusher.waitOnTermination();
     sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
+    // Check after draining the pusher so that the TaskKilledException thrown here does not leak
+    // the push task queue. The check must still come before mapperEnd so a partial map output
+    // is never committed to the shuffle service.
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -384,13 +384,15 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     writeMetrics.incWriteTime(System.nanoTime() - pushMergedDataTime);
     updateRecordsWrittenMetrics();
 
+    // The check must come before mapperEnd so a partial map output is never committed to the
+    // shuffle service.
+    // Check BEFORE releasing buffers and draining the pusher(the outer finally block will handle
+    // that).
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
+
     long waitStartTime = System.nanoTime();
     dataPusher.waitOnTermination();
     sendBufferPool.returnPushTaskQueue(dataPusher.getAndResetIdleQueue());
-    // Check after draining the pusher so that the TaskKilledException thrown here does not leak
-    // the push task queue. The check must still come before mapperEnd so a partial map output
-    // is never committed to the shuffle service.
-    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -212,17 +212,24 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     return peakMemoryUsedBytes;
   }
 
-  void doWrite(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
+  // Returns true if the iterator still has records (i.e., not fully consumed)
+  @VisibleForTesting
+  boolean doWrite(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
     if (canUseFastWrite()) {
       fastWrite0(records);
+      return records.hasNext();
     } else if (dep.mapSideCombine()) {
       if (dep.aggregator().isEmpty()) {
         throw new UnsupportedOperationException(
             "When using map side combine, an aggregator must be specified.");
       }
-      write0(dep.aggregator().get().combineValuesByKey(records, taskContext));
+      scala.collection.Iterator<?> combinedIterator =
+          dep.aggregator().get().combineValuesByKey(records, taskContext);
+      write0(combinedIterator);
+      return combinedIterator.hasNext();
     } else {
       write0(records);
+      return records.hasNext();
     }
   }
 
@@ -230,8 +237,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   public void write(scala.collection.Iterator<Product2<K, V>> records) throws IOException {
     boolean needCleanupPusher = true;
     try {
-      doWrite(records);
-      close();
+      boolean iteratorHasNext = doWrite(records);
+      close(iteratorHasNext);
       needCleanupPusher = false;
     } finally {
       if (needCleanupPusher) {
@@ -371,7 +378,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  private void close() throws IOException {
+  private void close(boolean iteratorHasNext) throws IOException {
     logger.info("Memory used {}", Utils.bytesToString(pusher.getUsed()));
     long pushStartTime = System.nanoTime();
     pusher.pushData(false);
@@ -380,6 +387,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     shuffleClient.pushMergedData(shuffleId, mapId, encodedAttemptId);
     writeMetrics.incWriteTime(System.nanoTime() - pushStartTime);
     writeMetrics.incRecordsWritten(tmpRecordsWritten);
+
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
 
     long waitStartTime = System.nanoTime();
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -382,13 +382,18 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     logger.info("Memory used {}", Utils.bytesToString(pusher.getUsed()));
     long pushStartTime = System.nanoTime();
     pusher.pushData(false);
+
+    // The check must come BEFORE mapperEnd so a partial map output is never committed to the
+    // shuffle service.
+    // Check BEFORE pusher.close() so if we throw here the outer finally block will handle the
+    // closing thing.
+    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
+
     pusher.close(true);
 
     shuffleClient.pushMergedData(shuffleId, mapId, encodedAttemptId);
     writeMetrics.incWriteTime(System.nanoTime() - pushStartTime);
     writeMetrics.incRecordsWritten(tmpRecordsWritten);
-
-    SparkUtils.assertIteratorFullyConsumed(iteratorHasNext);
 
     long waitStartTime = System.nanoTime();
     shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers, numPartitions);

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -716,4 +716,18 @@ public class SparkUtils {
     String master = conf.get("spark.master", "");
     return master.equals("local") || master.startsWith("local[");
   }
+
+  /**
+   * Asserts that the shuffle writer's iterator has been fully consumed. Only call this when the
+   * shuffle writer finishes writing records. If records remain in the iterator, the task will be
+   * killed.
+   *
+   * @param iteratorHasNext true if the iterator still has records remaining
+   */
+  public static void assertIteratorFullyConsumed(boolean iteratorHasNext) {
+    if (iteratorHasNext) {
+      TaskInterruptedHelper.throwTaskKillException(
+          "Shuffle write task finished but iterator was not fully consumed.");
+    }
+  }
 }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -66,6 +66,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.exception.CelebornRuntimeException;
 import org.apache.celeborn.common.network.protocol.TransportMessage;
 import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse;
@@ -719,14 +720,14 @@ public class SparkUtils {
 
   /**
    * Asserts that the shuffle writer's iterator has been fully consumed. Only call this when the
-   * shuffle writer finishes writing records. If records remain in the iterator, the task will be
-   * killed.
+   * shuffle writer finishes writing records. If records remain in the iterator, the task will fail
+   * with an IOException.
    *
    * @param iteratorHasNext true if the iterator still has records remaining
    */
-  public static void assertIteratorFullyConsumed(boolean iteratorHasNext) {
+  public static void assertIteratorFullyConsumed(boolean iteratorHasNext) throws IOException {
     if (iteratorHasNext) {
-      TaskInterruptedHelper.throwTaskKillException(
+      throw new CelebornIOException(
           "Shuffle write task finished but iterator was not fully consumed.");
     }
   }

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -46,6 +46,8 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.SparkVersionUtil;
 import org.apache.spark.TaskContext;
+import org.apache.spark.TaskContext$;
+import org.apache.spark.TaskKilledException;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -148,10 +150,13 @@ public abstract class CelebornShuffleWriterSuiteBase {
 
     Mockito.doReturn(metrics).when(taskContext).taskMetrics();
     Mockito.doReturn(taskMemoryManager).when(taskContext).taskMemoryManager();
+    Mockito.doReturn(None$.MODULE$).when(taskContext).getKillReason();
 
     Mockito.doReturn(bmId).when(blockManager).shuffleServerId();
     Mockito.doReturn(blockManager).when(env).blockManager();
     Mockito.doReturn(sparkConf).when(env).conf();
+    Mockito.doReturn(false).when(dependency).mapSideCombine();
+    Mockito.doReturn(Option.empty()).when(dependency).aggregator();
     SparkEnv.set(env);
   }
 
@@ -304,6 +309,25 @@ public abstract class CelebornShuffleWriterSuiteBase {
     }
 
     client.shutdown();
+  }
+
+  @Test
+  public void testAssertIteratorFullyConsumed() {
+    // Test that assertIteratorFullyConsumed does not throw when iterator is empty
+    SparkUtils.assertIteratorFullyConsumed(false);
+  }
+
+  @Test
+  public void testAssertIteratorFullyConsumedThrows() {
+    TaskContext$.MODULE$.setTaskContext(taskContext);
+    try {
+      SparkUtils.assertIteratorFullyConsumed(true);
+      fail("Expected TaskKilledException when iterator is not fully consumed");
+    } catch (TaskKilledException e) {
+      assertTrue(e.reason().contains("not fully consumed"));
+    } finally {
+      TaskContext$.MODULE$.setTaskContext(null);
+    }
   }
 
   private void check(

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -47,7 +47,6 @@ import org.apache.spark.SparkEnv;
 import org.apache.spark.SparkVersionUtil;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
-import org.apache.spark.TaskKilledException;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -322,9 +321,9 @@ public abstract class CelebornShuffleWriterSuiteBase {
     TaskContext$.MODULE$.setTaskContext(taskContext);
     try {
       SparkUtils.assertIteratorFullyConsumed(true);
-      fail("Expected TaskKilledException when iterator is not fully consumed");
-    } catch (TaskKilledException e) {
-      assertTrue(e.reason().contains("not fully consumed"));
+      fail("Expected IOException when iterator is not fully consumed");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("not fully consumed"));
     } finally {
       TaskContext$.MODULE$.setTaskContext(null);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a post-write safety check to HashBasedShuffleWriter and SortBasedShuffleWriter: after the write loop completes, verify the input iterator was fully consumed. If records remain, kill the task with TaskKilledException. This guards against silent data loss.

### Why are the changes needed?

It could give another layer of correctness guarantee.


### Does this PR resolve a correctness bug?

Enhance correctness guarantee.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.
