### PR TITLE
[CELEBORN-2404] Fix required field typo in SendWorkerEventRequest schema

### DIFF
--- a/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
+++ b/openapi/openapi-client/src/main/java/org/apache/celeborn/rest/v1/model/SendWorkerEventRequest.java
@@ -136,9 +136,9 @@ public class SendWorkerEventRequest {
    * The workers to send the event.
    * @return workers
    */
-  @javax.annotation.Nullable
+  @javax.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_WORKERS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public List<WorkerId> getWorkers() {
     return workers;
@@ -146,7 +146,7 @@ public class SendWorkerEventRequest {
 
 
   @JsonProperty(JSON_PROPERTY_WORKERS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setWorkers(List<WorkerId> workers) {
     this.workers = workers;
   }

--- a/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
+++ b/openapi/openapi-client/src/main/openapi3/master_rest_v1.yaml
@@ -1301,7 +1301,7 @@ components:
             $ref: '#/components/schemas/WorkerId'
       required:
         - eventType
-        - worker
+        - workers
 
     RatisElectionTransferRequest:
       type: object


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a typo in `master_rest_v1.yaml`: the `SendWorkerEventRequest` schema declared `worker` in its `required` list, but the actual property name is `workers`.

### Why are the changes needed?

The openapi-generator silently ignores the non-existent `worker` field, so the generated client compiles fine, but the spec declares a required field that does not exist and Swagger UI misleadingly shows `worker` as required. The server side validates `request.getWorkers.isEmpty`, consistent with the `workers` property.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

- Regenerated the openapi client (`./build/mvn clean generate-sources -pl openapi/openapi-client`): no diff in generated code, as the generator does not emit anything for `required`.
- The module builds successfully, which also validates the YAML syntax.
