### PR TITLE
[CELEBORN-2407][CLI] Expose Ratis REST API operations in CLI

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/common/CommonOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/common/CommonOptions.scala
@@ -107,6 +107,26 @@ class CommonOptions {
   private[cli] var loggerLevel: String = _
 
   @Option(
+    names = Array("--peer-address"),
+    paramLabel = "host:port",
+    description = Array("The address of the ratis peer to transfer the leader to."))
+  private[cli] var peerAddress: String = _
+
+  @Option(
+    names = Array("--ratis-peers"),
+    paramLabel = "id1|host1:port1,id2|host2:port2,...",
+    description = Array("The comma separated ratis peers in the format of `id|host:port`." +
+      " The peer id is required."))
+  private[cli] var ratisPeers: String = _
+
+  @Option(
+    names = Array("--peer-priorities"),
+    paramLabel = "host1:port1=priority1,host2:port2=priority2,...",
+    description = Array("The comma separated ratis peer address and priority pairs" +
+      " in the format of `host:port=priority`."))
+  private[cli] var peerPriorities: String = _
+
+  @Option(
     names = Array("--auth-header"),
     paramLabel = "authHeader",
     description = Array("The http `Authorization` header for authentication. " +

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -150,4 +150,60 @@ final class MasterOptions {
     paramLabel = "workerId1=timestamp,workerId2=timestamp,workerId3=timestamp",
     description = Array("Update interruption notices of workers."))
   private[master] var updateInterruptionNotices: String = _
+
+  @Option(
+    names = Array("--ratis-election-transfer"),
+    description = Array("Transfer the ratis group leader to the peer specified by --peer-address."))
+  private[master] var ratisElectionTransfer: Boolean = _
+
+  @Option(
+    names = Array("--ratis-election-step-down"),
+    description = Array("Make the ratis group leader step down its leadership."))
+  private[master] var ratisElectionStepDown: Boolean = _
+
+  @Option(
+    names = Array("--ratis-election-pause"),
+    description = Array("Pause leader election at the current master." +
+      " Then, the current master would not start a leader election."))
+  private[master] var ratisElectionPause: Boolean = _
+
+  @Option(
+    names = Array("--ratis-election-resume"),
+    description = Array("Resume leader election at the current master."))
+  private[master] var ratisElectionResume: Boolean = _
+
+  @Option(
+    names = Array("--ratis-peer-add"),
+    description = Array("Add new peers specified by --ratis-peers to the ratis group."))
+  private[master] var ratisPeerAdd: Boolean = _
+
+  @Option(
+    names = Array("--ratis-peer-remove"),
+    description = Array("Remove peers specified by --ratis-peers from the ratis group."))
+  private[master] var ratisPeerRemove: Boolean = _
+
+  @Option(
+    names = Array("--ratis-peer-set-priority"),
+    description = Array("Set the priority of the ratis peers specified by --peer-priorities."))
+  private[master] var ratisPeerSetPriority: Boolean = _
+
+  @Option(
+    names = Array("--ratis-snapshot-create"),
+    description = Array("Trigger the current master to take a ratis snapshot."))
+  private[master] var ratisSnapshotCreate: Boolean = _
+
+  @Option(
+    names = Array("--ratis-download-raft-meta-conf"),
+    paramLabel = "path",
+    description = Array("Download the raft-meta.conf file of the current master" +
+      " to the specified local file path."))
+  private[master] var ratisDownloadRaftMetaConf: String = _
+
+  @Option(
+    names = Array("--ratis-generate-new-raft-meta-conf"),
+    paramLabel = "path",
+    description = Array("Generate a new-raft-meta.conf file based on the original raft-meta.conf" +
+      " and the new peers specified by --ratis-peers, which is used to move a ratis node" +
+      " to a new node. The generated file is saved to the specified local file path."))
+  private[master] var ratisGenerateNewRaftMetaConf: String = _
 }

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommand.scala
@@ -25,7 +25,7 @@ import picocli.CommandLine.Model.CommandSpec
 import org.apache.celeborn.cli.CelebornCli
 import org.apache.celeborn.cli.common.{BaseCommand, CliLogging, CommonOptions}
 import org.apache.celeborn.cli.config.CliConfigManager
-import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, LoggerApi, MasterApi, ShuffleApi, WorkerApi}
+import org.apache.celeborn.rest.v1.master.{ApplicationApi, ConfApi, DefaultApi, LoggerApi, MasterApi, RatisApi, ShuffleApi, WorkerApi}
 import org.apache.celeborn.rest.v1.master.invoker.ApiClient
 import org.apache.celeborn.rest.v1.model._
 
@@ -69,6 +69,7 @@ trait MasterSubcommand extends BaseCommand {
   private[master] def defaultApi: DefaultApi = new DefaultApi(apiClient)
   private[master] def loggerApi: LoggerApi = new LoggerApi(apiClient)
   private[master] def masterApi: MasterApi = new MasterApi(apiClient)
+  private[master] def ratisApi: RatisApi = new RatisApi(apiClient)
   private[master] def shuffleApi: ShuffleApi = new ShuffleApi(apiClient)
   private[master] def workerApi: WorkerApi = new WorkerApi(apiClient)
 
@@ -127,5 +128,25 @@ trait MasterSubcommand extends BaseCommand {
   private[master] def deleteApps: HandleResponse
 
   private[master] def updateInterruptionNotices: HandleResponse
+
+  private[master] def runRatisElectionTransfer: HandleResponse
+
+  private[master] def runRatisElectionStepDown: HandleResponse
+
+  private[master] def runRatisElectionPause: HandleResponse
+
+  private[master] def runRatisElectionResume: HandleResponse
+
+  private[master] def runRatisPeerAdd: HandleResponse
+
+  private[master] def runRatisPeerRemove: HandleResponse
+
+  private[master] def runRatisPeerSetPriority: HandleResponse
+
+  private[master] def runRatisSnapshotCreate: HandleResponse
+
+  private[master] def runRatisDownloadRaftMetaConf: Unit
+
+  private[master] def runRatisGenerateNewRaftMetaConf: Unit
 
 }

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.cli.master
 
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import java.util
 
 import scala.collection.JavaConverters._
@@ -62,6 +63,18 @@ class MasterSubcommandImpl extends MasterSubcommand {
     if (masterOptions.deleteApps) log(deleteApps)
     if (!StringUtils.isBlank(masterOptions.updateInterruptionNotices))
       log(updateInterruptionNotices)
+    if (masterOptions.ratisElectionTransfer) log(runRatisElectionTransfer)
+    if (masterOptions.ratisElectionStepDown) log(runRatisElectionStepDown)
+    if (masterOptions.ratisElectionPause) log(runRatisElectionPause)
+    if (masterOptions.ratisElectionResume) log(runRatisElectionResume)
+    if (masterOptions.ratisPeerAdd) log(runRatisPeerAdd)
+    if (masterOptions.ratisPeerRemove) log(runRatisPeerRemove)
+    if (masterOptions.ratisPeerSetPriority) log(runRatisPeerSetPriority)
+    if (masterOptions.ratisSnapshotCreate) log(runRatisSnapshotCreate)
+    if (!StringUtils.isBlank(masterOptions.ratisDownloadRaftMetaConf))
+      runRatisDownloadRaftMetaConf
+    if (!StringUtils.isBlank(masterOptions.ratisGenerateNewRaftMetaConf))
+      runRatisGenerateNewRaftMetaConf
     if (masterOptions.addClusterAlias != null && masterOptions.addClusterAlias.nonEmpty)
       runAddClusterAlias
     if (masterOptions.removeClusterAlias != null && masterOptions.removeClusterAlias.nonEmpty)
@@ -338,6 +351,148 @@ class MasterSubcommandImpl extends MasterSubcommand {
 
     val request = new UpdateInterruptionNoticeRequest().workers(workerInterruptionNotices.asJava)
     workerApi.updateInterruptionNotice(request, commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisElectionTransfer: HandleResponse = {
+    val peerAddress = commonOptions.peerAddress
+    if (StringUtils.isBlank(peerAddress)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        "Peer address must be provided via --peer-address for this command.")
+    }
+    val request = new RatisElectionTransferRequest().peerAddress(peerAddress)
+    logInfo(s"Transferring ratis group leader to peer $peerAddress.")
+    ratisApi.transferRatisLeader(request, commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisElectionStepDown: HandleResponse = {
+    logInfo("Making the ratis group leader step down its leadership.")
+    ratisApi.stepDownRatisLeader(commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisElectionPause: HandleResponse = {
+    logInfo("Pausing leader election at the current master.")
+    ratisApi.pauseRatisElection(commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisElectionResume: HandleResponse = {
+    logInfo("Resuming leader election at the current master.")
+    ratisApi.resumeRatisElection(commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisPeerAdd: HandleResponse = {
+    val peers = getRatisPeers
+    logInfo(s"Adding ratis peers: $peers")
+    val request = new RatisPeerAddRequest().peers(peers)
+    ratisApi.addRatisPeer(request, commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisPeerRemove: HandleResponse = {
+    val peers = getRatisPeers
+    logInfo(s"Removing ratis peers: $peers")
+    val request = new RatisPeerRemoveRequest().peers(peers)
+    ratisApi.removeRatisPeer(request, commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisPeerSetPriority: HandleResponse = {
+    val addressPriorities = getRatisPeerPriorities
+    logInfo(s"Setting ratis peer priorities: $addressPriorities")
+    val request = new RatisPeerSetPriorityRequest().addressPriorities(addressPriorities)
+    ratisApi.setRatisPeerPriority(request, commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisSnapshotCreate: HandleResponse = {
+    logInfo("Triggering the current master to take a ratis snapshot.")
+    ratisApi.createRatisSnapshot(commonOptions.getAuthHeader)
+  }
+
+  override private[master] def runRatisDownloadRaftMetaConf: Unit = {
+    val targetPath = validatedTargetPath(masterOptions.ratisDownloadRaftMetaConf)
+    val file = ratisApi.getLocalRaftMetaConf(commonOptions.getAuthHeader)
+    Files.copy(file.toPath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+    logInfo(s"raft-meta.conf downloaded to $targetPath.")
+  }
+
+  override private[master] def runRatisGenerateNewRaftMetaConf: Unit = {
+    val peers = getRatisPeers
+    val targetPath = validatedTargetPath(masterOptions.ratisGenerateNewRaftMetaConf)
+    val request = new RatisLocalRaftMetaConfRequest().peers(peers)
+    val file = ratisApi.generateNewRaftMetaConf(request, commonOptions.getAuthHeader)
+    Files.copy(file.toPath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+    logInfo(s"new-raft-meta.conf generated at $targetPath.")
+  }
+
+  private def getRatisPeers: util.List[RatisPeer] = {
+    val peersStr = commonOptions.ratisPeers
+    if (StringUtils.isBlank(peersStr)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        "Ratis peers must be provided via --ratis-peers in the format of `id|host:port`.")
+    }
+    peersStr.trim.split(",").map(toRatisPeer).toList.asJava
+  }
+
+  private def toRatisPeer(peerString: String): RatisPeer = {
+    val idAndAddress = peerString.split("\\|", -1)
+    if (idAndAddress.length != 2 || idAndAddress(0).isEmpty) {
+      throw new ParameterException(
+        spec.commandLine(),
+        s"Invalid ratis peer: '$peerString'. Expected format: id|host:port")
+    }
+    val hostAndPort = idAndAddress(1).split(":", -1)
+    if (hostAndPort.length != 2 || hostAndPort(0).isEmpty || hostAndPort(1).isEmpty) {
+      throw new ParameterException(
+        spec.commandLine(),
+        s"Invalid ratis peer address: '${idAndAddress(1)}'. Expected format: host:port")
+    }
+    try {
+      hostAndPort(1).toInt
+    } catch {
+      case _: NumberFormatException =>
+        throw new ParameterException(
+          spec.commandLine(),
+          s"Invalid ratis peer address: '${idAndAddress(1)}'. Port is not a valid integer")
+    }
+    new RatisPeer().id(idAndAddress(0)).address(idAndAddress(1))
+  }
+
+  private def getRatisPeerPriorities: util.Map[String, Integer] = {
+    val prioritiesStr = commonOptions.peerPriorities
+    if (StringUtils.isBlank(prioritiesStr)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        "Peer priorities must be provided via --peer-priorities" +
+          " in the format of `host:port=priority`.")
+    }
+    prioritiesStr.trim.split(",").map { pair =>
+      val parts = pair.split("=", 2)
+      if (parts.length != 2 || parts(0).isEmpty) {
+        throw new ParameterException(
+          spec.commandLine(),
+          s"Invalid peer priority: '$pair'. Expected format: host:port=priority")
+      }
+      val priority =
+        try {
+          parts(1).toInt
+        } catch {
+          case _: NumberFormatException =>
+            throw new ParameterException(
+              spec.commandLine(),
+              s"Invalid priority for peer '${parts(0)}': '${parts(1)}' is not a valid integer")
+        }
+      (parts(0), Integer.valueOf(priority))
+    }.toMap.asJava
+  }
+
+  private def validatedTargetPath(pathStr: String): Path = {
+    val targetPath = Paths.get(pathStr)
+    val parent = targetPath.toAbsolutePath.getParent
+    if (parent == null || !Files.isDirectory(parent)) {
+      throw new ParameterException(
+        spec.commandLine(),
+        s"Invalid file path: '$pathStr'. The parent directory does not exist.")
+    }
+    targetPath
   }
 
 }

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -420,6 +420,54 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureErrorAndValidateResponse(args, "Invalid timestamp for worker")
   }
 
+  test("master --ratis-election-transfer validates inputs") {
+    val args = prepareMasterArgs() :+ "--ratis-election-transfer"
+    captureErrorAndValidateResponse(args, "Peer address must be provided via --peer-address")
+  }
+
+  test("master --ratis-peer-add and --ratis-peer-remove validate inputs") {
+    Seq(
+      Array("--ratis-peer-add") ->
+        "Ratis peers must be provided via --ratis-peers",
+      Array("--ratis-peer-remove") ->
+        "Ratis peers must be provided via --ratis-peers",
+      Array("--ratis-peer-add", "--ratis-peers", "host1:9872") ->
+        "Invalid ratis peer: 'host1:9872'. Expected format: id|host:port",
+      Array("--ratis-peer-add", "--ratis-peers", "id1|host1") ->
+        "Invalid ratis peer address: 'host1'. Expected format: host:port",
+      Array("--ratis-peer-add", "--ratis-peers", "id1|host1:abc") ->
+        "Port is not a valid integer").foreach { case (command, expectedError) =>
+      captureErrorAndValidateResponse(prepareMasterArgs() ++ command, expectedError)
+    }
+  }
+
+  test("master --ratis-peer-set-priority validates inputs") {
+    Seq(
+      Array("--ratis-peer-set-priority") ->
+        "Peer priorities must be provided via --peer-priorities",
+      Array("--ratis-peer-set-priority", "--peer-priorities", "host1:9872") ->
+        "Invalid peer priority: 'host1:9872'. Expected format: host:port=priority",
+      Array("--ratis-peer-set-priority", "--peer-priorities", "host1:9872=abc") ->
+        "Invalid priority for peer 'host1:9872': 'abc' is not a valid integer").foreach {
+      case (command, expectedError) =>
+        captureErrorAndValidateResponse(prepareMasterArgs() ++ command, expectedError)
+    }
+  }
+
+  test("master --ratis-generate-new-raft-meta-conf validates inputs") {
+    val args = prepareMasterArgs() ++ Array(
+      "--ratis-generate-new-raft-meta-conf",
+      "new-raft-meta.conf")
+    captureErrorAndValidateResponse(args, "Ratis peers must be provided via --ratis-peers")
+  }
+
+  test("master --ratis-download-raft-meta-conf validates target path") {
+    val args = prepareMasterArgs() ++ Array(
+      "--ratis-download-raft-meta-conf",
+      "/nonexistent-celeborn-cli-test-dir/raft-meta.conf")
+    captureErrorAndValidateResponse(args, "The parent directory does not exist")
+  }
+
   test("--version") {
     val versionInfo = "Could not resolve version of Celeborn since no RELEASE file was found"
     captureOutputAndValidateResponse(Array("--version"), versionInfo)

--- a/docs/celeborn_cli.md
+++ b/docs/celeborn_cli.md
@@ -83,8 +83,11 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                            [--config-name=username] [--config-tenant=tenant_id]
                            [--delete-configs=c1,c2,c3...] [--host-list=h1,h2,
                            h3...] [--hostport=host:port] [--logger-level=level]
-                           [--logger-name=logger_name] [--upsert-configs=k1:
-                           v1,k2:v2,k3:v3...] [--worker-ids=w1,w2,w3...]
+                           [--logger-name=logger_name] [--peer-address=host:
+                           port] [--peer-priorities=host1:port1=priority1,host2:
+                           port2=priority2,...] [--ratis-peers=id1|host1:port1,
+                           id2|host2:port2,...] [--upsert-configs=k1:v1,k2:v2,
+                           k3:v3...] [--worker-ids=w1,w2,w3...]
                            (--show-masters-info | --show-cluster-apps |
                            --show-cluster-apps-info | --show-cluster-shuffles |
                            --unregister-shuffles | --exclude-worker |
@@ -106,7 +109,14 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                            --remove-workers-unavailable-info |
                            --revise-lost-shuffles | --delete-apps |
                            --update-interruption-notices=workerId1=timestamp,
-                           workerId2=timestamp,workerId3=timestamp)
+                           workerId2=timestamp,workerId3=timestamp |
+                           --ratis-election-transfer |
+                           --ratis-election-step-down | --ratis-election-pause
+                           | --ratis-election-resume | --ratis-peer-add |
+                           --ratis-peer-remove | --ratis-peer-set-priority |
+                           --ratis-snapshot-create |
+                           --ratis-download-raft-meta-conf=path |
+                           --ratis-generate-new-raft-meta-conf=path)
                            [[--shuffleIds=shuffleId[,shuffleId...]]...]
       --add-cluster-alias=alias
                              Add alias to use in the cli for the given set of
@@ -138,6 +148,46 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                              The logger name to query or set the level for. If
                                not specified for --show-loggers, all configured
                                loggers are returned.
+      --peer-address=host:port
+                             The address of the ratis peer to transfer the
+                               leader to.
+      --peer-priorities=host1:port1=priority1,host2:port2=priority2,...
+                             The comma separated ratis peer address and
+                               priority pairs in the format of `host:
+                               port=priority`.
+      --ratis-download-raft-meta-conf=path
+                             Download the raft-meta.conf file of the current
+                               master to the specified local file path.
+      --ratis-election-pause Pause leader election at the current master. Then,
+                               the current master would not start a leader
+                               election.
+      --ratis-election-resume
+                             Resume leader election at the current master.
+      --ratis-election-step-down
+                             Make the ratis group leader step down its
+                               leadership.
+      --ratis-election-transfer
+                             Transfer the ratis group leader to the peer
+                               specified by --peer-address.
+      --ratis-generate-new-raft-meta-conf=path
+                             Generate a new-raft-meta.conf file based on the
+                               original raft-meta.conf and the new peers
+                               specified by --ratis-peers, which is used to
+                               move a ratis node to a new node. The generated
+                               file is saved to the specified local file path.
+      --ratis-peer-add       Add new peers specified by --ratis-peers to the
+                               ratis group.
+      --ratis-peer-remove    Remove peers specified by --ratis-peers from the
+                               ratis group.
+      --ratis-peer-set-priority
+                             Set the priority of the ratis peers specified by
+                               --peer-priorities.
+      --ratis-peers=id1|host1:port1,id2|host2:port2,...
+                             The comma separated ratis peers in the format of
+                               `id|host:port`. The peer id is required.
+      --ratis-snapshot-create
+                             Trigger the current master to take a ratis
+                               snapshot.
       --remove-cluster-alias=alias
                              Remove alias to use in the cli for the given set
                                of masters


### PR DESCRIPTION
### What changes were proposed in this pull request?

Expose all 10 operations of the already-generated master-side `RatisApi` OpenAPI client (`/api/v1/ratis/*`) as new flags of the `celeborn-cli master` subcommand:

- `--ratis-election-transfer` (with `--peer-address`) — transfer the group leader to the specified peer
- `--ratis-election-step-down` — make the group leader step down its leadership
- `--ratis-election-pause` / `--ratis-election-resume` — pause/resume leader election at the current server
- `--ratis-peer-add` / `--ratis-peer-remove` (with `--ratis-peers id|host:port,...`) — add/remove peers in the raft group
- `--ratis-peer-set-priority` (with `--peer-priorities host:port=priority,...`) — set the priority of peers
- `--ratis-snapshot-create` — trigger the current server to take a snapshot
- `--ratis-download-raft-meta-conf <path>` — download the local raft-meta.conf file
- `--ratis-generate-new-raft-meta-conf <path>` (with `--ratis-peers`) — generate a new-raft-meta.conf file for moving a raft node to a new node

The two file-download flags save the response to the given local path. Invalid peer/priority arguments are rejected client-side with `ParameterException`. No changes to the OpenAPI spec, generated code, or server side are needed. `docs/celeborn_cli.md` is updated with the actual `master -h` output.

### Why are the changes needed?

The master REST v1 API exposes 10 Ratis operations and the OpenAPI-generated `RatisApi` client is already shipped, but none of them are exposed in `celeborn-cli`. Operators have to fall back to `curl` or the experimental ratis-shell for routine Ratis maintenance (leader transfer, membership changes, snapshots, raft-meta.conf handling).

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [x] Yes — new `celeborn-cli master` flags: `--ratis-election-transfer`, `--ratis-election-step-down`, `--ratis-election-pause`, `--ratis-election-resume`, `--ratis-peer-add`, `--ratis-peer-remove`, `--ratis-peer-set-priority`, `--ratis-snapshot-create`, `--ratis-download-raft-meta-conf`, `--ratis-generate-new-raft-meta-conf`, and common options `--peer-address`, `--ratis-peers`, `--peer-priorities`.

### How was this patch tested?

- New argument-validation test cases in `TestCelebornCliCommands`; the full suite passes (52 tests, 0 failures).
- Success paths of the ratis endpoints require master HA (ratis) enabled, which the CLI mini-cluster test setup does not enable (same limitation as the existing `--show-masters-info` case), so end-to-end success paths were verified by compilation and manual checks against the generated client signatures.