### PR TITLE
[CELEBORN-2396][CLI] Fix CelebornCli.main discarding the configured CommandLine instance

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/CelebornCli.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/CelebornCli.scala
@@ -40,6 +40,6 @@ object CelebornCli {
     val cmd = new CommandLine(new CelebornCli())
     cmd.setOptionsCaseInsensitive(false)
     cmd.setSubcommandsCaseInsensitive(false)
-    new CommandLine(new CelebornCli()).execute(args: _*)
+    cmd.execute(args: _*)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Call `execute()` on the configured `CommandLine` instance instead of creating and executing a new one.

### Why are the changes needed?

`CelebornCli.main` creates a `CommandLine`, sets case-sensitivity options on it, but then executes a brand-new instance, so the configuration is silently discarded and the two setter calls are dead code.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

