### PR TITLE
[MINOR] Fix broken image links in docs

### DIFF
--- a/docs/developers/faulttolerant.md
+++ b/docs/developers/faulttolerant.md
@@ -36,7 +36,7 @@ Celeborn does not eagerly consider `Worker` lost when push data fails, instead i
 unavailable, and asks for another (pair of) `PartitionLocation`(s) on different `Worker`(s) to continue pushing.
 The process is called `Revive`:
 
-![Revive](../../assets/img/revive.svg)
+![Revive](../assets/img/revive.svg)
 
 Handling [PushMergedData](../../developers/shuffleclient#push-or-merge) failure is similar but more complex. Currently,
 `PushMergedData` is in all-or-nothing fashion, meaning either all data batches in the request succeed or all fail.
@@ -57,7 +57,7 @@ When a `Worker` is down, all `PartitionLocation`s on the `Worker` will be revive
 to `LifecycleManager`. To alleviate this, `ShuffleClient` batches all `Revive` requests before sending to
 `LifecycleManager`:
 
-![BatchRevive](../../assets/img/batchrevive.svg)
+![BatchRevive](../assets/img/batchrevive.svg)
 
 ## Handle Fetch Failure
 As [ReducePartition](../../developers/storage#reducepartition) describes, data file consists of chunks, `ShuffleClient`

--- a/docs/developers/overview.md
+++ b/docs/developers/overview.md
@@ -25,7 +25,7 @@ please refer to dedicated articles.
 In distributed compute engines, data exchange between compute nodes is common but expensive. The cost comes from
 the disk and network inefficiency (M * N between Mappers and Reducers) in traditional shuffle frame, as following:
 
-![ESS](../../assets/img/ess.svg)
+![ESS](../assets/img/ess.svg)
 
 Besides inefficiency, traditional shuffle framework requires large local storage in compute node to store shuffle
 data, thus blocks the adoption of disaggregated architecture.
@@ -33,7 +33,7 @@ data, thus blocks the adoption of disaggregated architecture.
 Apache Celeborn solves the problems by reorganizing shuffle data in a more efficient way, and storing the data in
 a separate service. The high level architecture of Celeborn is as follows:
 
-![Celeborn](../../assets/img/celeborn.svg)
+![Celeborn](../assets/img/celeborn.svg)
 
 ## Components
 Celeborn has three primary components: Master, Worker, and Client.

--- a/docs/developers/shuffleclient.md
+++ b/docs/developers/shuffleclient.md
@@ -112,7 +112,7 @@ There are two kinds of Split:
 
 The process of `SOFT_SPLIT` is as follows:
 
-![softsplit](../../assets/img/softsplit.svg)
+![softsplit](../assets/img/softsplit.svg)
 
 `LifecycleManager` keeps the split information and tells reducer to read from all splits of the `PartitionLocation`
 to guarantee no data is lost.

--- a/docs/developers/storage.md
+++ b/docs/developers/storage.md
@@ -38,7 +38,7 @@ Celeborn supports two kinds of partitions:
 #### ReducePartition
 The layout of `ReducePartition` is as follows:
 
-![ReducePartition](../../assets/img/reducepartition.svg)
+![ReducePartition](../assets/img/reducepartition.svg)
 
 `ReducePartition` data file consists of several chunks (defaults to 8 MiB). Each data file has an in-memory index
 which points to start positions of each chunk. Upon requesting data from some partition, `Worker` first returns the
@@ -52,7 +52,7 @@ replica contain the same data batches in normal cases.
 #### MapPartition
 The layout of `MapPartition` is as follows:
 
-![MapPartition](../../assets/img/mappartition.svg)
+![MapPartition](../assets/img/mappartition.svg)
 
 `MapPartition` data file consists of several regions (defaults to 64MiB), each region is sorted by partition id.
 Each region has an in-memory index which points to start positions of each partition. Upon requesting data from
@@ -114,7 +114,7 @@ The principles of data placement are:
 
 The high-level design of multi-layered storage is:
 
-![storage](../../assets/img/multilayer.svg)
+![storage](../assets/img/multilayer.svg)
 
 `Worker`'s memory is divided into two logical regions: `Push Region` and `Cache Region`. `ShuffleClient` pushes data
 into `Push Region`, as ① indicates. Whenever the buffered data in `PushRegion` for a `PartitionLocation` exceeds the

--- a/docs/developers/trafficcontrol.md
+++ b/docs/developers/trafficcontrol.md
@@ -53,7 +53,7 @@ time force flush to release memory.
 `Worker` high-frequently checks used direct memory ratio, and triggers `Pause Receive`, `Pause Replicate` and `Resume`
 accordingly. The state machine is as follows:
 
-![backpressure](../../assets/img/backpressure.svg)
+![backpressure](../assets/img/backpressure.svg)
 
 `Back Pressure` is the basic traffic control and can't be disabled. Users can tune the three watermarks through the
 following configuration.


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix broken local image links in the documentation, mainly under `docs/developers/`, by correcting relative paths so they resolve to the actual assets in `docs/assets/img/`. 



### Why are the changes needed?
Several documentation pages were pointing to non-existent image locations, so the diagrams would not render correctly in the generated docs. These updates restore the intended images and make the docs display properly.



### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?
Verified by scanning the repository for local image references and checking that each updated path resolves to an existing file in the repo. Also confirmed there are no remaining broken local image references in the affected markdown/docs files.





