### PR TITLE
[CIP-14][CELEBORN-2220] Support Slow Start Push in C++ Client

### DIFF
--- a/cpp/celeborn/client/tests/CMakeLists.txt
+++ b/cpp/celeborn/client/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
         ShuffleClientImplTest.cpp
         CelebornInputStreamRetryTest.cpp
         PushStateTest.cpp
+        PushStrategyTest.cpp
         ReviveManagerTest.cpp
         Lz4DecompressorTest.cpp
         ZstdDecompressorTest.cpp

--- a/cpp/celeborn/client/tests/PushStrategyTest.cpp
+++ b/cpp/celeborn/client/tests/PushStrategyTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celeborn/client/writer/PushStrategy.h"
+
+using namespace celeborn;
+using namespace celeborn::client;
+
+namespace {
+std::unique_ptr<SlowStartPushStrategy> createSlowStartStrategy(
+    int maxReqsInFlightPerWorker,
+    const std::string& maxSleepTime) {
+  conf::CelebornConf conf;
+  conf.registerProperty(
+      conf::CelebornConf::kClientPushMaxReqsInFlightPerWorker,
+      std::to_string(maxReqsInFlightPerWorker));
+  conf.registerProperty(
+      conf::CelebornConf::kClientPushLimitStrategy, "slowstart");
+  conf.registerProperty(
+      conf::CelebornConf::kClientPushSlowStartMaxSleepTime, maxSleepTime);
+  auto strategy = PushStrategy::create(conf);
+  EXPECT_NE(dynamic_cast<SlowStartPushStrategy*>(strategy.get()), nullptr);
+  return std::unique_ptr<SlowStartPushStrategy>(
+      dynamic_cast<SlowStartPushStrategy*>(strategy.release()));
+}
+} // namespace
+
+TEST(PushStrategyTest, createStrategy) {
+  conf::CelebornConf conf;
+  // Default strategy is SIMPLE.
+  EXPECT_NE(
+      dynamic_cast<SimplePushStrategy*>(PushStrategy::create(conf).get()),
+      nullptr);
+
+  // The strategy name is case-insensitive, as the Java config entry
+  // uppercases the configured value.
+  conf.registerProperty(
+      conf::CelebornConf::kClientPushLimitStrategy, "slowstart");
+  EXPECT_NE(
+      dynamic_cast<SlowStartPushStrategy*>(PushStrategy::create(conf).get()),
+      nullptr);
+
+  conf.registerProperty(
+      conf::CelebornConf::kClientPushLimitStrategy, "UNKNOWN");
+  EXPECT_THROW(PushStrategy::create(conf), std::exception);
+}
+
+TEST(PushStrategyTest, sleepTime) {
+  auto strategy = createSlowStartStrategy(32, "3s");
+  const std::string dummyHostPort = "test:9087";
+  auto context = strategy->getCongestControlContextByAddress(dummyHostPort);
+
+  // If the currentReq is 1, should sleep 440 ms
+  EXPECT_EQ(440, strategy->getSleepTime(*context));
+
+  // If the currentReq is 8, should sleep 20 ms
+  for (int i = 0; i < 7; i++) {
+    strategy->onSuccess(dummyHostPort);
+  }
+  EXPECT_EQ(20, strategy->getSleepTime(*context));
+
+  // If the currentReq is 16, should sleep 0 ms
+  for (int i = 0; i < 8; i++) {
+    strategy->onSuccess(dummyHostPort);
+  }
+  EXPECT_EQ(0, strategy->getSleepTime(*context));
+
+  // Congest the requests, the currentReq reduced to 8, should sleep 20 ms
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(20, strategy->getSleepTime(*context));
+
+  // Congest the requests, the currentReq reduced to 4, should sleep 260 ms
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(260, strategy->getSleepTime(*context));
+  // Congest the requests, the currentReq reduced to 2, should sleep 380 ms
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(380, strategy->getSleepTime(*context));
+  // Congest the requests, the currentReq reduced to 1, should sleep 440 ms
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(440, strategy->getSleepTime(*context));
+  // Keep congest the requests even the currentReq reduced to 1, will increase
+  // the sleep time 1s
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(1440, strategy->getSleepTime(*context));
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(2440, strategy->getSleepTime(*context));
+
+  // Cannot exceed the max sleep time
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(3000, strategy->getSleepTime(*context));
+
+  // If start to return success, the currentReq is increased to 2, should
+  // sleep 380 ms
+  strategy->onSuccess(dummyHostPort);
+  EXPECT_EQ(380, strategy->getSleepTime(*context));
+}
+
+TEST(PushStrategyTest, congestStrategy) {
+  auto strategy = createSlowStartStrategy(5, "4s");
+  const std::string dummyHostPort = "test:9087";
+  // Slow start, should exponentially increase the currentReq
+  strategy->onSuccess(dummyHostPort);
+  EXPECT_EQ(2, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  EXPECT_EQ(4, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+
+  // Will linearly increase the currentReq if meet the maxReqsInFlight
+  EXPECT_EQ(5, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  strategy->onSuccess(dummyHostPort);
+  EXPECT_EQ(6, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+
+  // Congest controlled, should half the currentReq
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(3, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(1, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+
+  // Cannot lower than 1
+  strategy->onCongestControl(dummyHostPort);
+  EXPECT_EQ(1, strategy->getCurrentMaxReqsInFlight(dummyHostPort));
+}
+
+TEST(PushStrategyTest, multiHosts) {
+  auto strategy = createSlowStartStrategy(3, "3s");
+  const std::string dummyHostPort1 = "test1:9087";
+  const std::string dummyHostPort2 = "test2:9087";
+  auto context1 = strategy->getCongestControlContextByAddress(dummyHostPort1);
+  auto context2 = strategy->getCongestControlContextByAddress(dummyHostPort2);
+
+  EXPECT_EQ(440, strategy->getSleepTime(*context1));
+  EXPECT_EQ(440, strategy->getSleepTime(*context2));
+
+  // Control the dummyHostPort1, should not affect dummyHostPort2
+  for (int i = 0; i < 3; i++) {
+    strategy->onSuccess(dummyHostPort1);
+  }
+  EXPECT_EQ(0, strategy->getSleepTime(*context1));
+  EXPECT_EQ(440, strategy->getSleepTime(*context2));
+}

--- a/cpp/celeborn/client/writer/PushStrategy.cpp
+++ b/cpp/celeborn/client/writer/PushStrategy.cpp
@@ -17,17 +17,117 @@
 
 #include "celeborn/client/writer/PushStrategy.h"
 
+#include <algorithm>
+#include <thread>
+
 namespace celeborn {
 namespace client {
 
 std::unique_ptr<PushStrategy> PushStrategy::create(
     const conf::CelebornConf& conf) {
   auto strategyName = conf.clientPushLimitStrategy();
+  // The Java config entry uppercases the configured value.
+  std::transform(
+      strategyName.begin(),
+      strategyName.end(),
+      strategyName.begin(),
+      ::toupper);
   if (strategyName == conf::CelebornConf::kSimplePushStrategy) {
     return std::make_unique<SimplePushStrategy>(conf);
+  } else if (strategyName == conf::CelebornConf::kSlowStartPushStrategy) {
+    return std::make_unique<SlowStartPushStrategy>(conf);
   } else {
     CELEBORN_FAIL("unsupported pushStrategy: " + strategyName);
   }
+}
+
+void SlowStartPushStrategy::CongestControlContext::increaseCurrentMaxReqs() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  continueCongestedNumber_.store(0);
+  if (currentMaxReqsInFlight_.load() >= reqsInFlightBlockThreshold_) {
+    // Congestion avoidance
+    congestionAvoidanceFlag_++;
+    if (congestionAvoidanceFlag_ >= currentMaxReqsInFlight_.load()) {
+      currentMaxReqsInFlight_.fetch_add(1);
+      congestionAvoidanceFlag_ = 0;
+    }
+  } else {
+    // Slow start
+    currentMaxReqsInFlight_.fetch_add(1);
+  }
+}
+
+void SlowStartPushStrategy::CongestControlContext::decreaseCurrentMaxReqs() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (currentMaxReqsInFlight_.load() <= 1) {
+    currentMaxReqsInFlight_.store(1);
+    continueCongestedNumber_.fetch_add(1);
+  } else {
+    currentMaxReqsInFlight_.store(currentMaxReqsInFlight_.load() / 2);
+  }
+  reqsInFlightBlockThreshold_ = currentMaxReqsInFlight_.load();
+  congestionAvoidanceFlag_ = 0;
+}
+
+std::shared_ptr<SlowStartPushStrategy::CongestControlContext>
+SlowStartPushStrategy::getCongestControlContextByAddress(
+    const std::string& hostAndPushPort) {
+  return congestControlInfoPerAddress_.computeIfAbsent(hostAndPushPort, [&]() {
+    return std::make_shared<CongestControlContext>(maxInFlightPerWorker_);
+  });
+}
+
+void SlowStartPushStrategy::onSuccess(const std::string& hostAndPushPort) {
+  getCongestControlContextByAddress(hostAndPushPort)->increaseCurrentMaxReqs();
+}
+
+void SlowStartPushStrategy::onCongestControl(
+    const std::string& hostAndPushPort) {
+  getCongestControlContextByAddress(hostAndPushPort)->decreaseCurrentMaxReqs();
+}
+
+long SlowStartPushStrategy::getSleepTime(CongestControlContext& context) const {
+  int currentMaxReqs = context.getCurrentMaxReqsInFlight();
+  if (currentMaxReqs >= maxInFlightPerWorker_) {
+    return 0;
+  }
+
+  long sleepInterval = initialSleepMills_ - 60L * currentMaxReqs;
+
+  if (currentMaxReqs == 1) {
+    return std::min(
+        sleepInterval + context.getContinueCongestedNumber() * 1000L,
+        maxSleepMills_);
+  }
+
+  return std::max(sleepInterval, 0L);
+}
+
+void SlowStartPushStrategy::limitPushSpeed(
+    PushState& pushState,
+    const std::string& hostAndPushPort) {
+  auto exceptionMsg = pushState.getExceptionMsg();
+  if (exceptionMsg.has_value()) {
+    CELEBORN_FAIL(exceptionMsg.value());
+  }
+  auto congestControlContext =
+      getCongestControlContextByAddress(hostAndPushPort);
+  long sleepInterval = getSleepTime(*congestControlContext);
+  if (sleepInterval > 0L) {
+    VLOG(1) << "Will sleep " << sleepInterval
+            << " ms to control the push speed to " << hostAndPushPort << ".";
+    std::this_thread::sleep_for(utils::MS(sleepInterval));
+  }
+}
+
+int SlowStartPushStrategy::getCurrentMaxReqsInFlight(
+    const std::string& hostAndPushPort) {
+  return getCongestControlContextByAddress(hostAndPushPort)
+      ->getCurrentMaxReqsInFlight();
+}
+
+void SlowStartPushStrategy::clear() {
+  congestControlInfoPerAddress_.clear();
 }
 
 } // namespace client

--- a/cpp/celeborn/client/writer/PushStrategy.h
+++ b/cpp/celeborn/client/writer/PushStrategy.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 
 #include "celeborn/client/writer/PushState.h"
 #include "celeborn/conf/CelebornConf.h"
+#include "celeborn/utils/CelebornUtils.h"
 
 namespace celeborn {
 namespace client {
@@ -73,7 +76,67 @@ class SimplePushStrategy : public PushStrategy {
   const int maxInFlightPerWorker_;
 };
 
-// TODO: support SlowStartPushStrategy
+class SlowStartPushStrategy : public PushStrategy {
+ public:
+  class CongestControlContext {
+   public:
+    CongestControlContext(int reqsInFlightBlockThreshold)
+        : reqsInFlightBlockThreshold_(reqsInFlightBlockThreshold) {}
+
+    void increaseCurrentMaxReqs();
+
+    void decreaseCurrentMaxReqs();
+
+    int getCurrentMaxReqsInFlight() const {
+      return currentMaxReqsInFlight_.load();
+    }
+
+    int getContinueCongestedNumber() const {
+      return continueCongestedNumber_.load();
+    }
+
+   private:
+    std::mutex mutex_;
+    std::atomic<int> currentMaxReqsInFlight_{1};
+    // Indicate the number of congested times even after the in flight
+    // requests reduced to 1.
+    std::atomic<int> continueCongestedNumber_{0};
+    int congestionAvoidanceFlag_{0};
+    int reqsInFlightBlockThreshold_;
+  };
+
+  SlowStartPushStrategy(const conf::CelebornConf& conf)
+      : maxInFlightPerWorker_(conf.clientPushMaxReqsInFlightPerWorker()),
+        initialSleepMills_(conf.clientPushSlowStartInitialSleepTime()),
+        maxSleepMills_(conf.clientPushSlowStartMaxSleepMills()) {}
+
+  ~SlowStartPushStrategy() override = default;
+
+  void onSuccess(const std::string& hostAndPushPort) override;
+
+  void onCongestControl(const std::string& hostAndPushPort) override;
+
+  void clear() override;
+
+  void limitPushSpeed(PushState& pushState, const std::string& hostAndPushPort)
+      override;
+
+  int getCurrentMaxReqsInFlight(const std::string& hostAndPushPort) override;
+
+  // Visible for testing.
+  std::shared_ptr<CongestControlContext> getCongestControlContextByAddress(
+      const std::string& hostAndPushPort);
+
+  // Visible for testing.
+  long getSleepTime(CongestControlContext& context) const;
+
+ private:
+  const int maxInFlightPerWorker_;
+  const long initialSleepMills_;
+  const long maxSleepMills_;
+  utils::ConcurrentHashMap<std::string, std::shared_ptr<CongestControlContext>>
+      congestControlInfoPerAddress_;
+};
 
 } // namespace client
 } // namespace celeborn

--- a/cpp/celeborn/conf/CelebornConf.cpp
+++ b/cpp/celeborn/conf/CelebornConf.cpp
@@ -147,6 +147,8 @@ CelebornConf::defaultProperties() {
           NUM_PROP(kClientPushReviveBatchSize, 2048),
           NUM_PROP(kClientPushMaxReviveTimes, 5),
           STR_PROP(kClientPushLimitStrategy, kSimplePushStrategy),
+          STR_PROP(kClientPushSlowStartInitialSleepTime, "500ms"),
+          STR_PROP(kClientPushSlowStartMaxSleepTime, "2s"),
           NUM_PROP(kClientPushMaxReqsInFlightPerWorker, 32),
           NUM_PROP(kClientPushMaxReqsInFlightTotal, 256),
           NUM_PROP(kClientPushLimitInFlightTimeoutMs, 240000),
@@ -256,6 +258,20 @@ int CelebornConf::clientPushMaxReviveTimes() const {
 
 std::string CelebornConf::clientPushLimitStrategy() const {
   return optionalProperty(kClientPushLimitStrategy).value();
+}
+
+long CelebornConf::clientPushSlowStartInitialSleepTime() const {
+  return utils::toTimeout(
+             toDuration(optionalProperty(kClientPushSlowStartInitialSleepTime)
+                            .value()))
+      .count();
+}
+
+long CelebornConf::clientPushSlowStartMaxSleepMills() const {
+  return utils::toTimeout(
+             toDuration(
+                 optionalProperty(kClientPushSlowStartMaxSleepTime).value()))
+      .count();
 }
 
 int CelebornConf::clientPushMaxReqsInFlightPerWorker() const {

--- a/cpp/celeborn/conf/CelebornConf.h
+++ b/cpp/celeborn/conf/CelebornConf.h
@@ -77,6 +77,14 @@ class CelebornConf : public BaseConf {
 
   static constexpr std::string_view kSimplePushStrategy{"SIMPLE"};
 
+  static constexpr std::string_view kSlowStartPushStrategy{"SLOWSTART"};
+
+  static constexpr std::string_view kClientPushSlowStartInitialSleepTime{
+      "celeborn.client.push.slowStart.initialSleepTime"};
+
+  static constexpr std::string_view kClientPushSlowStartMaxSleepTime{
+      "celeborn.client.push.slowStart.maxSleepTime"};
+
   static constexpr std::string_view kClientPushMaxReqsInFlightPerWorker{
       "celeborn.client.push.maxReqsInFlight.perWorker"};
 
@@ -184,6 +192,10 @@ class CelebornConf : public BaseConf {
   int clientPushMaxReviveTimes() const;
 
   std::string clientPushLimitStrategy() const;
+
+  long clientPushSlowStartInitialSleepTime() const;
+
+  long clientPushSlowStartMaxSleepMills() const;
 
   int clientPushMaxReqsInFlightPerWorker() const;
 

--- a/cpp/celeborn/conf/tests/CelebornConfTest.cpp
+++ b/cpp/celeborn/conf/tests/CelebornConfTest.cpp
@@ -54,6 +54,9 @@ void testDefaultValues(CelebornConf* conf) {
   EXPECT_EQ(conf->clientFetchMaxRetriesForEachReplica(), 3);
   EXPECT_EQ(conf->networkIoRetryWait(), SECOND(5));
   EXPECT_FALSE(conf->clientPushReplicateEnabled());
+  EXPECT_EQ(conf->clientPushLimitStrategy(), CelebornConf::kSimplePushStrategy);
+  EXPECT_EQ(conf->clientPushSlowStartInitialSleepTime(), 500);
+  EXPECT_EQ(conf->clientPushSlowStartMaxSleepMills(), 2000);
   EXPECT_FALSE(conf->clientFetchExcludeWorkerOnFailureEnabled());
   EXPECT_EQ(conf->clientFetchExcludedWorkerExpireTimeout(), SECOND(60));
   EXPECT_FALSE(conf->clientAdaptiveOptimizeSkewedPartitionReadEnabled());
@@ -101,6 +104,16 @@ TEST(CelebornConfTest, setValues) {
   EXPECT_TRUE(conf->clientPushReplicateEnabled());
   conf->registerProperty(CelebornConf::kClientPushReplicateEnabled, "false");
   EXPECT_FALSE(conf->clientPushReplicateEnabled());
+  conf->registerProperty(
+      CelebornConf::kClientPushLimitStrategy,
+      std::string(CelebornConf::kSlowStartPushStrategy));
+  EXPECT_EQ(
+      conf->clientPushLimitStrategy(), CelebornConf::kSlowStartPushStrategy);
+  conf->registerProperty(
+      CelebornConf::kClientPushSlowStartInitialSleepTime, "1s");
+  EXPECT_EQ(conf->clientPushSlowStartInitialSleepTime(), 1000);
+  conf->registerProperty(CelebornConf::kClientPushSlowStartMaxSleepTime, "3s");
+  EXPECT_EQ(conf->clientPushSlowStartMaxSleepMills(), 3000);
   conf->registerProperty(
       CelebornConf::kClientFetchExcludeWorkerOnFailureEnabled, "true");
   EXPECT_TRUE(conf->clientFetchExcludeWorkerOnFailureEnabled());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Implement SlowStartPushStrategy in the C++ client, mirroring the Java client's TCP-like congestion control for push speed:

- Track a per worker CongestControlContext that grows the in-flight request limit on success (slow start, then congestion avoidance once the limit reaches the threshold) and halves it on congestion, falling back to sleeping when congestion persists at a limit of 1.

- Select the strategy through celeborn.client.push.limitStrategy=SLOWSTART

- Add configs celeborn.client.push.slowStart.initialSleepTime (default 500ms) and celeborn.client.push.slowStart.maxSleepTime (default 2s) to control sleep intervals while ramping up.

- Add PushStrategyTest covering strategy creation, sleep time calculation, congestion control, and per host isolation, and add to CelebornConfTest with the new configs.

### Why are the changes needed?

This is needed to bridge the gap between features that the java client has vs what the c++ client has.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

CI/CD