### PR TITLE
[CELEBORN-2380] Support JmxSink for exposing metrics as JMX MBeans

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -226,6 +226,7 @@ com.zaxxer:HikariCP
 info.picocli:picocli
 io.dropwizard.metrics:metrics-core
 io.dropwizard.metrics:metrics-graphite
+io.dropwizard.metrics:metrics-jmx
 io.dropwizard.metrics:metrics-jvm
 io.netty:netty-all
 io.netty:netty-buffer

--- a/charts/celeborn/files/conf/metrics.properties
+++ b/charts/celeborn/files/conf/metrics.properties
@@ -19,5 +19,5 @@
 *.sink.jsonServlet.class=org.apache.celeborn.common.metrics.sink.JsonServlet
 *.sink.loggerSink.class=org.apache.celeborn.common.metrics.sink.LoggerSink
 
-# Expose metrics as JMX MBeans. Disabled by default; uncomment to enable.
-# *.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink
+# Expose metrics as JMX MBeans.
+*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/charts/celeborn/files/conf/metrics.properties
+++ b/charts/celeborn/files/conf/metrics.properties
@@ -18,3 +18,6 @@
 *.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
 *.sink.jsonServlet.class=org.apache.celeborn.common.metrics.sink.JsonServlet
 *.sink.loggerSink.class=org.apache.celeborn.common.metrics.sink.LoggerSink
+
+# Expose metrics as JMX MBeans. Disabled by default; uncomment to enable.
+#*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/charts/celeborn/files/conf/metrics.properties
+++ b/charts/celeborn/files/conf/metrics.properties
@@ -20,4 +20,4 @@
 *.sink.loggerSink.class=org.apache.celeborn.common.metrics.sink.LoggerSink
 
 # Expose metrics as JMX MBeans. Disabled by default; uncomment to enable.
-#*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink
+# *.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
+          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
 
   - it: Should change checksum annotation when celeborn config changes
     template: master/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
+          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 069125df96d33be7e8eb2b3e61c2f33c914be0b77efff204628b1b5dc4184464
+          value: df60eb0f4e9bb5ad6e07f4eda40842e81265c7529faaf5c4371808617d7a0515
 
   - it: Should add extra pod annotations if `master.annotations` is specified
     template: master/statefulset.yaml

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
+          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
 
   - it: Should change checksum annotation when celeborn config changes
     template: master/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
+          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 118d5c045d52fbbd4e8f05cf0522044373165960aa57893f645a6f9e8844dd68
+          value: 069125df96d33be7e8eb2b3e61c2f33c914be0b77efff204628b1b5dc4184464
 
   - it: Should add extra pod annotations if `master.annotations` is specified
     template: master/statefulset.yaml

--- a/charts/celeborn/tests/master/statefulset_test.yaml
+++ b/charts/celeborn/tests/master/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
+          value: 035c23a53d85eb407eecf3fe864be5e623afae38e8ecdd4c10579e76d85f5c6b
 
   - it: Should change checksum annotation when celeborn config changes
     template: master/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
+          value: 035c23a53d85eb407eecf3fe864be5e623afae38e8ecdd4c10579e76d85f5c6b
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: df60eb0f4e9bb5ad6e07f4eda40842e81265c7529faaf5c4371808617d7a0515
+          value: d15c180987eca7e3b13dc37e3277c057a4060799ddd45cf20490ebb91da21ee1
 
   - it: Should add extra pod annotations if `master.annotations` is specified
     template: master/statefulset.yaml

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
+          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
 
   - it: Should change checksum annotation when celeborn config changes
     template: worker/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 7e9a27719ab1f2c1cea53e4879a807782abd48d87ec2a45774084990af6125b3
