### PR TITLE
[CELEBORN-2320] Grafana dashboard linter should build from a checkout instead

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -44,10 +44,13 @@ jobs:
         check-latest: true
     # See https://github.com/grafana/dashboard-linter
     - name: Install dashboard-linter
-      run: go install github.com/grafana/dashboard-linter@latest
+      run: |
+        git clone https://github.com/grafana/dashboard-linter.git
+        cd dashboard-linter
+        go build -o dashboard-linter
     - name: Lint Celeborn Dashboards
       run: |
         for dashboard in assets/grafana/*.json; do
           python3 dev/lint_grafana.py "$dashboard"
-          dashboard-linter lint "$dashboard" --config assets/grafana/.lint --strict
+          ./dashboard-linter/dashboard-linter lint "$dashboard" --config assets/grafana/.lint --strict
         done


### PR DESCRIPTION
### What changes were proposed in this pull request?

Grafana dashboard linter should build from a checkout instead.

Backport https://github.com/grafana/dashboard-linter/pull/252.

### Why are the changes needed?

This PR introduces [GoReleaser](https://github.com/goreleaser/goreleaser-action) to help create GitHub releases and compiled binaries.

The new release workflow will trigger on git tags starting with v.

In particular, providing pre-built release binaries addresses the following problem currently seen in main:

```
go: downloading github.com/grafana/dashboard-linter v0.1.0
go: github.com/grafana/dashboard-linter@latest (in github.com/grafana/dashboard-linter@v0.1.0):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

`go install github.com/grafana/dashboard-linter@<version>` does not currently work because `go.mod` contains a `replace` directive — Go refuses to install a module with replaces. Build from a checkout instead:

```
$ git clone https://github.com/grafana/dashboard-linter.git
$ cd dashboard-linter
$ go build -o dashboard-linter .
$ ./dashboard-linter lint dashboard.json
```

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`Grafana Dashboard CI / lint (pull_request)`.