### PR TITLE
[CELEBORN-2441] Add drainIncompleteFrame mechanism to recover from backpressure deadlock

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
@@ -51,10 +51,36 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
   private static final int MAX_FRAME_SIZE = Integer.MAX_VALUE;
   private static final int UNKNOWN_FRAME_SIZE = -1;
 
+  /**
+   * Netty's {@code AdaptiveRecvByteBufAllocator} caps a single {@code channelRead} at this many
+   * bytes. Used to spot likely-large stuck frames; see {@link #hasLikelyLargeIncompleteFrame()}.
+   */
+  public static final long MAX_SINGLE_READ_BYTES = 65536;
+
   private final LinkedList<ByteBuf> buffers = new LinkedList<>();
 
-  private long totalSize = 0;
+  // Written by the Netty I/O thread; read by checkService via hasLikelyLargeIncompleteFrame().
+  private volatile long totalSize = 0;
   private long nextFrameSize = UNKNOWN_FRAME_SIZE;
+
+  /**
+   * When set, this channel is resumed only to drain its stuck half-received frame (in {@link
+   * #buffers}) and release the memory, not to resume normal traffic.
+   */
+  private volatile boolean frameDrain = false;
+
+  /** Enables single-frame drain mode: the next decoded frame fires {@link FrameDrainCompleted}. */
+  public void enableFrameDrain() {
+    this.frameDrain = true;
+  }
+
+  /**
+   * True if the stuck frame's buffered bytes exceed one {@code channelRead} worth ({@link
+   * #MAX_SINGLE_READ_BYTES}), making it a strong candidate for the backpressure root cause.
+   */
+  public boolean hasLikelyLargeIncompleteFrame() {
+    return totalSize > MAX_SINGLE_READ_BYTES;
+  }
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object data) {
@@ -73,7 +99,19 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
       }
       ctx.fireChannelRead(msg);
       clear();
+
+      if (frameDrain) {
+        // Frame drained; notify to re-pause before the next syscall. Already-buffered frames are
+        // still dispatched.
+        frameDrain = false;
+        ctx.channel().pipeline().fireUserEventTriggered(FrameDrainCompleted.INSTANCE);
+      }
     }
+  }
+
+  /** Fired once, right after frame-drain mode completes a single frame. */
+  public enum FrameDrainCompleted {
+    INSTANCE
   }
 
   private void clear() {

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
@@ -53,7 +53,7 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
 
   /**
    * Netty's {@code AdaptiveRecvByteBufAllocator} caps a single {@code channelRead} at this many
-   * bytes. Used to spot likely-large stuck frames; see {@link #hasLikelyLargeIncompleteFrame()}.
+   * bytes.
    */
   public static final long MAX_SINGLE_READ_BYTES = 65536;
 
@@ -76,13 +76,13 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
   }
 
   /**
-   * True if the stuck frame is a strong candidate for the backpressure root cause. Uses the
-   * decoded frame length ({@code nextFrameSize}) when known, since a large frame paused right
-   * after its first {@code channelRead} may still have a small {@code totalSize}; falls back to
-   * {@code totalSize} while the header hasn't been fully read yet.
+   * True if the stuck half-frame looks unusually large. When {@code byFrameSize} is true, ranks by
+   * the frame currently being decoded (falling back to {@code totalSize} while the header hasn't
+   * been fully read yet); otherwise ranks by {@code totalSize}, the total unparsed bytes piled up
+   * regardless of frame boundaries.
    */
