### PR TITLE
[CELEBORN-2351] Partition file sorting should only be paused for PUSH_AND_REPLICATE_PAUSED

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -72,7 +72,7 @@ public class MemoryManager {
   private final AtomicLong diskBufferCounter = new AtomicLong(0);
   private final LongAdder pausePushDataCounter = new LongAdder();
   private final LongAdder pausePushDataAndReplicateCounter = new LongAdder();
-  public ServingState servingState = ServingState.NONE_PAUSED;
+  public volatile ServingState servingState = ServingState.NONE_PAUSED;
   private long pausePushDataStartTime = -1L;
   private long pausePushDataTime = 0L;
   private long pausePushDataAndReplicateStartTime = -1L;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -435,7 +435,8 @@ public class MemoryManager {
 
   public boolean sortMemoryReady() {
     return maxSortMemory == 0
-        || (servingState == ServingState.NONE_PAUSED && sortMemoryCounter.get() < maxSortMemory);
+        || (servingState != ServingState.PUSH_AND_REPLICATE_PAUSED
+            && sortMemoryCounter.get() < maxSortMemory);
   }
 
   public void releaseSortMemory(long size) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -372,8 +372,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
     assert(memoryManager.sortMemoryReady())
 
     // PUSH_PAUSED: sort must be allowed so that fetch reads can proceed while push is
-    // back-pressured. Before Fix 1 this incorrectly returned false.
-    Mockito.when(memoryManager.getMemoryUsage).thenReturn(pushThreshold + 1)
+    // back-pressured (previously sorting was also blocked in this state).
     memoryManager.switchServingState()
     assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
     sortMemoryCounter.set(0)
@@ -397,7 +396,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
     MemoryManager.reset()
   }
 
-  test("sortMemoryReady always returns true when sort memory threshold is disabled") {
+  test("sortMemoryReady returns true when sort memory threshold is disabled") {
     val conf = new CelebornConf()
     conf.set(CelebornConf.WORKER_DIRECT_MEMORY_CHECK_INTERVAL.key, "300s")
     conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_INTERVAL.key, "0")

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -346,6 +346,82 @@ class MemoryManagerSuite extends CelebornFunSuite {
     MemoryManager.reset()
   }
 
+  test("sortMemoryReady allows sorting in PUSH_PAUSED but blocks in PUSH_AND_REPLICATE_PAUSED") {
+    val conf = new CelebornConf()
+    // Disable the automatic check thread so we drive state transitions manually
+    conf.set(CelebornConf.WORKER_DIRECT_MEMORY_CHECK_INTERVAL.key, "300s")
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_INTERVAL.key, "0")
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val maxDirectMemory = memoryManager.maxDirectMemory
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * maxDirectMemory).longValue()
+    val replicateThreshold =
+      (conf.workerDirectMemoryRatioToPauseReplicate * maxDirectMemory).longValue()
+    val maxSortMemory =
+      (conf.workerPartitionSorterDirectMemoryRatioThreshold * maxDirectMemory).longValue()
+    val sortMemoryCounter = memoryManager.getSortMemoryCounter
+
+    Mockito.when(memoryManager.getNettyPinnedDirectMemory).thenReturn(0L)
+
+    // NONE_PAUSED: sort is allowed
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(0L)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.NONE_PAUSED)
+    sortMemoryCounter.set(0)
+    assert(memoryManager.sortMemoryReady())
+
+    // PUSH_PAUSED: sort must be allowed so that fetch reads can proceed while push is
+    // back-pressured. Before Fix 1 this incorrectly returned false.
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(pushThreshold + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+    sortMemoryCounter.set(0)
+    assert(
+      memoryManager.sortMemoryReady(),
+      "sortMemoryReady must return true in PUSH_PAUSED: fetch reads of already-written " +
+        "data should not be blocked by push back-pressure")
+
+    // PUSH_PAUSED but sort budget exhausted: sort must be blocked
+    sortMemoryCounter.set(maxSortMemory)
+    assert(!memoryManager.sortMemoryReady())
+
+    // PUSH_AND_REPLICATE_PAUSED: sort must be blocked regardless of sort budget
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(replicateThreshold + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_AND_REPLICATE_PAUSED)
+    sortMemoryCounter.set(0)
+    assert(
+      !memoryManager.sortMemoryReady(),
+      "sortMemoryReady must return false in PUSH_AND_REPLICATE_PAUSED")
+    MemoryManager.reset()
+  }
+
+  test("sortMemoryReady always returns true when sort memory threshold is disabled") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_DIRECT_MEMORY_CHECK_INTERVAL.key, "300s")
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_INTERVAL.key, "0")
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(
+      CelebornConf.WORKER_PARTITION_SORTER_DIRECT_MEMORY_RATIO_THRESHOLD.key,
+      "0")
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val maxDirectMemory = memoryManager.maxDirectMemory
+    val replicateThreshold =
+      (conf.workerDirectMemoryRatioToPauseReplicate * maxDirectMemory).longValue()
+
+    Mockito.when(memoryManager.getNettyPinnedDirectMemory).thenReturn(0L)
+
+    // Even in PUSH_AND_REPLICATE_PAUSED, threshold=0 means skip all checks
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(replicateThreshold + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_AND_REPLICATE_PAUSED)
+    assert(
+      memoryManager.sortMemoryReady(),
+      "sortMemoryReady must return true when threshold is 0 regardless of serving state")
+    MemoryManager.reset()
+  }
+
   class MockMemoryPressureListener(
       val belongModuleName: String,
       var isPause: Boolean = false) extends MemoryPressureListener {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -373,6 +373,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
 
     // PUSH_PAUSED: sort must be allowed so that fetch reads can proceed while push is
     // back-pressured (previously sorting was also blocked in this state).
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(pushThreshold + 1)
     memoryManager.switchServingState()
     assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
     sortMemoryCounter.set(0)
@@ -396,7 +397,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
     MemoryManager.reset()
   }
 
