### PR TITLE
[CELEBORN-2337] Celeborn OpenAPI client should not shade slf4j-api

### DIFF
--- a/openapi/openapi-client/pom.xml
+++ b/openapi/openapi-client/pom.xml
@@ -116,10 +116,6 @@
               <shadedPattern>${shading.prefix}.org.apache.hc</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.slf4j</pattern>
-              <shadedPattern>${shading.prefix}.org.slf4j</shadedPattern>
-            </relocation>
-            <relocation>
               <pattern>META-INF/versions/11/com/fasterxml/jackson</pattern>
               <shadedPattern>META-INF/versions/11/org/apache/celeborn/shaded/com/fasterxml/jackson</shadedPattern>
             </relocation>
@@ -144,7 +140,6 @@
               <include>com.google.code.findbugs:jsr305</include>
               <include>jakarta.annotation:jakarta.annotation-api</include>
               <include>org.openapitools:jackson-databind-nullable</include>
-              <include>org.slf4j:slf4j-api</include>
             </includes>
           </artifactSet>
           <filters>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1802,8 +1802,7 @@ object CelebornOpenApi {
             name.startsWith("httpclient5-") ||
             name.startsWith("httpcore5-") ||
             name.startsWith("httpcore5-h2-") ||
-            name.startsWith("jackson-databind-nullable-") ||
-            name.startsWith("slf4j-api-"))
+            name.startsWith("jackson-databind-nullable-"))
         }
       },
 
@@ -1814,8 +1813,7 @@ object CelebornOpenApi {
         ShadeRule.rename("jakarta.validation.**" -> "org.apache.celeborn.shaded.jakarta.validation.@1").inAll,
         ShadeRule.rename("javax.validation.**" -> "org.apache.celeborn.shaded.javax.validation.@1").inAll,
         ShadeRule.rename("javax.ws.rs.ext.**" -> "org.apache.celeborn.shaded.javax.ws.rs.ext.@1").inAll,
-        ShadeRule.rename("org.apache.hc.**" -> "org.apache.celeborn.shaded.org.apache.hc.@1").inAll,
-        ShadeRule.rename("org.slf4j.**" -> "org.apache.celeborn.shaded.org.slf4j.@1").inAll
+        ShadeRule.rename("org.apache.hc.**" -> "org.apache.celeborn.shaded.org.apache.hc.@1").inAll
     ),
 
     (assembly / assemblyMergeStrategy) := {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As the title, it's a packaging change.

### Why are the changes needed?

I found that `celeborn-cli` always prints such warnings, but actually the slf4j-api and log4j2 jars are correctly present in classpath. 

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

after some investigation, I found that `celeborn-openapi-client-*.jar` bundles shaded slf4j classes, which causes the issue.

```
$ jar tf $CELEBORN_HOME/cli-jars/celeborn-openapi-client-*.jar | grep slf4j
...
org/apache/celeborn/shaded/org/slf4j/
org/apache/celeborn/shaded/org/slf4j/ILoggerFactory.class
org/apache/celeborn/shaded/org/slf4j/IMarkerFactory.class
org/apache/celeborn/shaded/org/slf4j/Logger.class
...
```

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

Tested with `celeborn-cli`, `SLF4J` binding warnings have gone.