### PR TITLE
[CELEBORN-2424] Log worker hosts for each reduce partition read in ShuffleClientImpl

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -2048,6 +2048,19 @@ public class ShuffleClientImpl extends ShuffleClient {
       logger.warn("Shuffle data is empty for shuffle {} partition {}.", shuffleId, partitionId);
       return CelebornInputStream.empty();
     } else {
+      if (logger.isInfoEnabled()) {
+        Set<String> workerHosts = new LinkedHashSet<>();
+        for (PartitionLocation location : locations) {
+          if (location != null) {
+            workerHosts.add(location.getHost());
+          }
+        }
+        logger.info(
+            "Reduce task for shuffle {} partition {} reads data from worker hosts: {}",
+            shuffleId,
+            partitionId,
+            workerHosts);
+      }
       String shuffleKey = Utils.makeShuffleKey(appUniqueId, shuffleId);
       assert dataClientFactory != null;
       return CelebornInputStream.create(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an INFO-level log in `ShuffleClientImpl.readPartition()`, right before the
`CelebornInputStream` is created, recording the worker hosts a reduce partition
reads its data from:

```
Reduce task for shuffle {} partition {} reads data from worker hosts: {}
```

Hosts are de-duplicated (order preserved) since a partition split across epochs
may reuse the same worker. `readPartition()` is the single, engine-agnostic read
entry point, so the log applies to the Spark, MR and Tez clients.

### Why are the changes needed?

When a Spark job is slow on shuffle read, the Stages UI shows almost the entire
task duration is spent in "Shuffle Read Blocked Time" (e.g. 14-19 min out of a
16-20 min task). But the only host shown there is the executor running the
reduce task, not the Celeborn worker actually serving the data — so operators
cannot tell which worker is the slow one. This log provides that missing
partition-to-worker(s) mapping on the normal read path.

JIRA: https://issues.apache.org/jira/browse/CELEBORN-2424

### Does this PR resolve a correctness bug?

No

### Does this PR introduce any user-facing change?

No. Log output only.

### How was this patch tested?

Existing tests. The change is a single log statement on the read path.
