### PR TITLE
[CELEBORN-2340] Explicitly trim Flusher thread pool cache when flusher queue is empty

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -95,9 +95,9 @@ abstract private[worker] class Flusher(
                   }
                   lastBeginFlushTime.set(index, -1)
                 }
-                Utils.tryLogNonFatalError(returnBuffer(task.buffer, task.keepBuffer))
-                task.notifier.numPendingFlushes.decrementAndGet()
               }
+              Utils.tryLogNonFatalError(returnBuffer(task.buffer, task.keepBuffer))
+              task.notifier.numPendingFlushes.decrementAndGet()
             } else {
               allocator match {
                 case alloc: PooledByteBufAllocator =>

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -73,29 +73,38 @@ abstract private[worker] class Flusher(
             copyBytes = new Array[Byte](maxTaskSize.toInt)
           }
           while (!stopFlag.get()) {
-            val task = workingQueues(index).take()
-            val key = s"Flusher-$this-${Random.nextInt()}"
-            workerSource.sample(getFlushTimeMetric(), key) {
-              if (!task.notifier.hasException) {
-                try {
-                  val flushBeginTime = System.nanoTime()
-                  lastBeginFlushTime.set(index, flushBeginTime)
-                  task.flush(copyBytes)
-                  if (flushTimeMetric != null) {
-                    val delta = System.nanoTime() - flushBeginTime
-                    flushTimeMetric.update(delta)
+            val task = workingQueues(index).poll(1000, TimeUnit.MILLISECONDS)
+            if (task != null) {
+              val key = s"Flusher-$this-${Random.nextInt()}"
+              workerSource.sample(getFlushTimeMetric(), key) {
+                if (!task.notifier.hasException) {
+                  try {
+                    val flushBeginTime = System.nanoTime()
+                    lastBeginFlushTime.set(index, flushBeginTime)
+                    task.flush(copyBytes)
+                    if (flushTimeMetric != null) {
+                      val delta = System.nanoTime() - flushBeginTime
+                      flushTimeMetric.update(delta)
+                    }
+                  } catch {
+                    case t: Throwable =>
+                      val e = ExceptionUtils.wrapThrowableToIOException(t)
+                      task.notifier.setException(e)
+                      processIOException(e, DiskStatus.READ_OR_WRITE_FAILURE)
+                      logWarning(s"Flusher-$this-thread-$index encounter exception.", t)
                   }
-                } catch {
-                  case t: Throwable =>
-                    val e = ExceptionUtils.wrapThrowableToIOException(t)
-                    task.notifier.setException(e)
-                    processIOException(e, DiskStatus.READ_OR_WRITE_FAILURE)
-                    logWarning(s"Flusher-$this-thread-$index encounter exception.", t)
+                  lastBeginFlushTime.set(index, -1)
                 }
-                lastBeginFlushTime.set(index, -1)
+                Utils.tryLogNonFatalError(returnBuffer(task.buffer, task.keepBuffer))
+                task.notifier.numPendingFlushes.decrementAndGet()
               }
-              Utils.tryLogNonFatalError(returnBuffer(task.buffer, task.keepBuffer))
-              task.notifier.numPendingFlushes.decrementAndGet()
+            } else {
+              allocator match {
+                case alloc: PooledByteBufAllocator =>
+                  // Free buffer pool memory to main direct memory when flush thread is idle.
+                  alloc.trimCurrentThreadCache
+                case _ =>
+              }
             }
           }
         }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/FlusherSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/FlusherSuite.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.storage
+
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.netty.buffer.{ByteBufAllocator, CompositeByteBuf, PooledByteBufAllocator, UnpooledByteBufAllocator}
+import org.mockito.Mockito.{timeout, verify}
+import org.mockito.MockitoSugar.{mock, spy}
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.Futures.{interval, timeout => patienceTimeout}
+import org.scalatest.time.SpanSugar._
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.meta.DiskStatus
+import org.apache.celeborn.common.metrics.source.AbstractSource
+import org.apache.celeborn.service.deploy.worker.WorkerSource
+import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
+
+class FlusherSuite extends CelebornFunSuite {
+
+  // The flusher worker threads block in poll() for up to 1000ms (see Flusher)
+  // before falling through to the idle/trim branch, so verifications must allow
+  // at least that long plus scheduling slack.
+  private val VERIFY_TIMEOUT_MS = 5000
+
+  private val flushers = new ArrayBuffer[TestFlusher]()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    MemoryManager.reset()
+  }
+
+  override protected def afterEach(): Unit = {
+    flushers.foreach(_.shutdown())
+    flushers.clear()
+    MemoryManager.reset()
+    super.afterEach()
+  }
+
+  /**
+   * Minimal concrete [[Flusher]] used to exercise the worker loop in isolation.
+   * The base class starts its worker threads in `init()` on construction.
+   */
+  private class TestFlusher(
+      workerSource: AbstractSource,
+      allocator: ByteBufAllocator,
+      threadCount: Int)
+    extends Flusher(
+      workerSource,
+      threadCount,
+      allocator,
+      16,
+      null,
+      "test-mount",
+      false,
+      1024L) {
+
+    override def processIOException(e: IOException, deviceErrorType: DiskStatus): Unit = {}
+
+    override def getFlushTimeMetric(): String = WorkerSource.FLUSH_LOCAL_DATA_TIME
+
+    def shutdown(): Unit = {
+      stopFlag.set(true)
+      // Interrupt the threads blocked in poll() so they exit promptly and the
+      // suite's ThreadAudit does not report a leak.
+      workers.foreach(worker => if (worker != null) worker.shutdownNow())
+    }
+  }
+
+  private def newFlusher(
+      allocator: ByteBufAllocator,
+      threadCount: Int = 1,
+      workerSource: AbstractSource = mock[AbstractSource]): TestFlusher = {
+    val flusher = new TestFlusher(workerSource, allocator, threadCount)
+    flushers += flusher
+    flusher
+  }
+
+  test("trimCurrentThreadCache is invoked when the working queue stays empty") {
+    val allocator = spy(new PooledByteBufAllocator(true))
+    newFlusher(allocator)
+
+    // With no tasks ever submitted, the idle branch must trim the pooled
+    // allocator's thread-local cache, returning that memory to the shared pool.
+    verify(allocator, timeout(VERIFY_TIMEOUT_MS).atLeastOnce()).trimCurrentThreadCache
+  }
+
+  test("each idle flusher worker thread trims its own thread cache") {
+    val threadCount = 3
+    val allocator = spy(new PooledByteBufAllocator(true))
+    newFlusher(allocator, threadCount)
+
+    // trimCurrentThreadCache trims only the calling thread's cache, so every
+    // idle worker thread must call it - expect at least one call per thread.
+    verify(allocator, timeout(VERIFY_TIMEOUT_MS).atLeast(threadCount)).trimCurrentThreadCache
+  }
+
+  test("non-pooled allocator skips trim and the worker loop keeps processing tasks") {
+    MemoryManager.initialize(new CelebornConf())
+    val workerSource = new WorkerSource(new CelebornConf())
+    // A non-pooled allocator has no thread cache: the idle branch must take the
+    // `case _ =>` no-op path. UnpooledByteBufAllocator has no trimCurrentThreadCache
+    // to call, so the only way this test passes is if that path is a clean no-op.
+    val flusher = newFlusher(UnpooledByteBufAllocator.DEFAULT, workerSource = workerSource)
+
+    // Let the worker spin through several idle poll cycles before submitting work,
+    // so we know the idle branch ran without disrupting the loop.
+    Thread.sleep(2500)
+    assertTaskIsFlushed(flusher, workerSource)
+  }
+
+  test("submitted task is still flushed after switching take() to poll()") {
+    MemoryManager.initialize(new CelebornConf())
+    val workerSource = new WorkerSource(new CelebornConf())
+    val allocator = spy(new PooledByteBufAllocator(true))
+    val flusher = newFlusher(allocator, workerSource = workerSource)
+
+    assertTaskIsFlushed(flusher, workerSource)
+  }
+
+  /** Submits one task and asserts it is flushed and its pending count drained. */
+  private def assertTaskIsFlushed(flusher: TestFlusher, source: AbstractSource): Unit = {
+    val bytes = "flush-after-poll".getBytes("UTF-8")
+    val buffer: CompositeByteBuf = UnpooledByteBufAllocator.DEFAULT.compositeBuffer()
+    buffer.writeBytes(bytes)
+
+    val notifier = new FlushNotifier()
+    notifier.numPendingFlushes.incrementAndGet()
+    val flushed = new AtomicBoolean(false)
+    val task = new FlushTask(buffer, notifier, false, source) {
+      override def flush(copyBytes: Array[Byte]): Unit = flushed.set(true)
+    }
+
+    assert(flusher.addTask(task, 1000, 0))
+
+    eventually(patienceTimeout(VERIFY_TIMEOUT_MS.millis), interval(50.millis)) {
+      assert(flushed.get(), "flush() should have been invoked via the poll() path")
+      assert(
+        notifier.numPendingFlushes.get() == 0,
+        "pending flush count should be decremented after the task is processed")
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

We are using 0.5.3 and noticed that after a worker processes a heavy shuffle workload, its Netty direct memory metric (usedDirectMemory) spikes to a high value and then gets stuck and never recovers — even after the all flush ends and the worker becomes completely idle. The memory stays stuck until the worker is restarted.

<img width="1372" height="327" alt="Screenshot 2026-05-19 at 2 25 38 PM" src="https://github.com/user-attachments/assets/294ccb97-a1dc-4785-ad27-ecda36db0ed4" />

Although i noticed that there are fixes which tries to handle this by using pinnedMemory – https://github.com/apache/celeborn/pull/3018 and https://github.com/apache/celeborn/pull/3099 but i think that this PR is the correct way to handle this instead of relying on pinnedMemory.

### Why are the changes needed?

`PooledByteBufAllocator` maintains a per-thread `PoolThreadCache` for each Flusher thread. When a ByteBuf is released, instead of immediately returning its slot to the `PoolArena`, it goes into this thread-local cache. But the PoolArena's view of the underlying `PoolChunk` is not updated. `usedDirectMemory` counts all `PoolChunk` native memory regardless of how much is truly in use vs. sitting in thread caches.

The thread cache is only swept when the owning thread crosses a allocation threshold, but since the worker is in pause state  after all flush items end, all flush thread gets blocked on workingQueue(index).take(). The cache is never swept, `PoolChunks` in thread cache are never freed, and usedDirectMemory stays frozen.

In this PR, we are changing take() with poll() and on poll() timeout we are explicitly calling `allocator.trimCurrentThreadCache()` to flush cached `PoolChunks` back to the `PoolArena`, allowing fully-free chunks to be destroyed and usedDirectMemory to recover.

A similar pattern is already used by:

https://github.com/apache/celeborn/blob/main/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java#L131

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