-  public boolean hasLikelyLargeIncompleteFrame() {
-    if (nextFrameSize != UNKNOWN_FRAME_SIZE) {
+  public boolean hasLikelyLargeIncompleteFrame(boolean byFrameSize) {
+    if (byFrameSize && nextFrameSize != UNKNOWN_FRAME_SIZE) {
       return nextFrameSize > MAX_SINGLE_READ_BYTES;
     }
     return totalSize > MAX_SINGLE_READ_BYTES;

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
@@ -59,9 +59,10 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
 
   private final LinkedList<ByteBuf> buffers = new LinkedList<>();
 
-  // Written by the Netty I/O thread; read by checkService via hasLikelyLargeIncompleteFrame().
+  // totalSize and nextFrameSize: written by the Netty I/O thread, read by checkService via
+  // hasLikelyLargeIncompleteFrame().
   private volatile long totalSize = 0;
-  private long nextFrameSize = UNKNOWN_FRAME_SIZE;
+  private volatile long nextFrameSize = UNKNOWN_FRAME_SIZE;
 
   /**
    * When set, this channel is resumed only to drain its stuck half-received frame (in {@link
@@ -75,10 +76,15 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
   }
 
   /**
-   * True if the stuck frame's buffered bytes exceed one {@code channelRead} worth ({@link
-   * #MAX_SINGLE_READ_BYTES}), making it a strong candidate for the backpressure root cause.
+   * True if the stuck frame is a strong candidate for the backpressure root cause. Uses the
+   * decoded frame length ({@code nextFrameSize}) when known, since a large frame paused right
+   * after its first {@code channelRead} may still have a small {@code totalSize}; falls back to
+   * {@code totalSize} while the header hasn't been fully read yet.
    */
   public boolean hasLikelyLargeIncompleteFrame() {
+    if (nextFrameSize != UNKNOWN_FRAME_SIZE) {
+      return nextFrameSize > MAX_SINGLE_READ_BYTES;
+    }
     return totalSize > MAX_SINGLE_READ_BYTES;
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1451,6 +1451,14 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerDirectMemoryReportIntervalSecond: Long = get(WORKER_DIRECT_MEMORY_REPORT_INTERVAL)
   def workerDirectMemoryTrimChannelWaitInterval: Long =
     get(WORKER_DIRECT_MEMORY_TRIM_CHANNEL_WAIT_INTERVAL)
+  def workerDrainIncompleteFrameEnabled: Boolean =
+    get(WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED)
+  def workerDrainIncompleteFrameIntervalMs: Long =
+    get(WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL)
+  def workerDrainIncompleteFrameRatio: Double =
+    get(WORKER_DRAIN_INCOMPLETE_FRAME_RATIO)
+  def workerDrainIncompleteFrameWatermarkRatio: Double =
+    get(WORKER_DRAIN_INCOMPLETE_FRAME_WATERMARK_RATIO)
   def workerDirectMemoryTrimFlushWaitInterval: Long =
     get(WORKER_DIRECT_MEMORY_TRIM_FLUSH_WAIT_INTERVAL)
   def workerDirectMemoryRatioForMemoryFilesStorage: Double =
@@ -4163,6 +4171,48 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1s")
+
+  val WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.monitor.drainIncompleteFrame.enabled")
+      .categories("worker")
+      .doc(
+        "When true, gradually drains a fixed ratio of paused channels per tick to flush " +
+          "incomplete frames in TransportFrameDecoder buffers and recover from backpressure deadlock.")
+      .version("0.7.1")
+      .booleanConf
+      .createWithDefaultString("true")
+
+  val WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.worker.monitor.drainIncompleteFrame.interval")
+      .categories("worker")
+      .doc(
+        "Minimum interval between drainIncompleteFrame ticks. Draining arms when usage is at/below " +
+          "the watermark and disarms when above; a new batch of channels is drained each interval.")
+      .version("0.7.1")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("5ms")
+
+  val WORKER_DRAIN_INCOMPLETE_FRAME_RATIO: ConfigEntry[Double] =
+    buildConf("celeborn.worker.monitor.drainIncompleteFrame.ratio")
+      .categories("worker")
+      .doc(
+        "Fraction of paused channels to drain per tick. Draining disarms automatically when " +
+          "application-layer usage rises above the watermark. 0.05 (5%) gives gradual recovery.")
+      .version("0.7.1")
+      .doubleConf
+      .checkValue(v => v > 0 && v <= 1, "Should be in (0, 1].")
+      .createWithDefault(0.05)
+
+  val WORKER_DRAIN_INCOMPLETE_FRAME_WATERMARK_RATIO: ConfigEntry[Double] =
+    buildConf("celeborn.worker.monitor.drainIncompleteFrame.watermark.ratio")
+      .categories("worker")
+      .doc(
+        "Application-layer usage watermark (ratio of max direct memory): draining arms when usage " +
+          "is at/below this value and disarms when above. Tune from celeborn.worker.monitor.memory.report.interval.")
+      .version("0.7.1")
+      .doubleConf
+      .checkValue(v => v >= 0 && v <= 1, "Should be in [0, 1].")
+      .createWithDefault(0.1)
 
   val WORKER_DIRECT_MEMORY_TRIM_FLUSH_WAIT_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.monitor.memory.trimFlushWaitInterval")

--- a/common/src/test/java/org/apache/celeborn/common/network/util/TransportFrameDecoderSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/util/TransportFrameDecoderSuiteJ.java
@@ -84,7 +84,8 @@ public class TransportFrameDecoderSuiteJ {
 
   @Test
   public void hasLikelyLargeIncompleteFrameIsFalseInitially() {
-    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(true));
   }
 
   @Test
@@ -95,16 +96,17 @@ public class TransportFrameDecoderSuiteJ {
     ByteBuf partial = full.retainedSlice(0, FrameDecoder.HEADER_SIZE + 2);
     decoder.channelRead(ctx, partial);
 
-    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(true));
     full.release();
   }
 
   @Test
   public void hasLikelyLargeIncompleteFrameIsTrueOnceLeftoverExceedsSingleReadCap()
       throws IOException {
-    // A single channelRead cannot deliver more than 64KB (Netty's AdaptiveRecvByteBufAllocator
-    // default maximum), so leftover bytes beyond that can only have piled up over multiple reads
-    // that each failed to complete the frame — i.e. a genuinely large frame stuck mid-transfer.
+    // A single channelRead cannot deliver more than 64KB, so leftover bytes beyond that can only
+    // have piled up over multiple reads — i.e. a genuinely large frame stuck mid-transfer. Here
+    // the whole leftover belongs to a single frame, so both checks agree.
     int oversizedBodyLength = 65536 + 1024;
     byte[] payload = new byte[oversizedBodyLength];
     ByteBuf full = encodeMessage(oneWayMessage(payload));
@@ -112,7 +114,8 @@ public class TransportFrameDecoderSuiteJ {
     ByteBuf partial = full.retainedSlice(0, full.readableBytes() - 1);
     decoder.channelRead(ctx, partial);
 
-    assertTrue(decoder.hasLikelyLargeIncompleteFrame());
+    assertTrue(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertTrue(decoder.hasLikelyLargeIncompleteFrame(true));
     assertTrue(decodedMessages.isEmpty());
     full.release();
   }
@@ -129,16 +132,18 @@ public class TransportFrameDecoderSuiteJ {
     ByteBuf partial = full.retainedSlice(0, full.readableBytes() - 1);
     decoder.channelRead(ctx, partial);
 
-    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(true));
     assertTrue(decodedMessages.isEmpty());
     full.release();
   }
 
   @Test
-  public void hasLikelyLargeIncompleteFrameIsTrueUsingDecodedFrameLengthEvenWithinSingleReadCap()
-      throws IOException {
-    // A 256KB frame paused right after its first 64KB read: totalSize alone stays under the cap,
-    // but the decoded nextFrameSize correctly flags it as a large incomplete frame.
+  public void
+      hasLikelyLargeIncompleteFrameSizeIsTrueUsingDecodedFrameLengthEvenWithinSingleReadCap()
+          throws IOException {
+    // A 256KB frame paused right after its first 64KB read: totalSize (leftover body bytes only)
+    // stays under the cap, but the decoded frame length correctly flags it as large.
     int largeFrameBodyLength = 256 * 1024 - FrameDecoder.HEADER_SIZE - 4;
     byte[] payload = new byte[largeFrameBodyLength];
     ByteBuf full = encodeMessage(oneWayMessage(payload));
@@ -147,20 +152,22 @@ public class TransportFrameDecoderSuiteJ {
     ByteBuf partial = full.retainedSlice(0, 65536);
     decoder.channelRead(ctx, partial);
 
-    assertTrue(decoder.hasLikelyLargeIncompleteFrame());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertTrue(decoder.hasLikelyLargeIncompleteFrame(true));
     assertTrue(decodedMessages.isEmpty());
     full.release();
   }
 
   @Test
-  public void hasLikelyLargeIncompleteFrameFallsBackToTotalSizeWhenHeaderNotYetFullyRead()
+  public void hasLikelyLargeIncompleteFrameSizeFallsBackToTotalSizeWhenHeaderNotYetFullyRead()
       throws IOException {
     // Header not fully read yet, so nextFrameSize is unknown and the check falls back to totalSize.
     ByteBuf full = encodeMessage(oneWayMessage(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
     ByteBuf partial = full.retainedSlice(0, FrameDecoder.HEADER_SIZE - 2);
     decoder.channelRead(ctx, partial);
 
-    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(true));
     full.release();
   }
 
@@ -174,7 +181,8 @@ public class TransportFrameDecoderSuiteJ {
     decoder.channelRead(ctx, full);
 
     assertEquals(1, decodedMessages.size());
-    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(false));
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame(true));
   }
 
   @Test

--- a/common/src/test/java/org/apache/celeborn/common/network/util/TransportFrameDecoderSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/util/TransportFrameDecoderSuiteJ.java
@@ -120,18 +120,61 @@ public class TransportFrameDecoderSuiteJ {
   @Test
   public void hasLikelyLargeIncompleteFrameIsFalseWhenLeftoverExactlyEqualsSingleReadCap()
       throws IOException {
-    // The check is a strict ">", not ">=": leftover bytes exactly at the single-channelRead cap
-    // (64KB) are still fully explainable by one read, so this boundary must not be flagged yet.
+    // Strict ">", not ">=": both totalSize and the frame's total length sit exactly at the cap,
+    // so neither check should trip yet.
     int singleReadCapBytes = 65536;
-    byte[] payload = new byte[singleReadCapBytes + 1024];
+    byte[] payload = new byte[singleReadCapBytes - FrameDecoder.HEADER_SIZE - 4];
     ByteBuf full = encodeMessage(oneWayMessage(payload));
-    // Header (9 bytes) + exactly singleReadCapBytes of body, leaving totalSize == 65536.
-    ByteBuf partial = full.retainedSlice(0, FrameDecoder.HEADER_SIZE + singleReadCapBytes);
+    assertEquals(singleReadCapBytes, full.readableBytes());
+    ByteBuf partial = full.retainedSlice(0, full.readableBytes() - 1);
     decoder.channelRead(ctx, partial);
 
     assertFalse(decoder.hasLikelyLargeIncompleteFrame());
     assertTrue(decodedMessages.isEmpty());
     full.release();
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameIsTrueUsingDecodedFrameLengthEvenWithinSingleReadCap()
+      throws IOException {
+    // A 256KB frame paused right after its first 64KB read: totalSize alone stays under the cap,
+    // but the decoded nextFrameSize correctly flags it as a large incomplete frame.
+    int largeFrameBodyLength = 256 * 1024 - FrameDecoder.HEADER_SIZE - 4;
+    byte[] payload = new byte[largeFrameBodyLength];
+    ByteBuf full = encodeMessage(oneWayMessage(payload));
+    assertEquals(256 * 1024, full.readableBytes());
+
+    ByteBuf partial = full.retainedSlice(0, 65536);
+    decoder.channelRead(ctx, partial);
+
+    assertTrue(decoder.hasLikelyLargeIncompleteFrame());
+    assertTrue(decodedMessages.isEmpty());
+    full.release();
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameFallsBackToTotalSizeWhenHeaderNotYetFullyRead()
+      throws IOException {
+    // Header not fully read yet, so nextFrameSize is unknown and the check falls back to totalSize.
+    ByteBuf full = encodeMessage(oneWayMessage(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
+    ByteBuf partial = full.retainedSlice(0, FrameDecoder.HEADER_SIZE - 2);
+    decoder.channelRead(ctx, partial);
+
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    full.release();
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameResetsAfterFrameCompletesAndNextHeaderNotYetRead()
+      throws IOException {
+    // After a large frame is fully decoded, nextFrameSize resets; the predicate must not keep
+    // reporting true based on stale state.
+    int largeFrameBodyLength = 256 * 1024 - FrameDecoder.HEADER_SIZE;
+    ByteBuf full = encodeMessage(oneWayMessage(new byte[largeFrameBodyLength]));
+    decoder.channelRead(ctx, full);
+
+    assertEquals(1, decodedMessages.size());
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
   }
 
   @Test

--- a/common/src/test/java/org/apache/celeborn/common/network/util/TransportFrameDecoderSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/util/TransportFrameDecoderSuiteJ.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.util;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
+import org.apache.celeborn.common.network.protocol.Message;
+import org.apache.celeborn.common.network.protocol.OneWayMessage;
+
+public class TransportFrameDecoderSuiteJ {
+
+  private TransportFrameDecoder decoder;
+  private ChannelHandlerContext ctx;
+  private Channel channel;
+  private ChannelPipeline pipeline;
+  private final List<Object> decodedMessages = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+    decoder = new TransportFrameDecoder();
+    ctx = mock(ChannelHandlerContext.class);
+    channel = mock(Channel.class);
+    pipeline = mock(ChannelPipeline.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.pipeline()).thenReturn(pipeline);
+    decodedMessages.clear();
+    when(ctx.fireChannelRead(any()))
+        .thenAnswer(
+            invocation -> {
+              decodedMessages.add(invocation.getArgument(0));
+              return ctx;
+            });
+  }
+
+  private ByteBuf encodeMessage(Message message) throws IOException {
+    ByteBuf buf = Unpooled.buffer();
+    buf.writeInt(message.encodedLength());
+    message.type().encode(buf);
+    if (message.body() != null) {
+      buf.writeInt((int) message.body().size());
+    } else {
+      buf.writeInt(0);
+    }
+    message.encode(buf);
+    if (message.body() != null) {
+      buf.writeBytes(message.body().nioByteBuffer());
+    }
+    return buf;
+  }
+
+  private OneWayMessage oneWayMessage(byte[] payload) {
+    return new OneWayMessage(new NioManagedBuffer(java.nio.ByteBuffer.wrap(payload)));
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameIsFalseInitially() {
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameIsFalseForASmallStuckHalfFrame() throws IOException {
+    // A small amount of leftover bytes is well within what a single channelRead can deliver, so
+    // it isn't evidence of a large frame stuck across multiple reads.
+    ByteBuf full = encodeMessage(oneWayMessage(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
+    ByteBuf partial = full.retainedSlice(0, FrameDecoder.HEADER_SIZE + 2);
+    decoder.channelRead(ctx, partial);
+
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    full.release();
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameIsTrueOnceLeftoverExceedsSingleReadCap()
+      throws IOException {
+    // A single channelRead cannot deliver more than 64KB (Netty's AdaptiveRecvByteBufAllocator
+    // default maximum), so leftover bytes beyond that can only have piled up over multiple reads
+    // that each failed to complete the frame — i.e. a genuinely large frame stuck mid-transfer.
+    int oversizedBodyLength = 65536 + 1024;
+    byte[] payload = new byte[oversizedBodyLength];
+    ByteBuf full = encodeMessage(oneWayMessage(payload));
+    // Withhold the last byte so the frame never actually completes.
+    ByteBuf partial = full.retainedSlice(0, full.readableBytes() - 1);
+    decoder.channelRead(ctx, partial);
+
+    assertTrue(decoder.hasLikelyLargeIncompleteFrame());
+    assertTrue(decodedMessages.isEmpty());
+    full.release();
+  }
+
+  @Test
+  public void hasLikelyLargeIncompleteFrameIsFalseWhenLeftoverExactlyEqualsSingleReadCap()
+      throws IOException {
+    // The check is a strict ">", not ">=": leftover bytes exactly at the single-channelRead cap
+    // (64KB) are still fully explainable by one read, so this boundary must not be flagged yet.
+    int singleReadCapBytes = 65536;
+    byte[] payload = new byte[singleReadCapBytes + 1024];
+    ByteBuf full = encodeMessage(oneWayMessage(payload));
+    // Header (9 bytes) + exactly singleReadCapBytes of body, leaving totalSize == 65536.
+    ByteBuf partial = full.retainedSlice(0, FrameDecoder.HEADER_SIZE + singleReadCapBytes);
+    decoder.channelRead(ctx, partial);
+
+    assertFalse(decoder.hasLikelyLargeIncompleteFrame());
+    assertTrue(decodedMessages.isEmpty());
+    full.release();
+  }
+
+  @Test
+  public void frameDrainFiresEventOnceButStillDispatchesFramesAlreadyBuffered() throws IOException {
+    // Two complete frames arrive in a single channelRead call, simulating data that piles up
+    // while frame-drain resumes a channel that has more than just the stuck half-frame available.
+    // Since both frames are already fully in memory (no extra I/O needed to obtain them), both
+    // should still be decoded and dispatched to the downstream handler right away; only the
+    // drain-completed notification (which governs whether autoRead stays on) fires once.
+    ByteBuf frame1 = encodeMessage(oneWayMessage(new byte[] {1, 2, 3}));
+    ByteBuf frame2 = encodeMessage(oneWayMessage(new byte[] {4, 5, 6}));
+    ByteBuf combined = Unpooled.wrappedBuffer(frame1, frame2);
+
+    decoder.enableFrameDrain();
+    decoder.channelRead(ctx, combined);
+
+    // Both frames already sitting in memory should have been decoded and dispatched...
+    assertEquals(2, decodedMessages.size());
+    // ...while the drain-completed event fires exactly once, right after the first frame.
+    verify(pipeline, times(1))
+        .fireUserEventTriggered(TransportFrameDecoder.FrameDrainCompleted.INSTANCE);
+  }
+
+  @Test
+  public void nonFrameDrainModeConsumesAllAvailableFramesWithoutFiringEvent() throws IOException {
+    ByteBuf frame1 = encodeMessage(oneWayMessage(new byte[] {1, 2, 3}));
+    ByteBuf frame2 = encodeMessage(oneWayMessage(new byte[] {4, 5, 6}));
+    ByteBuf combined = Unpooled.wrappedBuffer(frame1, frame2);
+
+    decoder.channelRead(ctx, combined);
+
+    assertEquals(2, decodedMessages.size());
+    verify(pipeline, times(0)).fireUserEventTriggered(any());
+  }
+
+  @Test
+  public void frameDrainFlagIsResetAfterFirstFrameCompletes() throws IOException {
+    ByteBuf frame1 = encodeMessage(oneWayMessage(new byte[] {1, 2, 3}));
+    decoder.enableFrameDrain();
+    decoder.channelRead(ctx, frame1);
+    verify(pipeline, times(1))
+        .fireUserEventTriggered(TransportFrameDecoder.FrameDrainCompleted.INSTANCE);
+
+    // A subsequent frame, arriving after frame-drain mode has already been consumed, should not
+    // fire the event again since frameDrain was reset to false.
+    ByteBuf frame2 = encodeMessage(oneWayMessage(new byte[] {4, 5, 6}));
+    decoder.channelRead(ctx, frame2);
+    verify(pipeline, times(1))
+        .fireUserEventTriggered(TransportFrameDecoder.FrameDrainCompleted.INSTANCE);
+    assertEquals(2, decodedMessages.size());
+  }
+}

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -156,6 +156,10 @@ license: |
 | celeborn.worker.monitor.disk.notifyError.expireTimeout | 10m | false | The expire timeout of non-critical device error. Only notify critical error when the number of non-critical errors for a period of time exceeds threshold. | 0.3.0 |  | 
 | celeborn.worker.monitor.disk.notifyError.threshold | 64 | false | Device monitor will only notify critical error once the accumulated valid non-critical error number exceeding this threshold. | 0.3.0 |  | 
 | celeborn.worker.monitor.disk.sys.block.dir | /sys/block | false | The directory where linux file block information is stored. | 0.2.0 |  | 
+| celeborn.worker.monitor.drainIncompleteFrame.enabled | true | false | When true, gradually drains a fixed ratio of paused channels per tick to flush incomplete frames in TransportFrameDecoder buffers and recover from backpressure deadlock. | 0.7.1 |  | 
+| celeborn.worker.monitor.drainIncompleteFrame.interval | 5ms | false | Minimum interval between drainIncompleteFrame ticks. Draining arms when usage is at/below the watermark and disarms when above; a new batch of channels is drained each interval. | 0.7.1 |  | 
+| celeborn.worker.monitor.drainIncompleteFrame.ratio | 0.05 | false | Fraction of paused channels to drain per tick. Draining disarms automatically when application-layer usage rises above the watermark. 0.05 (5%) gives gradual recovery. | 0.7.1 |  | 
+| celeborn.worker.monitor.drainIncompleteFrame.watermark.ratio | 0.1 | false | Application-layer usage watermark (ratio of max direct memory): draining arms when usage is at/below this value and disarms when above. Tune from celeborn.worker.monitor.memory.report.interval. | 0.7.1 |  | 
 | celeborn.worker.monitor.memory.check.interval | 10ms | false | Interval of worker direct memory checking. | 0.3.0 | celeborn.worker.memory.checkInterval | 
 | celeborn.worker.monitor.memory.report.interval | 10s | false | Interval of worker direct memory tracker reporting to log. | 0.3.0 | celeborn.worker.memory.reportInterval | 
 | celeborn.worker.monitor.memory.trimChannelWaitInterval | 1s | false | Wait time after worker trigger channel to trim cache. | 0.3.0 |  | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
@@ -41,10 +41,14 @@ public class ChannelsLimiter extends ChannelDuplexHandler
     implements MemoryManager.MemoryPressureListener {
 
   private static final Logger logger = LoggerFactory.getLogger(ChannelsLimiter.class);
+  // Throttles the "drainIncompleteFrame resumed" INFO log to at most once per interval, since
+  // sustained backpressure can otherwise emit it on every tick (default every 5ms).
+  private static final long DRAIN_RESUME_LOG_INTERVAL_MS = 10000L;
   private final Set<Channel> channels = ConcurrentHashMap.newKeySet();
   private final String moduleName;
   private final AtomicBoolean isPaused = new AtomicBoolean(false);
   private final AtomicInteger needTrimChannels = new AtomicInteger(0);
+  private volatile long lastDrainResumeLogTime = -1L;
   private final long waitTrimInterval;
   private final boolean allowCache;
 
@@ -192,10 +196,11 @@ public class ChannelsLimiter extends ChannelDuplexHandler
     }
 
     if (candidates.isEmpty()) {
-      // Only worth logging when backpressure is actually active; if isPaused is false there are
-      // no paused channels to scan, so a zero result is expected and uninteresting.
-      if (isPaused.get()) {
-        logger.info(
+      // DEBUG, not INFO: under sustained backpressure with no qualifying candidate, this tick
+      // repeats every drainIncompleteFrame interval (default 5ms) and would otherwise flood logs
+      // (~100/s per paused limiter) right when the incident is already stressing log storage.
+      if (isPaused.get() && logger.isDebugEnabled()) {
+        logger.debug(
             "{} drainIncompleteFrame skipped this tick: no paused channel found with a stuck "
                 + "half-frame larger than {} bytes.",
             moduleName,
@@ -227,14 +232,19 @@ public class ChannelsLimiter extends ChannelDuplexHandler
       }
     }
     if (resumed > 0) {
-      logger.info(
-          "{} drainIncompleteFrame resumed {}/{} channels with a stuck half-frame larger than "
-              + "{} bytes (ratio={})",
-          moduleName,
-          resumed,
-          candidates.size(),
-          TransportFrameDecoder.MAX_SINGLE_READ_BYTES,
-          ratio);
+      long now = System.currentTimeMillis();
+      if (lastDrainResumeLogTime < 0
+          || now - lastDrainResumeLogTime >= DRAIN_RESUME_LOG_INTERVAL_MS) {
+        lastDrainResumeLogTime = now;
+        logger.info(
+            "{} drainIncompleteFrame resumed {}/{} channels with a stuck half-frame larger than "
+                + "{} bytes (ratio={})",
+            moduleName,
+            resumed,
+            candidates.size(),
+            TransportFrameDecoder.MAX_SINGLE_READ_BYTES,
+            ratio);
+      }
     }
     return resumed;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.util.FrameDecoder;
 import org.apache.celeborn.common.network.util.TransportFrameDecoder;
+import org.apache.celeborn.common.protocol.TransportModuleConstants;
 
 @ChannelHandler.Sharable
 public class ChannelsLimiter extends ChannelDuplexHandler
@@ -179,18 +180,23 @@ public class ChannelsLimiter extends ChannelDuplexHandler
   }
 
   /**
-   * Resumes {@code ratio} fraction of paused channels that have a likely-large stuck half-frame
-   * ({@link TransportFrameDecoder#hasLikelyLargeIncompleteFrame()}), each in frame-drain mode.
+   * Resumes {@code ratio} fraction of paused channels that have a likely-large stuck half-frame,
+   * each in frame-drain mode. No-op if {@code moduleName} does not match this limiter's module.
    */
   @Override
-  public int drainIncompleteFrame(double ratio) {
+  public int drainIncompleteFrame(double ratio, String moduleName) {
+    if (!this.moduleName.equals(moduleName)) {
+      return 0;
+    }
     List<Channel> candidates = new ArrayList<>();
     for (Channel ch : channels) {
       if (!ch.isActive() || ch.config().isAutoRead()) {
         continue;
       }
       TransportFrameDecoder decoder = frameDecoderOf(ch);
-      if (decoder != null && decoder.hasLikelyLargeIncompleteFrame()) {
+      if (decoder != null
+          && decoder.hasLikelyLargeIncompleteFrame(
+              TransportModuleConstants.REPLICATE_MODULE.equals(moduleName))) {
         candidates.add(ch);
       }
     }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
@@ -17,6 +17,8 @@
 
 package org.apache.celeborn.service.deploy.worker.memory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.util.FrameDecoder;
+import org.apache.celeborn.common.network.util.TransportFrameDecoder;
 
 @ChannelHandler.Sharable
 public class ChannelsLimiter extends ChannelDuplexHandler
@@ -126,6 +130,20 @@ public class ChannelsLimiter extends ChannelDuplexHandler
         ((PooledByteBufAllocator) ctx.alloc()).trimCurrentThreadCache();
       }
       needTrimChannels.decrementAndGet();
+    } else if (evt instanceof TransportFrameDecoder.FrameDrainCompleted) {
+      onFrameDrainCompleted(ctx.channel());
+    }
+  }
+
+  /**
+   * Re-pauses the channel after its single drain frame completes, unless a full resume happened
+   * concurrently.
+   */
+  private void onFrameDrainCompleted(Channel channel) {
+    synchronized (isPaused) {
+      if (isPaused.get() && channel.config().isAutoRead()) {
+        channel.config().setAutoRead(false);
+      }
     }
   }
 
@@ -154,6 +172,76 @@ public class ChannelsLimiter extends ChannelDuplexHandler
     if (allowCache) {
       trimCache();
     }
+  }
+
+  /**
+   * Resumes {@code ratio} fraction of paused channels that have a likely-large stuck half-frame
+   * ({@link TransportFrameDecoder#hasLikelyLargeIncompleteFrame()}), each in frame-drain mode.
+   */
+  @Override
+  public int drainIncompleteFrame(double ratio) {
+    List<Channel> candidates = new ArrayList<>();
+    for (Channel ch : channels) {
+      if (!ch.isActive() || ch.config().isAutoRead()) {
+        continue;
+      }
+      TransportFrameDecoder decoder = frameDecoderOf(ch);
+      if (decoder != null && decoder.hasLikelyLargeIncompleteFrame()) {
+        candidates.add(ch);
+      }
+    }
+
+    if (candidates.isEmpty()) {
+      // Only worth logging when backpressure is actually active; if isPaused is false there are
+      // no paused channels to scan, so a zero result is expected and uninteresting.
+      if (isPaused.get()) {
+        logger.info(
+            "{} drainIncompleteFrame skipped this tick: no paused channel found with a stuck "
+                + "half-frame larger than {} bytes.",
+            moduleName,
+            TransportFrameDecoder.MAX_SINGLE_READ_BYTES);
+      }
+      return 0;
+    }
+
+    int targetCount = Math.max(1, (int) (candidates.size() * ratio));
+    int actualResume = Math.min(targetCount, candidates.size());
+
+    int resumed = 0;
+    synchronized (isPaused) {
+      if (!isPaused.get()) {
+        return 0;
+      }
+      for (int i = 0; i < actualResume; i++) {
+        Channel ch = candidates.get(i);
+        // Re-check: state may have changed since the scan above.
+        if (!ch.isActive() || ch.config().isAutoRead()) {
+          continue;
+        }
+        TransportFrameDecoder decoder = frameDecoderOf(ch);
+        if (decoder != null) {
+          decoder.enableFrameDrain();
+        }
+        ch.config().setAutoRead(true);
+        resumed++;
+      }
+    }
+    if (resumed > 0) {
+      logger.info(
+          "{} drainIncompleteFrame resumed {}/{} channels with a stuck half-frame larger than "
+              + "{} bytes (ratio={})",
+          moduleName,
+          resumed,
+          candidates.size(),
+          TransportFrameDecoder.MAX_SINGLE_READ_BYTES,
+          ratio);
+    }
+    return resumed;
+  }
+
+  private static TransportFrameDecoder frameDecoderOf(Channel channel) {
+    Object decoder = channel.pipeline().get(FrameDecoder.HANDLER_NAME);
+    return decoder instanceof TransportFrameDecoder ? (TransportFrameDecoder) decoder : null;
   }
 
   static class TrimCache {}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -56,6 +56,8 @@ public class MemoryManager {
   private final long maxSortMemory;
   private final int forceAppendPauseSpentTimeThreshold;
   private final List<MemoryPressureListener> memoryPressureListeners = new ArrayList<>();
+  // Replicate bytes handed off to a peer but not yet acknowledged; included in appActiveMemory.
+  private final AtomicLong pendingReplicateBytesCounter = new AtomicLong(0);
 
   private final ScheduledExecutorService checkService =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor("worker-memory-manager-checker");
@@ -101,6 +103,14 @@ public class MemoryManager {
   private boolean resumingByPinnedMemory = false;
   private long workerPinnedMemoryResumeKeepTime;
 
+  private final boolean drainIncompleteFrameEnabled;
+  private final long drainIncompleteFrameIntervalMs;
+  private final double drainIncompleteFrameRatio;
+  private final long drainIncompleteFrameWatermarkBytes;
+  // accessed only from the checkService thread:
+  private long drainIncompleteFrameLastTickTime = -1L;
+  private long drainPinnedMemoryLastLogTime = -1L;
+
   @VisibleForTesting
   public static MemoryManager initialize(CelebornConf conf) {
     return initialize(conf, null, null);
@@ -124,6 +134,18 @@ public class MemoryManager {
     }
   }
 
+  public void incrementPendingReplicateBytes(long bytes) {
+    pendingReplicateBytesCounter.addAndGet(bytes);
+  }
+
+  public void releasePendingReplicateBytes(long bytes) {
+    pendingReplicateBytesCounter.addAndGet(-bytes);
+  }
+
+  public long getPendingReplicateBytes() {
+    return pendingReplicateBytesCounter.get();
+  }
+
   public static MemoryManager instance() {
     return _INSTANCE;
   }
@@ -140,6 +162,10 @@ public class MemoryManager {
     this.pinnedMemoryCheckEnabled = conf.workerPinnedMemoryCheckEnabled();
     this.pinnedMemoryCheckInterval = conf.workerPinnedMemoryCheckIntervalMs();
     this.workerPinnedMemoryResumeKeepTime = conf.workerPinnedMemoryResumeKeepTime();
+    this.drainIncompleteFrameEnabled = conf.workerDrainIncompleteFrameEnabled();
+    this.drainIncompleteFrameIntervalMs = conf.workerDrainIncompleteFrameIntervalMs();
+    this.drainIncompleteFrameRatio = conf.workerDrainIncompleteFrameRatio();
+    double drainIncompleteFrameWatermarkRatio = conf.workerDrainIncompleteFrameWatermarkRatio();
     long reportInterval = conf.workerDirectMemoryReportIntervalSecond();
     double readBufferTargetRatio = conf.readBufferTargetRatio();
     long readBufferTargetUpdateInterval = conf.readBufferTargetUpdateInterval();
@@ -175,6 +201,8 @@ public class MemoryManager {
     readBufferThreshold = (long) (maxDirectMemory * readBufferRatio);
     readBufferTarget = (long) (readBufferThreshold * readBufferTargetRatio);
     memoryFileStorageThreshold = (long) (maxDirectMemory * memoryFileStorageRatio);
+    drainIncompleteFrameWatermarkBytes =
+        (long) (maxDirectMemory * drainIncompleteFrameWatermarkRatio);
 
     checkService.scheduleWithFixedDelay(
         () -> {
@@ -195,7 +223,7 @@ public class MemoryManager {
                     + "disk buffer size: {}, "
                     + "sort memory size: {}, "
                     + "read buffer size: {}, "
-                    + "memory file storage size : {}",
+                    + "memory file storage size: {}",
                 Utils.bytesToString(getNettyUsedDirectMemory()),
                 Utils.bytesToString(maxDirectMemory),
                 Utils.bytesToString(diskBufferCounter.get()),
@@ -365,6 +393,7 @@ public class MemoryManager {
               appendPauseSpentTime(servingState);
             }
           }
+          checkAndTriggerDrainIncompleteFrame();
         }
         logger.debug("Trigger action: TRIM");
         trimAllListeners();
@@ -393,6 +422,7 @@ public class MemoryManager {
                 trimCounter);
             appendPauseSpentTime(servingState);
           }
+          checkAndTriggerDrainIncompleteFrame();
         }
         logger.debug("Trigger action: TRIM");
         trimAllListeners();
@@ -400,6 +430,8 @@ public class MemoryManager {
       case NONE_PAUSED:
         // resume from paused mode, append pause spent time
         resumingByPinnedMemory = false;
+        drainIncompleteFrameLastTickTime = -1L; // reset for the next backpressure episode
+        drainPinnedMemoryLastLogTime = -1L;
         if (lastState == ServingState.PUSH_AND_REPLICATE_PAUSED) {
           resumeReplicate();
           resumePush();
@@ -408,6 +440,41 @@ public class MemoryManager {
           resumePush();
           appendPauseSpentTime(lastState);
         }
+    }
+  }
+
+  /**
+   * Fires a drainIncompleteFrame tick when backpressure is active and appActiveMemory is at/below
+   * the watermark.
+   */
+  private void checkAndTriggerDrainIncompleteFrame() {
+    if (!drainIncompleteFrameEnabled) return;
+
+    long appActiveMemory =
+        sortMemoryCounter.get()
+            + diskBufferCounter.get()
+            + memoryFileStorageCounter.sum()
+            + pendingReplicateBytesCounter.get();
+    if (appActiveMemory > drainIncompleteFrameWatermarkBytes) return;
+
+    long now = System.currentTimeMillis();
+    if (drainIncompleteFrameLastTickTime >= 0
+        && now - drainIncompleteFrameLastTickTime < drainIncompleteFrameIntervalMs) return;
+    drainIncompleteFrameLastTickTime = now;
+
+    int resumedChannels = 0;
+    for (MemoryPressureListener listener : memoryPressureListeners) {
+      resumedChannels += listener.drainIncompleteFrame(drainIncompleteFrameRatio);
+    }
+    if (resumedChannels > 0) {
+      logger.info(
+          "DrainIncompleteFrame resumed {} channels (ratio={})",
+          resumedChannels,
+          drainIncompleteFrameRatio);
+    }
+    if (drainPinnedMemoryLastLogTime < 0 || now - drainPinnedMemoryLastLogTime >= 10000L) {
+      drainPinnedMemoryLastLogTime = now;
+      logger.info("Pinned memory during backpressure: {}", Utils.bytesToString(getPinnedMemory()));
     }
   }
 
@@ -675,6 +742,14 @@ public class MemoryManager {
     void onResume(String moduleName);
 
     void onTrim();
+
+    /**
+     * Resume a small subset of paused channels to drain their stuck half-frames. Default no-op; see
+     * {@link ChannelsLimiter}.
+     */
+    default int drainIncompleteFrame(double ratio) {
+      return 0;
+    }
   }
 
   public interface ReadBufferTargetChangeListener {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -444,18 +444,20 @@ public class MemoryManager {
   }
 
   /**
-   * Fires a drainIncompleteFrame tick when backpressure is active and appActiveMemory is at/below
-   * the watermark.
+   * Fires a drainIncompleteFrame tick when backpressure is active and the relevant usage is
+   * at/below the watermark. REPLICATE_MODULE is evaluated without pendingReplicateBytesCounter,
+   * since that counter doesn't represent this worker's own memory footprint; every other module
+   * uses the full accounting.
    */
   private void checkAndTriggerDrainIncompleteFrame() {
     if (!drainIncompleteFrameEnabled) return;
 
-    long appActiveMemory =
-        sortMemoryCounter.get()
-            + diskBufferCounter.get()
-            + memoryFileStorageCounter.sum()
-            + pendingReplicateBytesCounter.get();
-    if (appActiveMemory > drainIncompleteFrameWatermarkBytes) return;
+    long localActiveMemory =
+        sortMemoryCounter.get() + diskBufferCounter.get() + memoryFileStorageCounter.sum();
+    long appActiveMemory = localActiveMemory + pendingReplicateBytesCounter.get();
+    boolean pushReady = appActiveMemory <= drainIncompleteFrameWatermarkBytes;
+    boolean replicateReady = localActiveMemory <= drainIncompleteFrameWatermarkBytes;
+    if (!pushReady && !replicateReady) return;
 
     long now = System.currentTimeMillis();
     if (drainIncompleteFrameLastTickTime >= 0
@@ -464,7 +466,16 @@ public class MemoryManager {
 
     int resumedChannels = 0;
     for (MemoryPressureListener listener : memoryPressureListeners) {
-      resumedChannels += listener.drainIncompleteFrame(drainIncompleteFrameRatio);
+      if (pushReady) {
+        resumedChannels +=
+            listener.drainIncompleteFrame(
+                drainIncompleteFrameRatio, TransportModuleConstants.PUSH_MODULE);
+      }
+      if (replicateReady) {
+        resumedChannels +=
+            listener.drainIncompleteFrame(
+                drainIncompleteFrameRatio, TransportModuleConstants.REPLICATE_MODULE);
+      }
     }
     if (resumedChannels > 0) {
       logger.info(
@@ -744,10 +755,10 @@ public class MemoryManager {
     void onTrim();
 
     /**
-     * Resume a small subset of paused channels to drain their stuck half-frames. Default no-op; see
-     * {@link ChannelsLimiter}.
+     * Resume a small subset of {@code moduleName}'s paused channels to drain their stuck
+     * half-frames. Default no-op; see {@link ChannelsLimiter}.
      */
-    default int drainIncompleteFrame(double ratio) {
+    default int drainIncompleteFrame(double ratio, String moduleName) {
       return 0;
     }
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -36,10 +36,10 @@ import org.apache.celeborn.common.meta.{DiskStatus, WorkerInfo, WorkerPartitionL
 import org.apache.celeborn.common.metrics.source.Source
 import org.apache.celeborn.common.network.buffer.{NettyManagedBuffer, NioManagedBuffer}
 import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient, TransportClientFactory}
-import org.apache.celeborn.common.network.protocol.{Message, PushData, PushDataHandShake, PushMergedData, RegionFinish, RegionStart, RequestMessage, RpcFailure, RpcRequest, RpcResponse, TransportMessage}
+import org.apache.celeborn.common.network.protocol._
 import org.apache.celeborn.common.network.protocol.Message.Type
 import org.apache.celeborn.common.network.server.BaseMessageHandler
-import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType, PbPushDataHandShake, PbPushMergedDataSplitPartitionInfo, PbRegionFinish, PbRegionStart, PbSegmentStart}
+import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.PbPartitionLocation.Mode
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.unsafe.Platform
@@ -291,16 +291,28 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       }
 
       pushData.body().retain()
+      val bodySize: Long = pushData.body().size()
+      MemoryManager.instance().incrementPendingReplicateBytes(bodySize)
+      val bytesReleased = new AtomicBoolean(false)
+      // Ensures the matching decrement below fires exactly once no matter which of the several
+      // failure/success branches below is taken.
+      def releasePendingReplicateBytes(): Unit = {
+        if (bytesReleased.compareAndSet(false, true)) {
+          MemoryManager.instance().releasePendingReplicateBytes(bodySize)
+        }
+      }
       replicateThreadPool.submit(new Runnable {
         override def run(): Unit = {
           if (unavailablePeers.containsKey(peerWorker)) {
             pushData.body().release()
+            releasePendingReplicateBytes()
             handlePushDataConnectionFail(callbackWithTimer, location)
             return
           }
           // Handle the response from replica
           val wrappedCallback = new RpcResponseCallback() {
             override def onSuccess(response: ByteBuffer): Unit = {
+              releasePendingReplicateBytes()
               Try(Await.result(writePromise.future, Duration.Inf)) match {
                 case Success(result) =>
                   if (result(0) != StatusCode.SUCCESS) {
@@ -342,6 +354,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
             }
 
             override def onFailure(e: Throwable): Unit = {
+              releasePendingReplicateBytes()
               logError(
                 s"PushData replication failed for shuffle: $shuffleKey, partitionLocation: $location",
                 e)
@@ -376,6 +389,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           } catch {
             case e: Exception =>
               pushData.body().release()
+              releasePendingReplicateBytes()
               unavailablePeers.put(peerWorker, System.currentTimeMillis())
               workerSource.incCounter(WorkerSource.REPLICATE_DATA_CREATE_CONNECTION_FAIL_COUNT)
               logError(
@@ -627,16 +641,28 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
         return
       }
       pushMergedData.body().retain()
+      val bodySize: Long = pushMergedData.body().size()
+      MemoryManager.instance().incrementPendingReplicateBytes(bodySize)
+      val bytesReleased = new AtomicBoolean(false)
+      // Ensures the matching decrement below fires exactly once no matter which of the several
+      // failure/success branches below is taken.
+      def releasePendingReplicateBytes(): Unit = {
+        if (bytesReleased.compareAndSet(false, true)) {
+          MemoryManager.instance().releasePendingReplicateBytes(bodySize)
+        }
+      }
       replicateThreadPool.submit(new Runnable {
         override def run(): Unit = {
           if (unavailablePeers.containsKey(peerWorker)) {
             pushMergedData.body().release()
+            releasePendingReplicateBytes()
             handlePushMergedDataConnectionFail(pushMergedDataCallback, location)
             return
           }
           // Handle the response from replica
           val wrappedCallback = new RpcResponseCallback() {
             override def onSuccess(response: ByteBuffer): Unit = {
+              releasePendingReplicateBytes()
               Try(Await.result(writePromise.future, Duration.Inf)) match {
                 case Success(result) =>
                   var index = 0
@@ -724,6 +750,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
             }
 
             override def onFailure(e: Throwable): Unit = {
+              releasePendingReplicateBytes()
               logError(
                 s"PushMergedData replicate failed for shuffle: $shuffleKey, partitionLocation: $location",
                 e)
@@ -763,6 +790,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
           } catch {
             case e: Exception =>
               pushMergedData.body().release()
+              releasePendingReplicateBytes()
               unavailablePeers.put(peerWorker, System.currentTimeMillis())
               workerSource.incCounter(WorkerSource.REPLICATE_DATA_CREATE_CONNECTION_FAIL_COUNT)
               logError(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -427,6 +427,9 @@ private[celeborn] class Worker(
   workerSource.addGauge(WorkerSource.EVICTED_DFS_FILE_COUNT) { () =>
     storageManager.evictedDfsFileCount.get()
   }
+  workerSource.addGauge(WorkerSource.PENDING_REPLICATE_BYTES) { () =>
+    memoryManager.getPendingReplicateBytes
+  }
   workerSource.addGauge(WorkerSource.MEMORY_STORAGE_FILE_COUNT) { () =>
     storageManager.memoryWriters.size()
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -263,6 +263,10 @@ object WorkerSource {
   val EVICTED_FILE_COUNT = "EvictedFileCount"
   val EVICTED_LOCAL_FILE_COUNT = "EvictedLocalFileCount"
   val EVICTED_DFS_FILE_COUNT = "EvictedDfsFileCount"
+  // Bytes of PushData/PushMergedData bodies handed off to a peer for replication but not yet
+  // acknowledged (replica response received, or the attempt failed/errored out beforehand); see
+  // PushDataHandler#getPendingReplicateBytes.
+  val PENDING_REPLICATE_BYTES = "PendingReplicateBytes"
 
   val MEMORY_STORAGE_FILE_COUNT = "MemoryStorageFileCount"
 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiterSuiteJ.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.memory;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.util.FrameDecoder;
+import org.apache.celeborn.common.network.util.TransportFrameDecoder;
+import org.apache.celeborn.common.protocol.TransportModuleConstants;
+
+public class ChannelsLimiterSuiteJ {
+
+  private ChannelsLimiter limiter;
+
+  @Before
+  public void setUp() {
+    MemoryManager.reset();
+    MemoryManager.initialize(new CelebornConf());
+    limiter = new ChannelsLimiter(TransportModuleConstants.PUSH_MODULE, new CelebornConf());
+  }
+
+  @After
+  public void tearDown() {
+    MemoryManager.reset();
+  }
+
+  /**
+   * Creates a channel whose autoRead state is backed by a real boolean, and adds it to the limiter.
+   */
+  private FakeChannel addPausedChannel(boolean hasIncompleteFrame) throws Exception {
+    return addPausedChannel(hasIncompleteFrame, false);
+  }
+
+  /**
+   * Creates a channel whose autoRead state is backed by a real boolean, and adds it to the limiter.
+   */
+  private FakeChannel addPausedChannel(
+      boolean hasIncompleteFrame, boolean hasLikelyLargeIncompleteFrame) throws Exception {
+    FakeChannel channel = new FakeChannel(hasIncompleteFrame, hasLikelyLargeIncompleteFrame);
+    limiter.handlerAdded(channel.ctx);
+    // pause it explicitly regardless of the global state, simulating a channel that was
+    // paused while backpressure was active.
+    channel.setAutoRead(false);
+    return channel;
+  }
+
+  @Test
+  public void drainIncompleteFrameReturnsZeroWhenNoChannelsArePaused() {
+    assertEquals(0, limiter.drainIncompleteFrame(1.0));
+  }
+
+  @Test
+  public void drainIncompleteFrameReturnsZeroWhenGlobalStateIsNotPaused() throws Exception {
+    // Channels exist and are individually "paused" (autoRead=false), but the limiter's global
+    // isPaused flag was never set (i.e. backpressure was never triggered globally).
+    addPausedChannel(true);
+    addPausedChannel(false);
+
+    assertEquals(0, limiter.drainIncompleteFrame(1.0));
+  }
+
+  @Test
+  public void drainIncompleteFrameOnlyResumesChannelsWithLikelyLargeIncompleteFrame()
+      throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+
+    FakeChannel withLargeHalfFrame = addPausedChannel(true, true);
+    FakeChannel withSmallHalfFrame = addPausedChannel(true, false);
+    FakeChannel withoutHalfFrame = addPausedChannel(false, false);
+
+    int resumed = limiter.drainIncompleteFrame(1.0);
+
+    assertEquals(1, resumed);
+    assertTrue(withLargeHalfFrame.isAutoRead());
+    assertFalse(withSmallHalfFrame.isAutoRead());
+    assertFalse(withoutHalfFrame.isAutoRead());
+    assertTrue(withLargeHalfFrame.decoder.frameDrainEnabled());
+  }
+
+  @Test
+  public void drainIncompleteFrameReturnsZeroWhenNoLargeIncompleteFrameFound() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+
+    // Neither a small half-frame nor no half-frame at all qualifies: draining must not fall back
+    // to resuming arbitrary paused channels.
+    FakeChannel withSmallHalfFrame = addPausedChannel(true, false);
+    FakeChannel withoutHalfFrame = addPausedChannel(false, false);
+
+    int resumed = limiter.drainIncompleteFrame(1.0);
+
+    assertEquals(0, resumed);
+    assertFalse(withSmallHalfFrame.isAutoRead());
+    assertFalse(withoutHalfFrame.isAutoRead());
+  }
+
+  @Test
+  public void drainIncompleteFrameWorksThroughLargeIncompleteFrameTierInScanOrderWithoutShuffling()
+      throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+
+    // All channels have a likely-large incomplete frame; with ratio < 1.0 only a prefix should
+    // be resumed each call, and repeated calls should eventually work through every one of them
+    // since already-resumed channels stop reporting a half-frame (mirroring real behavior where
+    // completing a probed frame clears totalSize) and thus drop out of the tier.
+    List<FakeChannel> channels = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      channels.add(addPausedChannel(true, true));
+    }
+
+    int firstBatch = limiter.drainIncompleteFrame(0.3);
+    assertEquals(3, firstBatch);
+    long resumedAfterFirst = channels.stream().filter(FakeChannel::isAutoRead).count();
+    assertEquals(3, resumedAfterFirst);
+
+    // Simulate the resumed channels completing their probed frame: they no longer have an
+    // incomplete frame, so they leave the large-incomplete-frame tier and re-pause.
+    for (FakeChannel ch : channels) {
+      if (ch.isAutoRead()) {
+        ch.decoder.clearIncompleteFrame();
+        ch.setAutoRead(false);
+      }
+    }
+
+    // Second tick: 0.3 * 7 = 2.1 → max(1,2) = 2 resumed from the remaining 7.
+    int secondBatch = limiter.drainIncompleteFrame(0.3);
+    assertEquals(2, secondBatch);
+    long resumedAfterSecond = channels.stream().filter(FakeChannel::isAutoRead).count();
+    assertEquals(2, resumedAfterSecond);
+    // The remaining 5 channels (7 - 2 resumed this tick) still report a large incomplete frame.
+    long stillInLargeTier =
+        channels.stream()
+            .filter(ch -> !ch.isAutoRead() && ch.decoder.hasLikelyLargeIncompleteFrame())
+            .count();
+    assertEquals(5, stillInLargeTier);
+  }
+
+  @Test
+  public void drainIncompleteFrameRespectsRatio() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+
+    List<FakeChannel> channels = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      channels.add(addPausedChannel(true, true));
+    }
+
+    int resumed = limiter.drainIncompleteFrame(0.3);
+
+    assertEquals(3, resumed);
+    long actuallyResumed = channels.stream().filter(FakeChannel::isAutoRead).count();
+    assertEquals(3, actuallyResumed);
+  }
+
+  @Test
+  public void drainIncompleteFrameSkipsInactiveOrAlreadyReadingChannels() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+
+    FakeChannel inactive = addPausedChannel(true, true);
+    inactive.active = false;
+    FakeChannel alreadyReading = addPausedChannel(true, true);
+    alreadyReading.setAutoRead(true);
+    FakeChannel eligible = addPausedChannel(true, true);
+
+    int resumed = limiter.drainIncompleteFrame(1.0);
+
+    assertEquals(1, resumed);
+    assertTrue(eligible.isAutoRead());
+    assertFalse(inactive.isAutoRead());
+  }
+
+  @Test
+  public void onFrameDrainCompletedReClosesChannelWhenStillGloballyPaused() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+    FakeChannel channel = addPausedChannel(true, true);
+    limiter.drainIncompleteFrame(1.0);
+    assertTrue(channel.isAutoRead());
+
+    limiter.userEventTriggered(channel.ctx, TransportFrameDecoder.FrameDrainCompleted.INSTANCE);
+
+    assertFalse(channel.isAutoRead());
+  }
+
+  @Test
+  public void onFrameDrainCompletedLeavesChannelOpenWhenGlobalResumeHappenedMeanwhile()
+      throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+    FakeChannel channel = addPausedChannel(true, true);
+    limiter.drainIncompleteFrame(1.0);
+    assertTrue(channel.isAutoRead());
+
+    // Backpressure is lifted globally while the frame-drain read was in flight.
+    limiter.onResume(TransportModuleConstants.PUSH_MODULE);
+    assertTrue(channel.isAutoRead());
+
+    limiter.userEventTriggered(channel.ctx, TransportFrameDecoder.FrameDrainCompleted.INSTANCE);
+
+    // Should remain open since backpressure is no longer active.
+    assertTrue(channel.isAutoRead());
+  }
+
+  @Test
+  public void userEventTriggeredIgnoresUnrelatedEvents() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+    FakeChannel channel = addPausedChannel(true, true);
+
+    // An unrelated event should not change the autoRead state.
+    limiter.userEventTriggered(channel.ctx, new Object());
+
+    assertFalse(channel.isAutoRead());
+  }
+
+  /**
+   * A minimal fake {@link Channel} wired up with a real {@link TransportFrameDecoder} in its
+   * pipeline, and an autoRead flag backed by a plain boolean so that ChannelsLimiter's read/write
+   * of autoRead behaves like a real Netty channel would.
+   */
+  private static class FakeChannel {
+    final Channel channel = mock(Channel.class);
+    final ChannelConfig config = mock(ChannelConfig.class);
+    final ChannelPipeline pipeline = mock(ChannelPipeline.class);
+    final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    final AtomicBoolean autoRead = new AtomicBoolean(true);
+    final TestableFrameDecoder decoder;
+    boolean active = true;
+
+    FakeChannel(boolean hasIncompleteFrame, boolean hasLikelyLargeIncompleteFrame) {
+      decoder = new TestableFrameDecoder(hasIncompleteFrame, hasLikelyLargeIncompleteFrame);
+      when(channel.config()).thenReturn(config);
+      when(channel.pipeline()).thenReturn(pipeline);
+      when(channel.isActive()).thenAnswer(inv -> active);
+      when(config.isAutoRead()).thenAnswer(inv -> autoRead.get());
+      when(config.setAutoRead(org.mockito.ArgumentMatchers.anyBoolean()))
+          .thenAnswer(
+              inv -> {
+                autoRead.set(inv.getArgument(0));
+                return config;
+              });
+      when(pipeline.get(FrameDecoder.HANDLER_NAME)).thenReturn(decoder);
+      when(ctx.channel()).thenReturn(channel);
+    }
+
+    void setAutoRead(boolean value) {
+      autoRead.set(value);
+    }
+
+    boolean isAutoRead() {
+      return autoRead.get();
+    }
+  }
+
+  /** Exposes frameDrain state for assertions without changing TransportFrameDecoder's API. */
+  private static class TestableFrameDecoder extends TransportFrameDecoder {
+    private boolean incomplete;
+    private boolean likelyLargeIncomplete;
+
+    TestableFrameDecoder(boolean incomplete, boolean likelyLargeIncomplete) {
+      this.incomplete = incomplete;
+      this.likelyLargeIncomplete = likelyLargeIncomplete;
+    }
+
+    @Override
+    public boolean hasLikelyLargeIncompleteFrame() {
+      return likelyLargeIncomplete;
+    }
+
+    /** Simulates the channel's stuck half-frame being fully consumed after being probed. */
+    void clearIncompleteFrame() {
+      incomplete = false;
+      likelyLargeIncomplete = false;
+    }
+
+    boolean frameDrainEnabled() {
+      // enableFrameDrain() has no visible side effect other than internal state; simply
+      // verifying it doesn't throw and that drainIncompleteFrame called it is enough here since
+      // the TransportFrameDecoder-level drain behavior itself is covered by
+      // TransportFrameDecoderSuiteJ. We track a local flag by overriding enableFrameDrain.
+      return enabledCalled;
+    }
+
+    private boolean enabledCalled = false;
+
+    @Override
+    public void enableFrameDrain() {
+      enabledCalled = true;
+      super.enableFrameDrain();
+    }
+  }
+}

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiterSuiteJ.java
@@ -61,12 +61,25 @@ public class ChannelsLimiterSuiteJ {
     return addPausedChannel(hasIncompleteFrame, false);
   }
 
+  private FakeChannel addPausedChannel(
+      boolean hasIncompleteFrame, boolean hasLikelyLargeIncompleteFrame) throws Exception {
+    return addPausedChannel(
+        hasIncompleteFrame, hasLikelyLargeIncompleteFrame, hasLikelyLargeIncompleteFrame);
+  }
+
   /**
    * Creates a channel whose autoRead state is backed by a real boolean, and adds it to the limiter.
    */
   private FakeChannel addPausedChannel(
-      boolean hasIncompleteFrame, boolean hasLikelyLargeIncompleteFrame) throws Exception {
-    FakeChannel channel = new FakeChannel(hasIncompleteFrame, hasLikelyLargeIncompleteFrame);
+      boolean hasIncompleteFrame,
+      boolean hasLikelyLargeIncompleteTotalSize,
+      boolean hasLikelyLargeIncompleteFrameSize)
+      throws Exception {
+    FakeChannel channel =
+        new FakeChannel(
+            hasIncompleteFrame,
+            hasLikelyLargeIncompleteTotalSize,
+            hasLikelyLargeIncompleteFrameSize);
     limiter.handlerAdded(channel.ctx);
     // pause it explicitly regardless of the global state, simulating a channel that was
     // paused while backpressure was active.
@@ -76,7 +89,7 @@ public class ChannelsLimiterSuiteJ {
 
   @Test
   public void drainIncompleteFrameReturnsZeroWhenNoChannelsArePaused() {
-    assertEquals(0, limiter.drainIncompleteFrame(1.0));
+    assertEquals(0, limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE));
   }
 
   @Test
@@ -86,7 +99,15 @@ public class ChannelsLimiterSuiteJ {
     addPausedChannel(true);
     addPausedChannel(false);
 
-    assertEquals(0, limiter.drainIncompleteFrame(1.0));
+    assertEquals(0, limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE));
+  }
+
+  @Test
+  public void drainIncompleteFrameReturnsZeroWhenModuleNameDoesNotMatch() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+    addPausedChannel(true, true);
+
+    assertEquals(0, limiter.drainIncompleteFrame(1.0, TransportModuleConstants.REPLICATE_MODULE));
   }
 
   @Test
@@ -98,7 +119,7 @@ public class ChannelsLimiterSuiteJ {
     FakeChannel withSmallHalfFrame = addPausedChannel(true, false);
     FakeChannel withoutHalfFrame = addPausedChannel(false, false);
 
-    int resumed = limiter.drainIncompleteFrame(1.0);
+    int resumed = limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE);
 
     assertEquals(1, resumed);
     assertTrue(withLargeHalfFrame.isAutoRead());
@@ -116,7 +137,7 @@ public class ChannelsLimiterSuiteJ {
     FakeChannel withSmallHalfFrame = addPausedChannel(true, false);
     FakeChannel withoutHalfFrame = addPausedChannel(false, false);
 
-    int resumed = limiter.drainIncompleteFrame(1.0);
+    int resumed = limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE);
 
     assertEquals(0, resumed);
     assertFalse(withSmallHalfFrame.isAutoRead());
@@ -137,7 +158,7 @@ public class ChannelsLimiterSuiteJ {
       channels.add(addPausedChannel(true, true));
     }
 
-    int firstBatch = limiter.drainIncompleteFrame(0.3);
+    int firstBatch = limiter.drainIncompleteFrame(0.3, TransportModuleConstants.PUSH_MODULE);
     assertEquals(3, firstBatch);
     long resumedAfterFirst = channels.stream().filter(FakeChannel::isAutoRead).count();
     assertEquals(3, resumedAfterFirst);
@@ -152,14 +173,14 @@ public class ChannelsLimiterSuiteJ {
     }
 
     // Second tick: 0.3 * 7 = 2.1 → max(1,2) = 2 resumed from the remaining 7.
-    int secondBatch = limiter.drainIncompleteFrame(0.3);
+    int secondBatch = limiter.drainIncompleteFrame(0.3, TransportModuleConstants.PUSH_MODULE);
     assertEquals(2, secondBatch);
     long resumedAfterSecond = channels.stream().filter(FakeChannel::isAutoRead).count();
     assertEquals(2, resumedAfterSecond);
     // The remaining 5 channels (7 - 2 resumed this tick) still report a large incomplete frame.
     long stillInLargeTier =
         channels.stream()
-            .filter(ch -> !ch.isAutoRead() && ch.decoder.hasLikelyLargeIncompleteFrame())
+            .filter(ch -> !ch.isAutoRead() && ch.decoder.hasLikelyLargeIncompleteFrame(false))
             .count();
     assertEquals(5, stillInLargeTier);
   }
@@ -173,7 +194,7 @@ public class ChannelsLimiterSuiteJ {
       channels.add(addPausedChannel(true, true));
     }
 
-    int resumed = limiter.drainIncompleteFrame(0.3);
+    int resumed = limiter.drainIncompleteFrame(0.3, TransportModuleConstants.PUSH_MODULE);
 
     assertEquals(3, resumed);
     long actuallyResumed = channels.stream().filter(FakeChannel::isAutoRead).count();
@@ -190,7 +211,7 @@ public class ChannelsLimiterSuiteJ {
     alreadyReading.setAutoRead(true);
     FakeChannel eligible = addPausedChannel(true, true);
 
-    int resumed = limiter.drainIncompleteFrame(1.0);
+    int resumed = limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE);
 
     assertEquals(1, resumed);
     assertTrue(eligible.isAutoRead());
@@ -201,7 +222,7 @@ public class ChannelsLimiterSuiteJ {
   public void onFrameDrainCompletedReClosesChannelWhenStillGloballyPaused() throws Exception {
     limiter.onPause(TransportModuleConstants.PUSH_MODULE);
     FakeChannel channel = addPausedChannel(true, true);
-    limiter.drainIncompleteFrame(1.0);
+    limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE);
     assertTrue(channel.isAutoRead());
 
     limiter.userEventTriggered(channel.ctx, TransportFrameDecoder.FrameDrainCompleted.INSTANCE);
@@ -214,7 +235,7 @@ public class ChannelsLimiterSuiteJ {
       throws Exception {
     limiter.onPause(TransportModuleConstants.PUSH_MODULE);
     FakeChannel channel = addPausedChannel(true, true);
-    limiter.drainIncompleteFrame(1.0);
+    limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE);
     assertTrue(channel.isAutoRead());
 
     // Backpressure is lifted globally while the frame-drain read was in flight.
@@ -238,6 +259,39 @@ public class ChannelsLimiterSuiteJ {
     assertFalse(channel.isAutoRead());
   }
 
+  @Test
+  public void pushModuleRanksCandidatesByTotalSizeNotFrameSize() throws Exception {
+    limiter.onPause(TransportModuleConstants.PUSH_MODULE);
+    FakeChannel largeTotalSizeOnly = addPausedChannel(true, true, false);
+
+    int resumed = limiter.drainIncompleteFrame(1.0, TransportModuleConstants.PUSH_MODULE);
+
+    assertEquals(1, resumed);
+    assertTrue(largeTotalSizeOnly.isAutoRead());
+  }
+
+  @Test
+  public void replicateModuleRanksCandidatesByFrameSizeNotTotalSize() throws Exception {
+    ChannelsLimiter replicateLimiter =
+        new ChannelsLimiter(TransportModuleConstants.REPLICATE_MODULE, new CelebornConf());
+    replicateLimiter.onPause(TransportModuleConstants.REPLICATE_MODULE);
+
+    FakeChannel largeFrameSizeOnly = new FakeChannel(true, false, true);
+    replicateLimiter.handlerAdded(largeFrameSizeOnly.ctx);
+    largeFrameSizeOnly.setAutoRead(false);
+
+    FakeChannel largeTotalSizeOnly = new FakeChannel(true, true, false);
+    replicateLimiter.handlerAdded(largeTotalSizeOnly.ctx);
+    largeTotalSizeOnly.setAutoRead(false);
+
+    int resumed =
+        replicateLimiter.drainIncompleteFrame(1.0, TransportModuleConstants.REPLICATE_MODULE);
+
+    assertEquals(1, resumed);
+    assertTrue(largeFrameSizeOnly.isAutoRead());
+    assertFalse(largeTotalSizeOnly.isAutoRead());
+  }
+
   /**
    * A minimal fake {@link Channel} wired up with a real {@link TransportFrameDecoder} in its
    * pipeline, and an autoRead flag backed by a plain boolean so that ChannelsLimiter's read/write
@@ -252,8 +306,15 @@ public class ChannelsLimiterSuiteJ {
     final TestableFrameDecoder decoder;
     boolean active = true;
 
-    FakeChannel(boolean hasIncompleteFrame, boolean hasLikelyLargeIncompleteFrame) {
-      decoder = new TestableFrameDecoder(hasIncompleteFrame, hasLikelyLargeIncompleteFrame);
+    FakeChannel(
+        boolean hasIncompleteFrame,
+        boolean hasLikelyLargeIncompleteTotalSize,
+        boolean hasLikelyLargeIncompleteFrameSize) {
+      decoder =
+          new TestableFrameDecoder(
+              hasIncompleteFrame,
+              hasLikelyLargeIncompleteTotalSize,
+              hasLikelyLargeIncompleteFrameSize);
       when(channel.config()).thenReturn(config);
       when(channel.pipeline()).thenReturn(pipeline);
       when(channel.isActive()).thenAnswer(inv -> active);
@@ -280,22 +341,28 @@ public class ChannelsLimiterSuiteJ {
   /** Exposes frameDrain state for assertions without changing TransportFrameDecoder's API. */
   private static class TestableFrameDecoder extends TransportFrameDecoder {
     private boolean incomplete;
-    private boolean likelyLargeIncomplete;
+    private boolean likelyLargeIncompleteTotalSize;
+    private boolean likelyLargeIncompleteFrameSize;
 
-    TestableFrameDecoder(boolean incomplete, boolean likelyLargeIncomplete) {
+    TestableFrameDecoder(
+        boolean incomplete,
+        boolean likelyLargeIncompleteTotalSize,
+        boolean likelyLargeIncompleteFrameSize) {
       this.incomplete = incomplete;
-      this.likelyLargeIncomplete = likelyLargeIncomplete;
+      this.likelyLargeIncompleteTotalSize = likelyLargeIncompleteTotalSize;
+      this.likelyLargeIncompleteFrameSize = likelyLargeIncompleteFrameSize;
     }
 
     @Override
-    public boolean hasLikelyLargeIncompleteFrame() {
-      return likelyLargeIncomplete;
+    public boolean hasLikelyLargeIncompleteFrame(boolean byFrameSize) {
+      return byFrameSize ? likelyLargeIncompleteFrameSize : likelyLargeIncompleteTotalSize;
     }
 
     /** Simulates the channel's stuck half-frame being fully consumed after being probed. */
     void clearIncompleteFrame() {
       incomplete = false;
-      likelyLargeIncomplete = false;
+      likelyLargeIncompleteTotalSize = false;
+      likelyLargeIncompleteFrameSize = false;
     }
 
     boolean frameDrainEnabled() {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -473,11 +473,13 @@ class MemoryManagerSuite extends CelebornFunSuite {
   }
 
   /**
-   * Records every drainIncompleteFrame invocation (and the ratio it was called with) for assertions.
+   * Records every drainIncompleteFrame invocation (module name and ratio) for assertions.
    */
   class RecordingDrainListener extends MemoryPressureListener {
     val ratios: scala.collection.mutable.ArrayBuffer[Double] =
       scala.collection.mutable.ArrayBuffer[Double]()
+    val moduleNames: scala.collection.mutable.ArrayBuffer[String] =
+      scala.collection.mutable.ArrayBuffer[String]()
 
     override def onPause(moduleName: String): Unit = {}
 
@@ -485,8 +487,9 @@ class MemoryManagerSuite extends CelebornFunSuite {
 
     override def onTrim(): Unit = {}
 
-    override def drainIncompleteFrame(ratio: Double): Int = {
+    override def drainIncompleteFrame(ratio: Double, moduleName: String): Int = {
       ratios += ratio
+      moduleNames += moduleName
       0
     }
   }
@@ -576,7 +579,8 @@ class MemoryManagerSuite extends CelebornFunSuite {
     MemoryManager.reset()
   }
 
-  test("[Trickle Resume] pending replicate bytes count towards app-layer usage and block arming") {
+  test("[Trickle Resume] pending replicate bytes above watermark blocks PUSH_MODULE but not " +
+    "REPLICATE_MODULE, since it doesn't reflect this worker's own memory footprint") {
     val conf = new CelebornConf()
     conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
     conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
@@ -591,24 +595,21 @@ class MemoryManagerSuite extends CelebornFunSuite {
     memoryManager.registerMemoryListener(listener)
     Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
 
-    // Sort/disk-buffer/memory-file-storage counters are all zero (pipeline looks drained), but
-    // the replicate client's outbound buffer is still backed up behind an unresponsive peer:
-    // app-layer usage must reflect that and stay above the watermark, so draining never arms.
+    // Pending replicate bytes above watermark: PUSH_MODULE stays blocked, REPLICATE_MODULE arms.
     memoryManager.incrementPendingReplicateBytes(watermarkBytes + 1)
     memoryManager.switchServingState()
     assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
-    assert(listener.ratios.isEmpty)
+    assert(!listener.moduleNames.contains(TransportModuleConstants.PUSH_MODULE))
+    assert(listener.moduleNames.contains(TransportModuleConstants.REPLICATE_MODULE))
 
-    // Once the peer connection drains (outbound buffer empties), app-layer usage drops below the
-    // watermark and draining can arm normally.
     memoryManager.releasePendingReplicateBytes(watermarkBytes + 1)
     memoryManager.switchServingState()
-    assert(listener.ratios.nonEmpty)
+    assert(listener.moduleNames.contains(TransportModuleConstants.PUSH_MODULE))
     MemoryManager.reset()
   }
 
-  test("[Trickle Resume] pending replicate bytes above watermark blocks arming; " +
-    "dropping below lets multiple listeners be trickled") {
+  test("[Trickle Resume] local footprint above watermark blocks REPLICATE_MODULE regardless of " +
+    "pending replicate bytes") {
     val conf = new CelebornConf()
     conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
     conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
@@ -619,24 +620,19 @@ class MemoryManagerSuite extends CelebornFunSuite {
     val pushThreshold =
       (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
     val watermarkBytes = (0.05 * memoryManager.maxDirectMemory).longValue()
-    val pushListener = new RecordingDrainListener
-    val replicateListener = new RecordingDrainListener
-    memoryManager.registerMemoryListener(pushListener)
-    memoryManager.registerMemoryListener(replicateListener)
+    val listener = new RecordingDrainListener
+    memoryManager.registerMemoryListener(listener)
     Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
 
-    // Pending replicate bytes above the watermark: no listener arms.
-    memoryManager.incrementPendingReplicateBytes(watermarkBytes + 1)
+    // Local footprint above watermark blocks REPLICATE_MODULE too.
+    memoryManager.incrementDiskBuffer(watermarkBytes.intValue() + 1)
     memoryManager.switchServingState()
     assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
-    assert(pushListener.ratios.isEmpty)
-    assert(replicateListener.ratios.isEmpty)
+    assert(listener.moduleNames.isEmpty)
 
-    // Once pending bytes drop to/below the watermark, draining arms and fires for every listener.
-    memoryManager.releasePendingReplicateBytes(watermarkBytes + 1)
+    memoryManager.releaseDiskBuffer(watermarkBytes.intValue() + 1)
     memoryManager.switchServingState()
-    assert(pushListener.ratios.nonEmpty)
-    assert(replicateListener.ratios.nonEmpty)
+    assert(listener.moduleNames.contains(TransportModuleConstants.REPLICATE_MODULE))
     MemoryManager.reset()
   }
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.celeborn.service.deploy.memory
 
-import java.util.concurrent.TimeUnit
-
 import scala.concurrent.duration.DurationInt
 
 import org.mockito.{Mockito, MockitoSugar}
@@ -472,6 +470,209 @@ class MemoryManagerSuite extends CelebornFunSuite {
     override def onTrim(): Unit = {
       // do nothing
     }
+  }
+
+  /**
+   * Records every drainIncompleteFrame invocation (and the ratio it was called with) for assertions.
+   */
+  class RecordingDrainListener extends MemoryPressureListener {
+    val ratios: scala.collection.mutable.ArrayBuffer[Double] =
+      scala.collection.mutable.ArrayBuffer[Double]()
+
+    override def onPause(moduleName: String): Unit = {}
+
+    override def onResume(moduleName: String): Unit = {}
+
+    override def onTrim(): Unit = {}
+
+    override def drainIncompleteFrame(ratio: Double): Int = {
+      ratios += ratio
+      0
+    }
+  }
+
+  test("[Trickle Resume] does not trigger trickle when disabled") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL.key, "0")
+    MemoryManager.reset()
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
+    val listener = new RecordingDrainListener()
+    memoryManager.registerMemoryListener(listener)
+
+    // Memory stuck in Netty (not tracked by app-layer counters) is exactly what draining
+    // targets, but must stay off entirely when disabled.
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+
+    assert(listener.ratios.isEmpty)
+    MemoryManager.reset()
+  }
+
+  test("[Trickle Resume] does not arm until app-layer usage drops to/below the watermark") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL.key, "0")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_WATERMARK_RATIO.key, "0.05")
+    MemoryManager.reset()
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
+    // Above the watermark: draining must not arm.
+    val aboveWatermarkBytes = (0.08 * memoryManager.maxDirectMemory).longValue()
+    val listener = new RecordingDrainListener()
+    memoryManager.registerMemoryListener(listener)
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+
+    memoryManager.incrementDiskBuffer(aboveWatermarkBytes.intValue())
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+    assert(listener.ratios.isEmpty)
+
+    // Repeated checks above the watermark still must not probe.
+    memoryManager.switchServingState()
+    assert(listener.ratios.isEmpty)
+    MemoryManager.reset()
+  }
+
+  test("[Trickle Resume] arms at/below watermark, disarms above it, with fixed ratio") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL.key, "0")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_WATERMARK_RATIO.key, "0.05")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_RATIO.key, "0.02")
+    MemoryManager.reset()
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
+    val watermarkBytes = (0.05 * memoryManager.maxDirectMemory).longValue()
+    val listener = new RecordingDrainListener()
+    memoryManager.registerMemoryListener(listener)
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+
+    // App-layer usage at/below the watermark: draining arms and fires at fixed ratio.
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+    assert(listener.ratios.nonEmpty)
+    assert(listener.ratios.last == 0.02) // 2%
+
+    // App-layer usage above the watermark: draining disarms.
+    memoryManager.incrementDiskBuffer(watermarkBytes.intValue() + 1)
+    val firedBeforeDisarm = listener.ratios.size
+    memoryManager.switchServingState()
+    assert(listener.ratios.size == firedBeforeDisarm)
+
+    // Drop back to/below the watermark: re-arms and probes again.
+    memoryManager.releaseDiskBuffer(watermarkBytes.intValue() + 1)
+    memoryManager.switchServingState()
+    assert(listener.ratios.size > firedBeforeDisarm)
+    assert(listener.ratios.last == 0.02)
+    MemoryManager.reset()
+  }
+
+  test("[Trickle Resume] pending replicate bytes count towards app-layer usage and block arming") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL.key, "0")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_WATERMARK_RATIO.key, "0.05")
+    MemoryManager.reset()
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
+    val watermarkBytes = (0.05 * memoryManager.maxDirectMemory).longValue()
+    val listener = new RecordingDrainListener
+    memoryManager.registerMemoryListener(listener)
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+
+    // Sort/disk-buffer/memory-file-storage counters are all zero (pipeline looks drained), but
+    // the replicate client's outbound buffer is still backed up behind an unresponsive peer:
+    // app-layer usage must reflect that and stay above the watermark, so draining never arms.
+    memoryManager.incrementPendingReplicateBytes(watermarkBytes + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+    assert(listener.ratios.isEmpty)
+
+    // Once the peer connection drains (outbound buffer empties), app-layer usage drops below the
+    // watermark and draining can arm normally.
+    memoryManager.releasePendingReplicateBytes(watermarkBytes + 1)
+    memoryManager.switchServingState()
+    assert(listener.ratios.nonEmpty)
+    MemoryManager.reset()
+  }
+
+  test("[Trickle Resume] pending replicate bytes above watermark blocks arming; " +
+    "dropping below lets multiple listeners be trickled") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL.key, "0")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_WATERMARK_RATIO.key, "0.05")
+    MemoryManager.reset()
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
+    val watermarkBytes = (0.05 * memoryManager.maxDirectMemory).longValue()
+    val pushListener = new RecordingDrainListener
+    val replicateListener = new RecordingDrainListener
+    memoryManager.registerMemoryListener(pushListener)
+    memoryManager.registerMemoryListener(replicateListener)
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+
+    // Pending replicate bytes above the watermark: no listener arms.
+    memoryManager.incrementPendingReplicateBytes(watermarkBytes + 1)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.PUSH_PAUSED)
+    assert(pushListener.ratios.isEmpty)
+    assert(replicateListener.ratios.isEmpty)
+
+    // Once pending bytes drop to/below the watermark, draining arms and fires for every listener.
+    memoryManager.releasePendingReplicateBytes(watermarkBytes + 1)
+    memoryManager.switchServingState()
+    assert(pushListener.ratios.nonEmpty)
+    assert(replicateListener.ratios.nonEmpty)
+    MemoryManager.reset()
+  }
+
+  test("[Trickle Resume] resets tick bookkeeping once backpressure episode ends") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.WORKER_PINNED_MEMORY_CHECK_ENABLED.key, "false")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_ENABLED.key, "true")
+    conf.set(CelebornConf.WORKER_DRAIN_INCOMPLETE_FRAME_INTERVAL.key, "10000")
+    MemoryManager.reset()
+    val memoryManager = MockitoSugar.spy(MemoryManager.initialize(conf))
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * memoryManager.maxDirectMemory).longValue()
+    val listener = new RecordingDrainListener()
+    memoryManager.registerMemoryListener(listener)
+
+    // Enter backpressure at the low watermark: arms and drains immediately (first tick is
+    // never throttled).
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+    memoryManager.switchServingState()
+    assert(listener.ratios.nonEmpty)
+    val firedBeforeResume = listener.ratios.size
+
+    // Checking again immediately is throttled by the (long) drainIncompleteFrame interval.
+    memoryManager.switchServingState()
+    assert(listener.ratios.size == firedBeforeResume)
+
+    // Lift backpressure entirely: resets tick bookkeeping.
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(0L)
+    memoryManager.switchServingState()
+    assert(memoryManager.servingState == ServingState.NONE_PAUSED)
+
+    // A fresh episode re-arms and probes immediately, unthrottled by the old interval.
+    Mockito.when(memoryManager.getNettyUsedDirectMemory).thenReturn(pushThreshold + 1)
+    memoryManager.switchServingState()
+    assert(listener.ratios.size > firedBeforeResume)
+    MemoryManager.reset()
   }
 
 }


### PR DESCRIPTION
<!--

Thanks for sending a pull request!  Here are some tips for you:

  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.

  - Be sure to keep the PR description updated to reflect all changes.

  - Please write your PR title to summarize what this PR proposes.

  - If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Introduce a `drainIncompleteFrame` mechanism to `MemoryManager` / `ChannelsLimiter` /
`TransportFrameDecoder` that lets a worker recover from a backpressure deadlock caused
by stuck half-frames in Netty's pipeline:

- `TransportFrameDecoder#hasLikelyLargeIncompleteFrame()` heuristically detects
  channels stuck with a large (> 64KB) buffered-but-undecoded frame.
- `TransportFrameDecoder#enableFrameDrain()` puts a channel into single-frame "drain"
  mode: once exactly one frame is decoded, it fires `FrameDrainCompleted` so the
  channel can be re-paused immediately without resuming full traffic.
- `MemoryManager#checkAndTriggerDrainIncompleteFrame()` periodically checks, while
  backpressure is active, whether application-layer active memory (sort memory + disk
  buffer + memory file storage + pending replicate bytes) is at/below a configurable
  watermark, and if so triggers a drain tick at a configurable interval.
- `ChannelsLimiter#drainIncompleteFrame(ratio)` scans paused channels for likely-stuck
  half-frames and resumes a configurable ratio of them in drain mode to release the
  stuck memory.

New configs added to `CelebornConf`:
- `celeborn.worker.monitor.drainIncompleteFrame.enabled` (default `true`)
- `celeborn.worker.monitor.drainIncompleteFrame.interval` (default `5ms`)
- `celeborn.worker.monitor.drainIncompleteFrame.ratio` (default `0.05`)
- `celeborn.worker.monitor.drainIncompleteFrame.watermark.ratio` (default `0.1`)

### Why are the changes needed?

Worker monitors direct memory usage and pauses reading from all business channels
(`autoRead=false`) once usage crosses a threshold, waiting for buffered data to be
consumed before resuming. However, if `autoRead=false` takes effect exactly when a
channel is mid-way through an incomplete frame, the buffered bytes stay stuck inside
`TransportFrameDecoder` — never dispatched, never released, and invisible to every
application-layer memory counter. This can produce a deadlock: application-layer
counters report near-zero usage while the underlying direct memory doesn't drop below
the resume threshold, because it's still holding onto these stuck half-frames — and
since reads stay globally paused, the stuck half-frame never receives the remaining
bytes needed to complete decoding. The worker becomes stuck and requires a manual
restart to recover.

This is not a rare corner case in practice: with the common frame size around a few
hundred KB (e.g. `celeborn.client.push.buffer.max.size=256KB`) and Netty's
`AdaptiveRecvByteBufAllocator` capping a single `channelRead` at ~64KB in steady state,
a frame typically needs 4~5 reads to complete, making a stuck half-frame at the moment
of pause fairly likely under sustained high throughput.

This issue was first discovered in production: some workers got stuck in backpressure
and never recovered even though application-layer memory counters had dropped to near
zero. Using Arthas thread/stack inspection together with internal memory metrics, we
confirmed the stuck memory was sitting inside the Netty pipeline (`TransportFrameDecoder`)
rather than any application-layer counter, matching the root cause above.

See [CELEBORN-2441](https://issues.apache.org/jira/browse/CELEBORN-2441) for more details.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [x] Yes

New configs are added under `celeborn.worker.monitor.drainIncompleteFrame.*`
(documented in `docs/configuration/worker.md`), all with safe defaults; behavior is
unchanged from prior versions when `celeborn.worker.monitor.drainIncompleteFrame.enabled=false`.

### How was this patch tested?

- Added unit tests:
  - `TransportFrameDecoderSuiteJ` covers `hasLikelyLargeIncompleteFrame()` and frame
    drain behavior.
  - `ChannelsLimiterSuiteJ` covers candidate selection and drain ratio behavior.
  - `MemoryManagerSuite` covers watermark-based triggering and pending replicate
    bytes accounting.
- Verified in production on a fleet of ~500 worker machines: after enabling
  `drainIncompleteFrame`, workers that previously got stuck in backpressure recovered
  automatically, with no observed CPU regression during normal operation.

  1. `celeborn.PausePushData.Delta` metric before/after rollout — a backpressure spike
     that used to stay stuck is now resolved within the same minute:

     
<img width="853" height="525" alt="image" src="https://github.com/user-attachments/assets/1fbfa269-0291-4770-9e92-05908854180f" />


  2. Worker log showing `drainIncompleteFrame` actively resuming stuck channels and
     the serving state transitioning back to `NONE_PAUSED` right after:
<img width="874" height="554" alt="3e3c6bdc-8619-439c-9e1b-3cb7ac927d79" src="https://github.com/user-attachments/assets/b5c2f165-4bd4-4a23-87af-ad323c07bb73" />

    

  3. `celeborn.PausePushDataTime.Delta` metric dropping back to `0` once
     `drainIncompleteFrame` takes effect, meaning the worker is no longer in
     backpressure for that minute:

    
<img width="1722" height="672" alt="image" src="https://github.com/user-attachments/assets/a73c34ce-bebf-4f50-a703-931925ef543b" />


