### PR TITLE
[CELEBORN-2426] Correct the calculation of the count of unreleased partitions at shutdown

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -485,8 +485,8 @@ private[celeborn] class Worker(
   // Unreleased partition location count when worker is restarting
   workerSource.addGauge(WorkerSource.UNRELEASED_PARTITION_LOCATION_COUNT) { () =>
     if (shutdown.get()) {
-      partitionLocationInfo.primaryPartitionLocations.size() +
-        partitionLocationInfo.replicaPartitionLocations.size()
+      partitionLocationCount(partitionLocationInfo.primaryPartitionLocations) +
+        partitionLocationCount(partitionLocationInfo.replicaPartitionLocations)
     } else {
       0
     }
@@ -507,6 +507,11 @@ private[celeborn] class Worker(
         workerSource.getCounterCount(WorkerSource.ACTIVE_CONNECTION_COUNT) >= activeConnectionMax
       case _ => false
     }
+  }
+
+  private def partitionLocationCount(
+      partitionLocations: WorkerPartitionLocationInfo#PartitionInfo): Int = {
+    partitionLocations.values().asScala.map(_.size()).sum
   }
 
   private def heartbeatToMaster(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR corrects the calculation of the number of unreleased partitions at shutdown.


### Why are the changes needed?

#### Bug
The current calculation of the number of unreleased partitions at shutdown is incorrect ([source](https://github.com/rjvkr2021/celeborn/blob/main/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala#L488-L489)).
```
partitionLocationInfo.primaryPartitionLocations.size() +
        partitionLocationInfo.replicaPartitionLocations.size()
```

#### Why so?

_primaryPartitionLocations__ and _replicaPartitionLocations__ are maps shaped as:
```
shuffleKey -> (uniquePartitionLocationId -> PartitionLocation)
```
Therefore, the current calculation counts the number of shuffles containing unreleased partitions at shutdown, not the number of unreleased partitions itself.

#### Fix

It should sum the sizes of the inner maps.
```
partitionLocationInfo.primaryPartitionLocations.values().asScala.map(_.size()).sum +
 partitionLocationInfo.replicaPartitionLocations.values().asScala.map(_.size()).sum
```


### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [x] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
No


### How was this patch tested?

NA