### PR TITLE
[CELEBORN-2356] Fix NPE before null-check in handleChunkFetchRequest

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -557,6 +557,14 @@ class FetchHandler(
       s" to fetch block $streamChunkSlice")
 
     val streamState = chunkStreamManager.getStreamState(streamChunkSlice.streamId)
+    if (streamState == null) {
+      val message = s"Stream ${streamChunkSlice.streamId} is not registered with worker. " +
+        "This can happen if the worker was restarted recently."
+      logError(message)
+      workerSource.incCounter(storageMetrics._3)
+      client.getChannel.writeAndFlush(new ChunkFetchFailure(streamChunkSlice, message))
+      return
+    }
     val storageMetrics = streamState.buffers match {
       case _: FileChunkBuffers => (
           WorkerSource.FETCH_LOCAL_CHUNK_TIME,
@@ -566,14 +574,6 @@ class FetchHandler(
           WorkerSource.FETCH_MEMORY_CHUNK_TIME,
           WorkerSource.FETCH_MEMORY_CHUNK_SUCCESS_COUNT,
           WorkerSource.FETCH_MEMORY_CHUNK_FAIL_COUNT)
-    }
-    if (streamState == null) {
-      val message = s"Stream ${streamChunkSlice.streamId} is not registered with worker. " +
-        "This can happen if the worker was restart recently."
-      logError(message)
-      workerSource.incCounter(storageMetrics._3)
-      client.getChannel.writeAndFlush(new ChunkFetchFailure(streamChunkSlice, message))
-      return
     }
 
     maxChunkBeingTransferred.foreach { threshold =>

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java
@@ -50,6 +50,7 @@ import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportResponseHandler;
+import org.apache.celeborn.common.network.protocol.ChunkFetchFailure;
 import org.apache.celeborn.common.network.protocol.ChunkFetchSuccess;
 import org.apache.celeborn.common.network.protocol.Message;
 import org.apache.celeborn.common.network.protocol.OpenStream;
@@ -300,6 +301,38 @@ public class FetchHandlerSuiteJ {
     } finally {
       cleanup(fileInfo);
     }
+  }
+
+  @Test
+  public void testFetchChunkForUnregisteredStream() {
+    EmbeddedChannel channel = new EmbeddedChannel();
+    TransportClient client = new TransportClient(channel, mock(TransportResponseHandler.class));
+    FetchHandler fetchHandler = mockFetchHandler(null);
+
+    // the stream is never opened, so it is unknown to the ChunkStreamManager
+    long unregisteredStreamId = 12345;
+    fetchHandler.receive(
+        client,
+        new RpcRequest(
+            TransportClient.requestId(),
+            new NioManagedBuffer(
+                new TransportMessage(
+                        MessageType.CHUNK_FETCH_REQUEST,
+                        PbChunkFetchRequest.newBuilder()
+                            .setStreamChunkSlice(
+                                PbStreamChunkSlice.newBuilder()
+                                    .setStreamId(unregisteredStreamId)
+                                    .setChunkIndex(0)
+                                    .setOffset(0)
+                                    .setLen(Integer.MAX_VALUE))
+                            .build()
+                            .toByteArray())
+                    .toByteBuffer())),
+        createRpcResponseCallback(channel));
+
+    ChunkFetchFailure chunkFetchFailure = channel.readOutbound();
+    assertEquals(unregisteredStreamId, chunkFetchFailure.streamChunkSlice.streamId);
+    assertTrue(chunkFetchFailure.errorString.contains("not registered"));
   }
 
   private FetchHandler mockFetchHandler(FileInfo fileInfo) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

getStreamState returns null for an unknown id. The streamState.buffers pattern match dereferences it before the null guard runs, throwing NullPointerException. The intended ChunkFetchFailure reply is unreachable. Here we should reorder null-check first, then compute storageMetrics.


### Why are the changes needed?

To prevent potential NPEs.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [x] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

CI/CD Unit tests.