### PR TITLE
[CELEBORN-2360] Fix ReviseLostShuffles RPC deserialization

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -1331,6 +1331,12 @@ object ControlMessages extends Logging {
       case BATCH_UNREGISTER_SHUFFLES_VALUE =>
         PbBatchUnregisterShuffles.parseFrom(message.getPayload)
 
+      case REVISE_LOST_SHUFFLES_VALUE =>
+        PbReviseLostShuffles.parseFrom(message.getPayload)
+
+      case REVISE_LOST_SHUFFLES_RESPONSE_VALUE =>
+        PbReviseLostShufflesResponse.parseFrom(message.getPayload)
+
       case UNREGISTER_SHUFFLE_RESPONSE_VALUE =>
         PbUnregisterShuffleResponse.parseFrom(message.getPayload)
 

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -29,8 +29,8 @@ import org.apache.celeborn.common.client.{MasterEndpointResolver, StaticMasterEn
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.identity.DefaultIdentityProvider
 import org.apache.celeborn.common.network.protocol.SerdeVersion
-import org.apache.celeborn.common.protocol.{PartitionLocation, TransportModuleConstants}
-import org.apache.celeborn.common.protocol.message.ControlMessages.{GetReducerFileGroupResponse, MapperEnd}
+import org.apache.celeborn.common.protocol.{PartitionLocation, PbReviseLostShuffles, PbReviseLostShufflesResponse, TransportModuleConstants}
+import org.apache.celeborn.common.protocol.message.ControlMessages.{GetReducerFileGroupResponse, MapperEnd, ReviseLostShuffles, ReviseLostShufflesResponse}
 import org.apache.celeborn.common.protocol.message.StatusCode
 
 class UtilsSuite extends CelebornFunSuite {
@@ -172,6 +172,21 @@ class UtilsSuite extends CelebornFunSuite {
     assert(mapperEnd.numPartitions == mapperEndTrans.numPartitions)
     mapperEnd.crc32PerPartition.array should contain theSameElementsInOrderAs mapperEndTrans.crc32PerPartition
     mapperEnd.bytesWrittenPerPartition.array should contain theSameElementsInOrderAs mapperEndTrans.bytesWrittenPerPartition
+  }
+
+  test("ReviseLostShuffles class convert with pb") {
+    val req = ReviseLostShuffles("app-1", util.Arrays.asList[Integer](1, 2, 3), "req-1")
+    val reqTrans = Utils.fromTransportMessage(Utils.toTransportMessage(req))
+      .asInstanceOf[PbReviseLostShuffles]
+    assert(req.getAppId == reqTrans.getAppId)
+    assert(req.getLostShufflesList == reqTrans.getLostShufflesList)
+    assert(req.getRequestId == reqTrans.getRequestId)
+
+    val resp = ReviseLostShufflesResponse(true, "ok")
+    val respTrans = Utils.fromTransportMessage(Utils.toTransportMessage(resp))
+      .asInstanceOf[PbReviseLostShufflesResponse]
+    assert(resp.getSuccess == respTrans.getSuccess)
+    assert(resp.getMessage == respTrans.getMessage)
   }
 
   test("validate HDFS compatible fs path") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

CELEBORN-1601 added ReviseLostShuffles support but only wired up the encode side (toTransportMessage), the master handler, and the client sender. The corresponding decode cases in ControlMessages.fromTransportMessage were never added. Since that match has no default case, receiving a REVISE_LOST_SHUFFLES (89) request on the master or a REVISE_LOST_SHUFFLES_RESPONSE (90) on the client throws a MatchError, so the feature is broken over RPC. The existing test exercises handleReviseLostShuffles directly and bypasses the RPC round-trip, which is why this was probably not caught.

To fix, I added the missing REVISE_LOST_SHUFFLES_VALUE and REVISE_LOST_SHUFFLES_RESPONSE_VALUE cases so the messages deserialize into PbReviseLostShuffles / PbReviseLostShufflesResponse.

I also added a round trip test in UtilsSuite covering both messages.

### Why are the changes needed?

To fix an existing bug. 

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [x] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

CI/CD