### PR TITLE
[CELEBORN-2414] Gate C++ push backpressure on both request count and byte size

### DIFF
--- a/cpp/celeborn/client/tests/PushStateTest.cpp
+++ b/cpp/celeborn/client/tests/PushStateTest.cpp
@@ -247,6 +247,26 @@ TEST_F(PushStateBytesSizeTest, limitMaxInFlightByTotalBytesSize) {
   EXPECT_TRUE(thirdBatchCompleted.load());
 }
 
+// The existing byte-size tests exceed the request-count limit at the same time
+// as the byte limit, so they pass either way. Here only the byte limit is
+// exceeded: two in-flight batches stay within maxReqsInFlight (2 total, 100 per
+// worker) while their 4000 bytes exceed both maxBytesSizeInFlight limits (3000
+// total, 2500 per worker). The push must block.
+TEST_F(PushStateBytesSizeTest, limitMaxInFlightByBytesSizeOnly) {
+  const std::string hostAndPushPort = "xx.xx.xx.xx:8080";
+  const int batchSize = 2000;
+
+  pushState_->addBatch(0, batchSize, hostAndPushPort);
+  pushState_->addBatch(1, batchSize, hostAndPushPort);
+
+  EXPECT_TRUE(pushState_->limitMaxInFlight(hostAndPushPort))
+      << "Push should be throttled while the in-flight bytes exceed the limit";
+
+  // Dropping one batch brings the bytes back under both limits.
+  pushState_->removeBatch(0, hostAndPushPort);
+  EXPECT_FALSE(pushState_->limitMaxInFlight(hostAndPushPort));
+}
+
 TEST_F(PushStateBytesSizeTest, cleanupClearsBytesSizeTracking) {
   const std::string hostAndPushPort = "xx.xx.xx.xx:8080";
 

--- a/cpp/celeborn/client/writer/PushState.cpp
+++ b/cpp/celeborn/client/writer/PushState.cpp
@@ -124,8 +124,23 @@ bool PushState::limitMaxInFlight(const std::string& hostAndPushPort) {
            batchBytesSize->load() <= maxInFlightBytesSizePerWorker_);
     }
 
-    if (reqCountWithinLimits ||
-        (maxInFlightBytesSizeEnabled_ && byteSizeWithinLimits)) {
+    // A send may proceed only when it is within limits. With byte-level
+    // backpressure enabled it must satisfy BOTH the request-count and the
+    // byte-size limits.
+    //
+    // Accepting either limit on its own leaves the byte limits unable to
+    // throttle at all: blocking would then require both limits to be
+    // exceeded, which is a strict subset of the request-count-only condition.
+    // Enabling maxBytesSizeInFlight could then only ever admit pushes that
+    // the request count alone would have blocked, which is the opposite of
+    // the memory guard these options document themselves as.
+    //
+    // Note the Java client's equivalent check in
+    // InFlightRequestTracker#limitMaxInFlight still accepts either limit.
+    const bool withinLimits = maxInFlightBytesSizeEnabled_
+        ? (reqCountWithinLimits && byteSizeWithinLimits)
+        : reqCountWithinLimits;
+    if (withinLimits) {
       break;
     }
 

--- a/cpp/celeborn/client/writer/PushState.h
+++ b/cpp/celeborn/client/writer/PushState.h
@@ -55,10 +55,9 @@ class PushState {
   // block until the ongoing package num decreases below max limit. If the
   // limit operation succeeds before timeout, return false, otherwise return
   // true.
-  // When maxBytesSizeInFlight is enabled, the limit check considers both
-  // request count and byte size limits. The push is allowed if either:
-  // 1. Request count is within limits, or
-  // 2. Byte size is within limits (when enabled)
+  // When maxBytesSizeInFlight is enabled, the push is allowed only once both
+  // the request count and the byte size are within limits; otherwise only the
+  // request count is checked.
   bool limitMaxInFlight(const std::string& hostAndPushPort);
 
   // Check if the pushState's ongoing package num reaches zero, if not, block


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `celeborn.client.push.maxBytesSizeInFlight.enabled` is on, `PushState::limitMaxInFlight` currently lets a send proceed when *either* limit is satisfied:

```cpp
if (reqCountWithinLimits ||
    (maxInFlightBytesSizeEnabled_ && byteSizeWithinLimits)) {
  break;
}
```

This PR requires both limits instead, leaves the request-count-only path unchanged when byte tracking is disabled, corrects the now-stale doc comment on `PushState::limitMaxInFlight`, and adds a regression test.

### Why are the changes needed?

With `||`, enabling the byte limit can only ever *widen* what the client is allowed to send. It adds an alternative way to pass the check rather than an additional condition to satisfy, so it cannot apply backpressure that the request-count limit is not already applying. A knob named `maxBytesSizeInFlight` that raises the effective ceiling when you turn it on is self-contradictory: the byte limit never engages, and the C++ client silently ignores a configured resource bound.

Concretely, the request-count limit is normally the looser of the two, so a burst of large batches stays under `celeborn.client.push.maxReqsInFlight.total` / `.perWorker`, satisfies the first disjunct, and is waved through with no byte accounting applied at all.

That is exactly the scenario the config was added for. CELEBORN-1917 introduced it because "in a vectorized shuffle (like blaze and gluten), a request might be greatly larger than the max buffer size, leading to too much inflight data and results OOM". A handful of oversized requests is precisely the case where the request count stays low, so under `||` the guard does not engage.

The config docs also describe the byte limit as "an addition to `celeborn.client.push.maxReqsInFlight.total`" — the "addition" reading only holds with `&&`.

The defaults keep the change low-risk: `clientPushMaxBytesSizeInFlightTotal` / `PerWorker` fall back to `maxReqsInFlight * pushBufferMaxSize` when the byte values are unset, so enabling the flag without tuning yields the same effective ceiling the request-count limit already implies.

### Does this PR resolve a correctness bug?

- [ ] Yes

Shuffle output is unaffected. This is a resource-limiting bug: the configured in-flight byte ceiling is not enforced, which can lead to client OOM under the vectorized-shuffle workloads the config was designed for.

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

No new or renamed config. Behaviour changes only for users who have explicitly set `celeborn.client.push.maxBytesSizeInFlight.enabled=true`, for whom the byte limit now actually throttles pushes as documented.

### How was this patch tested?

New unit test `PushStateBytesSizeTest.limitMaxInFlightBlocksWhenOnlyBytesSizeExceeded` in `cpp/celeborn/client/tests/PushStateTest.cpp`.

The pre-existing byte-size tests exceed the request-count limit at the same time as the byte limit, so they pass under either semantics. The new test isolates the byte limit: two in-flight batches stay within `maxReqsInFlight` (2 total, 100 per worker) while their 4000 bytes exceed both byte limits (3000 total, 2500 per worker), so the push must be throttled. Removing one batch brings it back under both limits and the push proceeds.

Covered by the `Celeborn Cpp Integration Test` workflow (`Run Unittests of Celeborn Cpp`).
