### PR TITLE
[CELEBORN-2363] Bump Flink version to 1.20.5, 2.0.2 and 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.9.14</maven.version>
 
-    <flink.version>1.20.1</flink.version>
+    <flink.version>1.20.5</flink.version>
     <spark.version>3.3.4</spark.version>
 
     <!-- use hadoop-3 as default  -->
@@ -1951,7 +1951,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>1.20.3</flink.version>
+        <flink.version>1.20.5</flink.version>
         <flink.binary.version>1.20</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.20_${scala.binary.version}</celeborn.flink.plugin.artifact>
@@ -1971,7 +1971,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>2.0.1</flink.version>
+        <flink.version>2.0.2</flink.version>
         <flink.binary.version>2.0</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-2.0_${scala.binary.version}</celeborn.flink.plugin.artifact>
@@ -1991,7 +1991,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>2.1.1</flink.version>
+        <flink.version>2.1.3</flink.version>
         <flink.binary.version>2.1</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-2.1_${scala.binary.version}</celeborn.flink.plugin.artifact>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1288,7 +1288,7 @@ object Flink119 extends FlinkClientProjects {
 }
 
 object Flink120 extends FlinkClientProjects {
-  val flinkVersion = "1.20.3"
+  val flinkVersion = "1.20.5"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-1.20"
@@ -1298,7 +1298,7 @@ object Flink120 extends FlinkClientProjects {
 }
 
 object Flink20 extends FlinkClientProjects {
-  val flinkVersion = "2.0.1"
+  val flinkVersion = "2.0.2"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-2.0"
@@ -1308,7 +1308,7 @@ object Flink20 extends FlinkClientProjects {
 }
 
 object Flink21 extends FlinkClientProjects {
-  val flinkVersion = "2.1.1"
+  val flinkVersion = "2.1.3"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-2.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump the supported Flink versions to their latest patch releases:

- Flink 1.20: `1.20.3` → `1.20.5` (and the default `flink.version` property `1.20.1` → `1.20.5`)
- Flink 2.0: `2.0.1` → `2.0.2`
- Flink 2.1: `2.1.1` → `2.1.3`

Updated in both `pom.xml` and `project/CelebornBuild.scala`.

### Why are the changes needed?

Keep the Flink clients aligned with the latest patch releases, which include bug fixes and security fixes from upstream Flink.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

Existing CI (Maven and SBT builds plus the Flink integration tests `tests/flink-it`).