### PR TITLE
[CELEBORN-2385] Guard ByteBufAllocator cast in ChannelsLimiter trim path

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
@@ -122,7 +122,9 @@ public class ChannelsLimiter extends ChannelDuplexHandler
   @Override
   public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
     if (evt instanceof TrimCache) {
-      ((PooledByteBufAllocator) ctx.alloc()).trimCurrentThreadCache();
+      if (ctx.alloc() instanceof PooledByteBufAllocator) {
+        ((PooledByteBufAllocator) ctx.alloc()).trimCurrentThreadCache();
+      }
       needTrimChannels.decrementAndGet();
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ChannelsLimiter#userEventTriggered` unconditionally casts `ctx.alloc()` to
`PooledByteBufAllocator` when handling a `TrimCache` event:

```java
((PooledByteBufAllocator) ctx.alloc()).trimCurrentThreadCache();
```

The concrete type of ctx.alloc() is determined by
celeborn.network.memory.allocator.pooled. When it is set to false (the
documented escape hatch for workers whose direct memory stays high even after
trimming), the allocator is an UnpooledByteBufAllocator, so this cast throws a
ClassCastException on the Netty EventLoop thread the next time memory pressure
triggers MemoryManager#trimAllListeners → ChannelsLimiter#onTrim →
trimCache().

### Why are the changes needed?



### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

