### PR TITLE
[MINOR] Configure GitHub workflows to use concurrency cancel-in-progress for pull requests

### DIFF
--- a/.github/workflows/cpp_integration.yml
+++ b/.github/workflows/cpp_integration.yml
@@ -27,6 +27,10 @@ on:
       - main
       - branch-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   celeborn_cpp_check_lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -27,6 +27,10 @@ on:
       - main
       - branch-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,10 @@ env:
   MINIKUBE_VERSION: v1.33.1
   KUBERNETES_VERSION: v1.30.0
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   celeborn_integration_test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,10 @@ on:
       - main
       - branch-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   service:
     runs-on: ubuntu-22.04

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -28,6 +28,10 @@ on:
       - main
       - branch-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   service:
     runs-on: ubuntu-22.04


### PR DESCRIPTION

see recommended best practices at Apache
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Configure GitHub workflows to use concurrency cancel-in-progress for pull requests. it means that if a PR is modified before the end of the execution of PR checks, the current runnign oe are cancelled to let more room for the new needed one.

### Why are the changes needed?

It will help to reduce the usage of GitHub runners. The pool of github runners is shared across whole Apache oganization, and the limit is regularly reached these days.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

similar changes were applied to several other Apache repositories