+          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 118d5c045d52fbbd4e8f05cf0522044373165960aa57893f645a6f9e8844dd68
+          value: 069125df96d33be7e8eb2b3e61c2f33c914be0b77efff204628b1b5dc4184464
 
   - it: Should add extra pod annotations if `worker.annotations` is specified
     template: worker/statefulset.yaml

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
+          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
 
   - it: Should change checksum annotation when celeborn config changes
     template: worker/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 402448664cbf4a61ccac0b5c456cb918305572d2442eafb232e1c7ed907410dc
+          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 069125df96d33be7e8eb2b3e61c2f33c914be0b77efff204628b1b5dc4184464
+          value: df60eb0f4e9bb5ad6e07f4eda40842e81265c7529faaf5c4371808617d7a0515
 
   - it: Should add extra pod annotations if `worker.annotations` is specified
     template: worker/statefulset.yaml

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
+          value: 035c23a53d85eb407eecf3fe864be5e623afae38e8ecdd4c10579e76d85f5c6b
 
   - it: Should change checksum annotation when celeborn config changes
     template: worker/statefulset.yaml
@@ -50,10 +50,10 @@ tests:
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: 96b3ee0b0e28b11a66e44bfbaeb689df5ee0063ae0c78244e8fe7015efe1a77a
+          value: 035c23a53d85eb407eecf3fe864be5e623afae38e8ecdd4c10579e76d85f5c6b
       - equal:
           path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
-          value: df60eb0f4e9bb5ad6e07f4eda40842e81265c7529faaf5c4371808617d7a0515
+          value: d15c180987eca7e3b13dc37e3277c057a4060799ddd45cf20490ebb91da21ee1
 
   - it: Should add extra pod annotations if `worker.annotations` is specified
     template: worker/statefulset.yaml

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>metrics-jvm</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala
@@ -22,7 +22,7 @@ import java.util.Properties
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.jmx.JmxReporter
 
