### PR TITLE
[CELEBORN-2322] Upgrade version of docker/login-action for Login to Docker Hub

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,7 +33,7 @@ jobs:
           tar -xzf apache-celeborn-${VERSION}-bin.tgz
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade version of docker/login-action for Login to Docker Hub to `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121`.

### Why are the changes needed?

There is error of dockerhub login in https://github.com/apache/celeborn/actions/runs/24821432736, which is as follows:

```
The action docker/login-action@v3 is not allowed in apache/celeborn because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: 1Password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6, 1Password/load-secrets-action@8d0d610af187e78a2772c2d18d627f4c52d3fbfb, 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259, 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101, DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23, JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f, JetBrains/qodana-action@89eb4357efd2b52e639f3216e63edaf33b82622b, Jimver/cuda-toolkit@3d45d157f327c...
```

[INFRA-27901](https://issues.apache.org/jira/projects/INFRA/issues/INFRA-27901) gives the following suggestion:


> Following the Trivy compromise, more controls have been put in place regarding use of third party actions.
> 
> The only allowed versions of this action are those in the repo:
> 
> https://github.com/apache/infrastructure-actions
> 
> In: https://raw.githubusercontent.com/apache/infrastructure-actions/refs/heads/main/actions.yml at the moment you can use :
> 
> - docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
> - docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
> - docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
> 
> which correspond to these tagged versions:
> 
> docker/login-action:
>   c94ce9fb468520275223c153574b00df6fe4bcc9:
>     tag: v3.7.0
>     expires_at: 2026-06-14
>   b45d80f862d83dbcd57f89517bcf500b2ab88fb2:
>     tag: v4.0.0
>     expires_at: 2026-07-05
>   4907a6ddec9925e35a0a9e82d7399ccc52663121:
>     tag: v4.1.0


### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.