### PR TITLE
[CELEBORN-2333] Bump Flink from 2.2.0 to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2010,7 +2010,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>2.2.0</flink.version>
+        <flink.version>2.2.1</flink.version>
         <flink.binary.version>2.2</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-2.2_${scala.binary.version}</celeborn.flink.plugin.artifact>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1304,7 +1304,7 @@ object Flink21 extends FlinkClientProjects {
 }
 
 object Flink22 extends FlinkClientProjects {
-  val flinkVersion = "2.2.0"
+  val flinkVersion = "2.2.1"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-2.2"
@@ -1343,7 +1343,7 @@ trait FlinkClientProjects {
     .aggregate(flinkCommon, flinkClient, flinkIt)
 
   // get flink major version. e.g:
-  //   2.2.0 -> 2.2
+  //   2.2.1 -> 2.2
   //   2.1.1 -> 2.1
   //   2.0.1 -> 2.0
   //   1.20.3 -> 1.20


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Flink from 2.2.0 to 2.2.1

### Why are the changes needed?

Flink 2.2.1 has been announced to release: [Apache Flink 2.2.1 Release Announcement](https://flink.apache.org/2026/05/15/apache-flink-2.2.1-release-announcement/). The profile flink-2.2 could bump Flink from 2.2.0 to 2.2.1.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.