### PR TITLE
[CELEBORN-2402] Log the hostname for celeborn shuffle fetch failures

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/celeborn/ExceptionMakerHelper.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/celeborn/ExceptionMakerHelper.scala
@@ -30,6 +30,7 @@ object ExceptionMakerHelper {
         appShuffleId: Int,
         shuffleId: Int,
         partitionId: Int,
+        workerHost: String,
         e: Exception): Exception = {
       new FetchFailedException(
         null,
@@ -37,7 +38,7 @@ object ExceptionMakerHelper {
         -1,
         -1,
         partitionId,
-        FETCH_FAILURE_ERROR_MSG + appShuffleId + "/" + shuffleId,
+        FETCH_FAILURE_ERROR_MSG + appShuffleId + "/" + shuffleId + " from worker " + workerHost,
         e)
     }
   }

--- a/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
+++ b/client-spark/spark-3/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.{CountDownLatch, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 
 import org.apache.spark.{Dependency, ShuffleDependency, TaskContext}
+import org.apache.spark.celeborn.ExceptionMakerHelper
 import org.apache.spark.shuffle.ShuffleReadMetricsReporter
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
@@ -340,6 +341,14 @@ class CelebornShuffleReaderSuite extends AnyFunSuite {
       caller.interrupt()
       caller.join(TimeUnit.SECONDS.toMillis(5))
     }
+  }
+
+  test("FetchFailureException message includes workerHost") {
+    val workerHost = "celeborn-worker-1"
+    val e = ExceptionMakerHelper.SHUFFLE_FETCH_FAILURE_EXCEPTION_MAKER
+      .makeFetchFailureException(1, 2, 3, workerHost, new IOException("test"))
+    assert(e.getMessage.contains(workerHost))
+    assert(e.getMessage.contains(ExceptionMakerHelper.FETCH_FAILURE_ERROR_MSG))
   }
 
   private def newLocation(id: Int, host: String, fetchPort: Int): PartitionLocation =

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -991,14 +991,22 @@ public abstract class CelebornInputStream extends InputStream {
         if (exceptionMaker != null) {
           if (shuffleClient.reportShuffleFetchFailure(appShuffleId, shuffleId, taskId)) {
             /*
-             * [[ExceptionMaker.makeException]], for spark applications with celeborn.client.spark.stageRerun.enabled enabled will result in creating
+             * [[ExceptionMaker.makeFetchFailureException]], for spark applications with celeborn.client.spark.stageRerun.enabled enabled will result in creating
              * a FetchFailedException; and that will make the TaskContext as failed with shuffle fetch issues - see SPARK-19276 for more.
              * Given this, Celeborn can wrap the FetchFailedException with our CelebornIOException
              */
+            String workerHost =
+                Optional.ofNullable(currentReader)
+                    .map(
+                        r ->
+                            Optional.ofNullable(r.getLocation())
+                                .map(l -> l.getHost())
+                                .orElse("unknown"))
+                    .orElse("unknown");
             ioe =
                 new CelebornIOException(
                     exceptionMaker.makeFetchFailureException(
-                        appShuffleId, shuffleId, partitionId, e));
+                        appShuffleId, shuffleId, partitionId, workerHost, e));
           }
         }
         throw ioe;

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
@@ -19,5 +19,5 @@ package org.apache.celeborn.common.util;
 
 public interface ExceptionMaker {
   Exception makeFetchFailureException(
-      int appShuffleId, int shuffleId, int partitionId, Exception e);
+      int appShuffleId, int shuffleId, int partitionId, String workerHost, Exception e);
 }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
@@ -319,6 +319,7 @@ class CelebornFetchFailureSuite extends AnyFunSuite
             appShuffleId,
             -1,
             context.partitionId(),
+            "unknown",
             new IOException("forced"))
         }
         iter


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added `workerHost` parameter to the `ExceptionMaker.makeFetchFailureException()` interface and all its implementations (spark-3). `CelebornInputStream` now resolves the hostname from `currentReader.getLocation()` (falling back to `"unknown"` if unavailable) and embeds it in the `FetchFailedException` message.

New exception message format:
```
Celeborn FetchFailure with appShuffleId/shuffleId: <id>/<id> from worker <host>
```

### Why are the changes needed?

Previously, the `FetchFailedException` message contained no information about which worker was involved in the failure. This made it difficult to identify the problematic worker during incident investigation. Embedding the hostname improves observability at no cost.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes

### How was this patch tested?

Added unit test in `CelebornShuffleReaderSuite` (spark-3) to verify that the worker hostname appears in the `FetchFailedException` message.
