### PR TITLE
[CELEBORN-2060][FOLLOWUP] Fix rack-aware replica storage selection

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/slotsalloc/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/slotsalloc/SlotsAllocator.java
@@ -458,6 +458,7 @@ public class SlotsAllocator {
                   replicaIndex,
                   index ->
                       !(sameWorkerCandidates && index == selectedPrimaryIndex)
+                          && canAssign(null, replicaWorkers.get(index), availableStorageTypes)
                           && satisfyRackAware(true, primaryWorker, replicaWorkers.get(index)));
         } else if (StorageInfo.localDiskAvailable(availableStorageTypes)) {
           selectedReplicaIndex =
@@ -476,10 +477,7 @@ public class SlotsAllocator {
         WorkerInfo replicaWorker = replicaWorkers.get(selectedReplicaIndex);
 
         StorageInfo replicaStorageInfo =
-            slotBudgets == null && shouldRackAware
-                ? primaryStorageInfo
-                : buildStorageInfo(
-                    replicaWorker, slotBudgets, workerDiskIndex, availableStorageTypes);
+            buildStorageInfo(replicaWorker, slotBudgets, workerDiskIndex, availableStorageTypes);
         PartitionLocation replicaPartition =
             createLocation(
                 partitionId,

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/slotsalloc/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/slotsalloc/SlotsAllocatorRackAwareSuiteJ.java
@@ -184,6 +184,69 @@ public class SlotsAllocatorRackAwareSuiteJ {
   }
 
   @Test
+  public void offerSlotsRackAwareFallbackRequiresReplicaDisk() {
+    List<WorkerInfo> workers =
+        Arrays.asList(
+            prepareWorker("disk-worker", "/rack/r1", "/mnt/disk1"),
+            prepareWorker("diskless-worker", "/rack/r2", null));
+
+    Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
+        SlotsAllocator.offerSlots(
+            workers,
+            Collections.singletonList(0),
+            true,
+            true,
+            StorageInfo.LOCAL_DISK_MASK,
+            false,
+            0,
+            SLOTS_ASSIGN_STRATEGY);
+
+    Assert.assertTrue(slots.isEmpty());
+  }
+
+  @Test
+  public void offerSlotsRackAwareFallbackUsesReplicaStorageInfo() {
+    List<WorkerInfo> workers =
+        Arrays.asList(
+            prepareWorker("worker1", "/rack/r1", "/mnt/disk1"),
+            prepareWorker("worker2", "/rack/r2", "/mnt/disk2"));
+
+    Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
+        SlotsAllocator.offerSlots(
+            workers,
+            Collections.singletonList(0),
+            true,
+            true,
+            StorageInfo.LOCAL_DISK_MASK,
+            false,
+            0,
+            SLOTS_ASSIGN_STRATEGY);
+
+    Assert.assertEquals(2, slots.size());
+    workers.forEach(
+        worker -> {
+          List<PartitionLocation> locations = new ArrayList<>();
+          locations.addAll(slots.get(worker)._1);
+          locations.addAll(slots.get(worker)._2);
+          Assert.assertEquals(1, locations.size());
+          Assert.assertEquals(
+              worker.diskInfos().keySet().iterator().next(),
+              locations.get(0).getStorageInfo().getMountPoint());
+        });
+  }
+
+  private static WorkerInfo prepareWorker(String host, String rack, String mountPoint) {
+    Map<String, DiskInfo> diskInfos = new HashMap<>();
+    if (mountPoint != null) {
+      // Keep availableSlots at zero to force allocation through the best-effort fallback.
+      diskInfos.put(mountPoint, new DiskInfo(mountPoint, 1024L, 1, 1, 0));
+    }
+    WorkerInfo worker = new WorkerInfo(host, 1, 2, 3, 4, 5, diskInfos, null);
+    worker.networkLocation_$eq(rack);
+    return worker;
+  }
+
+  @Test
   public void testRackAwareRoundRobinReplicaPatterns() {
     for (Tuple2<Integer, List<WorkerInfo>> tuple :
         Arrays.asList(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up to [PR #3781](https://github.com/apache/celeborn/pull/3781):

- Validates that rack-aware replica candidates support the requested storage type.
- Builds replica `StorageInfo` from the selected replica worker.
- Adds regression tests for diskless replicas and different mount points.

### Why are the changes needed?

During best-effort fallback, the allocator could select a diskless worker for a local-disk replica or incorrectly reuse the primary worker's mount point.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [x] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes

### How was this patch tested?

`build/mvn -pl master -am -Dtest=SlotsAllocatorRackAwareSuiteJ test`