### PR TITLE
[CELEBORN-2375] Support DecommissionThenIdle and Recommission via wor…

### DIFF
--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventRequest.java
@@ -71,7 +71,7 @@ public class WorkerEventRequest {
     }
   }
 
-  public static final String JSON_PROPERTY_EVENT_TYPE = "event_type";
+  public static final String JSON_PROPERTY_EVENT_TYPE = "eventType";
   private EventTypeEnum eventType;
 
   public WorkerEventRequest() {

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/WorkerEventRequest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.celeborn.rest.v1.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * WorkerEventRequest
+ */
+@JsonPropertyOrder({
+  WorkerEventRequest.JSON_PROPERTY_EVENT_TYPE
+})
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.8.0")
+public class WorkerEventRequest {
+  /**
+   * The type of the worker event. Legal types are &#39;DECOMMISSIONTHENIDLE&#39; and &#39;RECOMMISSION&#39;. 
+   */
+  public enum EventTypeEnum {
+    DECOMMISSIONTHENIDLE("DECOMMISSIONTHENIDLE"),
+    
+    RECOMMISSION("RECOMMISSION");
+
+    private String value;
+
+    EventTypeEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EventTypeEnum fromValue(String value) {
+      for (EventTypeEnum b : EventTypeEnum.values()) {
+        if (b.value.equalsIgnoreCase(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+  }
+
+  public static final String JSON_PROPERTY_EVENT_TYPE = "event_type";
+  private EventTypeEnum eventType;
+
+  public WorkerEventRequest() {
+  }
+
+  public WorkerEventRequest eventType(EventTypeEnum eventType) {
+    
+    this.eventType = eventType;
+    return this;
+  }
+
+  /**
+   * The type of the worker event. Legal types are &#39;DECOMMISSIONTHENIDLE&#39; and &#39;RECOMMISSION&#39;. 
+   * @return eventType
+   */
+  @javax.annotation.Nonnull
+  @JsonProperty(JSON_PROPERTY_EVENT_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public EventTypeEnum getEventType() {
+    return eventType;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EVENT_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setEventType(EventTypeEnum eventType) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WorkerEventRequest workerEventRequest = (WorkerEventRequest) o;
+    return Objects.equals(this.eventType, workerEventRequest.eventType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(eventType);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class WorkerEventRequest {\n");
+    sb.append("    eventType: ").append(toIndentedString(eventType)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/worker/WorkerApi.java
@@ -27,6 +27,7 @@ import org.apache.celeborn.rest.v1.worker.invoker.Pair;
 
 import org.apache.celeborn.rest.v1.model.HandleResponse;
 import org.apache.celeborn.rest.v1.model.UnAvailablePeersResponse;
+import org.apache.celeborn.rest.v1.model.WorkerEventRequest;
 import org.apache.celeborn.rest.v1.model.WorkerExitRequest;
 import org.apache.celeborn.rest.v1.model.WorkerInfoResponse;
 
@@ -169,6 +170,75 @@ public class WorkerApi extends BaseApi {
     return apiClient.invokeAPI(
         localVarPath,
         "GET",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * 
+   * Send an event to this worker to trigger a state transition. Legal event types are &#39;DECOMMISSIONTHENIDLE&#39; and &#39;RECOMMISSION&#39;. 
+   * @param workerEventRequest  (optional)
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse workerEvent(WorkerEventRequest workerEventRequest) throws ApiException {
+    return this.workerEvent(workerEventRequest, Collections.emptyMap());
+  }
+
+
+  /**
+   * 
+   * Send an event to this worker to trigger a state transition. Legal event types are &#39;DECOMMISSIONTHENIDLE&#39; and &#39;RECOMMISSION&#39;. 
+   * @param workerEventRequest  (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return HandleResponse
+   * @throws ApiException if fails to make API call
+   */
+  public HandleResponse workerEvent(WorkerEventRequest workerEventRequest, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = workerEventRequest;
+    
+    // create path and map variables
+    String localVarPath = "/api/v1/workers/events";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "basic" };
+
+    TypeReference<HandleResponse> localVarReturnType = new TypeReference<HandleResponse>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
         localVarQueryParams,
         localVarCollectionQueryParams,
         localVarQueryStringJoiner.toString(),

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -247,6 +247,7 @@ paths:
         Send an event to this worker to trigger a state transition.
         Legal event types are 'DECOMMISSIONTHENIDLE' and 'RECOMMISSION'.
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -784,7 +785,7 @@ components:
     WorkerEventRequest:
       type: object
       properties:
-        event_type:
+        eventType:
           type: string
           description: |
             The type of the worker event.
@@ -793,7 +794,7 @@ components:
             - DECOMMISSIONTHENIDLE
             - RECOMMISSION
       required:
-        - event_type
+        - eventType
 
     LoggerInfo:
       type: object

--- a/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/worker_rest_v1.yaml
@@ -238,6 +238,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/HandleResponse'
 
+  /api/v1/workers/events:
+    post:
+      tags:
+        - Worker
+      operationId: workerEvent
+      description: |
+        Send an event to this worker to trigger a state transition.
+        Legal event types are 'DECOMMISSIONTHENIDLE' and 'RECOMMISSION'.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkerEventRequest'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandleResponse'
+
   /api/v1/applications:
     get:
       tags:
@@ -759,6 +780,20 @@ components:
             - GRACEFUL
             - IMMEDIATELY
             - NONE
+
+    WorkerEventRequest:
+      type: object
+      properties:
+        event_type:
+          type: string
+          description: |
+            The type of the worker event.
+            Legal types are 'DECOMMISSIONTHENIDLE' and 'RECOMMISSION'.
+          enum:
+            - DECOMMISSIONTHENIDLE
+            - RECOMMISSION
+      required:
+        - event_type
 
     LoggerInfo:
       type: object

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -185,6 +185,8 @@ abstract class HttpService extends Service with Logging {
 
   def exit(exitType: String): String = throw new UnsupportedOperationException()
 
+  def workerEvent(eventType: String): String = throw new UnsupportedOperationException()
+
   def handleWorkerEvent(
       workerEventType: WorkerEventType,
       workers: Seq[WorkerInfo]): HandleResponse =

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -981,7 +981,7 @@ private[celeborn] class Worker(
     sb.append("============================ Worker Event =============================\n")
     sb.append(s"Worker event $eventType received (state=$state): \n")
     sb.append(workerInfo.toString()).append("\n")
-  }
+    sb.toString()
 
   def shutdownGracefully(): Unit = {
     // During shutdown, to avoid allocate slots in this worker,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -976,11 +976,11 @@ private[celeborn] class Worker(
       case _ =>
         return s"Unsupported worker event type: $eventType. Legal types are 'DECOMMISSIONTHENIDLE' and 'RECOMMISSION'."
     }
+    val state = workerStatusManager.getWorkerState()
     val sb = new StringBuilder
     sb.append("============================ Worker Event =============================\n")
-    sb.append(s"Worker event $eventType triggered: \n")
+    sb.append(s"Worker event $eventType received (state=$state): \n")
     sb.append(workerInfo.toString()).append("\n")
-    sb.toString()
   }
 
   def shutdownGracefully(): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -967,6 +967,22 @@ private[celeborn] class Worker(
     sb.toString()
   }
 
+  override def workerEvent(eventType: String): String = {
+    eventType.toUpperCase(Locale.ROOT) match {
+      case "DECOMMISSIONTHENIDLE" =>
+        workerStatusManager.doTransition(WorkerEventType.DecommissionThenIdle)
+      case "RECOMMISSION" =>
+        workerStatusManager.doTransition(WorkerEventType.Recommission)
+      case _ =>
+        return s"Unsupported worker event type: $eventType. Legal types are 'DECOMMISSIONTHENIDLE' and 'RECOMMISSION'."
+    }
+    val sb = new StringBuilder
+    sb.append("============================ Worker Event =============================\n")
+    sb.append(s"Worker event $eventType triggered: \n")
+    sb.append(workerInfo.toString()).append("\n")
+    sb.toString()
+  }
+
   def shutdownGracefully(): Unit = {
     // During shutdown, to avoid allocate slots in this worker,
     // add this worker to master's excluded list. When restart, register worker will

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/WorkerResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/WorkerResource.scala
@@ -97,7 +97,7 @@ class WorkerResource extends ApiRequestContext {
   @POST
   @Path("/events")
   def workerEvent(request: WorkerEventRequest): HandleResponse = {
-    if (request.getEventType == null) {
+    if (request == null || request.getEventType == null) {
       return new HandleResponse().success(false).message("eventType is required")
     }
     new HandleResponse()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/WorkerResource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/WorkerResource.scala
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.annotations.media.{Content, Schema}
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 
-import org.apache.celeborn.rest.v1.model.{HandleResponse, UnAvailablePeersResponse, WorkerExitRequest, WorkerInfoResponse, WorkerTimestampData}
+import org.apache.celeborn.rest.v1.model.{HandleResponse, UnAvailablePeersResponse, WorkerEventRequest, WorkerExitRequest, WorkerInfoResponse, WorkerTimestampData}
 import org.apache.celeborn.server.common.http.api.ApiRequestContext
 import org.apache.celeborn.server.common.http.api.v1.ApiUtils
 import org.apache.celeborn.service.deploy.worker.Worker
@@ -84,5 +84,24 @@ class WorkerResource extends ApiRequestContext {
     new HandleResponse()
       .success(true)
       .message(httpService.exit(request.getType.toString))
+  }
+
+  @Operation(description =
+    "Send an event to this worker to trigger a state transition. " +
+      "Legal event types are 'DECOMMISSIONTHENIDLE' and 'RECOMMISSION'.")
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = new Schema(implementation = classOf[HandleResponse]))))
+  @POST
+  @Path("/events")
+  def workerEvent(request: WorkerEventRequest): HandleResponse = {
+    if (request.getEventType == null) {
+      return new HandleResponse().success(false).message("eventType is required")
+    }
+    new HandleResponse()
+      .success(true)
+      .message(httpService.workerEvent(request.getEventType.toString))
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResourceSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/http/api/v1/ApiV1WorkerResourceSuite.scala
@@ -18,9 +18,10 @@
 package org.apache.celeborn.service.deploy.worker.http.api.v1
 
 import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.client.Entity
 import javax.ws.rs.core.MediaType
 
-import org.apache.celeborn.rest.v1.model.{ApplicationsResponse, ShufflePartitionsResponse, ShufflesResponse, UnAvailablePeersResponse, WorkerInfoResponse}
+import org.apache.celeborn.rest.v1.model.{ApplicationsResponse, HandleResponse, ShufflePartitionsResponse, ShufflesResponse, UnAvailablePeersResponse, WorkerEventRequest, WorkerInfoResponse}
 import org.apache.celeborn.server.common.HttpService
 import org.apache.celeborn.server.common.http.api.v1.ApiV1BaseResourceSuite
 import org.apache.celeborn.service.deploy.MiniClusterFeature
@@ -73,5 +74,43 @@ class ApiV1WorkerResourceSuite extends ApiV1BaseResourceSuite with MiniClusterFe
     response = webTarget.path("workers/unavailable_peers").request(MediaType.APPLICATION_JSON).get()
     assert(HttpServletResponse.SC_OK == response.getStatus)
     assert(response.readEntity(classOf[UnAvailablePeersResponse]).getPeers.isEmpty)
+  }
+
+  test("worker events resource") {
+    // null eventType → success:false
+    var response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(new WorkerEventRequest(), MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    val nullEventResponse = response.readEntity(classOf[HandleResponse])
+    assert(!nullEventResponse.getSuccess)
+    assert(nullEventResponse.getMessage.contains("eventType is required"))
+
+    // DECOMMISSIONTHENIDLE → success:true, worker enters shutdown/decommission path
+    response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(
+        new WorkerEventRequest().eventType(WorkerEventRequest.EventTypeEnum.DECOMMISSIONTHENIDLE),
+        MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[HandleResponse]).getSuccess)
+
+    // worker is now in shutdown state (InDecommissionThenIdle or Idle)
+    response = webTarget.path("workers").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[WorkerInfoResponse]).getIsShutdown)
+
+    // RECOMMISSION → success:true, worker returns to Normal
+    response = webTarget.path("workers/events").request(MediaType.APPLICATION_JSON).post(
+      Entity.entity(
+        new WorkerEventRequest().eventType(WorkerEventRequest.EventTypeEnum.RECOMMISSION),
+        MediaType.APPLICATION_JSON))
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    assert(response.readEntity(classOf[HandleResponse]).getSuccess)
+
+    // worker is back to normal: not shutdown, not decommissioning
+    response = webTarget.path("workers").request(MediaType.APPLICATION_JSON).get()
+    assert(HttpServletResponse.SC_OK == response.getStatus)
+    val restoredWorker = response.readEntity(classOf[WorkerInfoResponse])
+    assert(!restoredWorker.getIsShutdown)
+    assert(!restoredWorker.getIsDecommissioning)
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Introduces a new `POST /api/v1/workers/events` endpoint to the Worker HTTP API that allows operators to trigger worker state transitions directly on a specific worker node, without going through the Master:

  POST /api/v1/workers/events
  {"eventType": "DECOMMISSIONTHENIDLE"}   # drain traffic, stay alive
  {"eventType": "RECOMMISSION"}           # bring worker back to Normal

The endpoint is backed by:
- `WorkerEventRequest` — a new request model exposing only the two state-transition event types (`DECOMMISSIONTHENIDLE`, `RECOMMISSION`), deliberately excluding exit-bound types (`DECOMMISSION`, `GRACEFUL`, `IMMEDIATELY`) which belong to the existing `/exit` endpoint.
- `Worker#workerEvent()` — routes the event to `WorkerStatusManager#doTransition()`, reusing the existing state-machine logic.
- `WorkerApi#workerEvent()` — corresponding method in the generated Java client.

### Why are the changes needed?

The existing `POST /api/v1/workers/exit` endpoint conflates two semantically different operations — traffic draining and process termination — by accepting `DECOMMISSION`, `GRACEFUL`, and `IMMEDIATELY` as exit types. `DecommissionThenIdle` is fundamentally different: it removes the worker from the serving path while keeping the process alive, making it unsuitable for `/exit` both semantically and operationally.

The Master already exposes `POST /api/v1/workers/events` for cluster-wide worker lifecycle management. However, that endpoint requires the caller to resolve the current Master leader and know the target worker's full identity before dispatching the request. In practice — especially in multi-cluster deployments where dozens of independent Celeborn clusters share the same operations platform — requiring maintenance scripts to first discover the active Master leader per cluster significantly increases operational complexity and the blast radius of mis-targeting. A worker-local endpoint removes this indirection entirely: the script targets the exact host being decommissioned, sends a single HTTP request, and the worker handles the rest. A subsequent `RECOMMISSION` call to the same host restores the worker to service without a restart, making the operation fully reversible.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [x] Yes

A new REST endpoint `POST /api/v1/workers/events` is added to the Worker HTTP API, along with a corresponding `workerEvent()` method in the generated Java client (`WorkerApi`). Operators can now trigger `DECOMMISSIONTHENIDLE` and
  `RECOMMISSION` state transitions directly on a worker node without routing through the Master.

### How was this patch tested?

UT
