### PR TITLE
[CELEBORN-2410] Add missing module coverage to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -110,7 +110,9 @@
 "module:service":
   - changed-files:
     - any-glob-to-any-file: [
-      'service/**/*'
+      'service/**/*',
+      'lifecycle-manager/**/*',
+      'multipart-uploader/**/*',
     ]
 
 "module:spi":
@@ -161,4 +163,10 @@
   - changed-files:
     - any-glob-to-any-file: [
       'client-tez/**/*',
+    ]
+
+"module:rust":
+  - changed-files:
+    - any-glob-to-any-file: [
+      'rust/**/*',
     ]


### PR DESCRIPTION
### What changes were proposed in this pull request?

`labeler.yml` did not match changes under `lifecycle-manager/`, `multipart-uploader/`, and `rust/` — PRs touching only these paths received no module label.

- `lifecycle-manager/**` → `module:service` (daemon wrapper around `client.LifecycleManager`, package `org.apache.celeborn.server.lifecyclemanager`)
- `multipart-uploader/**` → `module:service` (S3/OSS impls of `server.common.service.mpu.MultipartUploadHandler`, defined in the `service` module)
- `rust/**` → new `module:rust` (independent Cargo-built Rust client)

### Why are the changes needed?

These three directories have real source but no labeler entry, so the labeler action silently skips them. Changes to them never get triaged into the correct module label.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

YAML syntax validated. Existing module globs unchanged.