### PR TITLE
[CELEBORN-2369] Retry stopped master Outbox failures

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
-import org.apache.celeborn.common.exception.CelebornException;
 import org.apache.celeborn.common.protocol.message.ControlMessages.OneWayMessageResponse$;
 import org.apache.celeborn.common.protocol.message.MasterRequestMessage;
 import org.apache.celeborn.common.protocol.message.Message;
@@ -75,8 +74,6 @@ public class MasterClient {
   }
 
   private static final String SPLITTER = "#";
-  private static final String OUTBOX_STOPPED_MESSAGE =
-      "Message is dropped because Outbox is stopped";
   private static final AtomicLong CALL_ID_COUNTER = new AtomicLong();
 
   static long nextCallId() {
@@ -197,13 +194,12 @@ public class MasterClient {
   }
 
   private boolean isRetryableRpcFailure(Throwable throwable) {
+    if (throwable.getCause() instanceof IOException || throwable instanceof RpcTimeoutException) {
+      return true;
+    }
     Throwable current = throwable;
     while (current != null) {
-      if (current instanceof IOException || current instanceof RpcTimeoutException) {
-        return true;
-      }
-      if (current instanceof CelebornException
-          && OUTBOX_STOPPED_MESSAGE.equals(current.getMessage())) {
+      if (current instanceof OutboxStoppedException) {
         return true;
       }
       current = current.getCause();

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornException;
 import org.apache.celeborn.common.protocol.message.ControlMessages.OneWayMessageResponse$;
 import org.apache.celeborn.common.protocol.message.MasterRequestMessage;
 import org.apache.celeborn.common.protocol.message.Message;
@@ -74,6 +75,8 @@ public class MasterClient {
   }
 
   private static final String SPLITTER = "#";
+  private static final String OUTBOX_STOPPED_MESSAGE =
+      "Message is dropped because Outbox is stopped";
   private static final AtomicLong CALL_ID_COUNTER = new AtomicLong();
 
   static long nextCallId() {
@@ -186,9 +189,24 @@ public class MasterClient {
         resetRpcEndpointRef(oldRef);
       }
       return true;
-    } else if (e.getCause() instanceof IOException || e instanceof RpcTimeoutException) {
+    } else if (isRetryableRpcFailure(e)) {
       resetRpcEndpointRef(oldRef);
       return true;
+    }
+    return false;
+  }
+
+  private boolean isRetryableRpcFailure(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof IOException || current instanceof RpcTimeoutException) {
+        return true;
+      }
+      if (current instanceof CelebornException
+          && OUTBOX_STOPPED_MESSAGE.equals(current.getMessage())) {
+        return true;
+      }
+      current = current.getCause();
     }
     return false;
   }

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/OutboxStoppedException.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/OutboxStoppedException.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.rpc
+
+import org.apache.celeborn.common.exception.CelebornException
+
+private[celeborn] class OutboxStoppedException()
+  extends CelebornException(OutboxStoppedException.MESSAGE)
+
+private[celeborn] object OutboxStoppedException {
+  val MESSAGE = "Message is dropped because Outbox is stopped"
+}

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
@@ -105,6 +105,8 @@ class NettyRpcEnv(
 
   private val stopped = new AtomicBoolean(false)
 
+  private[netty] def isStopped: Boolean = stopped.get()
+
   /**
    * A map for [[RpcAddress]] and [[Outbox]]. When we are connecting to a remote [[RpcAddress]],
    * we just put messages to its [[Outbox]] to implement a non-blocking `send` method.
@@ -208,7 +210,9 @@ class NettyRpcEnv(
       if (stopped.get) {
         // It's possible that we put `targetOutbox` after stopping. So we need to clean it.
         outboxes.remove(receiver.address)
-        targetOutbox.stop()
+        val cause = new RpcEnvStoppedException()
+        targetOutbox.stop(cause)
+        message.onFailure(cause)
       } else {
         targetOutbox.send(message)
       }
@@ -336,7 +340,7 @@ class NettyRpcEnv(
     while (iter.hasNext()) {
       val outbox = iter.next()
       outboxes.remove(outbox.address)
-      outbox.stop()
+      outbox.stop(new RpcEnvStoppedException())
     }
     if (timeoutScheduler != null) {
       timeoutScheduler.shutdownNow()

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Outbox.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Outbox.scala
@@ -23,10 +23,9 @@ import javax.annotation.concurrent.GuardedBy
 
 import scala.util.control.NonFatal
 
-import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient}
-import org.apache.celeborn.common.rpc.{RpcAddress, RpcEnvStoppedException}
+import org.apache.celeborn.common.rpc.{OutboxStoppedException, RpcAddress, RpcEnvStoppedException}
 
 sealed private[celeborn] trait OutboxMessage {
 
@@ -257,7 +256,7 @@ private[celeborn] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
   def stop(): Unit =
     stop(
       if (nettyEnv.isStopped) new RpcEnvStoppedException()
-      else new CelebornException("Message is dropped because Outbox is stopped"))
+      else new OutboxStoppedException())
 
   /** Stop [[Outbox]] and notify the remaining messages with the supplied cause. */
   def stop(cause: Throwable): Unit = {

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Outbox.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Outbox.scala
@@ -104,6 +104,9 @@ private[celeborn] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
   @GuardedBy("this")
   private var stopped = false
 
+  @GuardedBy("this")
+  private var stopCause: Throwable = null
+
   /**
    * If there is any thread draining the message queue
    */
@@ -112,19 +115,20 @@ private[celeborn] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
 
   /**
    * Send a message. If there is no active connection, cache it and launch a new connection. If
-   * [[Outbox]] is stopped, the sender will be notified with a [[CelebornException]].
+   * [[Outbox]] is stopped, the sender will be notified with the cause that stopped it.
    */
   def send(message: OutboxMessage): Unit = {
-    val dropped = synchronized {
+    val failure = synchronized {
       if (stopped) {
-        true
+        assert(stopCause != null)
+        stopCause
       } else {
         messages.add(message)
-        false
+        null
       }
     }
-    if (dropped) {
-      message.onFailure(new CelebornException("Message is dropped because Outbox is stopped"))
+    if (failure != null) {
+      message.onFailure(failure)
     } else {
       drainOutbox()
     }
@@ -225,6 +229,7 @@ private[celeborn] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
         return
       }
       stopped = true
+      stopCause = e
       closeClient()
     }
     // Remove this Outbox from nettyEnv so that the further messages will create a new Outbox along
@@ -248,16 +253,20 @@ private[celeborn] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
     client = null
   }
 
-  /**
-   * Stop [[Outbox]]. The remaining messages in the [[Outbox]] will be notified with a
-   * [[CelebornException]].
-   */
-  def stop(): Unit = {
+  /** Stop [[Outbox]] using a terminal cause when its owning RPC environment is shutting down. */
+  def stop(): Unit =
+    stop(
+      if (nettyEnv.isStopped) new RpcEnvStoppedException()
+      else new CelebornException("Message is dropped because Outbox is stopped"))
+
+  /** Stop [[Outbox]] and notify the remaining messages with the supplied cause. */
+  def stop(cause: Throwable): Unit = {
     synchronized {
       if (stopped) {
         return
       }
       stopped = true
+      stopCause = cause
       if (connectFuture != null) {
         connectFuture.cancel(true)
       }
@@ -268,7 +277,7 @@ private[celeborn] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
     // update messages and it's safe to just drain the queue.
     var message = messages.poll()
     while (message != null) {
-      message.onFailure(new CelebornException("Message is dropped because Outbox is stopped"))
+      message.onFailure(cause)
       message = messages.poll()
     }
   }

--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.common.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -44,6 +45,7 @@ import org.apache.celeborn.common.protocol.message.ControlMessages.HeartbeatFrom
 import org.apache.celeborn.common.protocol.message.ControlMessages.HeartbeatFromWorker;
 import org.apache.celeborn.common.protocol.message.ControlMessages.HeartbeatFromWorkerResponse;
 import org.apache.celeborn.common.protocol.message.ControlMessages.OneWayMessageResponse$;
+import org.apache.celeborn.common.rpc.OutboxStoppedException;
 import org.apache.celeborn.common.rpc.RpcAddress;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.rpc.RpcEnv;
@@ -257,8 +259,7 @@ public class MasterClientSuiteJ {
     Mockito.doAnswer(
             invocation -> {
               assertEquals(0, master1Attempts.getAndIncrement());
-              return Future$.MODULE$.failed(
-                  new CelebornException("Message is dropped because Outbox is stopped"));
+              return Future$.MODULE$.failed(new OutboxStoppedException());
             })
         .when(master1)
         .ask(Mockito.any(), Mockito.any(), Mockito.any());
@@ -309,35 +310,20 @@ public class MasterClientSuiteJ {
 
   @Test
   public void testStoppedRpcEnvFailureDoesNotReconnectInHA() {
-    final CelebornConf conf = prepareForCelebornConfWithHA();
-    final RpcEndpointRef master1 = Mockito.mock(RpcEndpointRef.class);
+    checkMasterAskFailureDoesNotReconnectInHA(new RpcEnvStoppedException());
+  }
 
-    Mockito.doReturn(Future$.MODULE$.failed(new RpcEnvStoppedException()))
-        .when(master1)
-        .ask(Mockito.any(), Mockito.any(), Mockito.any());
-    Mockito.doAnswer(
-            invocation -> {
-              RpcAddress address = invocation.getArgument(0, RpcAddress.class);
-              if ("host1".equals(address.host())) {
-                return master1;
-              }
-              fail("Should not reconnect through a stopped RpcEnv: " + address);
-              return null;
-            })
-        .when(rpcEnv)
-        .setupEndpointRef(Mockito.any(RpcAddress.class), Mockito.anyString());
+  @Test
+  public void testNestedIOExceptionDoesNotReconnectInHA() {
+    checkMasterAskFailureDoesNotReconnectInHA(
+        new CelebornException("Permanent failure", new IOException("test")));
+  }
 
-    MasterClient client = new MasterClient(rpcEnv, conf, false);
-    HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
-
-    CelebornException thrown =
-        assertThrows(
-            CelebornException.class,
-            () -> client.askSync(message, HeartbeatFromWorkerResponse.class));
-    assertTrue(thrown.getCause() instanceof RpcEnvStoppedException);
-    Mockito.verify(rpcEnv, Mockito.times(1))
-        .setupEndpointRef(
-            Mockito.eq(RpcAddress.fromHostAndPort("host1:9097")), Mockito.anyString());
+  @Test
+  public void testNestedRpcTimeoutDoesNotReconnectInHA() {
+    checkMasterAskFailureDoesNotReconnectInHA(
+        new CelebornException(
+            "Permanent failure", new RpcTimeoutException("test", new TimeoutException("test"))));
   }
 
   @Test
@@ -638,6 +624,39 @@ public class MasterClientSuiteJ {
     }
 
     assertEquals(mockResponse, response);
+  }
+
+  private void checkMasterAskFailureDoesNotReconnectInHA(Exception exception) {
+    final CelebornConf conf = prepareForCelebornConfWithHA();
+    final RpcEndpointRef master1 = Mockito.mock(RpcEndpointRef.class);
+
+    Mockito.doReturn(Future$.MODULE$.failed(exception))
+        .when(master1)
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.doAnswer(
+            invocation -> {
+              RpcAddress address = invocation.getArgument(0, RpcAddress.class);
+              if ("host1".equals(address.host())) {
+                return master1;
+              }
+              fail("Should not reconnect after a non-retryable failure: " + address);
+              return null;
+            })
+        .when(rpcEnv)
+        .setupEndpointRef(Mockito.any(RpcAddress.class), Mockito.anyString());
+
+    MasterClient client = new MasterClient(rpcEnv, conf, false);
+    HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
+
+    CelebornException thrown =
+        assertThrows(
+            CelebornException.class,
+            () -> client.askSync(message, HeartbeatFromWorkerResponse.class));
+    assertSame(exception, thrown.getCause());
+    Mockito.verify(master1, Mockito.times(1)).ask(Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.verify(rpcEnv, Mockito.times(1))
+        .setupEndpointRef(
+            Mockito.eq(RpcAddress.fromHostAndPort("host1:9097")), Mockito.anyString());
   }
 
   private void checkOneMasterAskFailedInHA(Exception exception) {

--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -47,6 +47,7 @@ import org.apache.celeborn.common.protocol.message.ControlMessages.OneWayMessage
 import org.apache.celeborn.common.rpc.RpcAddress;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.rpc.RpcEnv;
+import org.apache.celeborn.common.rpc.RpcEnvStoppedException;
 import org.apache.celeborn.common.rpc.RpcTimeoutException;
 
 public class MasterClientSuiteJ {
@@ -243,6 +244,100 @@ public class MasterClientSuiteJ {
   @Test
   public void testOneMasterTimeoutInHA() {
     checkOneMasterAskFailedInHA(new RpcTimeoutException("test", new TimeoutException("test")));
+  }
+
+  @Test
+  public void testStoppedOutboxFailureReconnectsToAnotherMasterInHA() {
+    final CelebornConf conf = prepareForCelebornConfWithHA();
+
+    final RpcEndpointRef master1 = Mockito.mock(RpcEndpointRef.class);
+    final RpcEndpointRef master2 = Mockito.mock(RpcEndpointRef.class);
+    final AtomicInteger master1Attempts = new AtomicInteger(0);
+
+    Mockito.doAnswer(
+            invocation -> {
+              assertEquals(0, master1Attempts.getAndIncrement());
+              return Future$.MODULE$.failed(
+                  new CelebornException("Message is dropped because Outbox is stopped"));
+            })
+        .when(master1)
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.doReturn(Future$.MODULE$.successful(mockResponse))
+        .when(master2)
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
+
+    Mockito.doAnswer(
+            invocation -> {
+              RpcAddress address = invocation.getArgument(0, RpcAddress.class);
+              switch (address.host()) {
+                case "host1":
+                  return master1;
+                case "host2":
+                  return master2;
+                default:
+                  fail(
+                      "Should reconnect from host1 to host2:"
+                          + masterPort
+                          + ", but use "
+                          + address);
+              }
+              return null;
+            })
+        .when(rpcEnv)
+        .setupEndpointRef(Mockito.any(RpcAddress.class), Mockito.anyString());
+
+    MasterClient client = new MasterClient(rpcEnv, conf, false);
+    HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
+
+    HeartbeatFromWorkerResponse response = null;
+    try {
+      response = client.askSync(message, HeartbeatFromWorkerResponse.class);
+    } catch (Throwable t) {
+      LOG.error("It should reconnect after a stopped outbox failure.", t);
+      fail("It should reconnect after a stopped outbox failure.");
+    }
+
+    assertEquals(mockResponse, response);
+    assertEquals(1, master1Attempts.get());
+    Mockito.verify(rpcEnv, Mockito.times(1))
+        .setupEndpointRef(
+            Mockito.eq(RpcAddress.fromHostAndPort("host1:9097")), Mockito.anyString());
+    Mockito.verify(rpcEnv, Mockito.times(1))
+        .setupEndpointRef(
+            Mockito.eq(RpcAddress.fromHostAndPort("host2:9097")), Mockito.anyString());
+  }
+
+  @Test
+  public void testStoppedRpcEnvFailureDoesNotReconnectInHA() {
+    final CelebornConf conf = prepareForCelebornConfWithHA();
+    final RpcEndpointRef master1 = Mockito.mock(RpcEndpointRef.class);
+
+    Mockito.doReturn(Future$.MODULE$.failed(new RpcEnvStoppedException()))
+        .when(master1)
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.doAnswer(
+            invocation -> {
+              RpcAddress address = invocation.getArgument(0, RpcAddress.class);
+              if ("host1".equals(address.host())) {
+                return master1;
+              }
+              fail("Should not reconnect through a stopped RpcEnv: " + address);
+              return null;
+            })
+        .when(rpcEnv)
+        .setupEndpointRef(Mockito.any(RpcAddress.class), Mockito.anyString());
+
+    MasterClient client = new MasterClient(rpcEnv, conf, false);
+    HeartbeatFromWorker message = Mockito.mock(HeartbeatFromWorker.class);
+
+    CelebornException thrown =
+        assertThrows(
+            CelebornException.class,
+            () -> client.askSync(message, HeartbeatFromWorkerResponse.class));
+    assertTrue(thrown.getCause() instanceof RpcEnvStoppedException);
+    Mockito.verify(rpcEnv, Mockito.times(1))
+        .setupEndpointRef(
+            Mockito.eq(RpcAddress.fromHostAndPort("host1:9097")), Mockito.anyString());
   }
 
   @Test

--- a/common/src/test/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnvSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnvSuite.scala
@@ -76,16 +76,21 @@ class NettyRpcEnvSuite extends RpcEnvSuite with TimeLimits {
         }
       })
     val clientEnv = createRpcEnv(createCelebornConf(), "stopped-client", 0, clientMode = true)
-    val endpointRef = clientEnv.setupEndpointRef(env.address, endpointName)
+    try {
+      val endpointRef = clientEnv.setupEndpointRef(env.address, endpointName)
 
-    clientEnv.shutdown()
-    clientEnv.awaitTermination()
+      clientEnv.shutdown()
+      clientEnv.awaitTermination()
 
-    failAfter(5.seconds) {
-      val e = intercept[CelebornException] {
-        endpointRef.askSync[String]("hello")
+      failAfter(5.seconds) {
+        val e = intercept[CelebornException] {
+          endpointRef.askSync[String]("hello")
+        }
+        assert(e.getCause.isInstanceOf[RpcEnvStoppedException])
       }
-      assert(e.getCause.isInstanceOf[RpcEnvStoppedException])
+    } finally {
+      clientEnv.shutdown()
+      clientEnv.awaitTermination()
     }
   }
 

--- a/common/src/test/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnvSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnvSuite.scala
@@ -65,6 +65,30 @@ class NettyRpcEnvSuite extends RpcEnvSuite with TimeLimits {
     assert(e.getCause.getMessage.contains(uri))
   }
 
+  test("ask through a stopped RPC environment fails immediately") {
+    val endpointName = "stopped-rpc-env"
+    env.setupEndpoint(
+      endpointName,
+      new RpcEndpoint {
+        override val rpcEnv: RpcEnv = env
+        override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+          case message => context.reply(message)
+        }
+      })
+    val clientEnv = createRpcEnv(createCelebornConf(), "stopped-client", 0, clientMode = true)
+    val endpointRef = clientEnv.setupEndpointRef(env.address, endpointName)
+
+    clientEnv.shutdown()
+    clientEnv.awaitTermination()
+
+    failAfter(5.seconds) {
+      val e = intercept[CelebornException] {
+        endpointRef.askSync[String]("hello")
+      }
+      assert(e.getCause.isInstanceOf[RpcEnvStoppedException])
+    }
+  }
+
   test("advertise address different from bind address") {
     val celebornConf = createCelebornConf()
     val config = RpcEnvConfig(

--- a/common/src/test/scala/org/apache/celeborn/common/rpc/netty/OutboxSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/rpc/netty/OutboxSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.rpc.netty
+
+import java.nio.ByteBuffer
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
+import org.mockito.Mockito.{mock, when}
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.exception.CelebornException
+import org.apache.celeborn.common.rpc.{RpcAddress, RpcEnvStoppedException}
+
+class OutboxSuite extends CelebornFunSuite {
+
+  private def failureMessage(
+      failure: AtomicReference[Throwable],
+      failed: CountDownLatch): RpcOutboxMessage =
+    RpcOutboxMessage(
+      ByteBuffer.allocate(0),
+      e => {
+        failure.set(e)
+        failed.countDown()
+      },
+      (_, _) => ())
+
+  test("send after terminal stop uses the original cause") {
+    val outbox = new Outbox(mock(classOf[NettyRpcEnv]), RpcAddress("localhost", 12345))
+    val cause = new RpcEnvStoppedException()
+    val failure = new AtomicReference[Throwable]()
+    val failed = new CountDownLatch(1)
+
+    outbox.stop(cause)
+    outbox.send(failureMessage(failure, failed))
+
+    assert(failed.await(10, TimeUnit.SECONDS))
+    assert(failure.get() eq cause)
+  }
+
+  test("send after transient stop remains retryable") {
+    val outbox = new Outbox(mock(classOf[NettyRpcEnv]), RpcAddress("localhost", 12345))
+    val failure = new AtomicReference[Throwable]()
+    val failed = new CountDownLatch(1)
+
+    outbox.stop()
+    outbox.send(failureMessage(failure, failed))
+
+    assert(failed.await(10, TimeUnit.SECONDS))
+    assert(failure.get().isInstanceOf[CelebornException])
+    assert(failure.get().getMessage === "Message is dropped because Outbox is stopped")
+  }
+
+  test("default stop after RPC environment shutdown uses the terminal cause") {
+    val nettyEnv = mock(classOf[NettyRpcEnv])
+    val outbox = new Outbox(nettyEnv, RpcAddress("localhost", 12345))
+    val failure = new AtomicReference[Throwable]()
+    val failed = new CountDownLatch(1)
+    when(nettyEnv.isStopped).thenReturn(true)
+
+    outbox.stop()
+    outbox.send(failureMessage(failure, failed))
+
+    assert(failed.await(10, TimeUnit.SECONDS))
+    assert(failure.get().isInstanceOf[RpcEnvStoppedException])
+  }
+}

--- a/common/src/test/scala/org/apache/celeborn/common/rpc/netty/OutboxSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/rpc/netty/OutboxSuite.scala
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicReference
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.celeborn.CelebornFunSuite
-import org.apache.celeborn.common.exception.CelebornException
-import org.apache.celeborn.common.rpc.{RpcAddress, RpcEnvStoppedException}
+import org.apache.celeborn.common.rpc.{OutboxStoppedException, RpcAddress, RpcEnvStoppedException}
 
 class OutboxSuite extends CelebornFunSuite {
 
@@ -62,8 +61,8 @@ class OutboxSuite extends CelebornFunSuite {
     outbox.send(failureMessage(failure, failed))
 
     assert(failed.await(10, TimeUnit.SECONDS))
-    assert(failure.get().isInstanceOf[CelebornException])
-    assert(failure.get().getMessage === "Message is dropped because Outbox is stopped")
+    assert(failure.get().isInstanceOf[OutboxStoppedException])
+    assert(failure.get().getMessage === OutboxStoppedException.MESSAGE)
   }
 
   test("default stop after RPC environment shutdown uses the terminal cause") {


### PR DESCRIPTION
## Why are the changes needed?

When a Celeborn client loses its cached master connection, the associated Outbox can be stopped before queued or late master RPC messages are sent. Those requests fail with `CelebornException: Message is dropped because Outbox is stopped`.

`MasterClient` currently retries I/O and RPC timeout failures, but it does not recognize this stopped-Outbox failure when it is wrapped by the normal `awaitResult` path. In HA mode, a request can therefore fail instead of clearing the stale `RpcEndpointRef` and reconnecting to another available master.

The same legacy message is also used when the local `RpcEnv` shuts down permanently. Treating every occurrence as retryable without distinguishing shutdown would cause futile reconnect attempts through an already-stopped environment.

JIRA: https://issues.apache.org/jira/browse/CELEBORN-2369

## What changes were proposed in this PR?

- Recognize the exact legacy stopped-Outbox failure through its cause chain and reset the cached master endpoint so the existing HA retry path can reconnect.
- Use `RpcEnvStoppedException` for terminal local shutdown so shutdown failures remain non-retryable.
- Preserve each Outbox's original stop cause for queued and late messages.
- Fail messages submitted after `RpcEnv` shutdown immediately with the terminal cause.
- Add focused coverage for HA reconnection, terminal no-reconnect behavior, and transient versus terminal Outbox causes.

### Does this PR resolve a correctness bug?

- [x] Yes

### Does this PR introduce _any_ user-facing change?

- [x] Yes. Master RPCs can now fail over after a transient stopped-Outbox failure instead of failing immediately. No public API or configuration changes are introduced.

## How was this PR tested?

Using JDK 17:

- `build/mvn --no-transfer-progress -DskipTests spotless:apply`
- `build/mvn --no-transfer-progress -pl common -DskipTests test-compile`
- `build/mvn --no-transfer-progress -pl common -DargLine= -Dtest=org.apache.celeborn.common.client.MasterClientSuiteJ surefire:test` — 17 tests passed.
- `build/mvn --no-transfer-progress -pl common -DargLine= -DwildcardSuites=org.apache.celeborn.common.rpc.netty.OutboxSuite scalatest:test` — 3 tests passed.
- `build/mvn --no-transfer-progress -pl common -DargLine= -DwildcardSuites=org.apache.celeborn.common.rpc.netty.NettyRpcEnvSuite scalatest:test` — 33 tests passed.
- `build/mvn --no-transfer-progress -DskipTests spotless:check` — all 10 reactor modules passed.
