### PR TITLE
[CELEBORN-2318] Miss increment to WRITE_DATA_HARD_SPLIT_COUNT on returning HARD_SPLIT in handlePushData

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -217,6 +217,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           // after worker restart, some tasks still push data to this HARD_SPLIT partition.
           logDebug(s"[Case2] Receive push data for committed hard split partition of " +
             s"(shuffle $shuffleKey, map $mapId attempt $attemptId)")
+          workerSource.incCounter(WorkerSource.WRITE_DATA_HARD_SPLIT_COUNT)
           callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
         } else {
           logWarning(s"While handle PushData, Partition location wasn't found for " +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Missing increment to `WRITE_DATA_HARD_SPLIT_COUNT` on returning HARD_SPLIT



### Why are the changes needed?
- The post-restart detection branch in `handlePushData` (Case2: shuffleKey in storageManager but not in shuffleMapperAttempts) returns HARD_SPLIT without incrementing `WRITE_DATA_HARD_SPLIT_COUNT`
- The sibling Case1 branch (line 398) and all other HARD_SPLIT return paths already increment it
- This makes Case2 invisible to monitoring during rolling restarts


### Does this PR resolve a correctness bug?
No
<!-- Yes/No. (Note: If yes, committer will add `correctness` label to current pull request). -->

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UTs
