### PR TITLE
[CELEBORN-2322][FOLLOWUP] Upgrade docker/login-action for release workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,7 +33,7 @@ jobs:
           tar -xzf apache-celeborn-${VERSION}-bin.tgz
 
       - name: Login to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,7 +33,7 @@ jobs:
           tar -xzf apache-celeborn-${VERSION}-bin.tgz
 
       - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade docker/login-action to the ASF-allowlisted v4.6.0 commit.

### Why are the changes needed?

Publishing v0.7.0 triggered https://github.com/apache/celeborn/actions/runs/31992095865, but the workflow failed at startup because the pinned action SHA is no longer allowed by the ASF GitHub Actions policy. After this change is merged, the workflow can be dispatched from main with celeborn_version=0.7.0.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

- Verified the new SHA is listed in apache/infrastructure-actions as docker/login-action v4.6.0.
- Verified the SHA matches the upstream v4.6.0 tag.
- Ran git diff --check.