### PR TITLE
[CELEBORN-2435] Make CelebornConfSuite transport io.mode expectation platform-aware

### DIFF
--- a/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
@@ -20,7 +20,6 @@ package org.apache.celeborn.common
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf._
 import org.apache.celeborn.common.internal.config.ConfigEntry
-import org.apache.celeborn.common.network.util.IOMode
 import org.apache.celeborn.common.protocol.StorageInfo
 
 class CelebornConfSuite extends CelebornFunSuite {
@@ -287,7 +286,7 @@ class CelebornConfSuite extends CelebornFunSuite {
 
   // Transport conf tests
 
-  private val transportTestNetworkIoMode = IOMode.EPOLL.name()
+  private val transportTestNetworkIoMode = CelebornConf.networkIoMode()
   private val transportTestNetworkIoPreferDirectBufs =
     !NETWORK_IO_PREFER_DIRECT_BUFS.defaultValue.get
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CelebornConfSuite`'s `transportTestNetworkIoMode` was hardcoded to `IOMode.EPOLL.name()`. This PR derives it from `CelebornConf.networkIoMode()` so the expected value follows the platform (EPOLL on Linux, KQUEUE on macOS, NIO when no native transport is available), and drops the now-unused `IOMode` import.

### Why are the changes needed?

Two transport-conf tests fail on macOS because the accessor under test, `CelebornConf#networkIoMode(module)`, falls back to the platform default (KQUEUE on macOS) while the expectation is hardcoded EPOLL:

```
"[EPOLL]" -> "[KQUEUE]"  (expected, actual)
```

On Linux the assertion passes only because the hardcoded EPOLL happens to equal the Linux platform default. Deriving the expectation from the same platform-aware helper keeps the suite meaningful on every platform.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

No: test-only change.

### How was this patch tested?

GitHub Actions (Linux) keeps exercising the EPOLL path. Since the failing scenario is macOS-only and CI has no macOS runner, verified locally on macOS (aarch64): before the change the two tests fail with `"[EPOLL]" -> "[KQUEUE]"`; after the change `mvn -pl common -am test` passes 234/234 in `celeborn-common`.