### PR TITLE
[CELEBORN-2432] Cache sbt launcher and dependencies in SBT CI workflow

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -53,6 +53,16 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.java }}
         check-latest: false
+    - name: Cache SBT launcher and dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/*.jar
+          ~/.sbt
+          ~/.cache/coursier
+        key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+        restore-keys: |
+          sbt-
     - name: Test Service with SBT
       run: |
         build/sbt ++${{ matrix.scala }} "clean; test"
@@ -157,6 +167,16 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.java }}
         check-latest: false
+    - name: Cache SBT launcher and dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/*.jar
+          ~/.sbt
+          ~/.cache/coursier
+        key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+        restore-keys: |
+          sbt-
     - name: Test with SBT
       run: |
         build/sbt -Dspark.shuffle.plugin.class=${{ matrix.shuffle-plugin-class }} -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
@@ -199,6 +219,16 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.java }}
           check-latest: false
+      - name: Cache SBT launcher and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            sbt-
       - name: Test with SBT
         run: |
           build/sbt -Dspark.shuffle.plugin.class=${{ matrix.shuffle-plugin-class }} -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
@@ -231,6 +261,16 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.java }}
           check-latest: false
+      - name: Cache SBT launcher and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            sbt-
       - name: Test with SBT
         run: |
           build/sbt -Pflink-${{ matrix.flink }} "clean; celeborn-flink-group/test"
@@ -264,6 +304,16 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.java }}
           check-latest: false
+      - name: Cache SBT launcher and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            sbt-
       - name: Test with SBT
         run: |
           build/sbt -Pflink-${{ matrix.flink }} "clean; celeborn-flink-group/test"
@@ -292,6 +342,16 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.java }}
           check-latest: false
+      - name: Cache SBT launcher and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            sbt-
       - name: Test with SBT
         run: |
           build/sbt -Pmr "clean; celeborn-mr-group/test"
@@ -320,6 +380,16 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.java }}
           check-latest: false
+      - name: Cache SBT launcher and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            sbt-
       - name: Test with SBT
         run: |
           build/sbt "clean;celeborn-openapi-client/check"

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -60,7 +60,7 @@ jobs:
           build/*.jar
           ~/.sbt
           ~/.cache/coursier
-        key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+        key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
         restore-keys: |
           sbt-
     - name: Test Service with SBT
@@ -174,7 +174,7 @@ jobs:
           build/*.jar
           ~/.sbt
           ~/.cache/coursier
-        key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+        key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
         restore-keys: |
           sbt-
     - name: Test with SBT
@@ -226,7 +226,7 @@ jobs:
             build/*.jar
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
           restore-keys: |
             sbt-
       - name: Test with SBT
@@ -268,7 +268,7 @@ jobs:
             build/*.jar
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
           restore-keys: |
             sbt-
       - name: Test with SBT
@@ -311,7 +311,7 @@ jobs:
             build/*.jar
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
           restore-keys: |
             sbt-
       - name: Test with SBT
@@ -349,7 +349,7 @@ jobs:
             build/*.jar
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
           restore-keys: |
             sbt-
       - name: Test with SBT
@@ -387,7 +387,7 @@ jobs:
             build/*.jar
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
+          key: sbt-${{ github.job }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.spark }}${{ matrix.flink }}-${{ hashFiles('project/**/*.scala', 'project/**/*.sbt', 'project/build.properties', 'build/sbt', 'build/sbt-launch-lib.bash') }}
           restore-keys: |
             sbt-
       - name: Test with SBT


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add an actions/cache step to every job in sbt.yml, caching:
- build/*.jar (the sbt launcher downloaded by build/sbt)
- ~/.sbt
- ~/.cache/coursier (dependency repository)

Keys are derived from hashFiles of the poms and build scripts, so downloads only happen when the build files change. This follows the pattern used by [Spark's `build_and_test.yml`](https://github.com/apache/spark/blob/52eb078867cf809a92fd6ebdc96c9d72bce63417/.github/workflows/build_and_test.yml#L720).

### Why are the changes needed?

The sbt CI jobs currently configure no caching at all: every run of every matrix job (~40 jobs) re-downloads the sbt launcher and the entire dependency set, which exposes CI to network flakes. Recent examples on PR CI and on main:

- "Our attempt to download sbt locally to build/sbt-launch-1.9.4.jar  failed" (job fails in ~15s)
- scala compile failing with MissingResourceException:
  org.scalactic.ScalacticBundle caused by java.io.IOException: Stream  closed (corrupted jar download)
<img width="2110" height="444" alt="image" src="https://github.com/user-attachments/assets/9d24b07d-3910-400e-b8ee-af550ca444e2" />


### Does this PR resolve a correctness bug?

- [ ] Yes  
### Does this PR introduce _any_ user-facing change?

- [ ] Ye 

### How was this patch tested?

Workflow-only change; the PR's own CI run exercises the new cache steps (first run populates the cache, subsequent runs hit it). 