### PR TITLE
[CELEBORN-2365] Bump Spark version from 4.0.1 to 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1678,7 +1678,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.13.16</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
-        <spark.version>4.0.1</spark.version>
+        <spark.version>4.0.3</spark.version>
         <zstd-jni.version>1.5.6-9</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1001,7 +1001,7 @@ object Spark40 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.13.16"
 
-  val sparkVersion = "4.0.1"
+  val sparkVersion = "4.0.3"
   val zstdJniVersion = "1.5.6-9"
   val scalaBinaryVersion = "2.13"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump the Spark 4.0 dependency version from `4.0.1` to `4.0.3` in both the Maven build (`pom.xml`) and the SBT build (`project/CelebornBuild.scala`).

### Why are the changes needed?

[Apache Spark 4.0.3](https://spark.apache.org/news/spark-4-0-3-released.html) is a maintenance release containing security and correctness fixes, and the Spark community strongly recommends all 4.0 users upgrade to this stable release. See the [release notes](https://spark.apache.org/releases/spark-release-4-0-3.html) for details.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes

### How was this patch tested?

Pass GitHub Actions.
