### PR TITLE
[CELEBORN-2339] Add tools.jar into classpath only for Java 8

### DIFF
--- a/bin/celeborn-class
+++ b/bin/celeborn-class
@@ -79,6 +79,8 @@ if [ ! -d "$CELEBORN_JARS_DIR" ]; then
   echo "Failed to find CELEBORN jars directory ($CELEBORN_JARS_DIR)." 1>&2
   echo "You need to build CELEBORN with the target \"package\" before running this program." 1>&2
   exit 1
+elif [ -z "$JAVA_TOOLS_JAR" ]; then
+  CELEBORN_CLASSPATH="$CELEBORN_CONF_DIR:$HADOOP_CONF_DIR:$CELEBORN_JARS_DIR/*"
 else
   CELEBORN_CLASSPATH="$CELEBORN_CONF_DIR:$HADOOP_CONF_DIR:$CELEBORN_JARS_DIR/*:$JAVA_TOOLS_JAR"
 fi

--- a/sbin/load-celeborn-env.sh
+++ b/sbin/load-celeborn-env.sh
@@ -51,14 +51,17 @@ else
   fi
 fi
 
-# Find the java tools.jar
-if [ -f "${JAVA_HOME}/lib/tools.jar" ]; then
-  export JAVA_TOOLS_JAR="${JAVA_HOME}/lib/tools.jar"
-else
-  if [ -f "${JAVA_HOME}/../lib/tools.jar" ]; then
-    export JAVA_TOOLS_JAR="${JAVA_HOME}/../lib/tools.jar"
+JAVA_VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ "$JAVA_VERSION" = 1.8.* ]]; then
+  # Find the java tools.jar when using Java 8
+  if [ -f "${JAVA_HOME}/lib/tools.jar" ]; then
+    export JAVA_TOOLS_JAR="${JAVA_HOME}/lib/tools.jar"
   else
-    echo "WARNING: cannot locate tools.jar. Expected to find it in either ${JAVA_HOME}/lib/tools.jar or ${JAVA_HOME}/../lib/tools.jar"
+    if [ -f "${JAVA_HOME}/../lib/tools.jar" ]; then
+      export JAVA_TOOLS_JAR="${JAVA_HOME}/../lib/tools.jar"
+    else
+      echo "WARNING: cannot locate tools.jar. Expected to find it in either ${JAVA_HOME}/lib/tools.jar or ${JAVA_HOME}/../lib/tools.jar"
+    fi
   fi
 fi
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This is an enhancement of CELEBORN-1682, limit the `tools.jar` injection only for Java 8.

### Why are the changes needed?

https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html

> Class and resource files previously stored in lib/rt.jar, lib/tools.jar, lib/dt.jar and various other internal JAR files are stored in a more efficient format in implementation-specific files in the lib directory.


### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

Ensure the warning has gone on JDK 17.

```
"WARNING: cannot locate tools.jar. Expected to find it in either /opt/openjdk-17/lib/tools.jar or /opt/openjdk-17/../lib/tools.jar"
```