### PR TITLE
[CELEBORN-2361] Unblock stage-end when CommitFilesResponse carries an empty map-id bitmap

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -361,6 +361,9 @@ public abstract class CelebornInputStream extends InputStream {
       if (bitmap == null && location.hasPeer()) {
         bitmap = location.getPeer().getMapIdBitMap();
       }
+      if (bitmap == null) {
+        return false;
+      }
       for (int i = startMapIndex; i < endMapIndex; i++) {
         if (bitmap.contains(i)) {
           return false;

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -210,23 +210,30 @@ class ReducePartitionCommitHandler(
       }
     }
 
-    // ask allLocations workers holding partitions to commit files
-    val allocatedWorkers = shuffleAllocatedWorkers.get(shuffleId)
-    val (dataLost, commitFailedWorkers) = handleFinalCommitFiles(shuffleId, allocatedWorkers)
-    recordWorkerFailure(commitFailedWorkers)
-    // reply
-    if (!dataLost) {
-      logInfo(s"Succeed to handle stageEnd for $shuffleId.")
-      // record in stageEndShuffleSet
-      setStageEnd(shuffleId)
-    } else {
-      logError(s"Failed to handle stageEnd for $shuffleId, lost file!")
-      dataLostShuffleSet.add(shuffleId)
-      // record in stageEndShuffleSet
-      setStageEnd(shuffleId)
+    try {
+      // ask allLocations workers holding partitions to commit files
+      val allocatedWorkers = shuffleAllocatedWorkers.get(shuffleId)
+      val (dataLost, commitFailedWorkers) = handleFinalCommitFiles(shuffleId, allocatedWorkers)
+      recordWorkerFailure(commitFailedWorkers)
+      // reply
+      if (!dataLost) {
+        logInfo(s"Succeed to handle stageEnd for $shuffleId.")
+        // record in stageEndShuffleSet
+        setStageEnd(shuffleId)
+      } else {
+        logError(s"Failed to handle stageEnd for $shuffleId, lost file!")
+        dataLostShuffleSet.add(shuffleId)
+        // record in stageEndShuffleSet
+        setStageEnd(shuffleId)
+      }
+      true
+    } finally {
+      // Always clear the in-process marker, even if commit threw. Otherwise the shuffle
+      // stays in inProcessStageEndShuffleSet with stageEnd never set, and every
+      // GetReducerFileGroup request parks until the executor RPC timeout. Clearing it
+      // here allows a subsequent stage-end attempt to retry the commit.
+      inProcessStageEndShuffleSet.remove(shuffleId)
     }
-    inProcessStageEndShuffleSet.remove(shuffleId)
-    true
   }
 
   private def handleFinalCommitFiles(

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -1480,7 +1480,14 @@ object ControlMessages extends Logging {
         pbCommitFilesResponse.getCommittedReplicaStorageInfosMap.asScala.foreach(entry =>
           committedReplicaStorageInfos.put(entry._1, StorageInfo.fromPb(entry._2)))
         pbCommitFilesResponse.getMapIdBitmapMap.asScala.foreach { entry =>
-          committedBitMap.put(entry._1, Utils.byteStringToRoaringBitmap(entry._2))
+          // byteStringToRoaringBitmap returns null for an empty bytestring (an empty
+          // RoaringBitmap is serialized as ByteString.EMPTY by the worker). Skip such
+          // entries so the null value does not propagate into the committedMapIdBitMap,
+          // where it would later throw NPE when merged into a ConcurrentHashMap via putAll.
+          val bitmap = Utils.byteStringToRoaringBitmap(entry._2)
+          if (bitmap != null) {
+            committedBitMap.put(entry._1, bitmap)
+          }
         }
         CommitFilesResponse(
           StatusCode.fromValue(pbCommitFilesResponse.getStatus),

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -20,6 +20,7 @@ package org.apache.celeborn.common.util
 import java.util
 import java.util.Collections
 
+import org.roaringbitmap.RoaringBitmap
 import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
@@ -257,6 +258,37 @@ class UtilsSuite extends CelebornFunSuite {
     val set =
       (response.fileGroup.values().toArray diff responseTrans.fileGroup.values().toArray).toSet
     assert(set.size == 0)
+  }
+
+  test("CommitFilesResponse with empty map-id bitmap survives transport round-trip") {
+    // Regression test: a worker serializes an empty RoaringBitmap as
+    // ByteString.EMPTY, which byteStringToRoaringBitmap deserializes back to null.
+    // That null must not end up in committedMapIdBitMap, otherwise putAll into the
+    // ConcurrentHashMap in CommitHandler.processResponse throws NPE and stage-end hangs.
+    val committedMapIdBitMap = new util.HashMap[String, RoaringBitmap]()
+    committedMapIdBitMap.put("0-0", new RoaringBitmap()) // empty bitmap
+    val nonEmpty = RoaringBitmap.bitmapOf(1, 2, 3)
+    committedMapIdBitMap.put("0-1", nonEmpty)
+
+    val response = CommitFilesResponse(
+      StatusCode.SUCCESS,
+      Collections.emptyList[String](),
+      Collections.emptyList[String](),
+      Collections.emptyList[String](),
+      Collections.emptyList[String](),
+      committedMapIdBitMap = committedMapIdBitMap)
+    val responseTrans = Utils.fromTransportMessage(Utils.toTransportMessage(response))
+      .asInstanceOf[CommitFilesResponse]
+
+    // The empty bitmap entry is dropped (not present as a null value), and merging into
+    // a ConcurrentHashMap must not throw.
+    assert(!responseTrans.committedMapIdBitMap.containsValue(null))
+    assert(!responseTrans.committedMapIdBitMap.containsKey("0-0"))
+    assert(responseTrans.committedMapIdBitMap.get("0-1") == nonEmpty)
+
+    val concurrent = new java.util.concurrent.ConcurrentHashMap[String, RoaringBitmap]()
+    concurrent.putAll(responseTrans.committedMapIdBitMap)
+    assert(concurrent.size() == 1)
   }
 
   test("validate number of client/server netty threads") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

A worker serializes an empty RoaringBitmap as an empty protobuf bytestring, and Utils.byteStringToRoaringBitmap deserializes empty bytes back to null. That null was stored in CommitFilesResponse.committedMapIdBitMap (a HashMap, which allows null values) and then merged into the ConcurrentHashMap ShuffleCommittedInfo.committedMapIdBitmap via putAll, which rejects null values and throws NPE in processResponse.

Since ReducePartitionCommitHandler.tryFinalCommit had no try/finally, the shuffle was left in inProcessStageEndShuffleSet and setStageEnd was never called, so every GetReducerFileGroup request parked until the executor RPC timeout, hanging the spark client process.

Fixes:
- ControlMessages: skip null bitmaps when deserializing CommitFilesResponse so null never reaches the ConcurrentHashMap.putAll.
- ReducePartitionCommitHandler: wrap the commit in try/finally so the in-process stage-end marker is always cleared, allowing retry.
- CelebornInputStream.skipLocation: treat a null mapId bitmap as "do not skip", guarding against the same empty->null round-trip in the read path.

I added a UtilsSuite regression test asserting a CommitFilesResponse with an empty bitmap survives the transport round-trip without null map values.

### Why are the changes needed?

Without this, spark clients can hang for a really long time and see lots of NPE errors. 

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [x] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

CI/CD
