### PR TITLE
[CELEBORN-2397][CLI] Expose logger level get/set endpoints in celeborn-cli

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/common/BaseCommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/common/BaseCommand.scala
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.StringUtils
 import picocli.CommandLine.{Command, ParameterException}
 import picocli.CommandLine.Model.CommandSpec
 
-import org.apache.celeborn.rest.v1.model.{DeleteDynamicConfigRequest, HandleResponse, UpsertDynamicConfigRequest}
+import org.apache.celeborn.rest.v1.model.{DeleteDynamicConfigRequest, HandleResponse, LoggerInfo, UpsertDynamicConfigRequest}
 
 @Command(mixinStandardHelpOptions = true, versionProvider = classOf[CliVersionProvider])
 abstract class BaseCommand extends Runnable with CliLogging {
@@ -80,6 +80,37 @@ abstract class BaseCommand extends Runnable with CliLogging {
         .configs(util.Arrays.asList[String](commonOptions.deleteConfigs.split(","): _*))
         .tenant(commonOptions.configTenant)
         .name(commonOptions.configName),
+      commonOptions.getAuthHeader)
+  }
+
+  private[cli] val validLoggerLevels =
+    Seq("OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL")
+
+  private[cli] def setLogLevel(
+      commonOptions: CommonOptions,
+      spec: CommandSpec,
+      set: (LoggerInfo, util.Map[String, String]) => HandleResponse): HandleResponse = {
+    if (StringUtils.isBlank(commonOptions.loggerName)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        "Logger name must be provided via --logger-name for this command.")
+    }
+    if (StringUtils.isBlank(commonOptions.loggerLevel)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        "Logger level must be provided via --logger-level for this command.")
+    }
+    val level = commonOptions.loggerLevel.toUpperCase
+    if (!validLoggerLevels.contains(level)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        s"Invalid logger level `${commonOptions.loggerLevel}`, must be one of " +
+          validLoggerLevels.mkString(", "))
+    }
+    set(
+      new LoggerInfo()
+        .name(commonOptions.loggerName)
+        .level(level),
       commonOptions.getAuthHeader)
   }
 }