-  test("sortMemoryReady returns true when sort memory threshold is disabled") {
+  test("sortMemoryReady always returns true when sort memory threshold is disabled") {
     val conf = new CelebornConf()
     conf.set(CelebornConf.WORKER_DIRECT_MEMORY_CHECK_INTERVAL.key, "300s")
     conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_INTERVAL.key, "0")
@@ -406,12 +407,30 @@ class MemoryManagerSuite extends CelebornFunSuite {
       "0")
     val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
     val maxDirectMemory = memoryManager.maxDirectMemory
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * maxDirectMemory).longValue()
     val replicateThreshold =
       (conf.workerDirectMemoryRatioToPauseReplicate * maxDirectMemory).longValue()
 
     Mockito.when(memoryManager.getNettyPinnedDirectMemory).thenReturn(0L)
 
-    // Even in PUSH_AND_REPLICATE_PAUSED, threshold=0 means skip all checks
+    // PUSH_PAUSED, threshold=0 means skip all checks
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(0L)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.NONE_PAUSED)
+    assert(
+      memoryManager.sortMemoryReady(),
+      "sortMemoryReady must return true when threshold is 0 regardless of serving state")
+
+    // PUSH_PAUSED, threshold=0 means skip all checks
+    Mockito.when(memoryManager.getMemoryUsage).thenReturn(pushThreshold + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+    assert(
+      memoryManager.sortMemoryReady(),
+      "sortMemoryReady must return true when threshold is 0 regardless of serving state")
+
+    // PUSH_AND_REPLICATE_PAUSED, threshold=0 means skip all checks
     Mockito.when(memoryManager.getMemoryUsage).thenReturn(replicateThreshold + 1)
     memoryManager.switchServingState()
     assert(memoryManager.servingState == ServingState.PUSH_AND_REPLICATE_PAUSED)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Partition file sorting should only be paused for `PUSH_AND_REPLICATE_PAUSED`, which represent very high memory pressure and cause OOM for workers. Sorting should be allowed for `PUSH_PAUSED` state.

### Why are the changes needed?

Currently even for push pause state we stop the sorting for partition files. If pause is sustained for a longer time then sorting can timeout and reader waiting for sorting will fail or be delayed.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [X] Yes

### How was this patch tested?

Existing UTs
