### PR TITLE
[CELEBORN-2331] Parallelize batch open stream client creation

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -256,7 +256,7 @@ class CelebornShuffleReader[K, C](
 
     val clientsByHostPort = CelebornShuffleReader.createClientsInParallel(
       locationsByHostPort.map { case (hostPort, locations) =>
-        (hostPort, locations.get(0))
+        (hostPort, locations.asScala.toSeq)
       }.toSeq,
       streamCreatorPool,
       location =>
@@ -559,20 +559,24 @@ object CelebornShuffleReader {
 
   @VisibleForTesting
   private[celeborn] def createClientsInParallel(
-      locationsByHostPort: Seq[(String, PartitionLocation)],
+      locationsByHostPort: Seq[(String, Seq[PartitionLocation])],
       streamCreatorPool: ThreadPoolExecutor,
       createClient: PartitionLocation => TransportClient,
       onClientCreateFailure: (String, PartitionLocation, Exception) => Unit)
       : Map[String, TransportClient] = {
     val clientsByHostPort = JavaUtils.newConcurrentHashMap[String, TransportClient]()
-    val futures = locationsByHostPort.map { case (hostPort, location) =>
+    val futures = locationsByHostPort.map { case (hostPort, locations) =>
       streamCreatorPool.submit(new Runnable {
         override def run(): Unit = {
-          try {
-            clientsByHostPort.put(hostPort, createClient(location))
-          } catch {
-            case ex: Exception =>
-              onClientCreateFailure(hostPort, location, ex)
+          locations.find { location =>
+            try {
+              clientsByHostPort.put(hostPort, createClient(location))
+              true
+            } catch {
+              case ex: Exception =>
+                onClientCreateFailure(hostPort, location, ex)
+                false
+            }
           }
         }
       })

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.BiFunction
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import com.google.common.annotations.VisibleForTesting
 import org.apache.commons.lang3.tuple.Pair
@@ -205,39 +206,16 @@ class CelebornShuffleReader[K, C](
     val partitionIdList = List.range(startPartition, endPartition).filter(p =>
       fileGroups.partitionGroups.containsKey(p))
 
-    def makeOpenStreamList(locations: JSet[PartitionLocation]): Unit = {
+    val locationsByHostPort =
+      new mutable.LinkedHashMap[String, JArrayList[PartitionLocation]]()
+
+    def groupOpenStreamLocations(locations: JSet[PartitionLocation]): Unit = {
       locations.asScala.foreach { location =>
         partCnt += 1
         val hostPort = location.hostAndFetchPort
-        if (!workerRequestMap.containsKey(hostPort)) {
-          try {
-            val client = shuffleClient.getDataClientFactory().createClient(
-              location.getHost,
-              location.getFetchPort)
-            val pbOpenStreamList = PbOpenStreamList.newBuilder()
-            pbOpenStreamList.setShuffleKey(shuffleKey)
-            workerRequestMap.put(
-              hostPort,
-              (client, new JArrayList[PartitionLocation], pbOpenStreamList))
-          } catch {
-            case ex: Exception =>
-              shuffleClient.excludeFailedFetchLocation(hostPort, ex)
-              logWarning(
-                s"Failed to create client for $shuffleKey-${location.getId} from host: ${hostPort}. " +
-                  s"Shuffle reader will try its replica if exists.")
-          }
-        }
-        workerRequestMap.get(hostPort) match {
-          case (_, locArr, pbOpenStreamListBuilder) =>
-            locArr.add(location)
-            pbOpenStreamListBuilder.addFileName(location.getFileName)
-              .addStartIndex(startMapIndex)
-              .addEndIndex(endMapIndex)
-            pbOpenStreamListBuilder.addReadLocalShuffle(
-              localFetchEnabled && location.getHost.equals(localHostAddress))
-          case _ =>
-            logDebug(s"Empty client for host ${hostPort}")
-        }
+        locationsByHostPort
+          .getOrElseUpdate(hostPort, new JArrayList[PartitionLocation]())
+          .add(location)
       }
     }
 
@@ -272,8 +250,38 @@ class CelebornShuffleReader[K, C](
           locations = filterLocations.asJava
         }
         partitionId2PartitionLocations.put(partitionId, locations)
-        makeOpenStreamList(locations)
+        groupOpenStreamLocations(locations)
       }
+    }
+
+    val clientsByHostPort = CelebornShuffleReader.createClientsInParallel(
+      locationsByHostPort.map { case (hostPort, locations) =>
+        (hostPort, locations.get(0))
+      }.toSeq,
+      streamCreatorPool,
+      location =>
+        shuffleClient.getDataClientFactory().createClient(
+          location.getHost,
+          location.getFetchPort),
+      (hostPort, location, ex) => {
+        shuffleClient.excludeFailedFetchLocation(hostPort, ex)
+        logWarning(
+          s"Failed to create client for $shuffleKey-${location.getId} from host: ${hostPort}. " +
+            s"Shuffle reader will try its replica if exists.")
+      })
+
+    clientsByHostPort.foreach { case (hostPort, client) =>
+      val locArr = locationsByHostPort(hostPort)
+      val pbOpenStreamList = PbOpenStreamList.newBuilder()
+      pbOpenStreamList.setShuffleKey(shuffleKey)
+      locArr.asScala.foreach { location =>
+        pbOpenStreamList.addFileName(location.getFileName)
+          .addStartIndex(startMapIndex)
+          .addEndIndex(endMapIndex)
+        pbOpenStreamList.addReadLocalShuffle(
+          localFetchEnabled && location.getHost.equals(localHostAddress))
+      }
+      workerRequestMap.put(hostPort, (client, locArr, pbOpenStreamList))
     }
 
     val locationStreamHandlerMap: ConcurrentHashMap[PartitionLocation, PbStreamHandler] =
@@ -548,6 +556,31 @@ class CelebornShuffleReader[K, C](
 
 object CelebornShuffleReader {
   var streamCreatorPool: ThreadPoolExecutor = null
+
+  @VisibleForTesting
+  private[celeborn] def createClientsInParallel(
+      locationsByHostPort: Seq[(String, PartitionLocation)],
+      streamCreatorPool: ThreadPoolExecutor,
+      createClient: PartitionLocation => TransportClient,
+      onClientCreateFailure: (String, PartitionLocation, Exception) => Unit)
+      : Map[String, TransportClient] = {
+    val clientsByHostPort = JavaUtils.newConcurrentHashMap[String, TransportClient]()
+    val futures = locationsByHostPort.map { case (hostPort, location) =>
+      streamCreatorPool.submit(new Runnable {
+        override def run(): Unit = {
+          try {
+            clientsByHostPort.put(hostPort, createClient(location))
+          } catch {
+            case ex: Exception =>
+              onClientCreateFailure(hostPort, location, ex)
+          }
+        }
+      })
+    }
+    futures.foreach(_.get())
+    clientsByHostPort.asScala.toMap
+  }
+
   // Register the deserializer for GetReducerFileGroupResponse broadcast
   ShuffleClient.registerDeserializeReducerFileGroupResponseFunction(new BiFunction[
     Integer,

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -568,20 +568,37 @@ object CelebornShuffleReader {
     val futures = locationsByHostPort.map { case (hostPort, locations) =>
       streamCreatorPool.submit(new Runnable {
         override def run(): Unit = {
-          locations.find { location =>
+          val locationsIterator = locations.iterator
+          var clientCreated = false
+          while (!clientCreated && locationsIterator.hasNext) {
+            val location = locationsIterator.next()
             try {
               clientsByHostPort.put(hostPort, createClient(location))
-              true
+              clientCreated = true
             } catch {
+              case ex: InterruptedException =>
+                Thread.currentThread().interrupt()
+                throw ex
               case ex: Exception =>
                 onClientCreateFailure(hostPort, location, ex)
-                false
             }
           }
         }
       })
     }
-    futures.foreach(_.get())
+    var waitCompleted = false
+    try {
+      futures.foreach(_.get())
+      waitCompleted = true
+    } catch {
+      case ex: InterruptedException =>
+        Thread.currentThread().interrupt()
+        throw ex
+    } finally {
+      if (!waitCompleted) {
+        futures.foreach(_.cancel(true))
+      }
+    }
     clientsByHostPort.asScala.toMap
   }
 

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -206,8 +206,45 @@ class CelebornShuffleReader[K, C](
     val partitionIdList = List.range(startPartition, endPartition).filter(p =>
       fileGroups.partitionGroups.containsKey(p))
 
+    val parallelClientCreationEnabled = conf.batchOpenStreamParallelClientCreationEnabled
     val locationsByHostPort =
       new mutable.LinkedHashMap[String, JArrayList[PartitionLocation]]()
+
+    def makeOpenStreamList(locations: JSet[PartitionLocation]): Unit = {
+      locations.asScala.foreach { location =>
+        partCnt += 1
+        val hostPort = location.hostAndFetchPort
+        if (!workerRequestMap.containsKey(hostPort)) {
+          try {
+            val client = shuffleClient.getDataClientFactory().createClient(
+              location.getHost,
+              location.getFetchPort)
+            val pbOpenStreamList = PbOpenStreamList.newBuilder()
+            pbOpenStreamList.setShuffleKey(shuffleKey)
+            workerRequestMap.put(
+              hostPort,
+              (client, new JArrayList[PartitionLocation], pbOpenStreamList))
+          } catch {
+            case ex: Exception =>
+              shuffleClient.excludeFailedFetchLocation(hostPort, ex)
+              logWarning(
+                s"Failed to create client for $shuffleKey-${location.getId} from host: ${hostPort}. " +
+                  s"Shuffle reader will try its replica if exists.")
+          }
+        }
+        workerRequestMap.get(hostPort) match {
+          case (_, locArr, pbOpenStreamListBuilder) =>
+            locArr.add(location)
+            pbOpenStreamListBuilder.addFileName(location.getFileName)
+              .addStartIndex(startMapIndex)
+              .addEndIndex(endMapIndex)
+            pbOpenStreamListBuilder.addReadLocalShuffle(
+              localFetchEnabled && location.getHost.equals(localHostAddress))
+          case _ =>
+            logDebug(s"Empty client for host ${hostPort}")
+        }
+      }
+    }
 
     def groupOpenStreamLocations(locations: JSet[PartitionLocation]): Unit = {
       locations.asScala.foreach { location =>
@@ -250,38 +287,44 @@ class CelebornShuffleReader[K, C](
           locations = filterLocations.asJava
         }
         partitionId2PartitionLocations.put(partitionId, locations)
-        groupOpenStreamLocations(locations)
+        if (parallelClientCreationEnabled) {
+          groupOpenStreamLocations(locations)
+        } else {
+          makeOpenStreamList(locations)
+        }
       }
     }
 
-    val clientsByHostPort = CelebornShuffleReader.createClientsInParallel(
-      locationsByHostPort.map { case (hostPort, locations) =>
-        (hostPort, locations.asScala.toSeq)
-      }.toSeq,
-      streamCreatorPool,
-      location =>
-        shuffleClient.getDataClientFactory().createClient(
-          location.getHost,
-          location.getFetchPort),
-      (hostPort, location, ex) => {
-        shuffleClient.excludeFailedFetchLocation(hostPort, ex)
-        logWarning(
-          s"Failed to create client for $shuffleKey-${location.getId} from host: ${hostPort}. " +
-            s"Shuffle reader will try its replica if exists.")
-      })
+    if (parallelClientCreationEnabled) {
+      val clientsByHostPort = CelebornShuffleReader.createClientsInParallel(
+        locationsByHostPort.map { case (hostPort, locations) =>
+          (hostPort, locations.asScala.toSeq)
+        }.toSeq,
+        streamCreatorPool,
+        location =>
+          shuffleClient.getDataClientFactory().createClient(
+            location.getHost,
+            location.getFetchPort),
+        (hostPort, location, ex) => {
+          shuffleClient.excludeFailedFetchLocation(hostPort, ex)
+          logWarning(
+            s"Failed to create client for $shuffleKey-${location.getId} from host: ${hostPort}. " +
+              s"Shuffle reader will try its replica if exists.")
+        })
 
-    clientsByHostPort.foreach { case (hostPort, client) =>
-      val locArr = locationsByHostPort(hostPort)
-      val pbOpenStreamList = PbOpenStreamList.newBuilder()
-      pbOpenStreamList.setShuffleKey(shuffleKey)
-      locArr.asScala.foreach { location =>
-        pbOpenStreamList.addFileName(location.getFileName)
-          .addStartIndex(startMapIndex)
-          .addEndIndex(endMapIndex)
-        pbOpenStreamList.addReadLocalShuffle(
-          localFetchEnabled && location.getHost.equals(localHostAddress))
+      clientsByHostPort.foreach { case (hostPort, client) =>
+        val locArr = locationsByHostPort(hostPort)
+        val pbOpenStreamList = PbOpenStreamList.newBuilder()
+        pbOpenStreamList.setShuffleKey(shuffleKey)
+        locArr.asScala.foreach { location =>
+          pbOpenStreamList.addFileName(location.getFileName)
+            .addStartIndex(startMapIndex)
+            .addEndIndex(endMapIndex)
+          pbOpenStreamList.addReadLocalShuffle(
+            localFetchEnabled && location.getHost.equals(localHostAddress))
+        }
+        workerRequestMap.put(hostPort, (client, locArr, pbOpenStreamList))
       }
-      workerRequestMap.put(hostPort, (client, locArr, pbOpenStreamList))
     }
 
     val locationStreamHandlerMap: ConcurrentHashMap[PartitionLocation, PbStreamHandler] =

--- a/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
+++ b/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.shuffle.celeborn
 
+import java.io.IOException
 import java.nio.file.Files
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.{CountDownLatch, TimeoutException, TimeUnit}
 
 import org.apache.spark.{Dependency, ShuffleDependency, TaskContext}
 import org.apache.spark.shuffle.ShuffleReadMetricsReporter
@@ -31,6 +32,9 @@ import org.apache.celeborn.client.{DummyShuffleClient, ShuffleClient}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.CelebornIOException
 import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.network.client.TransportClient
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.util.ThreadUtils
 
 class CelebornShuffleReaderSuite extends AnyFunSuite {
 
@@ -92,4 +96,73 @@ class CelebornShuffleReaderSuite extends AnyFunSuite {
       shuffleReader.shuffleClient.asInstanceOf[DummyShuffleClient].fetchFailureCount.get() === 2)
 
   }
+
+  test("create batch open stream clients in parallel per worker") {
+    val worker0 = newLocation(0, "worker-0", 19098)
+    val worker1 = newLocation(0, "worker-1", 19098)
+    val worker0Client = Mockito.mock(classOf[TransportClient])
+    val worker1Client = Mockito.mock(classOf[TransportClient])
+    val streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool("test-create-client", 2, 60)
+    val started = new CountDownLatch(2)
+    val release = new CountDownLatch(1)
+
+    try {
+      val clientsFuture = scala.concurrent.Future {
+        CelebornShuffleReader.createClientsInParallel(
+          Seq(
+            worker0.hostAndFetchPort -> worker0,
+            worker1.hostAndFetchPort -> worker1),
+          streamCreatorPool,
+          location => {
+            started.countDown()
+            assert(started.await(5, TimeUnit.SECONDS))
+            assert(release.await(5, TimeUnit.SECONDS))
+            if (location eq worker0) worker0Client else worker1Client
+          },
+          (_, _, ex) => fail("Unexpected client creation failure", ex))
+      }(scala.concurrent.ExecutionContext.global)
+
+      assert(started.await(5, TimeUnit.SECONDS))
+      release.countDown()
+      val clients =
+        scala.concurrent.Await.result(
+          clientsFuture,
+          scala.concurrent.duration.Duration(5, "seconds"))
+
+      assert(clients(worker0.hostAndFetchPort) eq worker0Client)
+      assert(clients(worker1.hostAndFetchPort) eq worker1Client)
+    } finally {
+      streamCreatorPool.shutdownNow()
+    }
+  }
+
+  test("skip failed batch open stream client creation while keeping healthy workers") {
+    val failedWorker = newLocation(0, "worker-0", 19098)
+    val healthyWorker = newLocation(0, "worker-1", 19098)
+    val healthyClient = Mockito.mock(classOf[TransportClient])
+    val streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool("test-create-client", 2, 60)
+    var failedHostPort: String = null
+
+    try {
+      val clients = CelebornShuffleReader.createClientsInParallel(
+        Seq(
+          failedWorker.hostAndFetchPort -> failedWorker,
+          healthyWorker.hostAndFetchPort -> healthyWorker),
+        streamCreatorPool,
+        location => {
+          if (location eq failedWorker) throw new IOException("boom")
+          healthyClient
+        },
+        (hostPort, _, _) => failedHostPort = hostPort)
+
+      assert(failedHostPort === failedWorker.hostAndFetchPort)
+      assert(!clients.contains(failedWorker.hostAndFetchPort))
+      assert(clients(healthyWorker.hostAndFetchPort) eq healthyClient)
+    } finally {
+      streamCreatorPool.shutdownNow()
+    }
+  }
+
+  private def newLocation(id: Int, host: String, fetchPort: Int): PartitionLocation =
+    new PartitionLocation(id, 0, host, 0, 0, fetchPort, 0, PartitionLocation.Mode.PRIMARY)
 }

--- a/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
+++ b/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
@@ -110,8 +110,8 @@ class CelebornShuffleReaderSuite extends AnyFunSuite {
       val clientsFuture = scala.concurrent.Future {
         CelebornShuffleReader.createClientsInParallel(
           Seq(
-            worker0.hostAndFetchPort -> worker0,
-            worker1.hostAndFetchPort -> worker1),
+            worker0.hostAndFetchPort -> Seq(worker0),
+            worker1.hostAndFetchPort -> Seq(worker1)),
           streamCreatorPool,
           location => {
             started.countDown()
@@ -146,8 +146,8 @@ class CelebornShuffleReaderSuite extends AnyFunSuite {
     try {
       val clients = CelebornShuffleReader.createClientsInParallel(
         Seq(
-          failedWorker.hostAndFetchPort -> failedWorker,
-          healthyWorker.hostAndFetchPort -> healthyWorker),
+          failedWorker.hostAndFetchPort -> Seq(failedWorker),
+          healthyWorker.hostAndFetchPort -> Seq(healthyWorker)),
         streamCreatorPool,
         location => {
           if (location eq failedWorker) throw new IOException("boom")
@@ -158,6 +158,30 @@ class CelebornShuffleReaderSuite extends AnyFunSuite {
       assert(failedHostPort === failedWorker.hostAndFetchPort)
       assert(!clients.contains(failedWorker.hostAndFetchPort))
       assert(clients(healthyWorker.hostAndFetchPort) eq healthyClient)
+    } finally {
+      streamCreatorPool.shutdownNow()
+    }
+  }
+
+  test("retry failed batch open stream client creation for the same worker") {
+    val failedLocation = newLocation(0, "worker-0", 19098)
+    val retryLocation = newLocation(1, "worker-0", 19098)
+    val client = Mockito.mock(classOf[TransportClient])
+    val streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool("test-create-client", 1, 60)
+    var failureCount = 0
+
+    try {
+      val clients = CelebornShuffleReader.createClientsInParallel(
+        Seq(failedLocation.hostAndFetchPort -> Seq(failedLocation, retryLocation)),
+        streamCreatorPool,
+        location => {
+          if (location eq failedLocation) throw new IOException("boom")
+          client
+        },
+        (_, _, _) => failureCount += 1)
+
+      assert(failureCount === 1)
+      assert(clients(failedLocation.hostAndFetchPort) eq client)
     } finally {
       streamCreatorPool.shutdownNow()
     }

--- a/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
+++ b/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.celeborn
 import java.io.IOException
 import java.nio.file.Files
 import java.util.concurrent.{CountDownLatch, TimeoutException, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import org.apache.spark.{Dependency, ShuffleDependency, TaskContext}
 import org.apache.spark.shuffle.ShuffleReadMetricsReporter
@@ -184,6 +185,73 @@ class CelebornShuffleReaderSuite extends AnyFunSuite {
       assert(clients(failedLocation.hostAndFetchPort) eq client)
     } finally {
       streamCreatorPool.shutdownNow()
+    }
+  }
+
+  test("cancel batch open stream client creation when waiting thread is interrupted") {
+    val blockedLocation = newLocation(0, "worker-0", 19098)
+    val retryLocation = newLocation(1, "worker-0", 19098)
+    val retryClient = Mockito.mock(classOf[TransportClient])
+    val streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool("test-create-client", 1, 60)
+    val clientStarted = new CountDownLatch(1)
+    val releaseClient = new CountDownLatch(1)
+    val clientInterrupted = new CountDownLatch(1)
+    val retried = new AtomicBoolean(false)
+    val failureReported = new AtomicBoolean(false)
+    val callerInterrupted = new AtomicBoolean(false)
+    val callerFailure = new AtomicReference[Throwable]()
+
+    val caller = new Thread(new Runnable {
+      override def run(): Unit = {
+        try {
+          CelebornShuffleReader.createClientsInParallel(
+            Seq(blockedLocation.hostAndFetchPort -> Seq(blockedLocation, retryLocation)),
+            streamCreatorPool,
+            location => {
+              if (location eq blockedLocation) {
+                clientStarted.countDown()
+                try {
+                  releaseClient.await()
+                  retryClient
+                } catch {
+                  case ex: InterruptedException =>
+                    clientInterrupted.countDown()
+                    throw ex
+                }
+              } else {
+                retried.set(true)
+                retryClient
+              }
+            },
+            (_, _, _) => failureReported.set(true))
+          callerFailure.set(new AssertionError("Expected waiting thread to be interrupted"))
+        } catch {
+          case _: InterruptedException =>
+            callerInterrupted.set(Thread.currentThread().isInterrupted)
+          case ex: Throwable =>
+            callerFailure.set(ex)
+        }
+      }
+    })
+
+    try {
+      caller.start()
+      assert(clientStarted.await(5, TimeUnit.SECONDS))
+      caller.interrupt()
+      caller.join(TimeUnit.SECONDS.toMillis(5))
+      assert(!caller.isAlive)
+      assert(clientInterrupted.await(5, TimeUnit.SECONDS))
+      streamCreatorPool.shutdown()
+      assert(streamCreatorPool.awaitTermination(5, TimeUnit.SECONDS))
+      assert(callerFailure.get() == null)
+      assert(callerInterrupted.get())
+      assert(!retried.get())
+      assert(!failureReported.get())
+    } finally {
+      releaseClient.countDown()
+      streamCreatorPool.shutdownNow()
+      caller.interrupt()
+      caller.join(TimeUnit.SECONDS.toMillis(5))
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1172,6 +1172,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def enableReadLocalShuffleFile: Boolean = get(READ_LOCAL_SHUFFLE_FILE)
   def readLocalShuffleThreads: Int = get(READ_LOCAL_SHUFFLE_THREADS)
   def readStreamCreatorPoolThreads: Int = get(READ_STREAM_CREATOR_POOL_THREADS)
+  def batchOpenStreamParallelClientCreationEnabled: Boolean =
+    get(CLIENT_SPARK_BATCH_OPEN_STREAM_PARALLEL_CLIENT_CREATION_ENABLED)
 
   def registerShuffleFilterExcludedWorkerEnabled: Boolean =
     get(REGISTER_SHUFFLE_FILTER_EXCLUDED_WORKER_ENABLED)
@@ -6323,6 +6325,15 @@ object CelebornConf extends Logging {
       .doc("Threads count for streamCreatorPool in CelebornShuffleReader.")
       .intConf
       .createWithDefault(32)
+
+  val CLIENT_SPARK_BATCH_OPEN_STREAM_PARALLEL_CLIENT_CREATION_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.spark.batch.openStream.parallelClientCreation.enabled")
+      .categories("client")
+      .version("0.6.3")
+      .doc("Whether to create data clients in parallel before sending Spark batch open-stream requests. " +
+        "When false, data clients are created serially.")
+      .booleanConf
+      .createWithDefault(true)
 
   val CLIENT_CHUNK_PREFETCH_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.client.chunk.prefetch.enabled")

--- a/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
@@ -492,4 +492,13 @@ class CelebornConfSuite extends CelebornFunSuite {
     }
   }
 
+  test("parallel Spark batch open stream client creation can be disabled") {
+    val conf = new CelebornConf()
+
+    assert(conf.batchOpenStreamParallelClientCreationEnabled)
+
+    conf.set(CLIENT_SPARK_BATCH_OPEN_STREAM_PARALLEL_CLIENT_CREATION_ENABLED.key, "false")
+    assert(!conf.batchOpenStreamParallelClientCreationEnabled)
+  }
+
 }

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -124,6 +124,7 @@ license: |
 | celeborn.client.shuffle.reviseLostShuffles.enabled | false | false | Whether to revise lost shuffles. | 0.6.0 |  | 
 | celeborn.client.shuffleDataLostOnUnknownWorker.enabled | false | false | Whether to mark shuffle data lost when unknown worker is detected. | 0.6.3 |  | 
 | celeborn.client.slot.assign.maxWorkers | 10000 | false | Max workers that slots of one shuffle can be allocated on. Will choose the smaller positive one from Master side and Client side, see `celeborn.master.slot.assign.maxWorkers`. | 0.3.1 |  | 
+| celeborn.client.spark.batch.openStream.parallelClientCreation.enabled | true | false | Whether to create data clients in parallel before sending Spark batch open-stream requests. When false, data clients are created serially. | 0.6.3 |  | 
 | celeborn.client.spark.fetch.cleanFailedShuffle | false | false | whether to clean those disk space occupied by shuffles which cannot be fetched | 0.6.0 |  | 
 | celeborn.client.spark.fetch.cleanFailedShuffleInterval | 1s | false | the interval to clean the failed-to-fetch shuffle files, only valid when celeborn.client.spark.fetch.cleanFailedShuffle is enabled | 0.6.0 |  | 
 | celeborn.client.spark.push.dynamicWriteMode.enabled | false | false | Whether to dynamically switch push write mode based on conditions.If true, shuffle mode will be only determined by partition count | 0.5.0 |  | 


### PR DESCRIPTION
## Why are the changes needed?

`CelebornShuffleReader` batches stream-open requests by worker, but it previously created the data client for each worker serially before sending those already-parallel batch requests. When a reducer reads from multiple workers, connection setup for a slow or unavailable worker can delay useful work against the remaining healthy workers.

Parallelizing this setup removes the worker-by-worker wait from the normal path. Because this changes task-side connection scheduling, the optimization also needs an operational fallback that restores the prior behavior without requiring a code rollback.

## What changes were proposed in this PR?

The reader now first gathers pending stream-open locations by worker address, then creates one data client per distinct worker concurrently using the existing stream-creator pool. Once client setup completes, it sends the existing `BATCH_OPEN_STREAM` requests only for workers with an available client, allowing healthy workers to proceed even if another worker fails during setup.

The client-creation phase preserves the prior retry behavior for later locations on the same worker when an earlier client attempt fails. It also handles task cancellation explicitly: if the waiting Spark task is interrupted, it restores the interrupt status and cancels unfinished setup work; worker-side interruption is propagated rather than treated as an ordinary retryable failure.

This optimization is controlled by `celeborn.client.spark.batch.openStream.parallelClientCreation.enabled`, which defaults to `true`. Setting it to `false` selects the original serial client-creation and request-building flow, giving deployments a targeted rollback switch if parallel connection setup causes unexpected operational behavior.

## How was this PR tested?

- Unit tests for parallel client setup, failure/retry handling, cancellation on interruption, and the new configuration default and override.
- Configuration documentation generation validation for the new client setting.
- Spotless formatting validation.