--- a/cli/src/main/scala/org/apache/celeborn/cli/common/CommonOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/common/CommonOptions.scala
@@ -94,6 +94,19 @@ class CommonOptions {
   private[cli] var apps: String = _
 
   @Option(
+    names = Array("--logger-name"),
+    paramLabel = "logger_name",
+    description = Array("The logger name to query or set the level for. " +
+      "If not specified for --show-loggers, all configured loggers are returned."))
+  private[cli] var loggerName: String = _
+
+  @Option(
+    names = Array("--logger-level"),
+    paramLabel = "level",
+    description = Array("The logger level to set, e.g. DEBUG, INFO, WARN, ERROR."))
+  private[cli] var loggerLevel: String = _
+
+  @Option(
     names = Array("--auth-header"),
     paramLabel = "authHeader",
     description = Array("The http `Authorization` header for authentication. " +

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -104,6 +104,12 @@ final class MasterOptions {
   @Option(names = Array("--show-thread-dump"), description = Array("Show master thread dump"))
   private[master] var showThreadDump: Boolean = _
 
+  @Option(names = Array("--show-loggers"), description = Array("Show logger levels"))
+  private[master] var showLoggers: Boolean = _
+
+  @Option(names = Array("--set-loglevel"), description = Array("Set logger level"))
+  private[master] var setLogLevel: Boolean = _
+
   @Option(names = Array("--show-container-info"), description = Array("Show container info"))
   private[master] var showContainerInfo: Boolean = _
 

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
@@ -25,7 +25,7 @@ import picocli.CommandLine.Model.CommandSpec
 import org.apache.celeborn.cli.CelebornCli
 import org.apache.celeborn.cli.common.{BaseCommand, CliLogging, CommonOptions}
 import org.apache.celeborn.cli.config.CliConfigManager
-import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, MasterApi, ShuffleApi, WorkerApi}
+import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, LoggerApi, MasterApi, ShuffleApi, WorkerApi}
 import org.apache.celeborn.rest.v1.master.invoker.ApiClient
 import org.apache.celeborn.rest.v1.model._
 
@@ -67,6 +67,7 @@ trait MasterSubcommand extends BaseCommand {
   private[master] def applicationApi: ApplicationApi = new ApplicationApi(apiClient)
   private[master] def confApi: ConfApi = new ConfApi(apiClient)
   private[master] def defaultApi: DefaultApi = new DefaultApi(apiClient)
+  private[master] def loggerApi: LoggerApi = new LoggerApi(apiClient)
   private[master] def masterApi: MasterApi = new MasterApi(apiClient)
   private[master] def shuffleApi: ShuffleApi = new ShuffleApi(apiClient)
   private[master] def workerApi: WorkerApi = new WorkerApi(apiClient)
@@ -114,6 +115,10 @@ trait MasterSubcommand extends BaseCommand {
   private[master] def runDeleteDynamicConf: HandleResponse
 
   private[master] def runShowThreadDump: ThreadStackResponse
+
+  private[master] def runShowLoggers: LoggerInfos
+
+  private[master] def runSetLogLevel: HandleResponse
 
   private[master] def reviseLostShuffles: HandleResponse
 

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -55,6 +55,8 @@ class MasterSubcommandImpl extends MasterSubcommand {
     if (masterOptions.upsertDynamicConf) log(runUpsertDynamicConf)
     if (masterOptions.deleteDynamicConf) log(runDeleteDynamicConf)
     if (masterOptions.showThreadDump) log(runShowThreadDump)
+    if (masterOptions.showLoggers) log(runShowLoggers)
+    if (masterOptions.setLogLevel) log(runSetLogLevel)
     if (masterOptions.reviseLostShuffles) log(reviseLostShuffles)
     if (masterOptions.deleteApps) log(deleteApps)
     if (!StringUtils.isBlank(masterOptions.updateInterruptionNotices))
@@ -228,6 +230,13 @@ class MasterSubcommandImpl extends MasterSubcommand {
 
   private[master] def runShowThreadDump: ThreadStackResponse =
     defaultApi.getThreadDump(commonOptions.getAuthHeader)
+
+  private[master] def runShowLoggers: LoggerInfos =
+    loggerApi.getLogger(commonOptions.loggerName, null, commonOptions.getAuthHeader)
+
+  private[master] def runSetLogLevel: HandleResponse = {
+    setLogLevel(commonOptions, spec, loggerApi.setLogger)
+  }
 
   private[master] def runAddClusterAlias: Unit = {
     val aliasToAdd = masterOptions.addClusterAlias

--- a/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerOptions.scala
@@ -79,4 +79,10 @@ final class WorkerOptions {
   @Option(names = Array("--show-thread-dump"), description = Array("Show worker thread dump"))
   private[worker] var showThreadDump: Boolean = _
 
+  @Option(names = Array("--show-loggers"), description = Array("Show logger levels"))
+  private[worker] var showLoggers: Boolean = _
+
+  @Option(names = Array("--set-loglevel"), description = Array("Set logger level"))
+  private[worker] var setLogLevel: Boolean = _
+
 }

--- a/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommand.scala
@@ -23,7 +23,7 @@ import picocli.CommandLine.Model.CommandSpec
 import org.apache.celeborn.cli.CelebornCli
 import org.apache.celeborn.cli.common.{BaseCommand, CliLogging, CommonOptions}
 import org.apache.celeborn.rest.v1.model._
-import org.apache.celeborn.rest.v1.worker.{ApplicationApi, ConfApi, DefaultApi, ShuffleApi, WorkerApi}
+import org.apache.celeborn.rest.v1.worker.{ApplicationApi, ConfApi, DefaultApi, LoggerApi, ShuffleApi, WorkerApi}
 import org.apache.celeborn.rest.v1.worker.invoker.ApiClient
 
 trait WorkerSubcommand extends BaseCommand {
@@ -53,6 +53,7 @@ trait WorkerSubcommand extends BaseCommand {
   private[worker] def applicationApi = new ApplicationApi(apiClient)
   private[worker] def confApi = new ConfApi(apiClient)
   private[worker] def defaultApi = new DefaultApi(apiClient)
+  private[worker] def loggerApi = new LoggerApi(apiClient)
   private[worker] def shuffleApi = new ShuffleApi(apiClient)
   private[worker] def workerApi = new WorkerApi(apiClient)
 
@@ -85,5 +86,9 @@ trait WorkerSubcommand extends BaseCommand {
   private[worker] def runDeleteDynamicConf: HandleResponse
 
   private[worker] def runShowThreadDump: ThreadStackResponse
+
+  private[worker] def runShowLoggers: LoggerInfos
+
+  private[worker] def runSetLogLevel: HandleResponse
 
 }

--- a/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/worker/WorkerSubcommandImpl.scala
@@ -41,6 +41,8 @@ class WorkerSubcommandImpl extends WorkerSubcommand {
     if (workerOptions.upsertDynamicConf) log(runUpsertDynamicConf)
     if (workerOptions.deleteDynamicConf) log(runDeleteDynamicConf)
     if (workerOptions.showThreadDump) log(runShowThreadDump)
+    if (workerOptions.showLoggers) log(runShowLoggers)
+    if (workerOptions.setLogLevel) log(runSetLogLevel)
   }
 
   private[worker] def runShowWorkerInfo: WorkerInfoResponse =
@@ -90,6 +92,13 @@ class WorkerSubcommandImpl extends WorkerSubcommand {
 
   private[worker] def runShowThreadDump: ThreadStackResponse =
     defaultApi.getThreadDump(commonOptions.getAuthHeader)
+
+  private[worker] def runShowLoggers: LoggerInfos =
+    loggerApi.getLogger(commonOptions.loggerName, null, commonOptions.getAuthHeader)
+
+  private[worker] def runSetLogLevel: HandleResponse = {
+    setLogLevel(commonOptions, spec, loggerApi.setLogger)
+  }
 
   private[worker] def runShowContainerInfo: ContainerInfo =
     defaultApi.getContainerInfo(commonOptions.getAuthHeader)

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -178,6 +178,26 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureOutputAndValidateResponse(args, "ThreadStackResponse")
   }
 
+  test("worker --show-loggers") {
+    val args = prepareWorkerArgs() :+ "--show-loggers"
+    captureOutputAndValidateResponse(args, "LoggerInfos")
+  }
+
+  test("worker --set-loglevel") {
+    val setArgs = prepareWorkerArgs() ++ Array(
+      "--set-loglevel",
+      "--logger-name",
+      "org.apache.celeborn.cli.TestWorkerLogger",
+      "--logger-level",
+      "DEBUG")
+    captureOutputAndValidateResponse(setArgs, "success: true")
+    val showArgs = prepareWorkerArgs() ++ Array(
+      "--show-loggers",
+      "--logger-name",
+      "org.apache.celeborn.cli.TestWorkerLogger")
+    captureOutputAndValidateResponse(showArgs, "level: DEBUG")
+  }
+
   test("master --show-masters-info") {
     cancel("This test is temporarily disabled since HA is not enabled in the unit tests.")
     val args = prepareMasterArgs() :+ "--show-masters-info"
@@ -282,6 +302,26 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
   test("master --show-thread-dump") {
     val args = prepareMasterArgs() :+ "--show-thread-dump"
     captureOutputAndValidateResponse(args, "ThreadStackResponse")
+  }
+
+  test("master --show-loggers") {
+    val args = prepareMasterArgs() :+ "--show-loggers"
+    captureOutputAndValidateResponse(args, "LoggerInfos")
+  }
+
+  test("master --set-loglevel") {
+    val setArgs = prepareMasterArgs() ++ Array(
+      "--set-loglevel",
+      "--logger-name",
+      "org.apache.celeborn.cli.TestMasterLogger",
+      "--logger-level",
+      "DEBUG")
+    captureOutputAndValidateResponse(setArgs, "success: true")
+    val showArgs = prepareMasterArgs() ++ Array(
+      "--show-loggers",
+      "--logger-name",
+      "org.apache.celeborn.cli.TestMasterLogger")
+    captureOutputAndValidateResponse(showArgs, "level: DEBUG")
   }
 
   test("master --exclude-worker and --remove-excluded-worker") {

--- a/docs/celeborn_cli.md
+++ b/docs/celeborn_cli.md
@@ -82,7 +82,8 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                            [--cluster=cluster_alias] [--config-level=level]
                            [--config-name=username] [--config-tenant=tenant_id]
                            [--delete-configs=c1,c2,c3...] [--host-list=h1,h2,
-                           h3...] [--hostport=host:port] [--upsert-configs=k1:
+                           h3...] [--hostport=host:port] [--logger-level=level]
+                           [--logger-name=logger_name] [--upsert-configs=k1:
                            v1,k2:v2,k3:v3...] [--worker-ids=w1,w2,w3...]
                            (--show-masters-info | --show-cluster-apps |
                            --show-cluster-apps-info | --show-cluster-shuffles |
@@ -98,6 +99,7 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                            --show-workers-topology | --show-conf |
                            --show-dynamic-conf | --upsert-dynamic-conf |
                            --delete-dynamic-conf | --show-thread-dump |
+                           --show-loggers | --set-loglevel |
                            --show-container-info | --add-cluster-alias=alias |
                            --remove-cluster-alias=alias |
                            --remove-workers-unavailable-info |
@@ -129,6 +131,12 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
       --host-list=h1,h2,h3...
                              List of hosts to pass to the command
       --hostport=host:port   The host and http port
+      --logger-level=level   The logger level to set, e.g. DEBUG, INFO, WARN,
+                               ERROR.
+      --logger-name=logger_name
+                             The logger name to query or set the level for. If
+                               not specified for --show-loggers, all configured
+                               loggers are returned.
       --remove-cluster-alias=alias
                              Remove alias to use in the cli for the given set
                                of masters
@@ -142,6 +150,7 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
       --send-worker-event=IMMEDIATELY | DECOMMISSION | DECOMMISSION_THEN_IDLE |
         GRACEFUL | RECOMMISSION | NONE
                              Send an event to a worker
+      --set-loglevel         Set logger level
       --show-cluster-apps    Show cluster application's ids
       --show-cluster-apps-info
                              Show cluster application's info
@@ -156,6 +165,7 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                              Show excluded workers
       --show-lifecycle-managers
                              Show lifecycle managers
+      --show-loggers         Show logger levels
       --show-lost-workers    Show lost workers
       --show-manual-excluded-workers
                              Show manual excluded workers
@@ -192,7 +202,8 @@ Usage: celeborn-cli worker [-hV] [--apps=appId] [--auth-header=authHeader]
                            [--cluster=cluster_alias] [--config-level=level]
                            [--config-name=username] [--config-tenant=tenant_id]
                            [--delete-configs=c1,c2,c3...] [--host-list=h1,h2,
-                           h3...] [--hostport=host:port] [--upsert-configs=k1:
+                           h3...] [--hostport=host:port] [--logger-level=level]
+                           [--logger-name=logger_name] [--upsert-configs=k1:
                            v1,k2:v2,k3:v3...] [--worker-ids=w1,w2,w3...]
                            (--show-worker-info | --show-apps-on-worker |
                            --show-shuffles-on-worker |
@@ -202,7 +213,7 @@ Usage: celeborn-cli worker [-hV] [--apps=appId] [--auth-header=authHeader]
                            --exit=exit_type | --show-conf |
                            --show-container-info | --show-dynamic-conf |
                            --upsert-dynamic-conf | --delete-dynamic-conf |
-                           --show-thread-dump)
+                           --show-thread-dump | --show-loggers | --set-loglevel)
       --apps=appId           The application Id list separated by comma.
       --auth-header=authHeader
                              The http `Authorization` header for
@@ -226,10 +237,18 @@ Usage: celeborn-cli worker [-hV] [--apps=appId] [--auth-header=authHeader]
       --is-decommissioning   Check if the system is decommissioning
       --is-registered        Check if the system is registered
       --is-shutdown          Check if the system is shutdown
+      --logger-level=level   The logger level to set, e.g. DEBUG, INFO, WARN,
+                               ERROR.
+      --logger-name=logger_name
+                             The logger name to query or set the level for. If
+                               not specified for --show-loggers, all configured
+                               loggers are returned.
+      --set-loglevel         Set logger level
       --show-apps-on-worker  Show applications running on the worker
       --show-conf            Show worker conf
       --show-container-info  Show container info
       --show-dynamic-conf    Show dynamic worker conf
+      --show-loggers         Show logger levels
       --show-partition-location-info
                              Show partition location information
       --show-shuffles-on-worker


### PR DESCRIPTION
### What changes were proposed in this pull request?

Expose the already-generated `LoggerApi` (`GET /api/v1/loggers` and `POST /api/v1/loggers`) in `celeborn-cli`, for both the `master` and `worker` subcommands:

- `--show-loggers` (with optional `--logger-name` filter) to query logger levels
- `--set-loglevel --logger-name <name> --logger-level <level>` to set a logger's level at runtime

Usage examples:

```bash
# Show all configured loggers of a worker
celeborn-cli worker --hostport host:port --show-loggers

# Show the level of a single logger of the master
celeborn-cli master --hostport host:port --show-loggers --logger-name org.apache.celeborn

# Set a logger level at runtime
celeborn-cli worker --hostport host:port --set-loglevel --logger-name org.apache.celeborn --logger-level DEBUG
```

### Why are the changes needed?

The logger level endpoints are already served by Master and Worker, and the `LoggerApi` client is already generated in `celeborn-openapi-client`, but they are not exposed in `celeborn-cli`. Exposing them allows adjusting log levels for troubleshooting without restarting Master/Worker or editing `log4j2.xml`.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [x] Yes. New `celeborn-cli` actions `--show-loggers` and `--set-loglevel` (with `--logger-name`/`--logger-level` options) for both `master` and `worker` subcommands.

### How was this patch tested?

New E2E test cases in `TestCelebornCliCommands` (mini cluster): `master/worker --show-loggers` and `master/worker --set-loglevel`, the latter verified by querying the level back. All 45 tests in the suite pass.