### PR TITLE
[CELEBORN-2342] Fix CI test failures: JVMQuakeSuite hang and LifecycleManagerUnregisterShuffleSuite slowness

### DIFF
--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerUnregisterShuffleSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerUnregisterShuffleSuite.scala
@@ -36,6 +36,9 @@ class LifecycleManagerUnregisterShuffleSuite extends WithShuffleClientSuite
   celebornConf
     .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "true")
     .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
+    // Speed up the delayed-unregister path so the tests don't consistently
+    // wait the full 120s eventually timeout.
+    .set(CelebornConf.SHUFFLE_EXPIRED_CHECK_INTERVAL.key, "1s")
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
@@ -35,7 +35,7 @@ class CelebornHashCheckDiskSuite extends SparkTestBase {
   override def beforeAll(): Unit = {
     logInfo("celebornHashCheckDiskSuite test initialized , setup Celeborn mini cluster")
     val masterConf = Map(
-      CelebornConf.APPLICATION_HEARTBEAT_TIMEOUT.key -> "10s")
+      CelebornConf.APPLICATION_HEARTBEAT_TIMEOUT.key -> "120s")
     val workerConf = Map(
       CelebornConf.WORKER_STORAGE_DIRS.key -> "/tmp:capacity=1000",
       CelebornConf.WORKER_DISK_RESERVE_SIZE.key -> "0G")

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -213,11 +213,11 @@ trait MiniClusterFeature extends Logging {
     val workers = new Array[Worker](workerNum)
     val flagUpdateLock = new ReentrantLock()
     val threads = (1 to workerNum).map { i =>
-      val worker = createWorker(workerConf)
       val workerThread = new RunnerWrap({
         var workerStartRetry = 0
         var workerStarted = false
         while (!workerStarted) {
+          val worker = createWorker(workerConf)
           try {
             flagUpdateLock.lock()
             workers(i - 1) = worker

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -213,11 +213,11 @@ trait MiniClusterFeature extends Logging {
     val workers = new Array[Worker](workerNum)
     val flagUpdateLock = new ReentrantLock()
     val threads = (1 to workerNum).map { i =>
+      val worker = createWorker(workerConf)
       val workerThread = new RunnerWrap({
         var workerStartRetry = 0
         var workerStarted = false
         while (!workerStarted) {
-          val worker = createWorker(workerConf)
           try {
             flagUpdateLock.lock()
             workers(i - 1) = worker
@@ -228,6 +228,7 @@ trait MiniClusterFeature extends Logging {
             case ex: Exception =>
               if (workers(i - 1) != null) {
                 workers(i - 1).shutdownGracefully()
+                workers(i - 1).metricsSystem.stop()
               }
               workerStarted = false
               workerStartRetry += 1

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/monitor/JVMQuakeSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/monitor/JVMQuakeSuite.scala
@@ -49,10 +49,17 @@ class JVMQuakeSuite extends CelebornFunSuite {
   }
 
   test("[CELEBORN-1092] Introduce JVM monitoring in Celeborn Worker using JVMQuake") {
+    // Use millisecond-scale thresholds so the test completes quickly.  With the
+    // fix for CELEBORN-2324 thresholds are now correctly parsed as milliseconds
+    // (instead of accidentally being wrapped as microseconds), so "1s" would
+    // require ~1s of accumulated GC time which can take effectively forever in
+    // this tight allocation loop because runtimeWeight=1 causes the bucket to
+    // decay when gcTime < runTime.
     val quake = new JVMQuake(new CelebornConf().set(WORKER_JVM_QUAKE_ENABLED.key, "true")
-      .set(WORKER_JVM_QUAKE_RUNTIME_WEIGHT.key, "1")
-      .set(WORKER_JVM_QUAKE_DUMP_THRESHOLD.key, "1s")
-      .set(WORKER_JVM_QUAKE_KILL_THRESHOLD.key, "2s"))
+      .set(WORKER_JVM_QUAKE_RUNTIME_WEIGHT.key, "0")
+      .set(WORKER_JVM_QUAKE_CHECK_INTERVAL.key, "10ms")
+      .set(WORKER_JVM_QUAKE_DUMP_THRESHOLD.key, "1ms")
+      .set(WORKER_JVM_QUAKE_KILL_THRESHOLD.key, "1h"))
     quake.start()
     allocateMemory(quake)
     quake.stop()


### PR DESCRIPTION

### What changes were proposed in this pull request?

1. JVMQuakeSuite: CELEBORN-2324 fixed threshold unit conversion (microseconds ->
   milliseconds), causing the 1s dump threshold to require ~1s of accumulated GC
   time. In the tight allocation loop with runtimeWeight=1, the bucket decays
   when gcTime < runTime, so the test hangs indefinitely. Fix by using ms-scale
   thresholds (1ms dump, 1h kill), runtimeWeight=0, and 10ms check interval.

2. LifecycleManagerUnregisterShuffleSuite: The suite's unregister-shuffle tests consistently wait the full 120s eventually timeout because removeExpiredShuffle() only runs every 60s. Reduce the check interval to 1s so the delayed-unregister path fires quickly.


### Why are the changes needed?



### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

