### PR TITLE
[CELEBORN-2310][FOLLOWUP] Account actualUsableSpace while excluding workers

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -44,7 +44,6 @@ import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.ApplicationInfo;
 import org.apache.celeborn.common.meta.ApplicationMeta;
 import org.apache.celeborn.common.meta.DiskInfo;
-import org.apache.celeborn.common.meta.DiskStatus;
 import org.apache.celeborn.common.meta.WorkerEventInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.meta.WorkerStatus;
@@ -691,8 +690,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   }
 
   private Pair<Boolean, Long> isExceedingUnhealthyThreshold(Map<String, DiskInfo> diskMap) {
-    long unhealthyCount =
-        diskMap.values().stream().filter(disk -> !disk.isHealthy()).count();
+    long unhealthyCount = diskMap.values().stream().filter(disk -> !disk.isHealthy()).count();
     return new ImmutablePair<>(
         unhealthyCount * 1.0 / diskMap.size() >= unhealthyDiskRatioThreshold, unhealthyCount);
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -692,7 +692,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
 
   private Pair<Boolean, Long> isExceedingUnhealthyThreshold(Map<String, DiskInfo> diskMap) {
     long unhealthyCount =
-        diskMap.values().stream().filter(disk -> !disk.status().equals(DiskStatus.HEALTHY)).count();
+        diskMap.values().stream().filter(disk -> !disk.isHealthy()).count();
     return new ImmutablePair<>(
         unhealthyCount * 1.0 / diskMap.size() >= unhealthyDiskRatioThreshold, unhealthyCount);
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Account actualUsableSpace while excluding workers. We should use `DeviceInfo.isHealthy()` which actually account for available actualUsableSpace.

### Why are the changes needed?

Currently we are just checking the DiskStatus, which could not be set if the device monitor is not enabled.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

Minor Change.