### PR TITLE
[CELEBORN-2420] Bump scala version  to 2.12.18

### DIFF
--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -76,8 +76,8 @@ netty-transport-native-unix-common/4.2.10.Final//netty-transport-native-unix-com
 netty-transport/4.2.10.Final//netty-transport-4.2.10.Final.jar
 paranamer/2.8//paranamer-2.8.jar
 protobuf-java/3.25.5//protobuf-java-3.25.5.jar
-scala-library/2.12.10//scala-library-2.12.10.jar
-scala-reflect/2.12.10//scala-reflect-2.12.10.jar
+scala-library/2.12.18//scala-library-2.12.18.jar
+scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -76,8 +76,8 @@ netty-transport-native-unix-common/4.2.10.Final//netty-transport-native-unix-com
 netty-transport/4.2.10.Final//netty-transport-4.2.10.Final.jar
 paranamer/2.8//paranamer-2.8.jar
 protobuf-java/3.25.5//protobuf-java-3.25.5.jar
-scala-library/2.12.10//scala-library-2.12.10.jar
-scala-reflect/2.12.10//scala-reflect-2.12.10.jar
+scala-library/2.12.18//scala-library-2.12.18.jar
+scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -76,8 +76,8 @@ netty-transport-native-unix-common/4.2.10.Final//netty-transport-native-unix-com
 netty-transport/4.2.10.Final//netty-transport-4.2.10.Final.jar
 paranamer/2.8//paranamer-2.8.jar
 protobuf-java/3.25.5//protobuf-java-3.25.5.jar
-scala-library/2.12.15//scala-library-2.12.15.jar
-scala-reflect/2.12.15//scala-reflect-2.12.15.jar
+scala-library/2.12.18//scala-library-2.12.18.jar
+scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -76,8 +76,8 @@ netty-transport-native-unix-common/4.2.10.Final//netty-transport-native-unix-com
 netty-transport/4.2.10.Final//netty-transport-4.2.10.Final.jar
 paranamer/2.8//paranamer-2.8.jar
 protobuf-java/3.25.5//protobuf-java-3.25.5.jar
-scala-library/2.12.15//scala-library-2.12.15.jar
-scala-reflect/2.12.15//scala-reflect-2.12.15.jar
+scala-library/2.12.18//scala-library-2.12.18.jar
+scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -76,8 +76,8 @@ netty-transport-native-unix-common/4.2.10.Final//netty-transport-native-unix-com
 netty-transport/4.2.10.Final//netty-transport-4.2.10.Final.jar
 paranamer/2.8//paranamer-2.8.jar
 protobuf-java/3.25.5//protobuf-java-3.25.5.jar
-scala-library/2.12.17//scala-library-2.12.17.jar
-scala-reflect/2.12.17//scala-reflect-2.12.17.jar
+scala-library/2.12.18//scala-library-2.12.18.jar
+scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.compiler.release></maven.compiler.release>
     <maven.version>3.9.16</maven.version>
 
     <flink.version>1.20.5</flink.version>
@@ -1541,7 +1540,7 @@
       <properties>
         <lz4-java.group>org.lz4</lz4-java.group>
         <lz4-java.version>1.7.1</lz4-java.version>
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.2.4</spark.version>
         <zstd-jni.version>1.5.0-4</zstd-jni.version>
@@ -1562,7 +1561,7 @@
       <properties>
         <lz4-java.group>org.lz4</lz4-java.group>
         <lz4-java.version>1.8.0</lz4-java.version>
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.4</spark.version>
         <zstd-jni.version>1.5.2-1</zstd-jni.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1496,11 +1496,10 @@
       <properties>
         <lz4-java.group>org.lz4</lz4-java.group>
         <lz4-java.version>1.7.1</lz4-java.version>
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.3</spark.version>
         <zstd-jni.version>1.4.4-3</zstd-jni.version>
-        <maven.plugin.silencer.version>1.6.0</maven.plugin.silencer.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
       </properties>
     </profile>
@@ -1518,11 +1517,10 @@
       <properties>
         <lz4-java.group>org.lz4</lz4-java.group>
         <lz4-java.version>1.7.1</lz4-java.version>
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.3</spark.version>
         <zstd-jni.version>1.4.8-1</zstd-jni.version>
