### PR TITLE
[CELEBORN-2376] Filter empty ResourceConsumption entries in WorkerInfo toString output

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -269,10 +269,15 @@ class WorkerInfo(
     val userResourceConsumptionString =
       if (userResourceConsumption == null || userResourceConsumption.isEmpty) {
         "empty"
-      } else if (userResourceConsumption != null) {
-        userResourceConsumption.asScala.map { case (userIdentifier, resourceConsumption) =>
-          s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
-        }.mkString("")
+      } else {
+        val nonEmpty = userResourceConsumption.asScala.filterNot(_._2.isEmpty)
+        if (nonEmpty.isEmpty) {
+          "empty"
+        } else {
+          nonEmpty.map { case (userIdentifier, resourceConsumption) =>
+            s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
+          }.mkString("")
+        }
       }
     s"""
        |Host: $host

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -270,14 +270,11 @@ class WorkerInfo(
       if (userResourceConsumption == null || userResourceConsumption.isEmpty) {
         "empty"
       } else {
-        val nonEmpty = userResourceConsumption.asScala.filterNot(_._2.isEmpty)
-        if (nonEmpty.isEmpty) {
-          "empty"
-        } else {
-          nonEmpty.map { case (userIdentifier, resourceConsumption) =>
+        val rendered = userResourceConsumption.asScala.iterator.collect {
+          case (userIdentifier, resourceConsumption) if !resourceConsumption.isEmpty =>
             s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
-          }.mkString("")
-        }
+        }.mkString("")
+        if (rendered.isEmpty) "empty" else rendered
       }
     s"""
        |Host: $host

--- a/common/src/main/scala/org/apache/celeborn/common/quota/ResourceConsumption.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/quota/ResourceConsumption.scala
@@ -76,6 +76,11 @@ case class ResourceConsumption(
     (add(other._1), addSubResourceConsumptions(other._2))
   }
 
+  def isEmpty: Boolean = {
+    diskBytesWritten == 0 && diskFileCount == 0 && hdfsBytesWritten == 0 && hdfsFileCount == 0 &&
+    CollectionUtils.isEmpty(subResourceConsumptions)
+  }
+
   override def toString: String = {
     val subResourceConsumptionString =
       if (CollectionUtils.isEmpty(subResourceConsumptions)) {


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added an `isEmpty()` method to `ResourceConsumption` that returns `true` when all four counters (`diskBytesWritten`, `diskFileCount`, `hdfsBytesWritten`, `hdfsFileCount`) are zero and `subResourceConsumptions` is empty.

`WorkerInfo.toString` now uses this method to skip users with no active resource consumption, so that only entries with non-zero usage are included in the output. An additional guard handles the edge case where all entries are filtered out, falling back to `"empty"` rather than producing a blank string.

### Why are the changes needed?

In clusters with many registered users, `WorkerInfo.toString` — surfaced in both HTTP API responses and log output — can include a large number of entries like:

UserIdentifier: tenant1.user1, ResourceConsumption(diskBytesWritten: 0 B, diskFileCount: 0, hdfsBytesWritten: 0 B, hdfsFileCount: 0, subResourceConsumptions: empty)

These zero-value entries carry no operational information and add noise that makes it harder to identify active workloads at a glance. Filtering them out keeps the output focused on users with actual resource usage.

### Does this PR resolve a correctness bug?

- [ ] Yes


### Does this PR introduce _any_ user-facing change?

- [x] Yes

`WorkerInfo.toString` output (returned by `GET /api/v1/workers` and visible in Worker logs) will no longer include users whose resource consumption is entirely zero.


### How was this patch tested?

Covered by existing unit tests.