### PR TITLE
[CELEBORN-2321] Avoid locking disk writers during memory split checks

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -122,13 +122,23 @@ public class PartitionDataWriter implements DeviceObserver {
     currentTierWriter.flush(false, false);
   }
 
-  public synchronized boolean needHardSplitForMemoryShuffleStorage() {
-    if (!(currentTierWriter instanceof MemoryTierWriter)) {
+  public boolean needHardSplitForMemoryShuffleStorage() {
+    // Disk-backed writers never need this memory-only split check. Avoid contending with writes and
+    // evictions on the hot push path for the common case.
+    TierWriterBase tierWriter = currentTierWriter;
+    if (!(tierWriter instanceof MemoryTierWriter)) {
       return false;
     }
-    return !storageManager.localOrDfsStorageAvailable()
-        && (currentTierWriter.fileInfo().getFileLength() > memoryFileStorageMaxFileSize
-            || !MemoryManager.instance().memoryFileStorageAvailable());
+
+    synchronized (this) {
+      tierWriter = currentTierWriter;
+      if (!(tierWriter instanceof MemoryTierWriter)) {
+        return false;
+      }
+      return !storageManager.localOrDfsStorageAvailable()
+          && (tierWriter.fileInfo().getFileLength() > memoryFileStorageMaxFileSize
+              || !MemoryManager.instance().memoryFileStorageAvailable());
+    }
   }
 
   public synchronized void write(ByteBuf data) throws IOException {


### PR DESCRIPTION
### Why are the changes needed?

`needHardSplitForMemoryShuffleStorage()` runs on the push path. Disk-backed writers can never require this memory-only split check, but the method currently acquires the writer lock before returning `false`. For the common disk-backed case, that adds avoidable contention with writes and evictions on a hot path.

### What changes were proposed in this PR?

This PR adds an unlocked fast path for non-memory writers so they return immediately without taking the `PartitionDataWriter` monitor. For memory-backed writers, it rechecks `currentTierWriter` after entering the synchronized block before evaluating the existing hard-split conditions, which preserves the original behavior if the writer tier changes concurrently.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Attempted `build/mvn -pl worker -am -DskipTests compile` on current `main`.
- The Maven reactor fails before reaching `worker` because `celeborn-master_2.12` cannot resolve snapshot test-jar artifacts for `celeborn-common_2.12` and `celeborn-service_2.12`; that failure is unrelated to this change.