-        <maven.plugin.silencer.version>1.6.0</maven.plugin.silencer.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
       </properties>
     </profile>
@@ -1582,7 +1580,7 @@
       <properties>
         <lz4-java.group>org.lz4</lz4-java.group>
         <lz4-java.version>1.8.0</lz4-java.version>
-        <scala.version>2.12.17</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.4.4</spark.version>
         <zstd-jni.version>1.5.2-5</zstd-jni.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.compiler.release></maven.compiler.release>
     <maven.version>3.9.16</maven.version>
 
     <flink.version>1.20.5</flink.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -900,7 +900,7 @@ object Spark30 extends SparkClientProjects {
   val sparkClientShadedProjectName = "celeborn-client-spark-3-shaded"
 
   val lz4JavaVersion = "1.7.1"
-  val sparkProjectScalaVersion = "2.12.10"
+  val sparkProjectScalaVersion = "2.12.18"
 
   val sparkVersion = "3.0.3"
   val zstdJniVersion = "1.4.4-3"
@@ -915,7 +915,7 @@ object Spark31 extends SparkClientProjects {
   val sparkClientShadedProjectName = "celeborn-client-spark-3-shaded"
 
   val lz4JavaVersion = "1.7.1"
-  val sparkProjectScalaVersion = "2.12.10"
+  val sparkProjectScalaVersion = "2.12.18"
 
   val sparkVersion = "3.1.3"
   val zstdJniVersion = "1.4.8-1"
@@ -963,7 +963,7 @@ object Spark34 extends SparkClientProjects {
   val sparkClientShadedProjectName = "celeborn-client-spark-3-shaded"
 
   val lz4JavaVersion = "1.8.0"
-  val sparkProjectScalaVersion = "2.12.17"
+  val sparkProjectScalaVersion = "2.12.18"
 
   val sparkVersion = "3.4.4"
   val zstdJniVersion = "1.5.2-5"

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -930,7 +930,7 @@ object Spark32 extends SparkClientProjects {
   val sparkClientShadedProjectName = "celeborn-client-spark-3-shaded"
 
   val lz4JavaVersion = "1.7.1"
-  val sparkProjectScalaVersion = "2.12.15"
+  val sparkProjectScalaVersion = "2.12.18"
 
   val sparkVersion = "3.2.4"
   val zstdJniVersion = "1.5.0-4"
@@ -947,7 +947,7 @@ object Spark33 extends SparkClientProjects {
   // val jacksonVersion = "2.13.4"
   // val jacksonDatabindVersion = "2.13.4.2"
   val lz4JavaVersion = "1.8.0"
-  val sparkProjectScalaVersion = "2.12.15"
+  val sparkProjectScalaVersion = "2.12.18"
   // scalaBinaryVersion
   // val scalaBinaryVersion = "2.12"
   val sparkVersion = "3.3.4"


### PR DESCRIPTION

### What changes were proposed in this pull request?

1. Unify `scala.version` to 2.12.18 across all spark-3.x profiles.
2. Remove `maven.plugin.silencer.version` override (1.6.0) from spark-3.0 and spark-3.1 profiles, so they use the default 1.7.19 which supports scala 2.12.18.



### Why are the changes needed?
scala-maven-plugin 4.9.x auto-generates `-release 8` from `maven.compiler.target=8` and passes it to scalac. Scala 2.12.10–2.12.17 all have issues with `-release` on JDK 8:

- **2.12.15/2.12.17**: unconditionally rejects `-release` on JDK 8
- **2.12.10**: predates the `-release` option, would fail with "bad option"



<img width="1346" height="372" alt="image" src="https://github.com/user-attachments/assets/8cd6588b-ad24-4a8b-8eba-b786288a6035" />


Scala 2.12.18 allows `-release 8` on JDK 8.


### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?
`./build/make-distribution.sh -Pspark-3.0` on JDK 8.
`./build/make-distribution.sh -Pspark-3.3` on JDK 8.

<img width="735" height="152" alt="image" src="https://github.com/user-attachments/assets/24b21ce0-8504-4a32-9f2c-6d234cc8110e" />