-private class JmxSink(val property: Properties, val registry: MetricRegistry) extends Sink {
+class JmxSink(val property: Properties, val registry: MetricRegistry) extends Sink {
 
   val reporter: JmxReporter = JmxReporter.forRegistry(registry).build()
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.metrics.sink
+
+import java.util.Properties
+
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.jmx.JmxReporter
+
+private class JmxSink(val property: Properties, val registry: MetricRegistry) extends Sink {
+
+  val reporter: JmxReporter = JmxReporter.forRegistry(registry).build()
+
+  override def start(): Unit = {
+    reporter.start()
+  }
+
+  override def stop(): Unit = {
+    reporter.stop()
+  }
+
+  override def report(): Unit = {}
+}

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala
@@ -24,7 +24,19 @@ import com.codahale.metrics.jmx.JmxReporter
 
 class JmxSink(val property: Properties, val registry: MetricRegistry) extends Sink {
 
-  val reporter: JmxReporter = JmxReporter.forRegistry(registry).build()
+  // Publish MBeans under a configurable, Celeborn-specific JMX domain (defaulting to
+  // `celeborn`) rather than JmxReporter's global default domain `metrics`. This avoids
+  // MBean name collisions when other components using Dropwizard metrics run in the
+  // same JVM. The domain can be overridden via `*.sink.jmx.domain=<domain>`.
+  val domain: String =
+    Option(property.getProperty(JmxSink.JMX_DOMAIN_KEY))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .getOrElse(JmxSink.JMX_DEFAULT_DOMAIN)
+
+  val reporter: JmxReporter = JmxReporter.forRegistry(registry)
+    .inDomain(domain)
+    .build()
 
   override def start(): Unit = {
     reporter.start()
@@ -35,4 +47,9 @@ class JmxSink(val property: Properties, val registry: MetricRegistry) extends Si
   }
 
   override def report(): Unit = {}
+}
+
+object JmxSink {
+  val JMX_DOMAIN_KEY = "domain"
+  val JMX_DEFAULT_DOMAIN = "celeborn"
 }

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -18,3 +18,6 @@
 *.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
 *.sink.jsonServlet.class=org.apache.celeborn.common.metrics.sink.JsonServlet
 *.sink.loggerSink.class=org.apache.celeborn.common.metrics.sink.LoggerSink
+
+# Expose metrics as JMX MBeans. Disabled by default; uncomment to enable.
+#*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -20,4 +20,6 @@
 *.sink.loggerSink.class=org.apache.celeborn.common.metrics.sink.LoggerSink
 
 # Expose metrics as JMX MBeans. Disabled by default; uncomment to enable.
+# MBeans are published under the `celeborn` JMX domain by default; override with
+# `*.sink.jmx.domain=<domain>` if needed.
 #*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -22,4 +22,4 @@
 # Expose metrics as JMX MBeans. Disabled by default; uncomment to enable.
 # MBeans are published under the `celeborn` JMX domain by default; override with
 # `*.sink.jmx.domain=<domain>` if needed.
-#*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink
+# *.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -36,6 +36,7 @@ lz4-java/1.10.4//lz4-java-1.10.4.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-flink-1.19
+++ b/dev/deps/dependencies-client-flink-1.19
@@ -36,6 +36,7 @@ lz4-java/1.10.4//lz4-java-1.10.4.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-flink-1.20
+++ b/dev/deps/dependencies-client-flink-1.20
@@ -36,6 +36,7 @@ lz4-java/1.10.4//lz4-java-1.10.4.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-flink-2.0
+++ b/dev/deps/dependencies-client-flink-2.0
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-flink-2.1
+++ b/dev/deps/dependencies-client-flink-2.1
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-flink-2.2
+++ b/dev/deps/dependencies-client-flink-2.2
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-flink-2.3
+++ b/dev/deps/dependencies-client-flink-2.3
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -138,6 +138,7 @@ lz4-java/1.10.4//lz4-java-1.10.4.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 mssql-jdbc/6.2.1.jre7//mssql-jdbc-6.2.1.jre7.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -36,6 +36,7 @@ lz4-java/1.7.1//lz4-java-1.7.1.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -36,6 +36,7 @@ lz4-java/1.7.1//lz4-java-1.7.1.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -36,6 +36,7 @@ lz4-java/1.7.1//lz4-java-1.7.1.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -36,6 +36,7 @@ lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -36,6 +36,7 @@ lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -36,6 +36,7 @@ lz4-java/1.8.0//lz4-java-1.8.0.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-4.0
+++ b/dev/deps/dependencies-client-spark-4.0
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-4.1
+++ b/dev/deps/dependencies-client-spark-4.1
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-spark-4.2
+++ b/dev/deps/dependencies-client-spark-4.2
@@ -35,6 +35,7 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 lz4-java/1.11.0//lz4-java-1.11.0.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-client-tez
+++ b/dev/deps/dependencies-client-tez
@@ -111,6 +111,7 @@ lz4-java/1.10.4//lz4-java-1.10.4.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 netty-all/4.2.10.Final//netty-all-4.2.10.Final.jar
 netty-buffer/4.2.10.Final//netty-buffer-4.2.10.Final.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -83,6 +83,7 @@ lz4-java/1.10.4//lz4-java-1.10.4.jar
 maven-jdk-tools-wrapper/0.1//maven-jdk-tools-wrapper-0.1.jar
 metrics-core/4.2.25//metrics-core-4.2.25.jar
 metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
 metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 mimepull/1.9.15//mimepull-1.9.15.jar
 mybatis/3.5.15//mybatis-3.5.15.jar

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -47,6 +47,7 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 * `PrometheusServlet`: Adds a servlet within the existing Celeborn REST API to serve metrics data in Prometheus format.
 * `JsonServlet`: Adds a servlet within the existing Celeborn REST API to serve metrics data in JSON format.
 * `GraphiteSink`: Sends metrics to a Graphite node.
+* `JmxSink`: Registers metrics for viewing in a JMX console.
 * `LoggerSink`: Scrape metrics periodically and output them to the logger files if you have enabled
   `celeborn.metrics.loggerSink.output.enabled`. This is used as safety valve to make sure the
   metrics data won't exist in the memory for a long time. If you don't have a metrics collector to

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,11 @@
         <version>${codahale.metrics.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-jmx</artifactId>
+        <version>${codahale.metrics.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.ratis</groupId>
         <artifactId>ratis-common</artifactId>
         <version>${ratis.version}</version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -142,6 +142,7 @@ object Dependencies {
   val ioDropwizardMetricsGraphite = "io.dropwizard.metrics" % "metrics-graphite" % metricsVersion excludeAll (
     ExclusionRule("com.rabbitmq", "amqp-client"))
   val ioDropwizardMetricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % metricsVersion
+  val ioDropwizardMetricsJmx = "io.dropwizard.metrics" % "metrics-jmx" % metricsVersion
   val ioNetty = "io.netty" % "netty-all" % nettyVersion excludeAll(
     ExclusionRule("io.netty", "netty-codec-haproxy"),
     ExclusionRule("io.netty", "netty-codec-memcache"),
@@ -679,6 +680,7 @@ object CelebornCommon {
         Dependencies.ioDropwizardMetricsCore,
         Dependencies.ioDropwizardMetricsGraphite,
         Dependencies.ioDropwizardMetricsJvm,
+        Dependencies.ioDropwizardMetricsJmx,
         Dependencies.ioNetty,
         Dependencies.ioNettyEpollLinuxX8664,
         Dependencies.ioNettyEpollLinuxAarch64,

--- a/service/src/test/resources/metrics-jmx.properties
+++ b/service/src/test/resources/metrics-jmx.properties
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink

--- a/service/src/test/scala/org/apache/celeborn/server/common/metrics/sink/JmxSinkSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/metrics/sink/JmxSinkSuite.scala
@@ -18,9 +18,12 @@
 package org.apache.celeborn.server.common.metrics.sink
 
 import java.lang.management.ManagementFactory
+import java.util.Properties
 import javax.management.ObjectName
 
 import scala.collection.JavaConverters._
+
+import com.codahale.metrics.MetricRegistry
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
@@ -59,26 +62,62 @@ class JmxSinkSuite extends CelebornFunSuite {
   test("test jmx sink registers and unregisters MBeans lifecycle case") {
     val metricsSystem = newMetricsSystem()
     val mBeanServer = ManagementFactory.getPlatformMBeanServer
-    // JmxReporter publishes metrics under the "metrics" JMX domain by default.
-    val jmxDomainPattern = new ObjectName("metrics:*")
+    // JmxSink publishes metrics under the Celeborn-specific default domain.
+    val jmxDomainPattern = new ObjectName(s"${JmxSink.JMX_DEFAULT_DOMAIN}:*")
 
     val beforeStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+    var registeredByJmxSink = Set.empty[ObjectName]
 
-    // start() runs registerSinks() (reflection-based loading) followed by Sink.start(),
-    // which makes the JmxSink's JmxReporter register the registry metrics as MBeans.
-    metricsSystem.start(true)
-    val afterStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
-    val registeredByJmxSink = afterStart -- beforeStart
+    try {
+      // start() runs registerSinks() (reflection-based loading) followed by Sink.start(),
+      // which makes the JmxSink's JmxReporter register the registry metrics as MBeans.
+      metricsSystem.start(true)
+      // report() is a no-op for JmxSink (JmxReporter reports on registration) but must be safe.
+      metricsSystem.report()
 
-    metricsSystem.stop()
+      val afterStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+      registeredByJmxSink = (afterStart -- beforeStart).toSet
+
+      assert(metricsSystem.sinks.exists(_.isInstanceOf[JmxSink]))
+      assert(
+        registeredByJmxSink.nonEmpty,
+        s"JmxSink.start() should register metric MBeans under the " +
+          s"'${JmxSink.JMX_DEFAULT_DOMAIN}' domain")
+    } finally {
+      metricsSystem.stop()
+    }
+
     val afterStop = mBeanServer.queryNames(jmxDomainPattern, null).asScala
-
-    assert(metricsSystem.sinks.exists(_.isInstanceOf[JmxSink]))
-    assert(
-      registeredByJmxSink.nonEmpty,
-      "JmxSink.start() should register metric MBeans under the 'metrics' domain")
     assert(
       registeredByJmxSink.forall(name => !afterStop.contains(name)),
       "JmxSink.stop() should unregister the MBeans it registered")
+  }
+
+  test("test jmx sink honors configured domain case") {
+    val domain = "celeborn-jmx-test-domain"
+    val properties = new Properties()
+    properties.setProperty(JmxSink.JMX_DOMAIN_KEY, domain)
+    val registry = new MetricRegistry()
+    registry.counter("test-counter").inc()
+
+    val sink = new JmxSink(properties, registry)
+    assert(sink.domain == domain)
+
+    val mBeanServer = ManagementFactory.getPlatformMBeanServer
+    val jmxDomainPattern = new ObjectName(s"$domain:*")
+
+    try {
+      sink.start()
+      sink.report()
+      assert(
+        mBeanServer.queryNames(jmxDomainPattern, null).asScala.nonEmpty,
+        s"JmxSink should register MBeans under the configured '$domain' domain")
+    } finally {
+      sink.stop()
+    }
+
+    assert(
+      mBeanServer.queryNames(jmxDomainPattern, null).isEmpty,
+      "JmxSink.stop() should unregister the MBeans under the configured domain")
   }
 }

--- a/service/src/test/scala/org/apache/celeborn/server/common/metrics/sink/JmxSinkSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/metrics/sink/JmxSinkSuite.scala
@@ -94,7 +94,10 @@ class JmxSinkSuite extends CelebornFunSuite {
   }
 
   test("test jmx sink honors configured domain case") {
-    val domain = "celeborn-jmx-test-domain"
+    // Use a unique domain per run so the assertions are robust against MBeans that may
+    // already exist in (or were leaked by a prior failed run into) the JVM-global
+    // MBeanServer, and assert on the before/after delta rather than absolute presence.
+    val domain = s"celeborn-jmx-test-${java.util.UUID.randomUUID()}"
     val properties = new Properties()
     properties.setProperty(JmxSink.JMX_DOMAIN_KEY, domain)
     val registry = new MetricRegistry()
@@ -106,18 +109,24 @@ class JmxSinkSuite extends CelebornFunSuite {
     val mBeanServer = ManagementFactory.getPlatformMBeanServer
     val jmxDomainPattern = new ObjectName(s"$domain:*")
 
+    val beforeStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+    var registeredByJmxSink = Set.empty[ObjectName]
+
     try {
       sink.start()
       sink.report()
+      val afterStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+      registeredByJmxSink = (afterStart -- beforeStart).toSet
       assert(
-        mBeanServer.queryNames(jmxDomainPattern, null).asScala.nonEmpty,
+        registeredByJmxSink.nonEmpty,
         s"JmxSink should register MBeans under the configured '$domain' domain")
     } finally {
       sink.stop()
     }
 
+    val afterStop = mBeanServer.queryNames(jmxDomainPattern, null).asScala
     assert(
-      mBeanServer.queryNames(jmxDomainPattern, null).isEmpty,
+      registeredByJmxSink.forall(name => !afterStop.contains(name)),
       "JmxSink.stop() should unregister the MBeans under the configured domain")
   }
 }

--- a/service/src/test/scala/org/apache/celeborn/server/common/metrics/sink/JmxSinkSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/metrics/sink/JmxSinkSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.metrics.sink
+
+import java.lang.management.ManagementFactory
+import javax.management.ObjectName
+
+import scala.collection.JavaConverters._
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.metrics.MetricsSystem
+import org.apache.celeborn.common.metrics.sink.JmxSink
+import org.apache.celeborn.common.metrics.source.JVMSource
+import org.apache.celeborn.common.network.TestHelper
+
+class JmxSinkSuite extends CelebornFunSuite {
+
+  private def newMetricsSystem(): MetricsSystem = {
+    val celebornConf = new CelebornConf()
+    celebornConf
+      .set(CelebornConf.METRICS_ENABLED.key, "true")
+      .set(
+        CelebornConf.METRICS_CONF.key,
+        TestHelper.getResourceAsAbsolutePath("/metrics-jmx.properties"))
+    val metricsSystem = MetricsSystem.createMetricsSystem("test", celebornConf)
+    metricsSystem.registerSource(new JVMSource(celebornConf, "test"))
+    metricsSystem
+  }
+
+  test("test load jmx sink case") {
+    val metricsSystem = newMetricsSystem()
+    metricsSystem.start(true)
+
+    try {
+      // JmxSink has no dedicated branch in MetricsSystem.registerSinks, so it must be
+      // instantiated reflectively via its (Properties, MetricRegistry) constructor.
+      assert(metricsSystem.sinks.exists(_.isInstanceOf[JmxSink]))
+    } finally {
+      metricsSystem.stop()
+    }
+  }
+
+  test("test jmx sink registers and unregisters MBeans lifecycle case") {
+    val metricsSystem = newMetricsSystem()
+    val mBeanServer = ManagementFactory.getPlatformMBeanServer
+    // JmxReporter publishes metrics under the "metrics" JMX domain by default.
+    val jmxDomainPattern = new ObjectName("metrics:*")
+
+    val beforeStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+
+    // start() runs registerSinks() (reflection-based loading) followed by Sink.start(),
+    // which makes the JmxSink's JmxReporter register the registry metrics as MBeans.
+    metricsSystem.start(true)
+    val afterStart = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+    val registeredByJmxSink = afterStart -- beforeStart
+
+    metricsSystem.stop()
+    val afterStop = mBeanServer.queryNames(jmxDomainPattern, null).asScala
+
+    assert(metricsSystem.sinks.exists(_.isInstanceOf[JmxSink]))
+    assert(
+      registeredByJmxSink.nonEmpty,
+      "JmxSink.start() should register metric MBeans under the 'metrics' domain")
+    assert(
+      registeredByJmxSink.forall(name => !afterStop.contains(name)),
+      "JmxSink.stop() should unregister the MBeans it registered")
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This PR adds a new `JmxSink` metrics sink that exposes Celeborn metrics as JMX MBeans.

- Add `JmxSink` (`common/src/main/scala/org/apache/celeborn/common/metrics/sink/JmxSink.scala`), backed by Dropwizard Metrics' `JmxReporter`. It follows the existing `Sink` contract and is loaded reflectively by `MetricsSystem` via the standard `(Properties, MetricRegistry)` constructor, so no changes to `MetricsSystem` are required.
- Add the `io.dropwizard.metrics:metrics-jmx` dependency (which contains `JmxReporter` in Dropwizard Metrics 4.x) to both the Maven build (`pom.xml` dependency management + `common/pom.xml`) and the SBT build (`project/CelebornBuild.scala`), pinned to the existing `${codahale.metrics.version}` (4.2.25).
- Add a commented-out example to `conf/metrics.properties.template` and `charts/celeborn/files/conf/metrics.properties` showing how to enable the sink.
- Document `JmxSink` in `docs/monitoring.md`.
- Register `metrics-jmx-4.2.25.jar` in all `dev/deps/dependencies-*` manifests (server + client profiles) and add `io.dropwizard.metrics:metrics-jmx` to `LICENSE-binary`, since the artifact is now bundled in the distributions.

Enabling the sink is opt-in:

```properties
*.sink.jmx.class=org.apache.celeborn.common.metrics.sink.JmxSink


Test Output:

<img width="1315" height="800" alt="Celeborn_jmx" src="https://github.com/user-attachments/assets/7af729f8-7eb9-4749-af9c-e2af64d48fb8" />
