### PR TITLE
[CELEBORN-2391] Eliminate intermediate byte[] allocation in Encoders.Strings via Netty ByteBufUtil

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -179,6 +179,17 @@
       <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- JMH benchmark dependencies -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Encoders.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Encoders.java
@@ -20,6 +20,7 @@ package org.apache.celeborn.common.network.protocol;
 import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 
 /** Provides a canonical set of Encoders for simple types. */
 public class Encoders {
@@ -27,13 +28,12 @@ public class Encoders {
   /** Strings are encoded with their length followed by UTF-8 bytes. */
   public static class Strings {
     public static int encodedLength(String s) {
-      return 4 + s.getBytes(StandardCharsets.UTF_8).length;
+      return 4 + ByteBufUtil.utf8Bytes(s);
     }
 
     public static void encode(ByteBuf buf, String s) {
-      byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
-      buf.writeInt(bytes.length);
-      buf.writeBytes(bytes);
+      buf.writeInt(ByteBufUtil.utf8Bytes(s));
+      ByteBufUtil.writeUtf8(buf, s);
     }
 
     public static String decode(ByteBuf buf) {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Encoders.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Encoders.java
@@ -32,8 +32,13 @@ public class Encoders {
     }
 
     public static void encode(ByteBuf buf, String s) {
-      buf.writeInt(ByteBufUtil.utf8Bytes(s));
-      ByteBufUtil.writeUtf8(buf, s);
+      // Reserve the length slot, write UTF-8 once, then backfill the actual byte length.
+      // This avoids a second full traversal of the string that utf8Bytes(s) would perform
+      // and matches the wire format callers expect: length followed by UTF-8 bytes.
+      int lenIdx = buf.writerIndex();
+      buf.writeInt(0);
+      int written = ByteBufUtil.writeUtf8(buf, s);
+      buf.setInt(lenIdx, written);
     }
 
     public static String decode(ByteBuf buf) {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -65,7 +65,7 @@ public abstract class Message implements Encodable {
     ByteBuf buf = Unpooled.buffer(encodedLength() + 1);
     buf.writeByte(type().id());
     encode(buf);
-    assert buf.writableBytes() == 0 : "Writable bytes remain: " + buf.writableBytes();
+    assert buf.writerIndex() == encodedLength() + 1 : "Bytes written: " + buf.writerIndex();
     return buf.nioBuffer();
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/MessageEncoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/MessageEncoder.java
@@ -86,7 +86,7 @@ public final class MessageEncoder extends MessageToMessageEncoder<Message> {
     msgType.encode(header);
     header.writeInt(bodyLength);
     in.encode(header);
-    assert header.writableBytes() == 0;
+    assert header.writerIndex() == headerLength;
 
     if (body != null) {
       if (body instanceof FileRegion && in.body() instanceof FileSegmentManagedBuffer) {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/SslMessageEncoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/SslMessageEncoder.java
@@ -83,7 +83,7 @@ public final class SslMessageEncoder extends MessageToMessageEncoder<Message> {
     msgType.encode(header);
     header.writeInt(bodyLength);
     in.encode(header);
-    assert header.writableBytes() == 0;
+    assert header.writerIndex() == headerLength;
 
     if (body != null && bodyLength > 0) {
       // We transfer ownership of the reference on in.body() to EncryptedMessageWithHeader.

--- a/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersJmhBenchmark.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersJmhBenchmark.java
@@ -79,6 +79,7 @@ public class EncodersJmhBenchmark {
   private String sampleString;
   private int[] sampleIntArray;
   private String[] sampleStringArray;
+  private ByteBuf encodeBuf;
 
   @Setup
   public void setup() {
@@ -92,6 +93,7 @@ public class EncodersJmhBenchmark {
     for (int i = 0; i < arrayLen; i++) {
       sampleStringArray[i] = randomString(random, stringBytes);
     }
+    encodeBuf = Unpooled.buffer(Encoders.StringArrays.encodedLength(sampleStringArray));
   }
 
   private static String randomString(SplittableRandom random, int byteLen) {
@@ -105,9 +107,9 @@ public class EncodersJmhBenchmark {
 
   @Benchmark
   public void encodeString(Blackhole blackhole) {
-    ByteBuf buf = Unpooled.buffer(Encoders.Strings.encodedLength(sampleString));
-    Encoders.Strings.encode(buf, sampleString);
-    blackhole.consume(buf);
+    encodeBuf.clear();
+    Encoders.Strings.encode(encodeBuf, sampleString);
+    blackhole.consume(encodeBuf);
   }
 
   @Benchmark
@@ -119,9 +121,9 @@ public class EncodersJmhBenchmark {
 
   @Benchmark
   public void encodeIntArray(Blackhole blackhole) {
-    ByteBuf buf = Unpooled.buffer(Encoders.IntArrays.encodedLength(sampleIntArray));
-    Encoders.IntArrays.encode(buf, sampleIntArray);
-    blackhole.consume(buf);
+    encodeBuf.clear();
+    Encoders.IntArrays.encode(encodeBuf, sampleIntArray);
+    blackhole.consume(encodeBuf);
   }
 
   @Benchmark
@@ -133,9 +135,9 @@ public class EncodersJmhBenchmark {
 
   @Benchmark
   public void encodeStringArray(Blackhole blackhole) {
-    ByteBuf buf = Unpooled.buffer(Encoders.StringArrays.encodedLength(sampleStringArray));
-    Encoders.StringArrays.encode(buf, sampleStringArray);
-    blackhole.consume(buf);
+    encodeBuf.clear();
+    Encoders.StringArrays.encode(encodeBuf, sampleStringArray);
+    blackhole.consume(encodeBuf);
   }
 
   @Benchmark

--- a/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersJmhBenchmark.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersJmhBenchmark.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * JMH benchmark for celeborn's {@link Encoders} serialization primitives.
+ *
+ * <p>{@code Encoders.Strings/IntArrays/StringArrays} are the canonical write/read primitives used
+ * by every concrete transport {@link Message} (e.g. {@link PushMergedData}, {@link PushData}). They
+ * are the micro-hot-path of the network serialization layer, so this benchmark mirrors the Kafka
+ * request/response serialization benchmarks (KAFKA-8106 / KAFKA-14633 reduce buffer allocation &
+ * data copy) but measures celeborn's own primitives rather than Kafka's protocol structs.
+ *
+ * <p>The {@code decode} paths allocate fresh {@code byte[]} / {@code String} objects each call, so
+ * the benchmark also captures allocation pressure; {@code encode} reuses a single destination
+ * buffer to isolate that from the encoding cost.
+ *
+ * <p>To run:
+ *
+ * <pre>{@code
+ * build/mvn -pl common -am test-compile
+ * build/mvn -pl common exec:java \
+ *   -Dexec.mainClass=org.apache.celeborn.common.network.protocol.EncodersJmhBenchmark \
+ *   -Dexec.classpathScope=test \
+ *   -Dexec.args="-f 0 -wi 1 -i 1"
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class EncodersJmhBenchmark {
+
+  @Param({"16", "256"})
+  private int stringBytes;
+
+  @Param({"8", "128"})
+  private int arrayLen;
+
+  @Param({"42"})
+  private int seed;
+
+  private String sampleString;
+  private int[] sampleIntArray;
+  private String[] sampleStringArray;
+
+  @Setup
+  public void setup() {
+    SplittableRandom random = new SplittableRandom(seed);
+    sampleString = randomString(random, stringBytes);
+    sampleIntArray = new int[arrayLen];
+    for (int i = 0; i < arrayLen; i++) {
+      sampleIntArray[i] = random.nextInt();
+    }
+    sampleStringArray = new String[arrayLen];
+    for (int i = 0; i < arrayLen; i++) {
+      sampleStringArray[i] = randomString(random, stringBytes);
+    }
+  }
+
+  private static String randomString(SplittableRandom random, int byteLen) {
+    byte[] bytes = new byte[byteLen];
+    for (int i = 0; i < byteLen; i++) {
+      // printable ascii range to keep UTF-8 length == byte length
+      bytes[i] = (byte) random.nextInt('a', 'z' + 1);
+    }
+    return new String(bytes);
+  }
+
+  @Benchmark
+  public void encodeString(Blackhole blackhole) {
+    ByteBuf buf = Unpooled.buffer(Encoders.Strings.encodedLength(sampleString));
+    Encoders.Strings.encode(buf, sampleString);
+    blackhole.consume(buf);
+  }
+
+  @Benchmark
+  public String decodeString() {
+    ByteBuf buf = Unpooled.buffer(Encoders.Strings.encodedLength(sampleString));
+    Encoders.Strings.encode(buf, sampleString);
+    return Encoders.Strings.decode(buf);
+  }
+
+  @Benchmark
+  public void encodeIntArray(Blackhole blackhole) {
+    ByteBuf buf = Unpooled.buffer(Encoders.IntArrays.encodedLength(sampleIntArray));
+    Encoders.IntArrays.encode(buf, sampleIntArray);
+    blackhole.consume(buf);
+  }
+
+  @Benchmark
+  public int[] decodeIntArray() {
+    ByteBuf buf = Unpooled.buffer(Encoders.IntArrays.encodedLength(sampleIntArray));
+    Encoders.IntArrays.encode(buf, sampleIntArray);
+    return Encoders.IntArrays.decode(buf);
+  }
+
+  @Benchmark
+  public void encodeStringArray(Blackhole blackhole) {
+    ByteBuf buf = Unpooled.buffer(Encoders.StringArrays.encodedLength(sampleStringArray));
+    Encoders.StringArrays.encode(buf, sampleStringArray);
+    blackhole.consume(buf);
+  }
+
+  @Benchmark
+  public String[] decodeStringArray() {
+    ByteBuf buf = Unpooled.buffer(Encoders.StringArrays.encodedLength(sampleStringArray));
+    Encoders.StringArrays.encode(buf, sampleStringArray);
+    return Encoders.StringArrays.decode(buf);
+  }
+
+  public static void main(String[] args) throws Exception {
+    org.openjdk.jmh.Main.main(args);
+  }
+}

--- a/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersSuiteJ.java
@@ -34,8 +34,18 @@ public class EncodersSuiteJ {
     "application_1700000000000_0001-0",
     "中文 shuffle key",
     "emoji 🚀🔥",
-    "mixed ASCII 中文 🚀"
+    "mixed ASCII 中文 🚀",
+    // NUL and control characters
+    "a\0b\1c",
+    // 2-byte / 3-byte UTF-8 boundaries
+    "߿ࠀ",
+    // BMP max and replacement char
+    "￿�"
   };
+
+  // Malformed inputs: UTF-8 encoding is lossy for unpaired surrogates (replaced with '?'),
+  // so these do not round-trip, but the encoded bytes must still match getBytes(UTF_8).
+  private static final String[] LOSSY_STRINGS = {"abc\uD800", "܀abc", "a\uD800\uD800b"};
 
   @Test
   public void testStringsRoundTrip() {
@@ -52,23 +62,44 @@ public class EncodersSuiteJ {
   @Test
   public void testStringsWireCompatibleWithGetBytesUtf8() {
     for (String s : TEST_STRINGS) {
-      byte[] utf8Bytes = s.getBytes(StandardCharsets.UTF_8);
-      ByteBuf expected = Unpooled.buffer(4 + utf8Bytes.length);
-      expected.writeInt(utf8Bytes.length);
-      expected.writeBytes(utf8Bytes);
-
-      ByteBuf actual = Unpooled.buffer(Encoders.Strings.encodedLength(s));
-      Encoders.Strings.encode(actual, s);
-
-      byte[] expectedBytes = new byte[expected.readableBytes()];
-      expected.readBytes(expectedBytes);
-      byte[] actualBytes = new byte[actual.readableBytes()];
-      actual.readBytes(actualBytes);
-      assertArrayEquals(expectedBytes, actualBytes);
-
-      expected.release();
-      actual.release();
+      assertWireCompatible(s);
     }
+    for (String s : LOSSY_STRINGS) {
+      assertWireCompatible(s);
+    }
+  }
+
+  @Test
+  public void testLossyStringsMatchGetBytesRoundTrip() {
+    for (String s : LOSSY_STRINGS) {
+      ByteBuf buf = Unpooled.buffer(Encoders.Strings.encodedLength(s));
+      Encoders.Strings.encode(buf, s);
+      // Unpaired surrogates are replaced with '?' during encoding; decoding must
+      // produce the same result as decoding getBytes(UTF_8) output.
+      assertEquals(
+          new String(s.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8),
+          Encoders.Strings.decode(buf));
+      buf.release();
+    }
+  }
+
+  private static void assertWireCompatible(String s) {
+    byte[] utf8Bytes = s.getBytes(StandardCharsets.UTF_8);
+    ByteBuf expected = Unpooled.buffer(4 + utf8Bytes.length);
+    expected.writeInt(utf8Bytes.length);
+    expected.writeBytes(utf8Bytes);
+
+    ByteBuf actual = Unpooled.buffer(Encoders.Strings.encodedLength(s));
+    Encoders.Strings.encode(actual, s);
+
+    byte[] expectedBytes = new byte[expected.readableBytes()];
+    expected.readBytes(expectedBytes);
+    byte[] actualBytes = new byte[actual.readableBytes()];
+    actual.readBytes(actualBytes);
+    assertArrayEquals(expectedBytes, actualBytes);
+
+    expected.release();
+    actual.release();
   }
 
   @Test

--- a/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/protocol/EncodersSuiteJ.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+public class EncodersSuiteJ {
+
+  private static final String[] TEST_STRINGS = {
+    "",
+    "ascii",
+    "application_1700000000000_0001-0",
+    "中文 shuffle key",
+    "emoji 🚀🔥",
+    "mixed ASCII 中文 🚀"
+  };
+
+  @Test
+  public void testStringsRoundTrip() {
+    for (String s : TEST_STRINGS) {
+      ByteBuf buf = Unpooled.buffer(Encoders.Strings.encodedLength(s));
+      Encoders.Strings.encode(buf, s);
+      assertEquals(Encoders.Strings.encodedLength(s), buf.readableBytes());
+      assertEquals(s, Encoders.Strings.decode(buf));
+      assertEquals(0, buf.readableBytes());
+      buf.release();
+    }
+  }
+
+  @Test
+  public void testStringsWireCompatibleWithGetBytesUtf8() {
+    for (String s : TEST_STRINGS) {
+      byte[] utf8Bytes = s.getBytes(StandardCharsets.UTF_8);
+      ByteBuf expected = Unpooled.buffer(4 + utf8Bytes.length);
+      expected.writeInt(utf8Bytes.length);
+      expected.writeBytes(utf8Bytes);
+
+      ByteBuf actual = Unpooled.buffer(Encoders.Strings.encodedLength(s));
+      Encoders.Strings.encode(actual, s);
+
+      byte[] expectedBytes = new byte[expected.readableBytes()];
+      expected.readBytes(expectedBytes);
+      byte[] actualBytes = new byte[actual.readableBytes()];
+      actual.readBytes(actualBytes);
+      assertArrayEquals(expectedBytes, actualBytes);
+
+      expected.release();
+      actual.release();
+    }
+  }
+
+  @Test
+  public void testStringArraysRoundTrip() {
+    ByteBuf buf = Unpooled.buffer(Encoders.StringArrays.encodedLength(TEST_STRINGS));
+    Encoders.StringArrays.encode(buf, TEST_STRINGS);
+    assertEquals(Encoders.StringArrays.encodedLength(TEST_STRINGS), buf.readableBytes());
+    assertArrayEquals(TEST_STRINGS, Encoders.StringArrays.decode(buf));
+    assertEquals(0, buf.readableBytes());
+    buf.release();
+  }
+}

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -706,7 +706,10 @@ object CelebornCommon {
         Dependencies.log4j12Api % "test",
         // SSL support
         Dependencies.bouncycastleBcprovJdk18on,
-        Dependencies.bouncycastleBcpkixJdk18on
+        Dependencies.bouncycastleBcpkixJdk18on,
+        // JMH benchmark dependencies
+        Dependencies.jmhCore,
+        Dependencies.jmhGeneratorAnnprocess
       ) ++ commonUnitTestDependencies,
       // maven-jdk-tools-wrapper (jdkTools) only provides jdk.tools (tools.jar) on
       // JDK 8; on JDK 9+ the tools API is built into the JDK, so the wrapper is a


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `s.getBytes(StandardCharsets.UTF_8)` in `Encoders.Strings#encodedLength` and `#encode` with Netty's `ByteBufUtil.utf8Bytes` / `ByteBufUtil.writeUtf8`, eliminating the intermediate `byte[]` allocated for every encoded string.

In `#encode`, write a zero length slot first, then `ByteBufUtil.writeUtf8`, then backfill the actual byte length via `setInt`. This avoids traversing the string twice — once for `utf8Bytes(s)` to size the length field, again inside `writeUtf8` — as suggested by @xhumanoid in the review. `#encodedLength` still uses `utf8Bytes(s)`, since message framing needs the exact total length up front to size the header buffer.

Also includes:

- `EncodersSuiteJ`: round-trip tests (ASCII / Chinese / emoji) plus byte-for-byte wire-compatibility tests against the previous `getBytes(UTF_8)` encoding, covering UTF-8 edge cases (NUL/control chars, 2/3-byte boundaries, BMP max, and lossy unpaired surrogates)
- `EncodersJmhBenchmark`: the JMH benchmark used for the measurements below, following the existing `SlotsAllocatorJmhBenchmark` pattern (test-scope `jmh-core` / `jmh-generator-annprocess` in `common/pom.xml` and `project/CelebornBuild.scala`)
- Exact-fill assertion adjustments in `MessageEncoder`, `SslMessageEncoder` and `Message#toByteBuffer` (see below)

**Note on the assertion adjustments.** `ByteBufUtil.writeUtf8` reserves `utf8MaxBytes` (up to 3 bytes per char) of capacity before writing, which may grow the target buffer beyond the exact encoded length. The three encoding paths allocate the header buffer with exact capacity and asserted `buf.writableBytes() == 0` after encoding; that assert fired under `-ea` in tests even though exactly `encodedLength()` bytes were written, because capacity had grown. The asserts now check `buf.writerIndex() == expectedLength`, which expresses the real invariant — *bytes written by `encode()` equal `encodedLength()`* — without depending on buffer capacity. The wire bytes are identical in both implementations.

### Why are the changes needed?

`Encoders.Strings` is on the hot path of every transport message (`PushData`, `PushMergedData`, `PushDataHandShake`, `RegionStart`, `RegionFinish`, ...). Each `getBytes(UTF_8)` call allocates a throwaway `byte[]`, which adds up to significant GC pressure under load.

Measured with `EncodersJmhBenchmark` (`-prof gc`, pure-ASCII strings — the only realistic case for shuffleKey/partitionUniqueId; encode paths reuse a pre-sized destination buffer to isolate the encoding cost). Allocation, before (original `getBytes`) vs after (this PR):

| Benchmark (stringBytes x arrayLen) | Metric | Before | After |
| ---------------------------------- | ------ | ------ | ----- |
| encodeString (16) | gc.alloc.rate.norm | 200 B/op | ≈0 B/op |
| encodeString (256) | gc.alloc.rate.norm | 1160 B/op | ≈0 B/op |
| encodeStringArray (128 x 16) | gc.alloc.rate.norm | 25600 B/op | ≈0 B/op |
| encodeStringArray (128 x 256) | gc.alloc.rate.norm | 148480 B/op | ≈0.01 B/op |

Throughput, before (original `getBytes`) vs after (this PR, including the encode backfill), `-f 0 -wi 5 -i 10`:

| Benchmark (stringBytes x arrayLen) | Before | After | Delta |
| ---------------------------------- | ------ | ----- | ----- |
| encodeString (16) | 37.0 ns/op | 25.6 ns/op | -31% |
| encodeString (256) | 465.7 ns/op | 243.8 ns/op | -48% |
| encodeStringArray (8 x 16) | 317.4 ns/op | 216.2 ns/op | -32% |
| encodeStringArray (128 x 256) | 59961 ns/op | 31142 ns/op | -48% |

The per-call `byte[]` allocation is eliminated in all cases, and throughput improves for both short and long strings. The backfill in `#encode` removes the extra `utf8Bytes(s)` traversal from the encode path, which is what previously made the long-string (256) case regress relative to the original `getBytes` + `writeBytes` path; with the backfill it now improves across the board.

Note: for ASCII-dominant keys, `writeUtf8` reserves 3x capacity and may grow the pooled header buffer once per encode. This reallocation is recycled within Netty's arena and produces no GC garbage, unlike the eliminated per-call `byte[]`.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- New unit tests `EncodersSuiteJ` (round-trip + wire compatibility, incl. UTF-8 edge cases) — re-run after the backfill change, all cases pass
- Existing network suites: `RpcIntegrationSuiteJ`, `SSLRpcIntegrationSuiteJ`, `AutoSSLRpcIntegrationSuite`, `SslMessageEncoderSuiteJ`, `RegistrationSuiteJ`
- `EncodersJmhBenchmark` reproduced with:

```
build/mvn -pl common -am test-compile
build/mvn -pl common exec:java \
  -Dexec.mainClass=org.apache.celeborn.common.network.protocol.EncodersJmhBenchmark \
  -Dexec.classpathScope=test \
  -Dexec.args="-f 0 -wi 1 -i 1"
```