### PR TITLE
[MINOR] Fix PbSerDeUtilsTest failure

### DIFF
--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -848,7 +848,7 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
       new TransportMessage(MessageType.HEARTBEAT_FROM_APPLICATION_RESPONSE, payload))
       .asInstanceOf[HeartbeatFromApplicationResponse]
     assert(
-      fromTransportHeartbeatFromApplicationResponse.checkQuotaResponse.isAvailable.equals(true))
+      fromTransportHeartbeatFromApplicationResponse.checkQuotaResponse.isAvailable)
     assert(fromTransportHeartbeatFromApplicationResponse.checkQuotaResponse.reason.equals(""))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix PbSerDeUtilsTest failure for spark4 jobs

```
Error:  /home/runner/work/celeborn/celeborn/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala:851: comparing values of types Boolean and Boolean using `equals` unsafely bypasses cooperative equality; use `==` instead
Error: [ERROR] one error found
``` 
https://github.com/apache/celeborn/actions/runs/27126367363/job/80055898287?pr=3720

### Why are the changes needed?

After this change https://github.com/apache/celeborn/pull/3675, some of tests are failing.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

Existing UTs.
