### PR TITLE
[CELEBORN-2438][INFRA] Remove empty protected_branches in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,7 +28,6 @@ github:
     squash: true
     merge: false
     rebase: false
-  protected_branches:
   features:
     issues: true
     discussions: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the empty protected_branches key from `.asf.yaml`.

### Why are the changes needed?

ASF infra validation rejects .asf.yaml because github.protected_branches
expects a mapping, and the empty value fails schema parsing. Branch
protection is already handled by github.rulesets, so the key is redundant.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

Parsed .asf.yaml with a YAML parser to confirm it loads.

Assisted-by: DeepSeek V4 Pro