### PR TITLE
[CELEBORN-2436] Speed up slow tests and fix LifecycleManager leaks in spark-it

### DIFF
--- a/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuiteJ.java
@@ -44,7 +44,7 @@ public class DataPushQueueSuiteJ {
   private static File tempDir = null;
 
   private final int shuffleId = 0;
-  private final int numPartitions = 1000000;
+  private final int numPartitions = 30000;
 
   @BeforeClass
   public static void beforeAll() {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -196,12 +196,13 @@ public class RatisMasterStatusSystemSuiteJ {
         RATISSERVER1.start();
         RATISSERVER2.start();
         RATISSERVER3.start();
-        // Poll for a raft leader instead of a fixed 15s sleep. Without a leader the rest
-        // of the suite cannot proceed, so fail here if none is elected within 30s.
-        awaitCondition(
-            () -> RATISSERVER1.isLeader() || RATISSERVER2.isLeader() || RATISSERVER3.isLeader());
-        if (!RATISSERVER1.isLeader() && !RATISSERVER2.isLeader() && !RATISSERVER3.isLeader()) {
-          Assert.fail("No raft leader was elected within 30 seconds");
+        // Poll for a *ready* raft leader instead of a fixed 15s sleep. Without a leader the
+        // rest of the suite cannot proceed, so fail here if none is elected within 30s.
+        // isLeader() alone is not enough: a newly elected leader rejects writes with
+        // LeaderNotReadyException until its no-op log entry for the new term is committed.
+        awaitCondition(RatisMasterStatusSystemSuiteJ::hasReadyLeader);
+        if (!hasReadyLeader()) {
+          Assert.fail("No ready raft leader was elected within 30 seconds");
         }
         serversStarted = true;
       } catch (Exception e) {
@@ -305,6 +306,24 @@ public class RatisMasterStatusSystemSuiteJ {
     while (!condition.getAsBoolean() && System.currentTimeMillis() < deadlineMs) {
       Thread.sleep(100L);
     }
+  }
+
+  // A leader is usable for writes only once it is ready, i.e. its no-op log entry for
+  // the current term has been committed; before that it is in LEADER state but rejects
+  // requests with LeaderNotReadyException.
+  private static boolean hasReadyLeader() {
+    for (HARaftServer server : Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3)) {
+      if (server.isLeader()) {
+        try {
+          if (server.getServer().getDivision(server.getGroupId()).getInfo().isLeaderReady()) {
+            return true;
+          }
+        } catch (IOException e) {
+          // Division not available yet; keep polling.
+        }
+      }
+    }
+    return false;
   }
 
   public HAMasterMetaManager pickLeaderStatusSystem() {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 
 import scala.Tuple2;
 
@@ -195,7 +196,13 @@ public class RatisMasterStatusSystemSuiteJ {
         RATISSERVER1.start();
         RATISSERVER2.start();
         RATISSERVER3.start();
-        Thread.sleep(15 * 1000);
+        // Poll for a raft leader instead of a fixed 15s sleep. Without a leader the rest
+        // of the suite cannot proceed, so fail here if none is elected within 30s.
+        awaitCondition(
+            () -> RATISSERVER1.isLeader() || RATISSERVER2.isLeader() || RATISSERVER3.isLeader());
+        if (!RATISSERVER1.isLeader() && !RATISSERVER2.isLeader() && !RATISSERVER3.isLeader()) {
+          Assert.fail("No raft leader was elected within 30 seconds");
+        }
         serversStarted = true;
       } catch (Exception e) {
         stopAllRaftServers();
@@ -289,6 +296,17 @@ public class RatisMasterStatusSystemSuiteJ {
     return MasterClient.encodeRequestId(UUID.randomUUID().toString(), callerId.incrementAndGet());
   }
 
+  // Waits until the given condition holds, polling every 100ms for up to 30 seconds.
+  // Replaces the fixed sleeps that gave raft replication time to reach all three status
+  // systems. On timeout it simply returns, so the original assertions below still fail
+  // with their regular diff instead of a new timeout exception.
+  private static void awaitCondition(BooleanSupplier condition) throws InterruptedException {
+    long deadlineMs = System.currentTimeMillis() + 30000L;
+    while (!condition.getAsBoolean() && System.currentTimeMillis() < deadlineMs) {
+      Thread.sleep(100L);
+    }
+  }
+
   public HAMasterMetaManager pickLeaderStatusSystem() {
     if (RATISSERVER1.isLeader()) {
       return STATUSSYSTEM1;
@@ -373,7 +391,14 @@ public class RatisMasterStatusSystemSuiteJ {
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3
+                && STATUSSYSTEM1.availableWorkers.size() == 3
+                && STATUSSYSTEM2.availableWorkers.size() == 3
+                && STATUSSYSTEM3.availableWorkers.size() == 3);
 
     Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
     Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
@@ -453,7 +478,14 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleWorkerExclude(
         Arrays.asList(workerInfo1, workerInfo2), Collections.emptyList(), getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.manuallyExcludedWorkers.size() == 2
+                && STATUSSYSTEM2.manuallyExcludedWorkers.size() == 2
+                && STATUSSYSTEM3.manuallyExcludedWorkers.size() == 2
+                && STATUSSYSTEM1.availableWorkers.isEmpty()
+                && STATUSSYSTEM2.availableWorkers.isEmpty()
+                && STATUSSYSTEM3.availableWorkers.isEmpty());
 
     Assert.assertEquals(2, STATUSSYSTEM1.manuallyExcludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM2.manuallyExcludedWorkers.size());
@@ -465,7 +497,14 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleWorkerExclude(
         Collections.emptyList(), Collections.singletonList(workerInfo1), getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.manuallyExcludedWorkers.size() == 1
+                && STATUSSYSTEM2.manuallyExcludedWorkers.size() == 1
+                && STATUSSYSTEM3.manuallyExcludedWorkers.size() == 1
+                && STATUSSYSTEM1.availableWorkers.size() == 1
+                && STATUSSYSTEM2.availableWorkers.size() == 1
+                && STATUSSYSTEM3.availableWorkers.size() == 1);
 
     Assert.assertEquals(1, STATUSSYSTEM1.manuallyExcludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.manuallyExcludedWorkers.size());
@@ -517,7 +556,14 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleWorkerLost(
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workersMap.size() == 2
+                && STATUSSYSTEM2.workersMap.size() == 2
+                && STATUSSYSTEM3.workersMap.size() == 2
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
 
     Assert.assertEquals(2, STATUSSYSTEM1.workersMap.size());
     Assert.assertEquals(2, STATUSSYSTEM2.workersMap.size());
@@ -674,7 +720,11 @@ public class RatisMasterStatusSystemSuiteJ {
         disks3,
         userResourceConsumption3,
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3);
 
     Assert.assertEquals(3, STATUSSYSTEM1.workersMap.size());
     Assert.assertEquals(3, STATUSSYSTEM2.workersMap.size());
@@ -699,7 +749,10 @@ public class RatisMasterStatusSystemSuiteJ {
         allocations);
 
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
-    Thread.sleep(3000L);
+    // Negative assertion: the checks below verify that used slots do NOT change, so
+    // polling cannot replace a fixed wait. 1s gives any unexpected replicated update
+    // enough time to be applied before the assertions run.
+    Thread.sleep(1000L);
 
     // Do not update diskinfo's activeslots
 
@@ -765,7 +818,12 @@ public class RatisMasterStatusSystemSuiteJ {
         userResourceConsumption3,
         getNewReqeustId());
 
-    Thread.sleep(3000L);
+    // Wait for the three registrations above to replicate before requesting slots.
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3);
     WorkerInfo workerInfo1 =
         new WorkerInfo(
             HOSTNAME1,
@@ -793,14 +851,22 @@ public class RatisMasterStatusSystemSuiteJ {
     workersToAllocate.put(workerInfo2.toUniqueId(), allocations);
 
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredAppAndShuffles.size() == 1
+                && STATUSSYSTEM2.registeredAppAndShuffles.size() == 1
+                && STATUSSYSTEM3.registeredAppAndShuffles.size() == 1);
 
     Assert.assertEquals(1, STATUSSYSTEM1.registeredAppAndShuffles.size());
     Assert.assertEquals(1, STATUSSYSTEM2.registeredAppAndShuffles.size());
     Assert.assertEquals(1, STATUSSYSTEM3.registeredAppAndShuffles.size());
 
     statusSystem.handleAppLost(APPID1, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredAppAndShuffles.isEmpty()
+                && STATUSSYSTEM2.registeredAppAndShuffles.isEmpty()
+                && STATUSSYSTEM3.registeredAppAndShuffles.isEmpty());
 
     Assert.assertTrue(STATUSSYSTEM1.registeredAppAndShuffles.isEmpty());
     Assert.assertTrue(STATUSSYSTEM2.registeredAppAndShuffles.isEmpty());
@@ -874,14 +940,22 @@ public class RatisMasterStatusSystemSuiteJ {
     workersToAllocate.put(workerInfo2.toUniqueId(), allocations);
 
     statusSystem.handleRequestSlots(SHUFFLEKEY1, HOSTNAME1, workersToAllocate, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredAppAndShuffles.size() == 1
+                && STATUSSYSTEM2.registeredAppAndShuffles.size() == 1
+                && STATUSSYSTEM3.registeredAppAndShuffles.size() == 1);
 
     Assert.assertEquals(1, STATUSSYSTEM1.registeredAppAndShuffles.size());
     Assert.assertEquals(1, STATUSSYSTEM2.registeredAppAndShuffles.size());
     Assert.assertEquals(1, STATUSSYSTEM3.registeredAppAndShuffles.size());
 
     statusSystem.handleUnRegisterShuffle(SHUFFLEKEY1, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredAppAndShuffles.isEmpty()
+                && STATUSSYSTEM2.registeredAppAndShuffles.isEmpty()
+                && STATUSSYSTEM3.registeredAppAndShuffles.isEmpty());
 
     Assert.assertTrue(STATUSSYSTEM1.registeredAppAndShuffles.isEmpty());
     Assert.assertTrue(STATUSSYSTEM2.registeredAppAndShuffles.isEmpty());
@@ -961,7 +1035,11 @@ public class RatisMasterStatusSystemSuiteJ {
       statusSystem.handleRequestSlots(shuffleKey, HOSTNAME1, workersToAllocate, getNewReqeustId());
     }
 
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredShuffleCount() == 4
+                && STATUSSYSTEM2.registeredShuffleCount() == 4
+                && STATUSSYSTEM3.registeredShuffleCount() == 4);
 
     Assert.assertEquals(4, STATUSSYSTEM1.registeredShuffleCount());
     Assert.assertEquals(4, STATUSSYSTEM2.registeredShuffleCount());
@@ -971,13 +1049,21 @@ public class RatisMasterStatusSystemSuiteJ {
     shuffleKeys1.add(shuffleKeysAll.get(0));
 
     statusSystem.handleBatchUnRegisterShuffles(shuffleKeys1, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredShuffleCount() == 3
+                && STATUSSYSTEM2.registeredShuffleCount() == 3
+                && STATUSSYSTEM3.registeredShuffleCount() == 3);
     Assert.assertEquals(3, STATUSSYSTEM1.registeredShuffleCount());
     Assert.assertEquals(3, STATUSSYSTEM2.registeredShuffleCount());
     Assert.assertEquals(3, STATUSSYSTEM3.registeredShuffleCount());
 
     statusSystem.handleBatchUnRegisterShuffles(shuffleKeysAll, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredShuffleCount() == 0
+                && STATUSSYSTEM2.registeredShuffleCount() == 0
+                && STATUSSYSTEM3.registeredShuffleCount() == 0);
 
     Assert.assertTrue(STATUSSYSTEM1.registeredShuffleCount() == 0);
     Assert.assertTrue(STATUSSYSTEM2.registeredShuffleCount() == 0);
@@ -992,7 +1078,11 @@ public class RatisMasterStatusSystemSuiteJ {
     long dummy = 1235L;
     statusSystem.handleAppHeartbeat(
         APPID1, 1, 1, 1, 1, new HashMap<>(), new HashMap<>(), dummy, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            Long.valueOf(dummy).equals(STATUSSYSTEM1.appHeartbeatTime.get(APPID1))
+                && Long.valueOf(dummy).equals(STATUSSYSTEM2.appHeartbeatTime.get(APPID1))
+                && Long.valueOf(dummy).equals(STATUSSYSTEM3.appHeartbeatTime.get(APPID1)));
     Assert.assertEquals(Long.valueOf(dummy), STATUSSYSTEM1.appHeartbeatTime.get(APPID1));
     Assert.assertEquals(Long.valueOf(dummy), STATUSSYSTEM2.appHeartbeatTime.get(APPID1));
     Assert.assertEquals(Long.valueOf(dummy), STATUSSYSTEM3.appHeartbeatTime.get(APPID1));
@@ -1000,7 +1090,14 @@ public class RatisMasterStatusSystemSuiteJ {
     String appId2 = "app02";
     statusSystem.handleAppHeartbeat(
         appId2, 1, 1, 2, 2, new HashMap<>(), new HashMap<>(), dummy, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            Long.valueOf(dummy).equals(STATUSSYSTEM1.appHeartbeatTime.get(appId2))
+                && Long.valueOf(dummy).equals(STATUSSYSTEM2.appHeartbeatTime.get(appId2))
+                && Long.valueOf(dummy).equals(STATUSSYSTEM3.appHeartbeatTime.get(appId2))
+                && STATUSSYSTEM1.appHeartbeatTime.size() == 2
+                && STATUSSYSTEM2.appHeartbeatTime.size() == 2
+                && STATUSSYSTEM3.appHeartbeatTime.size() == 2);
 
     Assert.assertEquals(Long.valueOf(dummy), STATUSSYSTEM1.appHeartbeatTime.get(appId2));
     Assert.assertEquals(Long.valueOf(dummy), STATUSSYSTEM2.appHeartbeatTime.get(appId2));
@@ -1062,7 +1159,17 @@ public class RatisMasterStatusSystemSuiteJ {
         false,
         workerStatus,
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.excludedWorkers.size() == 1
+                && STATUSSYSTEM2.excludedWorkers.size() == 1
+                && STATUSSYSTEM3.excludedWorkers.size() == 1
+                && STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
 
     Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
@@ -1088,7 +1195,17 @@ public class RatisMasterStatusSystemSuiteJ {
         false,
         workerStatus,
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.excludedWorkers.size() == 2
+                && STATUSSYSTEM2.excludedWorkers.size() == 2
+                && STATUSSYSTEM3.excludedWorkers.size() == 2
+                && STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3
+                && STATUSSYSTEM1.availableWorkers.size() == 1
+                && STATUSSYSTEM2.availableWorkers.size() == 1
+                && STATUSSYSTEM3.availableWorkers.size() == 1);
 
     Assert.assertEquals(2, statusSystem.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
@@ -1117,7 +1234,17 @@ public class RatisMasterStatusSystemSuiteJ {
         false,
         workerStatus,
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.excludedWorkers.size() == 1
+                && STATUSSYSTEM2.excludedWorkers.size() == 1
+                && STATUSSYSTEM3.excludedWorkers.size() == 1
+                && STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
 
     Assert.assertEquals(1, statusSystem.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
@@ -1146,7 +1273,17 @@ public class RatisMasterStatusSystemSuiteJ {
         true,
         workerStatus,
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.excludedWorkers.size() == 2
+                && STATUSSYSTEM2.excludedWorkers.size() == 2
+                && STATUSSYSTEM3.excludedWorkers.size() == 2
+                && STATUSSYSTEM1.workersMap.size() == 3
+                && STATUSSYSTEM2.workersMap.size() == 3
+                && STATUSSYSTEM3.workersMap.size() == 3
+                && STATUSSYSTEM1.availableWorkers.size() == 1
+                && STATUSSYSTEM2.availableWorkers.size() == 1
+                && STATUSSYSTEM3.availableWorkers.size() == 1);
     Assert.assertEquals(2, statusSystem.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
@@ -1219,7 +1356,12 @@ public class RatisMasterStatusSystemSuiteJ {
           userResourceConsumption3,
           getNewReqeustId());
 
-      Thread.sleep(3000L);
+      // Wait for the three registrations above to replicate before sending heartbeats.
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.workersMap.size() == 3
+                  && STATUSSYSTEM2.workersMap.size() == 3
+                  && STATUSSYSTEM3.workersMap.size() == 3);
 
       // worker2 and work3 are unhealthy
       statusSystem.handleWorkerHeartbeat(
@@ -1234,7 +1376,14 @@ public class RatisMasterStatusSystemSuiteJ {
           false,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 1
+                  && STATUSSYSTEM2.excludedWorkers.size() == 1
+                  && STATUSSYSTEM3.excludedWorkers.size() == 1
+                  && STATUSSYSTEM1.availableWorkers.size() == 2
+                  && STATUSSYSTEM2.availableWorkers.size() == 2
+                  && STATUSSYSTEM3.availableWorkers.size() == 2);
       Assert.assertEquals(1, statusSystem.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
@@ -1256,7 +1405,14 @@ public class RatisMasterStatusSystemSuiteJ {
           false,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 2
+                  && STATUSSYSTEM2.excludedWorkers.size() == 2
+                  && STATUSSYSTEM3.excludedWorkers.size() == 2
+                  && STATUSSYSTEM1.availableWorkers.size() == 1
+                  && STATUSSYSTEM2.availableWorkers.size() == 1
+                  && STATUSSYSTEM3.availableWorkers.size() == 1);
       Assert.assertEquals(2, statusSystem.excludedWorkers.size());
       Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
@@ -1279,7 +1435,14 @@ public class RatisMasterStatusSystemSuiteJ {
           false,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 1
+                  && STATUSSYSTEM2.excludedWorkers.size() == 1
+                  && STATUSSYSTEM3.excludedWorkers.size() == 1
+                  && STATUSSYSTEM1.availableWorkers.size() == 2
+                  && STATUSSYSTEM2.availableWorkers.size() == 2
+                  && STATUSSYSTEM3.availableWorkers.size() == 2);
       Assert.assertEquals(1, statusSystem.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
@@ -1301,7 +1464,14 @@ public class RatisMasterStatusSystemSuiteJ {
           false,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.isEmpty()
+                  && STATUSSYSTEM2.excludedWorkers.isEmpty()
+                  && STATUSSYSTEM3.excludedWorkers.isEmpty()
+                  && STATUSSYSTEM1.availableWorkers.size() == 3
+                  && STATUSSYSTEM2.availableWorkers.size() == 3
+                  && STATUSSYSTEM3.availableWorkers.size() == 3);
       Assert.assertEquals(0, statusSystem.excludedWorkers.size());
       Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(0, STATUSSYSTEM2.excludedWorkers.size());
@@ -1323,7 +1493,14 @@ public class RatisMasterStatusSystemSuiteJ {
           true,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 1
+                  && STATUSSYSTEM2.excludedWorkers.size() == 1
+                  && STATUSSYSTEM3.excludedWorkers.size() == 1
+                  && STATUSSYSTEM1.availableWorkers.size() == 2
+                  && STATUSSYSTEM2.availableWorkers.size() == 2
+                  && STATUSSYSTEM3.availableWorkers.size() == 2);
       Assert.assertEquals(1, statusSystem.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
@@ -1345,7 +1522,14 @@ public class RatisMasterStatusSystemSuiteJ {
           true,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.isEmpty()
+                  && STATUSSYSTEM2.excludedWorkers.isEmpty()
+                  && STATUSSYSTEM3.excludedWorkers.isEmpty()
+                  && STATUSSYSTEM1.availableWorkers.size() == 3
+                  && STATUSSYSTEM2.availableWorkers.size() == 3
+                  && STATUSSYSTEM3.availableWorkers.size() == 3);
       // release 2 workers with high workload
       Assert.assertEquals(0, statusSystem.excludedWorkers.size());
       Assert.assertEquals(0, STATUSSYSTEM1.excludedWorkers.size());
@@ -1369,7 +1553,14 @@ public class RatisMasterStatusSystemSuiteJ {
           true,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 1
+                  && STATUSSYSTEM2.excludedWorkers.size() == 1
+                  && STATUSSYSTEM3.excludedWorkers.size() == 1
+                  && STATUSSYSTEM1.availableWorkers.size() == 2
+                  && STATUSSYSTEM2.availableWorkers.size() == 2
+                  && STATUSSYSTEM3.availableWorkers.size() == 2);
       Assert.assertEquals(1, statusSystem.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
@@ -1391,7 +1582,14 @@ public class RatisMasterStatusSystemSuiteJ {
           false,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 1
+                  && STATUSSYSTEM2.excludedWorkers.size() == 1
+                  && STATUSSYSTEM3.excludedWorkers.size() == 1
+                  && STATUSSYSTEM1.availableWorkers.size() == 2
+                  && STATUSSYSTEM2.availableWorkers.size() == 2
+                  && STATUSSYSTEM3.availableWorkers.size() == 2);
       // release worker2
       Assert.assertEquals(1, statusSystem.excludedWorkers.size());
       Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
@@ -1414,7 +1612,14 @@ public class RatisMasterStatusSystemSuiteJ {
           true,
           workerStatus,
           getNewReqeustId());
-      Thread.sleep(3000L);
+      awaitCondition(
+          () ->
+              STATUSSYSTEM1.excludedWorkers.size() == 2
+                  && STATUSSYSTEM2.excludedWorkers.size() == 2
+                  && STATUSSYSTEM3.excludedWorkers.size() == 2
+                  && STATUSSYSTEM1.availableWorkers.size() == 1
+                  && STATUSSYSTEM2.availableWorkers.size() == 1
+                  && STATUSSYSTEM3.availableWorkers.size() == 1);
       Assert.assertEquals(2, statusSystem.excludedWorkers.size());
       Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
       Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
@@ -1567,7 +1772,17 @@ public class RatisMasterStatusSystemSuiteJ {
             userResourceConsumption1));
 
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.shutdownWorkers.size() == 1
+                && STATUSSYSTEM2.shutdownWorkers.size() == 1
+                && STATUSSYSTEM3.shutdownWorkers.size() == 1
+                && STATUSSYSTEM1.excludedWorkers.isEmpty()
+                && STATUSSYSTEM2.excludedWorkers.isEmpty()
+                && STATUSSYSTEM3.excludedWorkers.isEmpty()
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
     Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.shutdownWorkers.size());
@@ -1636,7 +1851,18 @@ public class RatisMasterStatusSystemSuiteJ {
         HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
     statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
 
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workersMap.size() == 2
+                && STATUSSYSTEM1.shutdownWorkers.size() == 1
+                && STATUSSYSTEM2.shutdownWorkers.size() == 1
+                && STATUSSYSTEM3.shutdownWorkers.size() == 1
+                && STATUSSYSTEM1.lostWorkers.size() == 1
+                && STATUSSYSTEM2.lostWorkers.size() == 1
+                && STATUSSYSTEM3.lostWorkers.size() == 1
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
     Assert.assertEquals(2, STATUSSYSTEM1.workersMap.size());
 
     Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
@@ -1652,7 +1878,17 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM3.availableWorkers.size());
 
     statusSystem.handleRemoveWorkersUnavailableInfo(unavailableWorkers, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.shutdownWorkers.isEmpty()
+                && STATUSSYSTEM2.shutdownWorkers.isEmpty()
+                && STATUSSYSTEM3.shutdownWorkers.isEmpty()
+                && STATUSSYSTEM1.lostWorkers.isEmpty()
+                && STATUSSYSTEM2.lostWorkers.isEmpty()
+                && STATUSSYSTEM3.lostWorkers.isEmpty()
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
 
     Assert.assertEquals(0, STATUSSYSTEM1.shutdownWorkers.size());
     Assert.assertEquals(0, STATUSSYSTEM2.shutdownWorkers.size());
@@ -1759,7 +1995,14 @@ public class RatisMasterStatusSystemSuiteJ {
         Lists.newArrayList(workerInfo1, workerInfo2),
         getNewReqeustId());
 
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workerEventInfos.size() == 2
+                && STATUSSYSTEM2.workerEventInfos.size() == 2
+                && STATUSSYSTEM3.workerEventInfos.size() == 2
+                && STATUSSYSTEM1.availableWorkers.size() == 1
+                && STATUSSYSTEM2.availableWorkers.size() == 1
+                && STATUSSYSTEM3.availableWorkers.size() == 1);
     Assert.assertEquals(2, STATUSSYSTEM1.workerEventInfos.size());
     Assert.assertEquals(2, STATUSSYSTEM2.workerEventInfos.size());
     Assert.assertEquals(2, STATUSSYSTEM3.workerEventInfos.size());
@@ -1779,7 +2022,14 @@ public class RatisMasterStatusSystemSuiteJ {
         ResourceProtos.WorkerEventType.None_VALUE,
         Lists.newArrayList(workerInfo1),
         getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workerEventInfos.size() == 1
+                && STATUSSYSTEM2.workerEventInfos.size() == 1
+                && STATUSSYSTEM3.workerEventInfos.size() == 1
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
     Assert.assertEquals(1, STATUSSYSTEM1.workerEventInfos.size());
     Assert.assertEquals(1, STATUSSYSTEM2.workerEventInfos.size());
     Assert.assertEquals(1, STATUSSYSTEM3.workerEventInfos.size());
@@ -1843,7 +2093,14 @@ public class RatisMasterStatusSystemSuiteJ {
         Lists.newArrayList(workerInfo1, workerInfo2),
         getNewReqeustId());
 
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workerEventInfos.size() == 2
+                && STATUSSYSTEM2.workerEventInfos.size() == 2
+                && STATUSSYSTEM3.workerEventInfos.size() == 2
+                && STATUSSYSTEM1.availableWorkers.size() == 1
+                && STATUSSYSTEM2.availableWorkers.size() == 1
+                && STATUSSYSTEM3.availableWorkers.size() == 1);
     Assert.assertEquals(2, STATUSSYSTEM1.workerEventInfos.size());
     Assert.assertEquals(2, STATUSSYSTEM2.workerEventInfos.size());
     Assert.assertEquals(2, STATUSSYSTEM3.workerEventInfos.size());
@@ -1861,7 +2118,14 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleWorkerEvent(
         WorkerEventType.None_VALUE, Lists.newArrayList(workerInfo1), getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.workerEventInfos.size() == 1
+                && STATUSSYSTEM2.workerEventInfos.size() == 1
+                && STATUSSYSTEM3.workerEventInfos.size() == 1
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
     Assert.assertEquals(1, STATUSSYSTEM1.workerEventInfos.size());
     Assert.assertEquals(1, STATUSSYSTEM2.workerEventInfos.size());
     Assert.assertEquals(1, STATUSSYSTEM3.workerEventInfos.size());
@@ -1880,7 +2144,11 @@ public class RatisMasterStatusSystemSuiteJ {
 
     statusSystem.handleReviseLostShuffles(
         "app-1", Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8), getNewReqeustId());
-    Thread.sleep(1000l);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.registeredShuffleCount() == 8
+                && STATUSSYSTEM2.registeredShuffleCount() == 8
+                && STATUSSYSTEM3.registeredShuffleCount() == 8);
     Assert.assertEquals(STATUSSYSTEM1.registeredShuffleCount(), 8);
     Assert.assertEquals(STATUSSYSTEM2.registeredShuffleCount(), 8);
     Assert.assertEquals(STATUSSYSTEM3.registeredShuffleCount(), 8);
@@ -2012,7 +2280,17 @@ public class RatisMasterStatusSystemSuiteJ {
             userResourceConsumption1));
 
     statusSystem.handleReportWorkerDecommission(workers, getNewReqeustId());
-    Thread.sleep(3000L);
+    awaitCondition(
+        () ->
+            STATUSSYSTEM1.decommissionWorkers.size() == 1
+                && STATUSSYSTEM2.decommissionWorkers.size() == 1
+                && STATUSSYSTEM3.decommissionWorkers.size() == 1
+                && STATUSSYSTEM1.excludedWorkers.isEmpty()
+                && STATUSSYSTEM2.excludedWorkers.isEmpty()
+                && STATUSSYSTEM3.excludedWorkers.isEmpty()
+                && STATUSSYSTEM1.availableWorkers.size() == 2
+                && STATUSSYSTEM2.availableWorkers.size() == 2
+                && STATUSSYSTEM3.availableWorkers.size() == 2);
     Assert.assertEquals(1, STATUSSYSTEM1.decommissionWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.decommissionWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.decommissionWorkers.size());

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
@@ -321,16 +321,16 @@ class QuotaManagerSuite extends CelebornFunSuite
   }
 
   test("test handleResourceConsumption time - case1") {
-    // 1000 users 100w applications, all exceeded
+    // 100 users 10000 applications, all exceeded
     conf.set("celeborn.quota.tenant.diskBytesWritten", "1mb")
     conf.set("celeborn.quota.cluster.diskBytesWritten", "1mb")
     configService.refreshCache()
     val MAX = 2L * 1024 * 1024 * 1024
     val MIN = 1L * 1024 * 1024 * 1024
     val random = new Random()
-    for (i <- 0 until 1000) {
+    for (i <- 0 until 100) {
       val user = UserIdentifier("default", s"user$i")
-      val subResourceConsumption = (0 until 1000).map {
+      val subResourceConsumption = (0 until 100).map {
         index =>
           val appId = s"$user$i app$index"
           val consumption = ResourceConsumption(
@@ -350,7 +350,7 @@ class QuotaManagerSuite extends CelebornFunSuite
     quotaManager.updateResourceConsumption()
 
     val res = resourceConsumptionSource.getMetrics
-    for (i <- 0 until 1000) {
+    for (i <- 0 until 100) {
       val user = UserIdentifier("default", s"user$i")
       assert(res.contains(
         s"""metrics_diskFileCount_Value{$metricsInstanceLabel,name="user$i",role="Master",tenantId="default"}"""))
@@ -361,7 +361,7 @@ class QuotaManagerSuite extends CelebornFunSuite
       assert(res.contains(
         s"""metrics_hdfsBytesWritten_Value{$metricsInstanceLabel,name="user$i",role="Master",tenantId="default"}"""))
       assertFalse(quotaManager.checkUserQuotaStatus(user).isAvailable)
-      (0 until 1000).foreach {
+      (0 until 100).foreach {
         index =>
           val appId = s"$user$i app$index"
           assertFalse(quotaManager.checkApplicationQuotaStatus(appId).isAvailable)
@@ -371,18 +371,18 @@ class QuotaManagerSuite extends CelebornFunSuite
   }
 
   test("test handleResourceConsumption time - case2") {
-    // 1000 users 2000000 applications, all exceeded
+    // 100 users 10000 applications, the first 10 users' applications all exceeded
     conf.set("celeborn.quota.tenant.diskBytesWritten", "1mb")
     conf.set("celeborn.quota.cluster.diskBytesWritten", "1mb")
     configService.refreshCache()
     val MAX = 2L * 1024 * 1024 * 1024
     val MIN = 1L * 1024 * 1024 * 1024
     val random = new Random()
-    for (i <- 0 until 1000) {
+    for (i <- 0 until 100) {
       val user = UserIdentifier("default", s"user$i")
       val subResourceConsumption =
-        if (i < 100) {
-          (0 until 1000).map {
+        if (i < 10) {
+          (0 until 100).map {
             index =>
               val appId = s"$user$i case2_app$index"
               val consumption = ResourceConsumption(
@@ -394,7 +394,7 @@ class QuotaManagerSuite extends CelebornFunSuite
               (appId, consumption)
           }.toMap
         } else {
-          (0 until 1000).map {
+          (0 until 100).map {
             index =>
               val appId = s"$user$i case2_app$index"
               val consumption = ResourceConsumption(0, 0, 0, 0)
@@ -411,7 +411,7 @@ class QuotaManagerSuite extends CelebornFunSuite
     quotaManager.updateResourceConsumption()
 
     val res = resourceConsumptionSource.getMetrics
-    for (i <- 0 until 1000) {
+    for (i <- 0 until 100) {
       val user = UserIdentifier("default", s"user$i")
       assert(res.contains(
         s"""metrics_diskFileCount_Value{$metricsInstanceLabel,name="user$i",role="Master",tenantId="default"}"""))
@@ -422,10 +422,10 @@ class QuotaManagerSuite extends CelebornFunSuite
       assert(res.contains(
         s"""metrics_hdfsBytesWritten_Value{$metricsInstanceLabel,name="user$i",role="Master",tenantId="default"}"""))
       assertFalse(quotaManager.checkUserQuotaStatus(user).isAvailable)
-      (0 until 1000).foreach {
+      (0 until 100).foreach {
         index =>
           val appId = s"$user$i case2_app$index"
-          if (i < 100) {
+          if (i < 10) {
             assertFalse(quotaManager.checkApplicationQuotaStatus(appId).isAvailable)
           } else {
             assertTrue(quotaManager.checkApplicationQuotaStatus(appId).isAvailable)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ChangePartitionManagerUpdateWorkersSuite.scala
@@ -444,10 +444,17 @@ class ChangePartitionManagerUpdateWorkersSuite extends WithShuffleClientSuite
     shuffles.values().asScala.foreach(it =>
       it.getPrimaryPartitions().asScala.foreach(loc =>
         assert(loc.getStorageInfo.availableStorageTypes == StorageInfo.LOCAL_DISK_MASK)))
+
+    lifecycleManager.stop()
   }
 
   override def afterEach(): Unit = {
     logInfo("test complete, stop celeborn mini cluster")
+    // Stop the LifecycleManager/ShuffleClient created by inherited tests via
+    // WithShuffleClientSuite.prepareService before tearing down the mini cluster,
+    // otherwise their app heartbeaters keep firing at the dead master port for the
+    // rest of this shared spark-it JVM.
+    super.afterEach()
     shutdownMiniCluster()
   }
 }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerReserveSlotsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerReserveSlotsSuite.scala
@@ -170,5 +170,11 @@ class LifecycleManagerReserveSlotsSuite extends AnyFunSuite
     assert(partitionLocationMap2.get(partitions(0)).getEpoch > 0)
     // epoch of partition(1) is 0 without split
     assert(partitionLocationMap2.get(partitions(1)).getEpoch == 0)
+
+    // Stop the LifecycleManager explicitly, otherwise its app heartbeater keeps
+    // firing at the dead master port for the rest of this shared spark-it JVM.
+    shuffleClient1.shutdown()
+    shuffleClient2.shutdown()
+    lifecycleManager.stop()
   }
 }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
@@ -124,6 +124,8 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
       assert(appInfo.extraInfo.get("k1") == "v1")
       assert(appInfo.registrationTime > 0 && appInfo.registrationTime < System.currentTimeMillis())
     }
+
+    lifecycleManager.stop()
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Test-only changes to cut CI wall time:

1. **DataPushQueueSuiteJ**: reduce `numPartitions` from 1,000,000 to 30,000.
2. **QuotaManagerSuite**: reduce case1/case2 scale from 1000 users × 1000 applications to 100 × 100 (and the inner check loop accordingly).
3. **RatisMasterStatusSystemSuiteJ** (plus its SSL and gRPC variants): add an `awaitCondition(BooleanSupplier)` helper (100ms poll interval, 30s upper bound, falls back to the original assertion on timeout) and convert 38 fixed `Thread.sleep` calls — including the hard 15s leader-election wait — to condition polling. One negative assertion that must observe state *not* changing keeps a (reduced) fixed wait.
4. **spark-it**: stop leaked `LifecycleManager`/`ShuffleClient` instances in `LifecycleManagerReserveSlotsSuite`, `LifecycleManagerSuite` and `ChangePartitionManagerUpdateWorkersSuite`. The key fix is adding the missing `super.afterEach()` in `ChangePartitionManagerUpdateWorkersSuite`: its parent `WithShuffleClientSuite` creates LifecycleManagers via `prepareService()` and relies on the trait's `afterEach` to stop them, so the override leaked 4 LifecycleManagers permanently.

### Why are the changes needed?

Several tests dominate CI time due to artificial data scale, fixed sleeps, and leaked LifecycleManagers whose app-heartbeat threads keep flooding `AskSync HeartbeatFromApplication failed` for the rest of the forked JVM (forkMode=once), stealing CPU from subsequent suites.

Measured locally:

- DataPushQueueSuiteJ: 28min → ~56s
- QuotaManagerSuite: ~11min → ~3s
- RatisMasterStatusSystemSuiteJ: 3×180s → 3×~53s
- Full spark-it run: BUILD SUCCESS, `HeartbeatFromApplication failed` drops from a continuous storm to 6 benign shutdown-race occurrences
- Full sbt test run: 25m26s

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

- All modified suites pass locally: DataPushQueueSuiteJ 2/2, QuotaManagerSuite 7/7, RatisMasterStatusSystemSuiteJ + SSL + gRPC variants all green
- Full `tests/spark-it` run (`-Pspark-3.5`): BUILD SUCCESS
- Full sbt test run passes (two pre-existing macOS-local environment failures unrelated to this change: EPOLL/KQUEUE config test and an SSL data-writer test)
- `spotless:check` passes for all touched modules