### PR TITLE
[CELEBORN-2354] Fix Helm chart indentation, PodMonitor flags and cluster-scoped PriorityClass namespace

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
     {{- end }}
     celeborn.master.endpoints={{ $endpoints | join "," }}
 
-    celeborn.master.internal.endpoints = {{ $endpoints | join "," }}
+    celeborn.master.internal.endpoints={{ $endpoints | join "," }}
 
     {{- range until (.Values.master.replicas | int) }}
     {{- $host := (printf "%s-%d.%s.%s.svc.%s.local" (include "celeborn.master.statefulSet.name" $) . (include "celeborn.master.service.name" $) $.Release.Namespace $.Values.cluster.name) }}

--- a/charts/celeborn/templates/master/podmonitor.yaml
+++ b/charts/celeborn/templates/master/podmonitor.yaml
@@ -15,8 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.podMonitor.enable }}
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" -}}
+{{- if and .Values.podMonitor.enable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -37,5 +36,4 @@ spec:
   selector:
     matchLabels:
       {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/celeborn/templates/master/priorityclass.yaml
+++ b/charts/celeborn/templates/master/priorityclass.yaml
@@ -20,7 +20,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "celeborn.master.priorityClass.name" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "celeborn.master.labels" . | nindent 4 }}
 value: {{ .Values.master.priorityClass.value }}

--- a/charts/celeborn/templates/worker/podmonitor.yaml
+++ b/charts/celeborn/templates/worker/podmonitor.yaml
@@ -15,8 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.podMonitor.enable }}
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" -}}
+{{- if and .Values.podMonitor.enable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -37,5 +36,4 @@ spec:
   selector:
     matchLabels:
       {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/celeborn/templates/worker/priorityclass.yaml
+++ b/charts/celeborn/templates/worker/priorityclass.yaml
@@ -20,7 +20,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "celeborn.worker.priorityClass.name" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "celeborn.worker.labels" . | nindent 4 }}
 value: {{ .Values.worker.priorityClass.value }}

--- a/charts/celeborn/tests/configmap_test.yaml
+++ b/charts/celeborn/tests/configmap_test.yaml
@@ -49,11 +49,11 @@ tests:
           path: data["celeborn-defaults.conf"]
           pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints=.*"
 
-  - it: Should render master endpoints keys with consistent key=value spacing
+  - it: Should render config entries without spaces before the key-value separator
     asserts:
       - matchRegex:
           path: data["celeborn-defaults.conf"]
           pattern: "(?m)^\\s*celeborn\\.master\\.endpoints=.*"
-      - matchRegex:
+      - notMatchRegex:
           path: data["celeborn-defaults.conf"]
-          pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints=.*"
+          pattern: "(?m)^\\s*[^#\\s][^=\\n]*\\s+=.*"

--- a/charts/celeborn/tests/configmap_test.yaml
+++ b/charts/celeborn/tests/configmap_test.yaml
@@ -47,4 +47,13 @@ tests:
     asserts:
       - matchRegex:
           path: data["celeborn-defaults.conf"]
-          pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints\\s*=.*"
+          pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints=.*"
+
+  - it: Should render master endpoints keys with consistent key=value spacing
+    asserts:
+      - matchRegex:
+          path: data["celeborn-defaults.conf"]
+          pattern: "(?m)^\\s*celeborn\\.master\\.endpoints=.*"
+      - matchRegex:
+          path: data["celeborn-defaults.conf"]
+          pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints=.*"

--- a/charts/celeborn/tests/master/priorityclass_test.yaml
+++ b/charts/celeborn/tests/master/priorityclass_test.yaml
@@ -40,7 +40,8 @@ tests:
           apiVersion: scheduling.k8s.io/v1
           kind: PriorityClass
           name: celeborn-master-priority-class
-          namespace: celeborn
+      - notExists:
+          path: metadata.namespace
 
   - it: Should use the specified priority class value
     set:

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
 
   - it: Should change checksum annotation when celeborn config changes
     template: master/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: fae6199c4ac5ac5a9fd9049705ac239ad6e3474a65db55bdd98f29720122b756
+          value: 118d5c045d52fbbd4e8f05cf0522044373165960aa57893f645a6f9e8844dd68
 
   - it: Should add extra pod annotations if `master.annotations` is specified
     template: master/statefulset.yaml

--- a/charts/celeborn/tests/worker/priorityclass_test.yaml
+++ b/charts/celeborn/tests/worker/priorityclass_test.yaml
@@ -40,7 +40,8 @@ tests:
           apiVersion: scheduling.k8s.io/v1
           kind: PriorityClass
           name: celeborn-worker-priority-class
-          namespace: celeborn
+      - notExists:
+          path: metadata.namespace
 
   - it: Should use the specified priority class value
     set:

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
 
   - it: Should change checksum annotation when celeborn config changes
     template: worker/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: fae6199c4ac5ac5a9fd9049705ac239ad6e3474a65db55bdd98f29720122b756
+          value: 118d5c045d52fbbd4e8f05cf0522044373165960aa57893f645a6f9e8844dd68
 
   - it: Should add extra pod annotations if `worker.annotations` is specified
     template: worker/statefulset.yaml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix helm chart indentation, podmonitor flags and remove the namespace option for priorityClass.

### Why are the changes needed?

Cleanup the helm chart .

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

No.