### PR TITLE
[CELEBORN-2315][FOLLOWUP] Change assertIteratorFullyConsumed to throw CelebornIOException

### DIFF
--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -217,7 +217,7 @@ public abstract class CelebornShuffleWriterSuiteBase {
   }
 
   @Test
-  public void testAssertIteratorFullyConsumed() {
+  public void testAssertIteratorFullyConsumed() throws IOException {
     SparkUtils.assertIteratorFullyConsumed(false);
   }
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle.celeborn;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashSet;

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -311,7 +311,7 @@ public abstract class CelebornShuffleWriterSuiteBase {
   }
 
   @Test
-  public void testAssertIteratorFullyConsumed() {
+  public void testAssertIteratorFullyConsumed() throws IOException {
     // Test that assertIteratorFullyConsumed does not throw when iterator is empty
     SparkUtils.assertIteratorFullyConsumed(false);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace TaskKilledException with CelebornIOException in assertIteratorFullyConsumed. CelebornIOException extends IOException and fits the existing throws IOException contract of all write() methods cleanly, without needing an unchecked exception workaround.

Also revert the throwTaskKillException(String message) overload added to TaskInterruptedHelper in CELEBORN-2315, which is now dead code.


### Why are the changes needed?



### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes


### How was this patch tested?

