### PR TITLE
[CELEBORN-2335] Bump Spark from 4.1.1 to 4.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1697,7 +1697,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.13.17</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
-        <spark.version>4.1.1</spark.version>
+        <spark.version>4.1.2</spark.version>
         <zstd-jni.version>1.5.7-6</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1004,7 +1004,7 @@ object Spark41 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.13.17"
 
-  val sparkVersion = "4.1.1"
+  val sparkVersion = "4.1.2"
   val zstdJniVersion = "1.5.7-6"
   val scalaBinaryVersion = "2.13"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Spark from 4.1.1 to 4.1.2.

### Why are the changes needed?

Spark 4.1.2 has been announced to release: [Spark 4.1.2 released](https://spark.apache.org/news/spark-4-1-2-released.html). The profile spark-4.1 could bump Spark from 4.1.1 to 4.1.2.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes


### How was this patch tested?

CI.