### PR TITLE
[CELEBORN-2326] Bump log4j-core version up to 2.25.4

### DIFF
--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -75,12 +75,11 @@ jetty-util/9.4.58.v20250814//jetty-util-9.4.58.v20250814.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
-log4j-1.2-api/2.24.3//log4j-1.2-api-2.24.3.jar
-log4j-api/2.24.3//log4j-api-2.24.3.jar
-log4j-core/2.24.3//log4j-core-2.24.3.jar
-log4j-slf4j-impl/2.24.3//log4j-slf4j-impl-2.24.3.jar
+log4j-1.2-api/2.25.4//log4j-1.2-api-2.25.4.jar
+log4j-api/2.25.4//log4j-api-2.25.4.jar
+log4j-core/2.25.4//log4j-core-2.25.4.jar
+log4j-slf4j-impl/2.25.4//log4j-slf4j-impl-2.25.4.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
-maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -80,6 +80,7 @@ log4j-api/2.25.4//log4j-api-2.25.4.jar
 log4j-core/2.25.4//log4j-core-2.25.4.jar
 log4j-slf4j-impl/2.25.4//log4j-slf4j-impl-2.25.4.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
+maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <guava.version>33.1.0-jre</guava.version>
     <junit.version>4.13.2</junit.version>
     <leveldb.version>1.8</leveldb.version>
-    <log4j2.version>2.24.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <disruptor.version>3.4.4</disruptor.version>
     <lz4-java.group>at.yawk.lz4</lz4-java.group>
     <lz4-java.version>1.10.4</lz4-java.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -58,7 +58,7 @@ object Dependencies {
   // don't forget update `junitInterfaceVersion` when we upgrade junit
   val junitVersion = "4.13.2"
   val leveldbJniVersion = "1.8"
-  val log4j2Version = "2.24.3"
+  val log4j2Version = "2.25.4"
   val disruptorVersion = "3.4.4"
   val jdkToolsVersion = "0.1"
   val metricsVersion = "4.2.25"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bump Log4j2 version from 2.24.3 to 2.25.4

### Why are the changes needed?
Apache Celeborn currently depends on Apache Log4j Core versions affected by CVE-2026-34480.

### Does this PR resolve a correctness bug?
No.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
CI.