### PR TITLE
[CELEBORN-2399] Fix HA worker heartbeat using stateStartTime instead of actual time

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -243,7 +243,7 @@ public class MetaHandler {
               fetchPort,
               replicatePort,
               diskInfos,
-              request.getWorkerHeartbeatRequest().getWorkerStatus().getStateStartTime(),
+              request.getWorkerHeartbeatRequest().getTime(),
               workerStatus,
               highWorkload);
           break;


### PR DESCRIPTION
### What changes were proposed in this pull request?

In HA `MetaHandler` for `WorkerHeartbeat`, pass `request.getWorkerHeartbeatRequest().getTime()` into `updateWorkerHeartbeatMeta` instead of `getWorkerStatus().getStateStartTime()`.

### Why are the changes needed?

`HAMasterMetaManager` correctly sets `.setTime(...)` when submitting the Ratis request. After CELEBORN-1984, the apply path reads the wrong field.

`stateStartTime` is fixed when the worker entered Normal, so `lastHeartbeat` never advances. Once `now > stateStartTime + workerHeartbeatTimeout`, the HA master treats workers as lost despite regular heartbeats.

Non-HA (`SingleMasterMetaManager`) is unaffected. `branch-0.6` still uses `getTime()` and is unaffected. Affects `main` / `branch-0.7` (including v0.7.0-rc0).

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

Root-cause analysis of submit path (`HAMasterMetaManager` sets `.setTime`) vs apply path (`MetaHandler` was reading `stateStartTime`). Verified the same code path on `branch-0.6` already uses `getTime()`. Observed in HA testing on v0.7 where workers were repeatedly marked lost after the heartbeat timeout.

(Should be cherry-picked to `branch-0.7` for 0.7.0 release)