### PR TITLE
[WIP][CELEBORN-2341] Preserve partially-committed partitions on CommitFiles timeout

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -932,8 +932,12 @@ private[deploy] object Controller {
     failedReplicaIds.removeAll(emptyFileReplicaIds)
     // COMMIT_FILE_EXCEPTION only when nothing committed and nothing empty; empty files are a
     // successful terminal state and must not be reported as failed.
+    val committedPrimaryIdList = new jArrayList[String](committedPrimaryIds)
+    val committedReplicaIdList = new jArrayList[String](committedReplicaIds)
+    // COMMIT_FILE_EXCEPTION only when nothing committed and nothing empty; empty files are a
+    // successful terminal state and must not be reported as failed.
     val status =
-      if (committedPrimaryIds.isEmpty && committedReplicaIds.isEmpty &&
+      if (committedPrimaryIdList.isEmpty && committedReplicaIdList.isEmpty &&
         emptyFilePrimaryIds.isEmpty && emptyFileReplicaIds.isEmpty) {
         StatusCode.COMMIT_FILE_EXCEPTION
       } else {
@@ -941,8 +945,8 @@ private[deploy] object Controller {
       }
     CommitFilesResponse(
       status,
-      new jArrayList[String](committedPrimaryIds),
-      new jArrayList[String](committedReplicaIds),
+      committedPrimaryIdList,
+      committedReplicaIdList,
       failedPrimaryIds,
       failedReplicaIds,
       new jHashMap[String, StorageInfo](committedPrimaryStorageInfos),

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -705,18 +705,25 @@ private[deploy] class Controller(
                 case throwable: Throwable =>
                   logError(s"$errMsg, an unexpected exception occurred.", throwable)
               }
+              val response = Controller.buildCommitFilesResponseOnCancel(
+                primaryIds,
+                replicaIds,
+                committedPrimaryIds,
+                committedReplicaIds,
+                emptyFilePrimaryIds,
+                emptyFileReplicaIds,
+                committedPrimaryStorageInfos,
+                committedReplicaStorageInfos,
+                committedMapIdBitMap,
+                partitionSizeList)
               commitInfo.synchronized {
-                commitInfo.response = CommitFilesResponse(
-                  StatusCode.COMMIT_FILE_EXCEPTION,
-                  List.empty.asJava,
-                  List.empty.asJava,
-                  primaryIds,
-                  replicaIds)
-
+                commitInfo.response = response
                 commitInfo.status = CommitInfo.COMMIT_FINISHED
               }
+              context.reply(response)
 
               workerSource.incCounter(WorkerSource.COMMIT_FILES_FAIL_COUNT)
+              workerSource.stopTimer(WorkerSource.COMMIT_FILES_TIME, shuffleKey)
             } else {
               // finish, cancel timeout job first.
               timeout.cancel()
@@ -896,5 +903,52 @@ private[deploy] class Controller(
       }
       mapIdx += 1
     }
+  }
+}
+
+private[deploy] object Controller {
+
+  def buildCommitFilesResponseOnCancel(
+      primaryIds: jList[String],
+      replicaIds: jList[String],
+      committedPrimaryIds: jSet[String],
+      committedReplicaIds: jSet[String],
+      emptyFilePrimaryIds: jSet[String],
+      emptyFileReplicaIds: jSet[String],
+      committedPrimaryStorageInfos: java.util.Map[String, StorageInfo],
+      committedReplicaStorageInfos: java.util.Map[String, StorageInfo],
+      committedMapIdBitMap: java.util.Map[String, RoaringBitmap],
+      partitionSizeList: java.util.Collection[Long]): CommitFilesResponse = {
+    // Commit tasks may still be running here: future.cancel(true) does not interrupt a
+    // CompletableFuture. Compute failed = requested - committed - empty, reading committed
+    // before snapshotting it below. The sets are append-only, so a partition that commits in
+    // this window lands in both failed and committed (safe over-report), never in neither --
+    // a partition in neither is read as empty-and-valid by the driver and silently dropped.
+    val failedPrimaryIds = new jArrayList[String](primaryIds)
+    failedPrimaryIds.removeAll(committedPrimaryIds)
+    failedPrimaryIds.removeAll(emptyFilePrimaryIds)
+    val failedReplicaIds = new jArrayList[String](replicaIds)
+    failedReplicaIds.removeAll(committedReplicaIds)
+    failedReplicaIds.removeAll(emptyFileReplicaIds)
+    // COMMIT_FILE_EXCEPTION only when nothing committed and nothing empty; empty files are a
+    // successful terminal state and must not be reported as failed.
+    val status =
+      if (committedPrimaryIds.isEmpty && committedReplicaIds.isEmpty &&
+        emptyFilePrimaryIds.isEmpty && emptyFileReplicaIds.isEmpty) {
+        StatusCode.COMMIT_FILE_EXCEPTION
+      } else {
+        StatusCode.PARTIAL_SUCCESS
+      }
+    CommitFilesResponse(
+      status,
+      new jArrayList[String](committedPrimaryIds),
+      new jArrayList[String](committedReplicaIds),
+      failedPrimaryIds,
+      failedReplicaIds,
+      new jHashMap[String, StorageInfo](committedPrimaryStorageInfos),
+      new jHashMap[String, StorageInfo](committedReplicaStorageInfos),
+      new jHashMap[String, RoaringBitmap](committedMapIdBitMap),
+      partitionSizeList.asScala.sum,
+      partitionSizeList.size())
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -690,6 +690,10 @@ private[deploy] class Controller(
         new BiFunction[Void, Throwable, Unit] {
           override def apply(v: Void, t: Throwable): Unit = {
             if (null != t) {
+              // Cancel the timeout task even on the exceptional path: otherwise, when the
+              // future fails for a reason other than the timer firing, the task fires later
+              // and logs a misleading "cancel all commit file jobs" warning.
+              timeout.cancel()
               val errMsg = s"Exception while handling commitFiles for shuffleId: $shuffleKey"
               t match {
                 case _: CancellationException =>
@@ -944,6 +948,9 @@ private[deploy] object Controller {
     failedReplicaIds.removeAll(emptyFileReplicaIds)
     val committedPrimaryIdList = new jArrayList[String](committedPrimaryIds)
     val committedReplicaIdList = new jArrayList[String](committedReplicaIds)
+    // Snapshot once: tasks may still be adding, so deriving totalWritten and fileCount from a
+    // single traversal keeps the two fields mutually consistent.
+    val partitionSizes = partitionSizeList.asScala.toVector
     // Derive status from the failed lists returned in this response. Empty failed lists mean
     // every requested partition reached a terminal good state before the snapshot (committed
     // or empty -- both sets are append-only), which is the normal path's SUCCESS condition;
@@ -969,7 +976,7 @@ private[deploy] object Controller {
       new jHashMap[String, StorageInfo](committedPrimaryStorageInfos),
       new jHashMap[String, StorageInfo](committedReplicaStorageInfos),
       new jHashMap[String, RoaringBitmap](committedMapIdBitMap),
-      partitionSizeList.asScala.sum,
-      partitionSizeList.size())
+      partitionSizes.sum,
+      partitionSizes.size)
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -705,6 +705,18 @@ private[deploy] class Controller(
                 case throwable: Throwable =>
                   logError(s"$errMsg, an unexpected exception occurred.", throwable)
               }
+              // Release slots and remove partition locations before reply, mirroring reply().
+              // Unlike reply(), commit tasks may still be running here (cancel(true) does not
+              // interrupt them): a task that has not yet fetched its location will then find it
+              // removed and mark the partition failed, which is harmless -- the response below
+              // already reports every not-committed-and-not-empty partition as failed, and the
+              // shuffle-expiry cleanup that previously reclaimed these slots is idempotent.
+              val releasePrimaryLocations =
+                partitionLocationInfo.removePrimaryPartitions(shuffleKey, primaryIds)
+              val releaseReplicaLocations =
+                partitionLocationInfo.removeReplicaPartitions(shuffleKey, replicaIds)
+              workerInfo.releaseSlots(shuffleKey, releasePrimaryLocations._1)
+              workerInfo.releaseSlots(shuffleKey, releaseReplicaLocations._1)
               val response = Controller.buildCommitFilesResponseOnCancel(
                 primaryIds,
                 replicaIds,
@@ -930,14 +942,19 @@ private[deploy] object Controller {
     val failedReplicaIds = new jArrayList[String](replicaIds)
     failedReplicaIds.removeAll(committedReplicaIds)
     failedReplicaIds.removeAll(emptyFileReplicaIds)
-    // COMMIT_FILE_EXCEPTION only when nothing committed and nothing empty; empty files are a
-    // successful terminal state and must not be reported as failed.
     val committedPrimaryIdList = new jArrayList[String](committedPrimaryIds)
     val committedReplicaIdList = new jArrayList[String](committedReplicaIds)
-    // COMMIT_FILE_EXCEPTION only when nothing committed and nothing empty; empty files are a
-    // successful terminal state and must not be reported as failed.
+    // Derive status from the failed lists returned in this response. Empty failed lists mean
+    // every requested partition reached a terminal good state before the snapshot (committed
+    // or empty -- both sets are append-only), which is the normal path's SUCCESS condition;
+    // replying PARTIAL_SUCCESS would needlessly land this worker in the client's
+    // commitFilesFailedWorkers. Empty files are a successful terminal state and must not be
+    // reported as failed, so COMMIT_FILE_EXCEPTION is returned only when nothing committed
+    // and nothing is empty.
     val status =
-      if (committedPrimaryIdList.isEmpty && committedReplicaIdList.isEmpty &&
+      if (failedPrimaryIds.isEmpty && failedReplicaIds.isEmpty) {
+        StatusCode.SUCCESS
+      } else if (committedPrimaryIdList.isEmpty && committedReplicaIdList.isEmpty &&
         emptyFilePrimaryIds.isEmpty && emptyFileReplicaIds.isEmpty) {
         StatusCode.COMMIT_FILE_EXCEPTION
       } else {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/ControllerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/ControllerSuite.scala
@@ -98,8 +98,8 @@ class ControllerSuite extends AnyFunSuite {
     assert(response.failedPrimaryIds.asScala.toSet == Set("p2", "p3"))
   }
 
-  test("CELEBORN-2341: all partitions empty (none committed, none in-flight) reports no " +
-    "failures, so the driver does not recompute") {
+  test("CELEBORN-2341: all partitions empty (none committed, none in-flight) is SUCCESS " +
+    "with no failures, so the driver neither recomputes nor records a failed worker") {
     val response = Controller.buildCommitFilesResponseOnCancel(
       primaryIds = ids("p0", "p1"),
       replicaIds = ids(),
@@ -112,6 +112,29 @@ class ControllerSuite extends AnyFunSuite {
       committedMapIdBitMap = emptyBitMaps,
       partitionSizeList = emptySizes)
 
+    assert(response.status == StatusCode.SUCCESS)
+    assert(response.failedPrimaryIds.isEmpty)
+    assert(response.failedReplicaIds.isEmpty)
+  }
+
+  test("CELEBORN-2341: every requested partition committed or empty before the snapshot " +
+    "(cancellation raced with completion) is SUCCESS, not PARTIAL_SUCCESS, so the worker " +
+    "is not recorded in commitFilesFailedWorkers") {
+    val response = Controller.buildCommitFilesResponseOnCancel(
+      primaryIds = ids("p0", "p1", "p2"),
+      replicaIds = ids("r0"),
+      committedPrimaryIds = set("p0", "p1"),
+      committedReplicaIds = set("r0"),
+      emptyFilePrimaryIds = set("p2"),
+      emptyFileReplicaIds = set(),
+      committedPrimaryStorageInfos = emptyStorageInfos,
+      committedReplicaStorageInfos = emptyStorageInfos,
+      committedMapIdBitMap = emptyBitMaps,
+      partitionSizeList = emptySizes)
+
+    assert(response.status == StatusCode.SUCCESS)
+    assert(response.committedPrimaryIds.asScala.toSet == Set("p0", "p1"))
+    assert(response.committedReplicaIds.asScala.toSet == Set("r0"))
     assert(response.failedPrimaryIds.isEmpty)
     assert(response.failedReplicaIds.isEmpty)
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/ControllerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/ControllerSuite.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker
+
+import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue}
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.protocol.StorageInfo
+import org.apache.celeborn.common.protocol.message.StatusCode
+
+class ControllerSuite extends AnyFunSuite {
+
+  private def ids(xs: String*): java.util.List[String] = xs.toList.asJava
+
+  private def set(xs: String*): java.util.Set[String] = {
+    val s = ConcurrentHashMap.newKeySet[String]()
+    xs.foreach(s.add)
+    s
+  }
+
+  private def emptyStorageInfos = new ConcurrentHashMap[String, StorageInfo]()
+  private def emptyBitMaps = new ConcurrentHashMap[String, org.roaringbitmap.RoaringBitmap]()
+  private def emptySizes = new LinkedBlockingQueue[Long]()
+
+  test("CELEBORN-2341: timeout response reports queued/in-flight partitions as failed " +
+    "so the driver recomputes them, while preserving committed partitions") {
+    val response = Controller.buildCommitFilesResponseOnCancel(
+      primaryIds = ids("p0", "p1", "p2", "p3", "p4"),
+      replicaIds = ids(),
+      committedPrimaryIds = set("p0", "p1"),
+      committedReplicaIds = set(),
+      emptyFilePrimaryIds = set("p2"),
+      emptyFileReplicaIds = set(),
+      committedPrimaryStorageInfos = emptyStorageInfos,
+      committedReplicaStorageInfos = emptyStorageInfos,
+      committedMapIdBitMap = emptyBitMaps,
+      partitionSizeList = emptySizes)
+
+    assert(response.status == StatusCode.PARTIAL_SUCCESS)
+    assert(response.committedPrimaryIds.asScala.toSet == Set("p0", "p1"))
+    assert(response.failedPrimaryIds.asScala.toSet == Set("p3", "p4"))
+  }
+
+  test("CELEBORN-2341: timeout response with nothing committed stays COMMIT_FILE_EXCEPTION " +
+    "and reports all requested partitions as failed") {
+    val response = Controller.buildCommitFilesResponseOnCancel(
+      primaryIds = ids("p0", "p1"),
+      replicaIds = ids("r0"),
+      committedPrimaryIds = set(),
+      committedReplicaIds = set(),
+      emptyFilePrimaryIds = set(),
+      emptyFileReplicaIds = set(),
+      committedPrimaryStorageInfos = emptyStorageInfos,
+      committedReplicaStorageInfos = emptyStorageInfos,
+      committedMapIdBitMap = emptyBitMaps,
+      partitionSizeList = emptySizes)
+
+    assert(response.status == StatusCode.COMMIT_FILE_EXCEPTION)
+    assert(response.failedPrimaryIds.asScala.toSet == Set("p0", "p1"))
+    assert(response.failedReplicaIds.asScala.toSet == Set("r0"))
+  }
+
+  test("CELEBORN-2341: empty-file partitions are never reported as failed when nothing " +
+    "committed, so they are not needlessly recomputed") {
+    // p0/p1 closed empty, p2/p3 were still queued at cancellation, nothing committed.
+    val response = Controller.buildCommitFilesResponseOnCancel(
+      primaryIds = ids("p0", "p1", "p2", "p3"),
+      replicaIds = ids(),
+      committedPrimaryIds = set(),
+      committedReplicaIds = set(),
+      emptyFilePrimaryIds = set("p0", "p1"),
+      emptyFileReplicaIds = set(),
+      committedPrimaryStorageInfos = emptyStorageInfos,
+      committedReplicaStorageInfos = emptyStorageInfos,
+      committedMapIdBitMap = emptyBitMaps,
+      partitionSizeList = emptySizes)
+
+    assert(response.status == StatusCode.PARTIAL_SUCCESS)
+    assert(response.committedPrimaryIds.isEmpty)
+    assert(response.failedPrimaryIds.asScala.toSet == Set("p2", "p3"))
+  }
+
+  test("CELEBORN-2341: all partitions empty (none committed, none in-flight) reports no " +
+    "failures, so the driver does not recompute") {
+    val response = Controller.buildCommitFilesResponseOnCancel(
+      primaryIds = ids("p0", "p1"),
+      replicaIds = ids(),
+      committedPrimaryIds = set(),
+      committedReplicaIds = set(),
+      emptyFilePrimaryIds = set("p0", "p1"),
+      emptyFileReplicaIds = set(),
+      committedPrimaryStorageInfos = emptyStorageInfos,
+      committedReplicaStorageInfos = emptyStorageInfos,
+      committedMapIdBitMap = emptyBitMaps,
+      partitionSizeList = emptySizes)
+
+    assert(response.failedPrimaryIds.isEmpty)
+    assert(response.failedReplicaIds.isEmpty)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This targets `main` and supersedes #3706 (which targeted `branch-0.6`).

When `celeborn.worker.commitFiles.timeout` fires, `Controller` cancels the per-partition commit tasks (`future.cancel(true)` / `task.cancel(true)`) and runs the `handleAsync` error branch. Today that branch:

1. **never calls `context.reply()`** — the originating `CommitFiles` RPC is left unanswered. The driver only learns the outcome after its ask times out (`celeborn.client.rpc.commitFiles.askTimeout`, which falls back to `celeborn.rpc.askTimeout`, default `60s`; often raised to `240s`+), after which it re-asks with the **same commit epoch** and the worker's dedup returns the cached response;
2. **reports empty committed lists** (`COMMIT_FILE_EXCEPTION` with all requested ids failed), discarding partitions that finished closing before the timer fired;
3. **never stops the `COMMIT_FILES_TIME` timer** (latent leak);
4. **never releases the reserved slots / partition locations** at commit time (they were only reclaimed later by the shuffle-expiry cleanup in `Worker.cleanup`).

This PR makes the cancel/timeout branch:
- `context.reply(response)` immediately, so the driver doesn't wait out the ask timeout;
- `workerSource.stopTimer(COMMIT_FILES_TIME, shuffleKey)`;
- release slots and remove partition locations before replying, mirroring the normal `reply()` path (previously they were held until shuffle expiry);
- build the response from the actual commit state via a new pure helper `Controller.buildCommitFilesResponseOnCancel`, deriving the status from the failed lists materialized in the response: `SUCCESS` when nothing actually failed (every requested partition committed or closed empty before the snapshot — i.e. cancellation raced with completion), the unchanged `COMMIT_FILE_EXCEPTION` when nothing committed and nothing is empty, and `PARTIAL_SUCCESS` otherwise.

The failed lists are computed as **`requested − committed − empty`**, not just the explicitly-failed ids (see correctness note below).

### Why are the changes needed?

**Primary — eliminate the driver stall.** On every commit timeout the driver currently blocks for a full `commitFiles.askTimeout` before the same-epoch retry retrieves the worker's cached response. Replying immediately removes that wait (and the redundant retry round). The `stopTimer` call fixes a timer leak on the same path. These two are unconditional wins on every timeout.

**Secondary — make the partial-success path safe.** Tasks still queued (or interrupted before reaching a terminal state) when cancellation fires land in *none* of the worker's `committed` / `empty` / `failed` sets. If such a partition were reported as neither committed nor failed, the driver would record it nowhere; `checkDataLost` keys only off the failed sets, so it would not flag it; `collectResult` would omit it from the reducer file group; and on the read side `CelebornShuffleReader` treats a partition **absent from the file group as empty-and-valid** (it filters the requested range to `partitionGroups.containsKey(p)`), so reducers would silently produce wrong results with no `FetchFailedException`. Computing `failed = requested − committed − empty` guarantees every not-actually-committed partition is reported failed, routing it through `checkDataLost` → `SHUFFLE_DATA_LOST` → stage recompute. This is required to return `PARTIAL_SUCCESS` without regressing into silent data loss.

**Status correctness.** The driver records the worker in `commitFilesFailedWorkers` (→ `WorkerStatusTracker.excludedWorkers`) for any terminal status other than `SUCCESS`. When cancellation races with completion and the failed lists come out empty, the response is functionally identical to a success-path response, so the helper returns `SUCCESS` — otherwise the worker would be excluded from this client's slot allocations despite no actual failure. This is safe because the committed/empty sets are append-only: empty failed lists imply every requested partition had already reached a terminal good state at snapshot time.

### Scope / honest limitations

Reduce-shuffle finalization is **all-or-nothing**: `ReducePartitionCommitHandler.handleFinalCommitFiles` calls `collectResult` (which populates the reducer file groups) only when `checkDataLost` returns `false`, and `checkDataLost` flags the **whole shuffle** if any primary failed (non-replicated) or any partition failed on both replicas. So this PR does **not** let reducers fetch the committed partitions while only the lost ones recompute — when a timeout leaves any partition uncommitted in a non-replicated shuffle, the whole map stage still recomputes, exactly as before. Preserving committed partitions avoids recompute only when the timeout left nothing actually uncommitted (e.g. the timer fired as the last file closed), and otherwise just keeps the worker's report truthful. The dependable, every-time benefits are the immediate reply and the timer fix.

### Does this PR introduce any user-facing change?

No protocol or API change. `StatusCode.PARTIAL_SUCCESS` is already part of `CommitFilesResponse` and is already handled by the driver as a terminal, non-retry status (same branch as `SUCCESS` in `CommitHandler.doParallelCommitFiles`). Note that, like any non-`SUCCESS` terminal status, it records the worker in `commitFilesFailedWorkers` — which is why the helper returns `SUCCESS` when the failed lists are empty.

### How was this patch tested?

New `ControllerSuite` unit tests for `buildCommitFilesResponseOnCancel`:
- some committed, one empty, two still-queued/in-flight → `PARTIAL_SUCCESS`, committed preserved, the in-flight ids reported failed, the empty id not failed;
- nothing committed → `COMMIT_FILE_EXCEPTION` with all requested ids failed;
- nothing committed, some empty, some in-flight → `PARTIAL_SUCCESS`, empty ids not reported failed;
- all requested partitions empty → `SUCCESS` with no failures;
- every requested partition committed or empty before the snapshot (cancellation raced with completion) → `SUCCESS`, committed preserved, no failures.

Built and `spotless:check`-clean on `worker` with Java 17; all 5 suite tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
