### PR TITLE
[CELEBORN-2344] Support to force set serving state via HTTP APIs

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -195,6 +195,11 @@ abstract class HttpService extends Service with Logging {
   def updateInterruptionNotice(workerInterruptionNotices: Map[String, Long]): HandleResponse =
     throw new UnsupportedOperationException()
 
+  def getServingState(): String = throw new UnsupportedOperationException()
+
+  def setServingState(state: String, timeoutMs: String): String =
+    throw new UnsupportedOperationException()
+
   def startHttpServer(): Unit = {
     httpServer = HttpServer(
       serviceName,

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -79,6 +79,8 @@ public class MemoryManager {
   private long pausePushDataAndReplicateTime = 0L;
   private int trimCounter = 0;
   private volatile boolean isPaused = false;
+  private volatile ServingState forcedServingState = null;
+  private volatile long forcedServingStateExpireTime = -1L; // -1 means no expiry
   // For credit stream
   private final AtomicLong readBufferCounter = new AtomicLong(0);
   private long readBufferThreshold;
@@ -307,6 +309,15 @@ public class MemoryManager {
   }
 
   public ServingState currentServingState() {
+    if (forcedServingState != null) {
+      if (forcedServingStateExpireTime > 0
+          && System.currentTimeMillis() > forcedServingStateExpireTime) {
+        this.clearForcedServingState();
+      } else {
+        return forcedServingState;
+      }
+    }
+
     long memoryUsage = getMemoryUsage();
     // pause replicate threshold always greater than pause push data threshold
     // so when trigger pause replicate, pause both push and replicate
@@ -585,6 +596,30 @@ public class MemoryManager {
 
   public void releaseMemoryFileStorage(int bytes) {
     memoryFileStorageCounter.add(-1 * bytes);
+  }
+
+  public ServingState getServingState() {
+    return servingState;
+  }
+
+  public ServingState getForcedServingState() {
+    return forcedServingState;
+  }
+
+  public void forceServingState(ServingState state, Long timeoutMs) {
+    this.forcedServingState = state;
+    this.forcedServingStateExpireTime =
+        timeoutMs > 0 ? System.currentTimeMillis() + timeoutMs : -1L;
+    logger.info(
+        "Serving state manually forced to {} with forcedServingStateExpireTime {}",
+        state,
+        timeoutMs);
+  }
+
+  public void clearForcedServingState() {
+    this.forcedServingState = null;
+    this.forcedServingStateExpireTime = -1L;
+    logger.info("Forced serving state override cleared");
   }
 
   public void close() {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -947,6 +947,51 @@ private[celeborn] class Worker(
     sb.toString()
   }
 
+  override def getServingState(): String = {
+    val sb = new StringBuilder
+    sb.append("====================== Worker Serving State ==========================\n")
+    val current = memoryManager.getServingState
+    sb.append(s"Current state: $current.\n")
+
+    val forced = memoryManager.getForcedServingState
+    if (forced != null) {
+      sb.append(s"Manual override active.\n")
+    }
+    sb.toString()
+  }
+
+  override def setServingState(state: String, timeoutStr: String): String = {
+    val sb = new StringBuilder
+    sb.append("====================== Set Serving State ============================\n")
+    if (state.isEmpty) {
+      memoryManager.clearForcedServingState()
+      sb.append("Manual servingState override cleared.\n")
+      return sb.toString()
+    }
+    val servingState =
+      try {
+        ServingState.valueOf(state.toUpperCase(Locale.ROOT))
+      } catch {
+        case _: IllegalArgumentException =>
+          return s"Invalid state '$state'. " +
+            s"Legal values: PUSH_AND_REPLICATE_PAUSED, PUSH_PAUSED, NONE_PAUSED\n"
+      }
+    val timeout =
+      if (timeoutStr.isEmpty) 0L
+      else
+        try {
+          JavaUtils.timeStringAsMs(timeoutStr)
+        } catch {
+          case e: NumberFormatException =>
+            return s"Invalid timeout '$timeoutStr'. $e\n"
+        }
+    memoryManager.forceServingState(servingState, timeout)
+    sb.append(s"Serving state forced to: $servingState\n")
+    if (timeout > 0) sb.append(s"Override will auto-clear after $timeoutStr.\n")
+    else sb.append("Override will persist until explicitly cleared.\n")
+    sb.toString()
+  }
+
   override def exit(exitType: String): String = {
     exitType.toUpperCase(Locale.ROOT) match {
       case "DECOMMISSION" =>

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/ApiWorkerResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/ApiWorkerResource.scala
@@ -88,4 +88,32 @@ class ApiWorkerResource extends ApiRequestContext {
   def exit(@FormParam("type") exitType: String): String = {
     httpService.exit(normalizeParam(exitType))
   }
+
+  @Path("/servingState")
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.TEXT_PLAIN)),
+    description =
+      "Show the current serving state and whether a manual override is active.")
+  @GET
+  def getServingState(): String = httpService.getServingState()
+
+  @Path("/servingState")
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_FORM_URLENCODED)),
+    description =
+      "Force the worker serving state. " +
+        "Legal values for 'state' are 'PUSH_AND_REPLICATE_PAUSED', 'PUSH_PAUSED' and 'NONE_PAUSED'," +
+        " or empty to clear the override. " +
+        "Optional 'timeoutMs' auto-clears the override after the given duration; omit to hold indefinitely.")
+  @POST
+  def setServingState(
+      @FormParam("state") state: String,
+      @FormParam("timeout") timeoutStr: String): String = {
+    httpService.setServingState(normalizeParam(state), normalizeParam(timeoutStr))
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Added /servingState which supports GET and POST http methods. 

- GET will just return the current serving state.

- POST can be used to force override the serving state of a worker.  It takes two params – state (override for serving state) and timeout (after which overridden state should clear up). If timeout is not present forced state will not clear up, unless someone overrides it to empty state.


- handling live migration scenarios and other cases where we don't want the worker to receive new data but still want to keep it running. Or maybe where we want to force unpause the worker.  

### Why are the changes needed?

This can be used for planned maintenance of worker or cases where worker is degraded or under high load but not having high memory pressure. This can also be used for cases to force resume worker which can be useful in cases like https://github.com/apache/celeborn/pull/3696

We are using this specifically during GCP live migration – https://docs.cloud.google.com/compute/docs/instances/live-migration-process

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

Tested in our dev setup 

```
>>> curl <host:port>/servingState
====================== Worker Serving State ==========================
Current state: NONE_PAUSED.

>>> curl -X POST "<host:port>/servingState"   -H "Content-Type: application/x-www-form-urlencoded"   -d "state=PUSH_PAUSED" -d "timeout=1m"
====================== Set Serving State ============================
Serving state forced to: PUSH_PAUSED
Override will auto-clear after 1m.

>>> curl <host:port>/servingState
====================== Worker Serving State ==========================
Current state: PUSH_PAUSED.
Manual override active.

// Cleared after 1 min
>>> curl <host:port>/servingState
====================== Worker Serving State ==========================
Current state: NONE_PAUSED.

// Forced without timeout
>>> curl -X POST "<host:port>/servingState"   -H "Content-Type: application/x-www-form-urlencoded"   -d "state=PUSH_PAUSED"
====================== Set Serving State ============================
Serving state forced to: PUSH_PAUSED
Override will persist until explicitly cleared.

>>> curl <host:port>/servingState
====================== Worker Serving State ==========================
Current state: PUSH_PAUSED.
Manual override active.

>>> curl -X POST "<host:port>/servingState"   -H "Content-Type: application/x-www-form-urlencoded"   -d "state="
====================== Set Serving State ============================
Manual servingState override cleared.

>>> curl <host:port>/servingState
====================== Worker Serving State ==========================
Current state: NONE_PAUSED.

// Invalid scenarios 
>>> curl -X POST "<host:port>/servingState"   -H "Content-Type: application/x-www-form-urlencoded"   -d "state=PUSH_PAUSED" -d "timeout=1k"
Invalid timeout '1k'. java.lang.NumberFormatException: Time must be specified as seconds (s), milliseconds (ms), microseconds (us), minutes (m or min), hour (h), or day (d). E.g. 50s, 100ms, or 250us.
Invalid suffix: "k"

>>> curl -X POST "<host:port>/servingState"   -H "Content-Type: application/x-www-form-urlencoded"   -d "state=INVALID"
Invalid state 'INVALID'. Legal values: PUSH_AND_REPLICATE_PAUSED, PUSH_PAUSED, NONE_PAUSED
```