### PR TITLE
[CELEBORN-XXXX] Expose manually excluded worker count metric

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -115,6 +115,7 @@ These metrics are exposed by Celeborn master.
     | WorkerCount                  | The count of active workers.                                                              |
     | LostWorkerCount              | The count of workers in lost list.                                                        |
     | ExcludedWorkerCount          | The count of workers in excluded list.                                                    |
+    | ManualExcludedWorkerCount    | The count of workers in manually excluded list.                                           |
     | AvailableWorkerCount         | The count of workers in available list.                                                   |
     | ShutdownWorkerCount          | The count of workers in shutdown list.                                                    |
     | DecommissionWorkerCount      | The count of workers in decommission list.                                                |

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -247,6 +247,9 @@ private[celeborn] class Master(
   masterSource.addGauge(MasterSource.EXCLUDED_WORKER_COUNT) { () =>
     statusSystem.excludedWorkers.size + statusSystem.manuallyExcludedWorkers.size
   }
+  masterSource.addGauge(MasterSource.MANUAL_EXCLUDED_WORKER_COUNT) { () =>
+    statusSystem.manuallyExcludedWorkers.size
+  }
   masterSource.addGauge(MasterSource.AVAILABLE_WORKER_COUNT) { () =>
     statusSystem.availableWorkers.size()
   }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -50,6 +50,8 @@ object MasterSource {
 
   val EXCLUDED_WORKER_COUNT = "ExcludedWorkerCount"
 
+  val MANUAL_EXCLUDED_WORKER_COUNT = "ManualExcludedWorkerCount"
+
   val SHUTDOWN_WORKER_COUNT = "ShutdownWorkerCount"
 
   val AVAILABLE_WORKER_COUNT = "AvailableWorkerCount"

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -27,6 +27,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.meta.WorkerInfo
 import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient}
 import org.apache.celeborn.common.protocol.{PbApplicationMetaRequest, PbCheckForWorkerTimeout, PbRegisterWorker}
 import org.apache.celeborn.common.protocol.message.ControlMessages.{RequestSlots, RequestSlotsResponse, ReviseLostShuffles}
@@ -210,6 +211,42 @@ class MasterSuite extends AnyFunSuite
     assert(response.status === StatusCode.WORKER_EXCLUDED)
 
     master.rpcEnv.shutdown()
+  }
+
+  test("manual excluded worker count metric follows manual exclusion state") {
+    val conf = new CelebornConf()
+    val randomMasterPort = selectRandomPort()
+    val randomHttpPort = selectRandomPort()
+    conf.set(CelebornConf.HA_ENABLED.key, "false")
+    conf.set(CelebornConf.MASTER_HTTP_HOST.key, "127.0.0.1")
+    conf.set(CelebornConf.MASTER_HTTP_PORT.key, randomHttpPort.toString)
+
+    val masterArgs = new MasterArguments(
+      Array("-h", "localhost", "-p", randomMasterPort.toString),
+      conf)
+    val master = new Master(conf, masterArgs)
+    val worker = mock(classOf[WorkerInfo])
+    val source = master.metricsSystem.getSourcesByName("master").head
+
+    def manualExcludedWorkerCount: Long = {
+      val metric =
+        """metrics_ManualExcludedWorkerCount_Value\{[^}]*\} ([0-9]+)""".r
+      metric.findFirstMatchIn(source.getMetrics).map(_.group(1).toLong).getOrElse {
+        fail("ManualExcludedWorkerCount metric was not emitted")
+      }
+    }
+
+    try {
+      assert(manualExcludedWorkerCount === 0L)
+
+      master.statusSystem.manuallyExcludedWorkers.add(worker)
+      assert(manualExcludedWorkerCount === 1L)
+
+      master.statusSystem.manuallyExcludedWorkers.remove(worker)
+      assert(manualExcludedWorkerCount === 0L)
+    } finally {
+      master.rpcEnv.shutdown()
+    }
   }
 
   test("PbApplicationMetaRequest rejects a caller requesting another application's secret") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `ManualExcludedWorkerCount` master gauge that reports only workers excluded through the manual exclusion mechanism.

The existing `ExcludedWorkerCount` remains unchanged and continues to report the combined automatic and manual exclusion count. The new gauge is also documented in the master metrics reference.

### Why are the changes needed?

`ExcludedWorkerCount` combines automatic and manual exclusions, so operators cannot determine from metrics whether persistent manual exclusion state is preventing otherwise healthy workers from becoming available.

The REST API exposes the two states separately, but diagnosing this condition currently requires querying the active master. Exporting the manual count separately makes the distinction observable through the existing metrics system without changing exclusion behavior.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

- Added a `MasterSuite` test that verifies the emitted gauge follows manual exclusion state from 0 to 1 and back to 0.
- Ran:
  - `./build/mvn -pl master -am -Dtest=none -DwildcardSuites=org.apache.celeborn.service.deploy.master.MasterSuite test`
  - `./build/mvn spotless:check -Pgoogle-mirror,spark-3.3`

Both commands passed locally.

### Draft note

The CELEBORN Jira is still to be created. Replace `CELEBORN-XXXX` in the title and link the Jira before marking this PR ready for review.
