### PR TITLE
[CELEBORN-2016] Fix the worker decommission and graceful shutdown condition

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -986,7 +986,7 @@ private[celeborn] class Worker(
     shutdown.set(true)
     val interval = conf.workerGracefulShutdownCheckSlotsFinishedInterval
     val timeout = conf.workerGracefulShutdownCheckSlotsFinishedTimeoutMs
-    var waitTimes = 0
+    var waitTimes = 1
 
     def waitTime: Long = waitTimes * interval
 
@@ -1027,7 +1027,7 @@ private[celeborn] class Worker(
     shutdown.set(true)
     val interval = conf.workerDecommissionCheckInterval
     val timeout = conf.workerDecommissionForceExitTimeout
-    var waitTimes = 0
+    var waitTimes = 1
 
     def waitTime: Long = waitTimes * interval
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -986,11 +986,11 @@ private[celeborn] class Worker(
     shutdown.set(true)
     val interval = conf.workerGracefulShutdownCheckSlotsFinishedInterval
     val timeout = conf.workerGracefulShutdownCheckSlotsFinishedTimeoutMs
-    var waitTimes = 1
+    var waitTimes = 0
 
     def waitTime: Long = waitTimes * interval
 
-    while (!partitionLocationInfo.isEmpty && waitTime < timeout) {
+    while (!partitionLocationInfo.isEmpty && waitTime + interval < timeout) {
       Thread.sleep(interval)
       waitTimes += 1
       logWarning(
@@ -1027,11 +1027,11 @@ private[celeborn] class Worker(
     shutdown.set(true)
     val interval = conf.workerDecommissionCheckInterval
     val timeout = conf.workerDecommissionForceExitTimeout
-    var waitTimes = 1
+    var waitTimes = 0
 
     def waitTime: Long = waitTimes * interval
 
-    while (!storageManager.shuffleKeySet().isEmpty && waitTime < timeout) {
+    while (!storageManager.shuffleKeySet().isEmpty && waitTime + interval < timeout) {
       Thread.sleep(interval)
       waitTimes += 1
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

In current code, we set the shutdown hook for `timeout` time and condition tries to check `timeSpent < timeout` when this condition is will become true, shutdown hook timer is already passed and VM will exit without executing the code below this point.

New condition will be `timeSpent + interval < timeout`, so we will get (0, interval] time to execute the below code.

### Why are the changes needed?

We current shutdown logic we have seen worker getting shutdown abruptly with timeout exception without completely executing the shutdown hook because of which Celeborn is unable to print unreleased partition location and unreleased shuffle on decommission and graceful shutdown.


### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

NA