### PR TITLE
[CELEBORN-2338] Remove hardcoded CELEBORN_PRINT_LAUNCH_COMMAND=0

### DIFF
--- a/bin/celeborn-class
+++ b/bin/celeborn-class
@@ -22,9 +22,6 @@ fi
 
 export CELEBORN_CONF_DIR="${CELEBORN_CONF_DIR:-"${CELEBORN_HOME}/conf"}"
 
-# print launch command for debug
-export CELEBORN_PRINT_LAUNCH_COMMAND="0"
-
 if [ -z "$CELEBORN_ENV_LOADED" ]; then
   export CELEBORN_ENV_LOADED=1
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Remove hardcoded `CELEBORN_PRINT_LAUNCH_COMMAND=0` in `bin/celeborn-class`

### Why are the changes needed?

It should be picked from the environment variable.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

```
$ CELEBORN_PRINT_LAUNCH_COMMAND=1 sbin/celeborn-cli --version
...
Start to launch /opt/java/openjdk/bin/java -XX:+IgnoreUnrecognizedVMOptions -cp /opt/celeborn/conf::/opt/celeborn/cli-jars/*: org.apache.celeborn.cli.CelebornCli --version
...
```