### PR TITLE
[CELEBORN-2419] Fix the warning: deprecated systemProperties parameter in maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1047,14 +1047,14 @@
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <argLine>${argLine} -ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs}</argLine>
-            <systemProperties>
+            <systemPropertyVariables>
               <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
               <log4j2.configurationFile>src/test/resources/log4j2-test.xml</log4j2.configurationFile>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <spark.driver.memory>8g</spark.driver.memory>
               <spark.shuffle.sort.io.plugin.class>${spark.shuffle.plugin.class}</spark.shuffle.sort.io.plugin.class>
               <spark.ui.enabled>false</spark.ui.enabled>
-            </systemProperties>
+            </systemPropertyVariables>
             <environmentVariables>
               <CELEBORN_LOCAL_HOSTNAME>localhost</CELEBORN_LOCAL_HOSTNAME>
               <FLINK_VERSION>${flink.version}</FLINK_VERSION>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace deprecated `<systemProperties>` with `<systemPropertyVariables>` in maven-surefire-plugin configuration in root `pom.xml`.


### Why are the changes needed?

Maven Surefire Plugin 3.0.0-M5+ deprecated the `<systemProperties>` parameter. Using it produces a warning on every build:
```
[INFO] --- surefire:3.0.0-M7:test (default-test) @ celeborn-client_2.12 ---
[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
[INFO] Tests are skipped.
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (test) @ celeborn-client_2.12 ---
[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
[INFO] Tests are skipped.

```


### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?

