### PR TITLE
[CELEBORN-2442] Optimize meta memory for very large partitions

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -185,6 +185,13 @@ public abstract class CelebornInputStream extends InputStream {
       // Missing filter metadata cannot prove that this location is irrelevant.
       return false;
     }
+    if (startMapIndex >= endMapIndex) {
+      return true;
+    }
+    if (startMapIndex >= 0) {
+      return !bitmap.intersects((long) startMapIndex, (long) endMapIndex);
+    }
+    // Preserve the previous unsigned-int behavior for unexpected negative map indexes.
     for (int i = startMapIndex; i < endMapIndex; i++) {
       if (bitmap.contains(i)) {
         return false;

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -172,6 +172,27 @@ public abstract class CelebornInputStream extends InputStream {
 
   public abstract int partitionsRead();
 
+  static boolean shouldSkipLocation(
+      boolean rangeReadFilter, int startMapIndex, int endMapIndex, PartitionLocation location) {
+    if (!rangeReadFilter || endMapIndex == Integer.MAX_VALUE) {
+      return false;
+    }
+    RoaringBitmap bitmap = location.getMapIdBitMapIfPresent();
+    if (bitmap == null && location.hasPeer()) {
+      bitmap = location.getPeer().getMapIdBitMapIfPresent();
+    }
+    if (bitmap == null) {
+      // Missing filter metadata cannot prove that this location is irrelevant.
+      return false;
+    }
+    for (int i = startMapIndex; i < endMapIndex; i++) {
+      if (bitmap.contains(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private static final class CelebornInputStreamImpl extends CelebornInputStream {
     private static final Random RAND = new Random();
 
@@ -362,22 +383,8 @@ public abstract class CelebornInputStream extends InputStream {
     }
 
     private boolean skipLocation(int startMapIndex, int endMapIndex, PartitionLocation location) {
-      if (!rangeReadFilter) {
-        return false;
-      }
-      if (endMapIndex == Integer.MAX_VALUE) {
-        return false;
-      }
-      RoaringBitmap bitmap = location.getMapIdBitMap();
-      if (bitmap == null && location.hasPeer()) {
-        bitmap = location.getPeer().getMapIdBitMap();
-      }
-      for (int i = startMapIndex; i < endMapIndex; i++) {
-        if (bitmap.contains(i)) {
-          return false;
-        }
-      }
-      return true;
+      return CelebornInputStream.shouldSkipLocation(
+          rangeReadFilter, startMapIndex, endMapIndex, location);
     }
 
     private Tuple2<PartitionLocation, PbStreamHandler> nextReadableLocation() {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -36,7 +36,6 @@ import scala.util.Random
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.cache.{Cache, CacheBuilder}
-import org.roaringbitmap.RoaringBitmap
 
 import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers}
 import org.apache.celeborn.client.listener.WorkerStatusListener
@@ -1654,7 +1653,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       PartitionLocation.Mode.PRIMARY,
       null,
       new StorageInfo("", storageTypes.head, availableStorageTypes),
-      new RoaringBitmap())
+      null)
     if (pushReplicateEnabled) {
       var replicaIndex = (primaryIndex + 1) % candidates.size
       while (pushRackAwareEnabled && isOnSameRack(primaryIndex, replicaIndex)
@@ -1676,7 +1675,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         PartitionLocation.Mode.REPLICA,
         primaryLocation,
         new StorageInfo("", storageTypes.head, availableStorageTypes),
-        new RoaringBitmap())
+        null)
       primaryLocation.setPeer(replicaLocation)
       val primaryAndReplicaPairs = slots.computeIfAbsent(candidates(replicaIndex), newLocationFunc)
       primaryAndReplicaPairs._2.add(replicaLocation)

--- a/client/src/test/java/org/apache/celeborn/client/read/CelebornInputStreamPeerFailoverTest.java
+++ b/client/src/test/java/org/apache/celeborn/client/read/CelebornInputStreamPeerFailoverTest.java
@@ -311,6 +311,33 @@ public class CelebornInputStreamPeerFailoverTest {
     assertTrue(CelebornInputStream.shouldSkipLocation(true, 6, 10, primary));
   }
 
+  @Test
+  public void testRangeReadFilterUsesHalfOpenRange() {
+    PartitionLocation location = createPartitionLocation(PRIMARY_HOST);
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(5);
+    bitmap.add(10);
+    location.setMapIdBitMap(bitmap);
+
+    assertFalse(CelebornInputStream.shouldSkipLocation(true, 5, 10, location));
+    assertTrue(CelebornInputStream.shouldSkipLocation(true, 6, 10, location));
+  }
+
+  @Test
+  public void testRangeReadFilterHandlesEmptyAndSentinelRanges() {
+    PartitionLocation location = createPartitionLocation(PRIMARY_HOST);
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(5);
+    location.setMapIdBitMap(bitmap);
+
+    assertTrue(CelebornInputStream.shouldSkipLocation(true, 5, 5, location));
+    assertTrue(CelebornInputStream.shouldSkipLocation(true, 10, 5, location));
+    assertTrue(CelebornInputStream.shouldSkipLocation(true, -1, -1, location));
+
+    bitmap.add(-1);
+    assertFalse(CelebornInputStream.shouldSkipLocation(true, -1, 0, location));
+  }
+
   private CelebornInputStream createInputStream(String primaryHost, String replicaHost)
       throws IOException {
     return createInputStream(primaryHost, replicaHost, null);

--- a/client/src/test/java/org/apache/celeborn/client/read/CelebornInputStreamPeerFailoverTest.java
+++ b/client/src/test/java/org/apache/celeborn/client/read/CelebornInputStreamPeerFailoverTest.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.client.read;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -45,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.roaringbitmap.RoaringBitmap;
 
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.client.security.CryptoHandler;
@@ -283,6 +285,30 @@ public class CelebornInputStreamPeerFailoverTest {
         new TestMetricsCallback(),
         false,
         Optional.<CryptoHandler>empty());
+  }
+
+  @Test
+  public void testRangeReadFilterReadsLocationWhenBothBitmapsAreAbsent() {
+    PartitionLocation primary = createPartitionLocation(PRIMARY_HOST);
+    PartitionLocation replica = createPartitionLocation(REPLICA_HOST);
+    primary.setPeer(replica);
+    replica.setPeer(primary);
+
+    assertFalse(CelebornInputStream.shouldSkipLocation(true, 0, 10, primary));
+    assertFalse(CelebornInputStream.shouldSkipLocation(false, 0, 10, primary));
+  }
+
+  @Test
+  public void testRangeReadFilterUsesPeerBitmapWhenPrimaryBitmapIsAbsent() {
+    PartitionLocation primary = createPartitionLocation(PRIMARY_HOST);
+    PartitionLocation replica = createPartitionLocation(REPLICA_HOST);
+    RoaringBitmap peerBitmap = new RoaringBitmap();
+    peerBitmap.add(5);
+    replica.setMapIdBitMap(peerBitmap);
+    primary.setPeer(replica);
+
+    assertFalse(CelebornInputStream.shouldSkipLocation(true, 0, 10, primary));
+    assertTrue(CelebornInputStream.shouldSkipLocation(true, 6, 10, primary));
   }
 
   private CelebornInputStream createInputStream(String primaryHost, String replicaHost)

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -161,7 +161,6 @@
     <dependency>
       <groupId>org.openjdk.jol</groupId>
       <artifactId>jol-core</artifactId>
-      <version>0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -159,6 +159,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.jol</groupId>
+      <artifactId>jol-core</artifactId>
+      <version>0.17</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -29,7 +29,6 @@ import org.apache.celeborn.common.meta.WorkerInfo;
  */
 public class PartitionLocation implements Serializable {
   private static final RoaringBitmap EMPTY_MAP_ID_BITMAP = new RoaringBitmap();
-  private static final long INVALID_PARSED_INT = Long.MIN_VALUE;
 
   public enum Mode {
     PRIMARY(0),
@@ -229,39 +228,6 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
-  public long getUniqueIdLong() {
-    return toUniqueIdLong(id, epoch);
-  }
-
-  public static long toUniqueIdLong(int id, int epoch) {
-    return ((long) id << 32) | (epoch & 0xffffffffL);
-  }
-
-  public static long toUniqueIdLong(String uniqueId) {
-    Long packedUniqueId = tryToUniqueIdLong(uniqueId);
-    if (packedUniqueId == null) {
-      throw new IllegalArgumentException("Invalid partition location unique id: " + uniqueId);
-    }
-    return packedUniqueId;
-  }
-
-  public static Long tryToUniqueIdLong(String uniqueId) {
-    if (uniqueId == null || uniqueId.length() < 3) {
-      return null;
-    }
-    int idStart = uniqueId.charAt(0) == '-' ? 1 : 0;
-    int separatorIndex = uniqueId.indexOf('-', idStart);
-    if (separatorIndex < 0) {
-      return null;
-    }
-    long id = tryParseInt(uniqueId, 0, separatorIndex);
-    long epoch = tryParseInt(uniqueId, separatorIndex + 1, uniqueId.length());
-    if (id == INVALID_PARSED_INT || epoch == INVALID_PARSED_INT) {
-      return null;
-    }
-    return toUniqueIdLong((int) id, (int) epoch);
-  }
-
   /** @see PartitionLocation#getFileName */
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
@@ -399,31 +365,5 @@ public class PartitionLocation implements Serializable {
 
   public synchronized void setMapIdBitMap(RoaringBitmap mapIdBitMap) {
     this.mapIdBitMap = mapIdBitMap;
-  }
-
-  private static long tryParseInt(String value, int start, int end) {
-    if (start >= end) {
-      return INVALID_PARSED_INT;
-    }
-    boolean negative = value.charAt(start) == '-';
-    int index = negative ? start + 1 : start;
-    if (index >= end) {
-      return INVALID_PARSED_INT;
-    }
-    long result = 0;
-    long limit = negative ? -(long) Integer.MIN_VALUE : Integer.MAX_VALUE;
-    while (index < end) {
-      char current = value.charAt(index);
-      if (current < '0' || current > '9') {
-        return INVALID_PARSED_INT;
-      }
-      int digit = current - '0';
-      if (result > (limit - digit) / 10) {
-        return INVALID_PARSED_INT;
-      }
-      result = result * 10 + digit;
-      index++;
-    }
-    return negative ? -result : result;
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -23,7 +23,14 @@ import org.roaringbitmap.RoaringBitmap;
 
 import org.apache.celeborn.common.meta.WorkerInfo;
 
+/**
+ * Describes a partition location. Java serialization is retained for same-version internal use; its
+ * serialized form is not a cross-version compatibility contract.
+ */
 public class PartitionLocation implements Serializable {
+  private static final RoaringBitmap EMPTY_MAP_ID_BITMAP = new RoaringBitmap();
+  private static final long INVALID_PARSED_INT = Long.MIN_VALUE;
+
   public enum Mode {
     PRIMARY(0),
     REPLICA(1);
@@ -54,26 +61,16 @@ public class PartitionLocation implements Serializable {
 
   private int id;
   private int epoch;
-  private String host;
-  private int rpcPort;
-  private int pushPort;
-  private int fetchPort;
-  private int replicatePort;
+  private volatile WorkerEndpoint endpoint;
   private Mode mode;
   private PartitionLocation peer;
-  private StorageInfo storageInfo;
-  private RoaringBitmap mapIdBitMap;
-  private transient String _hostPushPort;
-  private transient String _hostFetchPort;
+  private volatile StorageInfo storageInfo;
+  private volatile RoaringBitmap mapIdBitMap;
 
   public PartitionLocation(PartitionLocation loc) {
     this.id = loc.id;
     this.epoch = loc.epoch;
-    this.host = loc.host;
-    this.rpcPort = loc.rpcPort;
-    this.pushPort = loc.pushPort;
-    this.fetchPort = loc.fetchPort;
-    this.replicatePort = loc.replicatePort;
+    this.endpoint = loc.endpoint;
     this.mode = loc.mode;
     this.peer = loc.peer;
     this.storageInfo = loc.storageInfo;
@@ -89,18 +86,7 @@ public class PartitionLocation implements Serializable {
       int fetchPort,
       int replicatePort,
       Mode mode) {
-    this(
-        id,
-        epoch,
-        host,
-        rpcPort,
-        pushPort,
-        fetchPort,
-        replicatePort,
-        mode,
-        null,
-        new StorageInfo(),
-        new RoaringBitmap());
+    this(id, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode, null, null, null);
   }
 
   public PartitionLocation(
@@ -113,18 +99,7 @@ public class PartitionLocation implements Serializable {
       int replicatePort,
       Mode mode,
       PartitionLocation peer) {
-    this(
-        id,
-        epoch,
-        host,
-        rpcPort,
-        pushPort,
-        fetchPort,
-        replicatePort,
-        mode,
-        peer,
-        new StorageInfo(),
-        new RoaringBitmap());
+    this(id, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode, peer, null, null);
   }
 
   public PartitionLocation(
@@ -141,13 +116,9 @@ public class PartitionLocation implements Serializable {
       RoaringBitmap mapIdBitMap) {
     this.id = id;
     this.epoch = epoch;
-    this.host = host;
-    this.rpcPort = rpcPort;
-    this.pushPort = pushPort;
-    this.fetchPort = fetchPort;
-    this.replicatePort = replicatePort;
+    this.endpoint = WorkerEndpoint.apply(host, rpcPort, pushPort, fetchPort, replicatePort);
     this.mode = mode;
-    this.peer = peer;
+    setPeer(peer);
     this.storageInfo = hint;
     this.mapIdBitMap = mapIdBitMap;
   }
@@ -169,54 +140,69 @@ public class PartitionLocation implements Serializable {
   }
 
   public String getHost() {
-    return host;
+    return endpoint.host();
   }
 
-  public void setHost(String host) {
-    this.host = host;
+  public synchronized void setHost(String host) {
+    WorkerEndpoint current = endpoint;
+    this.endpoint =
+        WorkerEndpoint.apply(
+            host,
+            current.rpcPort(),
+            current.pushPort(),
+            current.fetchPort(),
+            current.replicatePort());
   }
 
   public int getPushPort() {
-    return pushPort;
+    return endpoint.pushPort();
   }
 
-  public void setPushPort(int pushPort) {
-    this.pushPort = pushPort;
+  public synchronized void setPushPort(int pushPort) {
+    WorkerEndpoint current = endpoint;
+    this.endpoint =
+        WorkerEndpoint.apply(
+            current.host(),
+            current.rpcPort(),
+            pushPort,
+            current.fetchPort(),
+            current.replicatePort());
   }
 
   public int getFetchPort() {
-    return fetchPort;
+    return endpoint.fetchPort();
   }
 
-  public void setFetchPort(int fetchPort) {
-    this.fetchPort = fetchPort;
+  public synchronized void setFetchPort(int fetchPort) {
+    WorkerEndpoint current = endpoint;
+    this.endpoint =
+        WorkerEndpoint.apply(
+            current.host(),
+            current.rpcPort(),
+            current.pushPort(),
+            fetchPort,
+            current.replicatePort());
   }
 
   public String hostAndPorts() {
     return "host-rpcPort-pushPort-fetchPort-replicatePort:"
-        + host
+        + getHost()
         + "-"
-        + rpcPort
+        + getRpcPort()
         + "-"
-        + pushPort
+        + getPushPort()
         + "-"
-        + fetchPort
+        + getFetchPort()
         + "-"
-        + replicatePort;
+        + getReplicatePort();
   }
 
   public String hostAndFetchPort() {
-    if (_hostFetchPort == null) {
-      _hostFetchPort = host + ":" + fetchPort;
-    }
-    return _hostFetchPort;
+    return endpoint.hostAndFetchPort();
   }
 
   public String hostAndPushPort() {
-    if (_hostPushPort == null) {
-      _hostPushPort = host + ":" + pushPort;
-    }
-    return _hostPushPort;
+    return endpoint.hostAndPushPort();
   }
 
   public Mode getMode() {
@@ -243,32 +229,93 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
+  public long getUniqueIdLong() {
+    return toUniqueIdLong(id, epoch);
+  }
+
+  public static long toUniqueIdLong(int id, int epoch) {
+    return ((long) id << 32) | (epoch & 0xffffffffL);
+  }
+
+  public static long toUniqueIdLong(String uniqueId) {
+    Long packedUniqueId = tryToUniqueIdLong(uniqueId);
+    if (packedUniqueId == null) {
+      throw new IllegalArgumentException("Invalid partition location unique id: " + uniqueId);
+    }
+    return packedUniqueId;
+  }
+
+  public static Long tryToUniqueIdLong(String uniqueId) {
+    if (uniqueId == null || uniqueId.length() < 3) {
+      return null;
+    }
+    int idStart = uniqueId.charAt(0) == '-' ? 1 : 0;
+    int separatorIndex = uniqueId.indexOf('-', idStart);
+    if (separatorIndex < 0) {
+      return null;
+    }
+    long id = tryParseInt(uniqueId, 0, separatorIndex);
+    long epoch = tryParseInt(uniqueId, separatorIndex + 1, uniqueId.length());
+    if (id == INVALID_PARSED_INT || epoch == INVALID_PARSED_INT) {
+      return null;
+    }
+    return toUniqueIdLong((int) id, (int) epoch);
+  }
+
   /** @see PartitionLocation#getFileName */
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
   }
 
   public int getRpcPort() {
-    return rpcPort;
+    return endpoint.rpcPort();
   }
 
-  public void setRpcPort(int rpcPort) {
-    this.rpcPort = rpcPort;
+  public synchronized void setRpcPort(int rpcPort) {
+    WorkerEndpoint current = endpoint;
+    this.endpoint =
+        WorkerEndpoint.apply(
+            current.host(),
+            rpcPort,
+            current.pushPort(),
+            current.fetchPort(),
+            current.replicatePort());
   }
 
   public int getReplicatePort() {
-    return replicatePort;
+    return endpoint.replicatePort();
   }
 
-  public void setReplicatePort(int replicatePort) {
-    this.replicatePort = replicatePort;
+  public synchronized void setReplicatePort(int replicatePort) {
+    WorkerEndpoint current = endpoint;
+    this.endpoint =
+        WorkerEndpoint.apply(
+            current.host(),
+            current.rpcPort(),
+            current.pushPort(),
+            current.fetchPort(),
+            replicatePort);
   }
 
   public StorageInfo getStorageInfo() {
-    return storageInfo;
+    return getStorageInfoOrCreate();
   }
 
-  public void setStorageInfo(StorageInfo storageInfo) {
+  public StorageInfo getStorageInfoOrCreate() {
+    StorageInfo current = storageInfo;
+    if (current == null) {
+      synchronized (this) {
+        current = storageInfo;
+        if (current == null) {
+          current = new StorageInfo();
+          storageInfo = current;
+        }
+      }
+    }
+    return current;
+  }
+
+  public synchronized void setStorageInfo(StorageInfo storageInfo) {
     this.storageInfo = storageInfo;
   }
 
@@ -280,15 +327,15 @@ public class PartitionLocation implements Serializable {
     PartitionLocation o = (PartitionLocation) other;
     return id == o.id
         && epoch == o.epoch
-        && host.equals(o.host)
-        && rpcPort == o.rpcPort
-        && pushPort == o.pushPort
-        && fetchPort == o.fetchPort;
+        && getHost().equals(o.getHost())
+        && getRpcPort() == o.getRpcPort()
+        && getPushPort() == o.getPushPort()
+        && getFetchPort() == o.getFetchPort();
   }
 
   @Override
   public int hashCode() {
-    return (id + epoch + host + rpcPort + pushPort + fetchPort).hashCode();
+    return (id + epoch + getHost() + getRpcPort() + getPushPort() + getFetchPort()).hashCode();
   }
 
   @Override
@@ -303,15 +350,15 @@ public class PartitionLocation implements Serializable {
         + "-"
         + epoch
         + "\n  host-rpcPort-pushPort-fetchPort-replicatePort:"
-        + host
+        + getHost()
         + "-"
-        + rpcPort
+        + getRpcPort()
         + "-"
-        + pushPort
+        + getPushPort()
         + "-"
-        + fetchPort
+        + getFetchPort()
         + "-"
-        + replicatePort
+        + getReplicatePort()
         + "\n  mode:"
         + mode
         + "\n  peer:("
@@ -319,19 +366,64 @@ public class PartitionLocation implements Serializable {
         + ")\n  storage hint:"
         + storageInfo
         + "\n  mapIdBitMap:"
-        + mapIdBitMap
+        + (mapIdBitMap == null ? EMPTY_MAP_ID_BITMAP : mapIdBitMap)
         + "]";
   }
 
   public WorkerInfo getWorker() {
-    return new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort);
+    return new WorkerInfo(
+        getHost(), getRpcPort(), getPushPort(), getFetchPort(), getReplicatePort());
   }
 
   public RoaringBitmap getMapIdBitMap() {
+    return getMapIdBitMapOrCreate();
+  }
+
+  public RoaringBitmap getMapIdBitMapIfPresent() {
     return mapIdBitMap;
   }
 
-  public void setMapIdBitMap(RoaringBitmap mapIdBitMap) {
+  public RoaringBitmap getMapIdBitMapOrCreate() {
+    RoaringBitmap current = mapIdBitMap;
+    if (current == null) {
+      synchronized (this) {
+        current = mapIdBitMap;
+        if (current == null) {
+          current = new RoaringBitmap();
+          mapIdBitMap = current;
+        }
+      }
+    }
+    return current;
+  }
+
+  public synchronized void setMapIdBitMap(RoaringBitmap mapIdBitMap) {
     this.mapIdBitMap = mapIdBitMap;
+  }
+
+  private static long tryParseInt(String value, int start, int end) {
+    if (start >= end) {
+      return INVALID_PARSED_INT;
+    }
+    boolean negative = value.charAt(start) == '-';
+    int index = negative ? start + 1 : start;
+    if (index >= end) {
+      return INVALID_PARSED_INT;
+    }
+    long result = 0;
+    long limit = negative ? -(long) Integer.MIN_VALUE : Integer.MAX_VALUE;
+    while (index < end) {
+      char current = value.charAt(index);
+      if (current < '0' || current > '9') {
+        return INVALID_PARSED_INT;
+      }
+      int digit = current - '0';
+      if (result > (limit - digit) / 10) {
+        return INVALID_PARSED_INT;
+      }
+      result = result * 10 + digit;
+      index++;
+    }
+    return negative ? -result : result;
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/WorkerEndpoint.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/WorkerEndpoint.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.protocol;
+
+import java.io.Serializable;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+
+/**
+ * Immutable and weakly interned worker endpoint shared by partition locations. Java serialization
+ * is retained for same-version internal use; its serialized form is not a cross-version
+ * compatibility contract.
+ */
+public final class WorkerEndpoint implements Serializable {
+  private static final Interner<WorkerEndpoint> INTERNED_ENDPOINTS = Interners.newWeakInterner();
+
+  private final String host;
+  private final int rpcPort;
+  private final int pushPort;
+  private final int fetchPort;
+  private final int replicatePort;
+  private transient volatile String hostPushPort;
+  private transient volatile String hostFetchPort;
+
+  private WorkerEndpoint(String host, int rpcPort, int pushPort, int fetchPort, int replicatePort) {
+    this.host = host;
+    this.rpcPort = rpcPort;
+    this.pushPort = pushPort;
+    this.fetchPort = fetchPort;
+    this.replicatePort = replicatePort;
+  }
+
+  public static WorkerEndpoint apply(
+      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort) {
+    WorkerEndpoint endpoint = new WorkerEndpoint(host, rpcPort, pushPort, fetchPort, replicatePort);
+    return INTERNED_ENDPOINTS.intern(endpoint);
+  }
+
+  public String host() {
+    return host;
+  }
+
+  public int rpcPort() {
+    return rpcPort;
+  }
+
+  public int pushPort() {
+    return pushPort;
+  }
+
+  public int fetchPort() {
+    return fetchPort;
+  }
+
+  public int replicatePort() {
+    return replicatePort;
+  }
+
+  public String hostAndPushPort() {
+    String current = hostPushPort;
+    if (current == null) {
+      current = host + ":" + pushPort;
+      hostPushPort = current;
+    }
+    return current;
+  }
+
+  public String hostAndFetchPort() {
+    String current = hostFetchPort;
+    if (current == null) {
+      current = host + ":" + fetchPort;
+      hostFetchPort = current;
+    }
+    return current;
+  }
+
+  private Object readResolve() {
+    return apply(host, rpcPort, pushPort, fetchPort, replicatePort);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof WorkerEndpoint)) {
+      return false;
+    }
+    WorkerEndpoint that = (WorkerEndpoint) other;
+    return rpcPort == that.rpcPort
+        && pushPort == that.pushPort
+        && fetchPort == that.fetchPort
+        && replicatePort == that.replicatePort
+        && host.equals(that.host);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = host.hashCode();
+    result = 31 * result + rpcPort;
+    result = 31 * result + pushPort;
+    result = 31 * result + fetchPort;
+    result = 31 * result + replicatePort;
+    return result;
+  }
+}

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
@@ -29,7 +29,7 @@ import org.apache.celeborn.common.util.{CollectionUtils, JavaUtils}
 
 class WorkerPartitionLocationInfo extends Logging {
 
-  // key: ShuffleKey, values: (uniqueId -> PartitionLocation))
+  // key: ShuffleKey, values: (uniqueId -> PartitionLocation)
   type PartitionInfo = ConcurrentHashMap[String, ConcurrentHashMap[String, PartitionLocation]]
   private[celeborn] val primaryPartitionLocations = new PartitionInfo
   private[celeborn] val replicaPartitionLocations = new PartitionInfo

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -382,7 +382,7 @@ object PbSerDeUtils {
       .setFetchPort(location.getFetchPort)
       .setReplicatePort(location.getReplicatePort)
       .setStorageInfo(StorageInfo.toPb(location.getStorageInfo))
-      .setMapIdBitmap(Utils.roaringBitmapToByteString(location.getMapIdBitMap))
+      .setMapIdBitmap(Utils.roaringBitmapToByteString(location.getMapIdBitMapIfPresent))
     if (location.hasPeer) {
       val peerBuilder = PbPartitionLocation.newBuilder
       if (location.getPeer.getMode eq Mode.PRIMARY) {
@@ -399,7 +399,7 @@ object PbSerDeUtils {
         .setFetchPort(location.getPeer.getFetchPort)
         .setReplicatePort(location.getPeer.getReplicatePort)
         .setStorageInfo(StorageInfo.toPb(location.getPeer.getStorageInfo))
-        .setMapIdBitmap(Utils.roaringBitmapToByteString(location.getMapIdBitMap))
+        .setMapIdBitmap(Utils.roaringBitmapToByteString(location.getPeer.getMapIdBitMapIfPresent))
       builder.setPeer(peerBuilder.build)
     }
     builder.build
@@ -562,7 +562,7 @@ object PbSerDeUtils {
     pbPackedLocationsBuilder.addEpoches(location.getEpoch)
     pbPackedLocationsBuilder.addWorkerIds(workerIdIndex(location.getWorker.toUniqueId))
     pbPackedLocationsBuilder.addMapIdBitMap(
-      Utils.roaringBitmapToByteString(location.getMapIdBitMap))
+      Utils.roaringBitmapToByteString(location.getMapIdBitMapIfPresent))
     pbPackedLocationsBuilder.addTypes(location.getStorageInfo.getType.getValue)
     pbPackedLocationsBuilder.addMountPoints(
       mountPointsIndex(location.getStorageInfo.getMountPoint))

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationMemorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationMemorySuiteJ.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.protocol;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("Manual JOL benchmark; run main to print retained-size comparisons.")
+public class PartitionLocationMemorySuiteJ {
+
+  private static final int ENDPOINT_COUNT = 2000;
+
+  public static void main(String[] args) throws Exception {
+    int pairCount = args.length > 0 && "largePeer".equals(args[0]) ? 1_000_000 : 10_000;
+    new PartitionLocationMemorySuiteJ().printPeerPairFootprint(pairCount, ENDPOINT_COUNT);
+  }
+
+  @Test
+  public void printPartitionLocationFootprint() throws Exception {
+    printPeerPairFootprint(10_000, ENDPOINT_COUNT);
+  }
+
+  private void printPeerPairFootprint(int pairCount, int endpointCount) throws Exception {
+    compare(
+        loadGraphLayout(),
+        pairCount + " partition peer pairs across " + endpointCount + " endpoints",
+        newOldLocationPairArray(pairCount, endpointCount),
+        newLocationPairArray(pairCount, endpointCount));
+  }
+
+  private PartitionLocation[] newLocationPairArray(int size, int endpointCount) {
+    PartitionLocation[] locations = new PartitionLocation[size * 2];
+    for (int i = 0; i < size; i++) {
+      int endpointIndex = i % endpointCount;
+      PartitionLocation primary = newLocation(i, endpointIndex, PartitionLocation.Mode.PRIMARY);
+      PartitionLocation replica = newLocation(i, endpointIndex, PartitionLocation.Mode.REPLICA);
+      primary.setPeer(replica);
+      replica.setPeer(primary);
+      locations[i * 2] = primary;
+      locations[i * 2 + 1] = replica;
+    }
+    return locations;
+  }
+
+  private PartitionLocation newLocation(int id, int endpointIndex, PartitionLocation.Mode mode) {
+    return new PartitionLocation(
+        id,
+        0,
+        "localhost-" + endpointIndex,
+        1001 + endpointIndex,
+        1002 + endpointIndex,
+        1003 + endpointIndex,
+        1004 + endpointIndex,
+        mode);
+  }
+
+  private PartitionLocationOld[] newOldLocationPairArray(int size, int endpointCount) {
+    PartitionLocationOld[] locations = new PartitionLocationOld[size * 2];
+    for (int i = 0; i < size; i++) {
+      int endpointIndex = i % endpointCount;
+      PartitionLocationOld primary =
+          newOldLocation(i, endpointIndex, PartitionLocation.Mode.PRIMARY);
+      PartitionLocationOld replica =
+          newOldLocation(i, endpointIndex, PartitionLocation.Mode.REPLICA);
+      primary.setPeer(replica);
+      replica.setPeer(primary);
+      locations[i * 2] = primary;
+      locations[i * 2 + 1] = replica;
+    }
+    return locations;
+  }
+
+  private PartitionLocationOld newOldLocation(
+      int id, int endpointIndex, PartitionLocation.Mode mode) {
+    return new PartitionLocationOld(
+        id,
+        0,
+        "localhost-" + endpointIndex,
+        1001 + endpointIndex,
+        1002 + endpointIndex,
+        1003 + endpointIndex,
+        1004 + endpointIndex,
+        mode);
+  }
+
+  private Class<?> loadGraphLayout() throws ClassNotFoundException {
+    return Class.forName("org.openjdk.jol.info.GraphLayout");
+  }
+
+  private void compare(Class<?> graphLayout, String label, Object oldValue, Object newValue)
+      throws Exception {
+    long oldSize = totalSize(graphLayout, oldValue);
+    long newLocationSize = totalSize(graphLayout, newValue);
+    long newSizeIncludingInterner = totalSize(graphLayout, newValue, endpointInterner());
+    long internerOverhead = newSizeIncludingInterner - newLocationSize;
+    long saved = oldSize - newSizeIncludingInterner;
+    double savedPercentage = oldSize == 0 ? 0 : saved * 100.0 / oldSize;
+    System.out.printf(
+        "PartitionLocation footprint [%s]: old=%d bytes, "
+            + "newLocations=%d bytes, weakInternerOverhead=%d bytes, "
+            + "newIncludingLiveInterner=%d bytes, savedIncludingLiveInterner=%d bytes (%.2f%%)%n",
+        label,
+        oldSize,
+        newLocationSize,
+        internerOverhead,
+        newSizeIncludingInterner,
+        saved,
+        savedPercentage);
+    if (newSizeIncludingInterner >= oldSize) {
+      throw new AssertionError(
+          "Optimized PartitionLocation retained size including its weak interner must be smaller for "
+              + label);
+    }
+  }
+
+  private long totalSize(Class<?> graphLayout, Object value) throws Exception {
+    return totalSize(graphLayout, value, null);
+  }
+
+  private long totalSize(Class<?> graphLayout, Object value, Object additionalRoot)
+      throws Exception {
+    Method parseInstance = graphLayout.getMethod("parseInstance", Object[].class);
+    Object[] roots =
+        additionalRoot == null ? new Object[] {value} : new Object[] {value, additionalRoot};
+    Object layout = parseInstance.invoke(null, new Object[] {roots});
+    return (Long) graphLayout.getMethod("totalSize").invoke(layout);
+  }
+
+  private Object endpointInterner() throws Exception {
+    Field field = WorkerEndpoint.class.getDeclaredField("INTERNED_ENDPOINTS");
+    field.setAccessible(true);
+    return field.get(null);
+  }
+}

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationMemorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationMemorySuiteJ.java
@@ -18,40 +18,77 @@
 package org.apache.celeborn.common.protocol;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.openjdk.jol.info.GraphLayout;
+import org.roaringbitmap.RoaringBitmap;
 
 @Ignore("Manual JOL benchmark; run main to print retained-size comparisons.")
 public class PartitionLocationMemorySuiteJ {
 
   private static final int ENDPOINT_COUNT = 2000;
+  private static final int DEFAULT_PAIR_COUNT = 10_000;
+  private static final String ALLOCATOR_SCENARIO = "allocator";
+  private static final String PACKED_DESERIALIZED_PAIR_SCENARIO = "packed-deserialized-pair";
 
   public static void main(String[] args) throws Exception {
-    int pairCount = args.length > 0 && "largePeer".equals(args[0]) ? 1_000_000 : 10_000;
-    new PartitionLocationMemorySuiteJ().printPeerPairFootprint(pairCount, ENDPOINT_COUNT);
+    String scenario = args.length > 0 ? args[0] : ALLOCATOR_SCENARIO;
+    int pairCount = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_PAIR_COUNT;
+    if (pairCount <= 0) {
+      throw new IllegalArgumentException("pairCount must be positive: " + pairCount);
+    }
+    if (!ALLOCATOR_SCENARIO.equals(scenario)
+        && !PACKED_DESERIALIZED_PAIR_SCENARIO.equals(scenario)) {
+      throw new IllegalArgumentException(
+          "Unknown scenario: " + scenario + ". Expected allocator or packed-deserialized-pair.");
+    }
+    new PartitionLocationMemorySuiteJ().printPeerPairFootprint(scenario, pairCount, ENDPOINT_COUNT);
   }
 
   @Test
   public void printPartitionLocationFootprint() throws Exception {
-    printPeerPairFootprint(10_000, ENDPOINT_COUNT);
+    printPeerPairFootprint(ALLOCATOR_SCENARIO, DEFAULT_PAIR_COUNT, ENDPOINT_COUNT);
   }
 
-  private void printPeerPairFootprint(int pairCount, int endpointCount) throws Exception {
+  private void printPeerPairFootprint(String scenario, int pairCount, int endpointCount)
+      throws Exception {
+    String[] endpointHosts = endpointHosts(endpointCount);
+    boolean allocatorShaped = ALLOCATOR_SCENARIO.equals(scenario);
     compare(
-        loadGraphLayout(),
-        pairCount + " partition peer pairs across " + endpointCount + " endpoints",
-        newOldLocationPairArray(pairCount, endpointCount),
-        newLocationPairArray(pairCount, endpointCount));
+        scenario + "-shaped, " + pairCount + " peer pairs across " + endpointCount + " endpoints",
+        newOldLocationPairArray(pairCount, endpointHosts, allocatorShaped),
+        newLocationPairArray(pairCount, endpointHosts, allocatorShaped));
   }
 
-  private PartitionLocation[] newLocationPairArray(int size, int endpointCount) {
+  private String[] endpointHosts(int endpointCount) {
+    String[] hosts = new String[endpointCount];
+    for (int i = 0; i < endpointCount; i++) {
+      hosts[i] = "localhost-" + i;
+    }
+    return hosts;
+  }
+
+  private PartitionLocation[] newLocationPairArray(
+      int size, String[] endpointHosts, boolean allocatorShaped) {
     PartitionLocation[] locations = new PartitionLocation[size * 2];
     for (int i = 0; i < size; i++) {
-      int endpointIndex = i % endpointCount;
-      PartitionLocation primary = newLocation(i, endpointIndex, PartitionLocation.Mode.PRIMARY);
-      PartitionLocation replica = newLocation(i, endpointIndex, PartitionLocation.Mode.REPLICA);
+      int primaryEndpointIndex = i % endpointHosts.length;
+      int replicaEndpointIndex = (primaryEndpointIndex + 1) % endpointHosts.length;
+      PartitionLocation primary =
+          newLocation(
+              i,
+              primaryEndpointIndex,
+              endpointHosts,
+              allocatorShaped,
+              PartitionLocation.Mode.PRIMARY);
+      PartitionLocation replica =
+          newLocation(
+              i,
+              replicaEndpointIndex,
+              endpointHosts,
+              allocatorShaped,
+              PartitionLocation.Mode.REPLICA);
       primary.setPeer(replica);
       replica.setPeer(primary);
       locations[i * 2] = primary;
@@ -60,26 +97,46 @@ public class PartitionLocationMemorySuiteJ {
     return locations;
   }
 
-  private PartitionLocation newLocation(int id, int endpointIndex, PartitionLocation.Mode mode) {
+  private PartitionLocation newLocation(
+      int id,
+      int endpointIndex,
+      String[] endpointHosts,
+      boolean allocatorShaped,
+      PartitionLocation.Mode mode) {
     return new PartitionLocation(
         id,
         0,
-        "localhost-" + endpointIndex,
+        locationHost(endpointHosts[endpointIndex], allocatorShaped),
         1001 + endpointIndex,
         1002 + endpointIndex,
         1003 + endpointIndex,
         1004 + endpointIndex,
-        mode);
+        mode,
+        null,
+        newStorageInfo(),
+        null);
   }
 
-  private PartitionLocationOld[] newOldLocationPairArray(int size, int endpointCount) {
+  private PartitionLocationOld[] newOldLocationPairArray(
+      int size, String[] endpointHosts, boolean allocatorShaped) {
     PartitionLocationOld[] locations = new PartitionLocationOld[size * 2];
     for (int i = 0; i < size; i++) {
-      int endpointIndex = i % endpointCount;
+      int primaryEndpointIndex = i % endpointHosts.length;
+      int replicaEndpointIndex = (primaryEndpointIndex + 1) % endpointHosts.length;
       PartitionLocationOld primary =
-          newOldLocation(i, endpointIndex, PartitionLocation.Mode.PRIMARY);
+          newOldLocation(
+              i,
+              primaryEndpointIndex,
+              endpointHosts,
+              allocatorShaped,
+              PartitionLocation.Mode.PRIMARY);
       PartitionLocationOld replica =
-          newOldLocation(i, endpointIndex, PartitionLocation.Mode.REPLICA);
+          newOldLocation(
+              i,
+              replicaEndpointIndex,
+              endpointHosts,
+              allocatorShaped,
+              PartitionLocation.Mode.REPLICA);
       primary.setPeer(replica);
       replica.setPeer(primary);
       locations[i * 2] = primary;
@@ -89,39 +146,57 @@ public class PartitionLocationMemorySuiteJ {
   }
 
   private PartitionLocationOld newOldLocation(
-      int id, int endpointIndex, PartitionLocation.Mode mode) {
+      int id,
+      int endpointIndex,
+      String[] endpointHosts,
+      boolean allocatorShaped,
+      PartitionLocation.Mode mode) {
     return new PartitionLocationOld(
         id,
         0,
-        "localhost-" + endpointIndex,
+        locationHost(endpointHosts[endpointIndex], allocatorShaped),
         1001 + endpointIndex,
         1002 + endpointIndex,
         1003 + endpointIndex,
         1004 + endpointIndex,
-        mode);
+        mode,
+        null,
+        newStorageInfo(),
+        allocatorShaped ? new RoaringBitmap() : null);
   }
 
-  private Class<?> loadGraphLayout() throws ClassNotFoundException {
-    return Class.forName("org.openjdk.jol.info.GraphLayout");
+  private String locationHost(String endpointHost, boolean allocatorShaped) {
+    // Allocators reuse WorkerInfo.host. Packed protobuf decoding creates a new host string per
+    // location while splitting the encoded worker ID. This scenario measures one decoded pair's
+    // retained object shape, not an entire WorkerResource response.
+    return allocatorShaped ? endpointHost : new String(endpointHost.toCharArray());
   }
 
-  private void compare(Class<?> graphLayout, String label, Object oldValue, Object newValue)
-      throws Exception {
-    long oldSize = totalSize(graphLayout, oldValue);
-    long newLocationSize = totalSize(graphLayout, newValue);
-    long newSizeIncludingInterner = totalSize(graphLayout, newValue, endpointInterner());
+  private StorageInfo newStorageInfo() {
+    return new StorageInfo("", StorageInfo.Type.MEMORY, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+  }
+
+  private void compare(String label, Object oldValue, Object newValue) throws Exception {
+    long oldSize = GraphLayout.parseInstance(oldValue).totalSize();
+    long newLocationSize = GraphLayout.parseInstance(newValue).totalSize();
+    long newSizeIncludingInterner =
+        GraphLayout.parseInstance(newValue, endpointInterner()).totalSize();
     long internerOverhead = newSizeIncludingInterner - newLocationSize;
     long saved = oldSize - newSizeIncludingInterner;
     double savedPercentage = oldSize == 0 ? 0 : saved * 100.0 / oldSize;
+    int locationCount = java.lang.reflect.Array.getLength(oldValue);
     System.out.printf(
         "PartitionLocation footprint [%s]: old=%d bytes, "
             + "newLocations=%d bytes, weakInternerOverhead=%d bytes, "
-            + "newIncludingLiveInterner=%d bytes, savedIncludingLiveInterner=%d bytes (%.2f%%)%n",
+            + "newIncludingLiveInterner=%d bytes, oldBytesPerLocation=%.2f, "
+            + "newBytesPerLocation=%.2f, savedIncludingLiveInterner=%d bytes (%.2f%%)%n",
         label,
         oldSize,
         newLocationSize,
         internerOverhead,
         newSizeIncludingInterner,
+        oldSize / (double) locationCount,
+        newSizeIncludingInterner / (double) locationCount,
         saved,
         savedPercentage);
     if (newSizeIncludingInterner >= oldSize) {
@@ -129,19 +204,6 @@ public class PartitionLocationMemorySuiteJ {
           "Optimized PartitionLocation retained size including its weak interner must be smaller for "
               + label);
     }
-  }
-
-  private long totalSize(Class<?> graphLayout, Object value) throws Exception {
-    return totalSize(graphLayout, value, null);
-  }
-
-  private long totalSize(Class<?> graphLayout, Object value, Object additionalRoot)
-      throws Exception {
-    Method parseInstance = graphLayout.getMethod("parseInstance", Object[].class);
-    Object[] roots =
-        additionalRoot == null ? new Object[] {value} : new Object[] {value, additionalRoot};
-    Object layout = parseInstance.invoke(null, new Object[] {roots});
-    return (Long) graphLayout.getMethod("totalSize").invoke(layout);
   }
 
   private Object endpointInterner() throws Exception {

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationOld.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationOld.java
@@ -45,20 +45,10 @@ final class PartitionLocationOld implements Serializable {
       int pushPort,
       int fetchPort,
       int replicatePort,
-      PartitionLocation.Mode mode) {
-    this(id, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode, null);
-  }
-
-  PartitionLocationOld(
-      int id,
-      int epoch,
-      String host,
-      int rpcPort,
-      int pushPort,
-      int fetchPort,
-      int replicatePort,
       PartitionLocation.Mode mode,
-      PartitionLocationOld peer) {
+      PartitionLocationOld peer,
+      StorageInfo storageInfo,
+      RoaringBitmap mapIdBitMap) {
     this.id = id;
     this.epoch = epoch;
     this.host = host;
@@ -68,8 +58,8 @@ final class PartitionLocationOld implements Serializable {
     this.replicatePort = replicatePort;
     this.mode = mode;
     this.peer = peer;
-    this.storageInfo = new StorageInfo();
-    this.mapIdBitMap = new RoaringBitmap();
+    this.storageInfo = storageInfo;
+    this.mapIdBitMap = mapIdBitMap;
   }
 
   void setPeer(PartitionLocationOld peer) {

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationOld.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationOld.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.protocol;
+
+import java.io.Serializable;
+
+import org.roaringbitmap.RoaringBitmap;
+
+/** Snapshot of the pre-optimization layout, used only as the JOL comparison baseline. */
+final class PartitionLocationOld implements Serializable {
+  private int id;
+  private int epoch;
+  private String host;
+  private int rpcPort;
+  private int pushPort;
+  private int fetchPort;
+  private int replicatePort;
+  private PartitionLocation.Mode mode;
+  private PartitionLocationOld peer;
+  private StorageInfo storageInfo;
+  private RoaringBitmap mapIdBitMap;
+  private transient String _hostPushPort;
+  private transient String _hostFetchPort;
+
+  PartitionLocationOld(
+      int id,
+      int epoch,
+      String host,
+      int rpcPort,
+      int pushPort,
+      int fetchPort,
+      int replicatePort,
+      PartitionLocation.Mode mode) {
+    this(id, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode, null);
+  }
+
+  PartitionLocationOld(
+      int id,
+      int epoch,
+      String host,
+      int rpcPort,
+      int pushPort,
+      int fetchPort,
+      int replicatePort,
+      PartitionLocation.Mode mode,
+      PartitionLocationOld peer) {
+    this.id = id;
+    this.epoch = epoch;
+    this.host = host;
+    this.rpcPort = rpcPort;
+    this.pushPort = pushPort;
+    this.fetchPort = fetchPort;
+    this.replicatePort = replicatePort;
+    this.mode = mode;
+    this.peer = peer;
+    this.storageInfo = new StorageInfo();
+    this.mapIdBitMap = new RoaringBitmap();
+  }
+
+  void setPeer(PartitionLocationOld peer) {
+    this.peer = peer;
+  }
+}

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationSuiteJ.java
@@ -321,37 +321,6 @@ public class PartitionLocationSuiteJ {
   }
 
   @Test
-  public void testUniqueIdLong() {
-    PartitionLocation location =
-        new PartitionLocation(100, 200, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
-
-    assertEquals(PartitionLocation.toUniqueIdLong(100, 200), location.getUniqueIdLong());
-    assertEquals(location.getUniqueIdLong(), PartitionLocation.toUniqueIdLong("100-200"));
-    assertEquals(
-        Long.valueOf(PartitionLocation.toUniqueIdLong(Integer.MIN_VALUE, Integer.MIN_VALUE)),
-        PartitionLocation.tryToUniqueIdLong("-2147483648--2147483648"));
-    assertEquals(
-        Long.valueOf(PartitionLocation.toUniqueIdLong(Integer.MAX_VALUE, Integer.MAX_VALUE)),
-        PartitionLocation.tryToUniqueIdLong("2147483647-2147483647"));
-  }
-
-  @Test
-  public void testInvalidUniqueIdFormatsAreRejected() {
-    assertNull(PartitionLocation.tryToUniqueIdLong(null));
-    assertNull(PartitionLocation.tryToUniqueIdLong(""));
-    assertNull(PartitionLocation.tryToUniqueIdLong("1"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("-"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("1-"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("-1"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("1-0-extra"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("1--0-extra"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("2147483648-0"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("0-2147483648"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("999999999999999999999999999999-0"));
-    assertNull(PartitionLocation.tryToUniqueIdLong("+1-0"));
-  }
-
-  @Test
   public void testWorkerEndpointKeepsWorkerInfoCompatible() {
     PartitionLocation location1 =
         new PartitionLocation(

--- a/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/protocol/PartitionLocationSuiteJ.java
@@ -18,6 +18,15 @@
 package org.apache.celeborn.common.protocol;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.junit.Test;
 import org.roaringbitmap.RoaringBitmap;
@@ -173,6 +182,189 @@ public class PartitionLocationSuiteJ {
   }
 
   @Test
+  public void testSetPeerMaintainsPeerReference() {
+    PartitionLocation primary =
+        new PartitionLocation(
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+    PartitionLocation replica =
+        new PartitionLocation(
+            partitionId,
+            epoch,
+            host,
+            rpcPort,
+            pushPort,
+            fetchPort,
+            replicatePort,
+            PartitionLocation.Mode.REPLICA);
+
+    primary.setPeer(replica);
+
+    assertEquals(true, primary.hasPeer());
+    assertSame(replica, primary.getPeer());
+
+    primary.setPeer(null);
+    assertEquals(false, primary.hasPeer());
+  }
+
+  @Test
+  public void testCopyPartitionLocationKeepsSharedFields() {
+    PartitionLocation primary =
+        new PartitionLocation(
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+    PartitionLocation replica =
+        new PartitionLocation(
+            partitionId,
+            epoch,
+            host,
+            rpcPort,
+            pushPort,
+            fetchPort,
+            replicatePort,
+            PartitionLocation.Mode.REPLICA);
+    primary.setPeer(replica);
+    StorageInfo storageInfo = primary.getStorageInfo();
+    RoaringBitmap bitmap = primary.getMapIdBitMapOrCreate();
+
+    PartitionLocation copy = new PartitionLocation(primary);
+
+    assertSame(replica, copy.getPeer());
+    assertSame(storageInfo, copy.getStorageInfo());
+    assertSame(bitmap, copy.getMapIdBitMap());
+  }
+
+  @Test
+  public void testLazyDefaultStorageInfoIsNotShared() {
+    PartitionLocation first =
+        new PartitionLocation(
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+    PartitionLocation second =
+        new PartitionLocation(
+            partitionId + 1, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+
+    StorageInfo storageInfo = first.getStorageInfo();
+    storageInfo.availableStorageTypes = StorageInfo.HDFS_MASK;
+    storageInfo.setMountPoint("/mnt/disk1");
+
+    assertSame(storageInfo, first.getStorageInfoOrCreate());
+    assertNotSame(first.getStorageInfo(), second.getStorageInfo());
+    assertEquals(StorageInfo.HDFS_MASK, first.getStorageInfo().availableStorageTypes);
+    assertEquals("/mnt/disk1", first.getStorageInfo().getMountPoint());
+    assertEquals(
+        StorageInfo.ALL_TYPES_AVAILABLE_MASK, second.getStorageInfo().availableStorageTypes);
+    assertEquals("", second.getStorageInfo().getMountPoint());
+  }
+
+  @Test
+  public void testLazyMapIdBitmapKeepsCompatibleGetter() {
+    PartitionLocation location =
+        new PartitionLocation(
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+
+    assertNull(location.getMapIdBitMapIfPresent());
+    RoaringBitmap bitmap = location.getMapIdBitMapOrCreate();
+    bitmap.add(1);
+
+    assertSame(bitmap, location.getMapIdBitMap());
+    assertEquals(1, location.getMapIdBitMap().getCardinality());
+  }
+
+  @Test
+  public void testWorkerEndpointIsInterned() {
+    WorkerEndpoint first = WorkerEndpoint.apply(host, rpcPort, pushPort, fetchPort, replicatePort);
+    WorkerEndpoint second = WorkerEndpoint.apply(host, rpcPort, pushPort, fetchPort, replicatePort);
+    WorkerEndpoint different =
+        WorkerEndpoint.apply(host, rpcPort, pushPort + 1, fetchPort, replicatePort);
+
+    assertSame(first, second);
+    assertNotSame(first, different);
+  }
+
+  @Test
+  public void testSameVersionJavaSerializationReinternsWorkerEndpoint() throws Exception {
+    WorkerEndpoint endpoint =
+        WorkerEndpoint.apply(host, rpcPort, pushPort, fetchPort, replicatePort);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(endpoint);
+    }
+
+    WorkerEndpoint deserialized;
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      deserialized = (WorkerEndpoint) input.readObject();
+    }
+
+    assertSame(endpoint, deserialized);
+    assertEquals("localhost:1", deserialized.hostAndPushPort());
+    assertEquals("localhost:2", deserialized.hostAndFetchPort());
+  }
+
+  @Test
+  public void testHostPortCachesAreInvalidatedBySetters() {
+    PartitionLocation location =
+        new PartitionLocation(
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+
+    assertEquals("localhost:1", location.hostAndPushPort());
+    assertEquals("localhost:2", location.hostAndFetchPort());
+
+    location.setHost("remoteHost");
+    location.setRpcPort(13);
+    location.setPushPort(11);
+    location.setFetchPort(12);
+    location.setReplicatePort(14);
+
+    assertEquals("remoteHost:11", location.hostAndPushPort());
+    assertEquals("remoteHost:12", location.hostAndFetchPort());
+    assertEquals(13, location.getRpcPort());
+    assertEquals(14, location.getReplicatePort());
+  }
+
+  @Test
+  public void testUniqueIdLong() {
+    PartitionLocation location =
+        new PartitionLocation(100, 200, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+
+    assertEquals(PartitionLocation.toUniqueIdLong(100, 200), location.getUniqueIdLong());
+    assertEquals(location.getUniqueIdLong(), PartitionLocation.toUniqueIdLong("100-200"));
+    assertEquals(
+        Long.valueOf(PartitionLocation.toUniqueIdLong(Integer.MIN_VALUE, Integer.MIN_VALUE)),
+        PartitionLocation.tryToUniqueIdLong("-2147483648--2147483648"));
+    assertEquals(
+        Long.valueOf(PartitionLocation.toUniqueIdLong(Integer.MAX_VALUE, Integer.MAX_VALUE)),
+        PartitionLocation.tryToUniqueIdLong("2147483647-2147483647"));
+  }
+
+  @Test
+  public void testInvalidUniqueIdFormatsAreRejected() {
+    assertNull(PartitionLocation.tryToUniqueIdLong(null));
+    assertNull(PartitionLocation.tryToUniqueIdLong(""));
+    assertNull(PartitionLocation.tryToUniqueIdLong("1"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("-"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("1-"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("-1"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("1-0-extra"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("1--0-extra"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("2147483648-0"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("0-2147483648"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("999999999999999999999999999999-0"));
+    assertNull(PartitionLocation.tryToUniqueIdLong("+1-0"));
+  }
+
+  @Test
+  public void testWorkerEndpointKeepsWorkerInfoCompatible() {
+    PartitionLocation location1 =
+        new PartitionLocation(
+            partitionId, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+    PartitionLocation location2 =
+        new PartitionLocation(
+            partitionId + 1, epoch, host, rpcPort, pushPort, fetchPort, replicatePort, mode);
+
+    assertEquals(location1.getWorker(), location2.getWorker());
+    assertNotNull(location1.hostAndPorts());
+  }
+
+  @Test
   public void testToStringOutput() {
     PartitionLocation location1 =
         new PartitionLocation(
@@ -209,7 +401,7 @@ public class PartitionLocationSuiteJ {
             + "  host-rpcPort-pushPort-fetchPort-replicatePort:localhost-3-1-2-4\n"
             + "  mode:PRIMARY\n"
             + "  peer:(empty)\n"
-            + "  storage hint:StorageInfo{type=MEMORY, mountPoint='', finalResult=false, filePath=null, fileSize=0, chunkOffsets=null}\n"
+            + "  storage hint:null\n"
             + "  mapIdBitMap:{}]";
     String exp2 =
         "PartitionLocation[\n"
@@ -217,7 +409,7 @@ public class PartitionLocationSuiteJ {
             + "  host-rpcPort-pushPort-fetchPort-replicatePort:localhost-3-1-2-4\n"
             + "  mode:PRIMARY\n"
             + "  peer:(host-rpcPort-pushPort-fetchPort-replicatePort:localhost-3-1-2-4)\n"
-            + "  storage hint:StorageInfo{type=MEMORY, mountPoint='', finalResult=false, filePath=null, fileSize=0, chunkOffsets=null}\n"
+            + "  storage hint:null\n"
             + "  mapIdBitMap:{}]";
     String exp3 =
         "PartitionLocation[\n"

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfoSuite.scala
@@ -64,6 +64,36 @@ class WorkerPartitionLocationInfoSuite extends CelebornFunSuite {
     assertEquals(workerPartitionLocationInfo.isEmpty, true)
   }
 
+  test("invalid unique ids do not interrupt lookup or release") {
+    val shuffleKey = "app_12345_12345_1-1"
+    val location0 = mockPartition(0, 0)
+    val location1 = mockPartition(1, 0)
+    val location2 = mockPartition(2, 0)
+    val locations = util.Arrays.asList(location0, location1, location2)
+    val workerPartitionLocationInfo = new WorkerPartitionLocationInfo
+    workerPartitionLocationInfo.addPrimaryPartitions(shuffleKey, locations)
+
+    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "invalid") == null)
+    val lookupResult =
+      workerPartitionLocationInfo.getPrimaryLocations(shuffleKey, Array("0-0", "invalid", "2-0"))
+    assert(lookupResult(0)._2 eq location0)
+    assert(lookupResult(1)._2 == null)
+    assert(lookupResult(2)._2 eq location2)
+
+    val releaseResult = workerPartitionLocationInfo.removePrimaryPartitions(
+      shuffleKey,
+      util.Arrays.asList("0-0", "invalid", "1-0"))
+    assertEquals(releaseResult._2, 2)
+    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "0-0") == null)
+    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "1-0") == null)
+    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "2-0") eq location2)
+
+    workerPartitionLocationInfo.removePrimaryPartitions(
+      shuffleKey,
+      util.Collections.singletonList("2-0"))
+    assert(workerPartitionLocationInfo.isEmpty)
+  }
+
   private def mockPartition(partitionId: Int, epoch: Int): PartitionLocation = {
     new PartitionLocation(
       partitionId,

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfoSuite.scala
@@ -64,36 +64,6 @@ class WorkerPartitionLocationInfoSuite extends CelebornFunSuite {
     assertEquals(workerPartitionLocationInfo.isEmpty, true)
   }
 
-  test("invalid unique ids do not interrupt lookup or release") {
-    val shuffleKey = "app_12345_12345_1-1"
-    val location0 = mockPartition(0, 0)
-    val location1 = mockPartition(1, 0)
-    val location2 = mockPartition(2, 0)
-    val locations = util.Arrays.asList(location0, location1, location2)
-    val workerPartitionLocationInfo = new WorkerPartitionLocationInfo
-    workerPartitionLocationInfo.addPrimaryPartitions(shuffleKey, locations)
-
-    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "invalid") == null)
-    val lookupResult =
-      workerPartitionLocationInfo.getPrimaryLocations(shuffleKey, Array("0-0", "invalid", "2-0"))
-    assert(lookupResult(0)._2 eq location0)
-    assert(lookupResult(1)._2 == null)
-    assert(lookupResult(2)._2 eq location2)
-
-    val releaseResult = workerPartitionLocationInfo.removePrimaryPartitions(
-      shuffleKey,
-      util.Arrays.asList("0-0", "invalid", "1-0"))
-    assertEquals(releaseResult._2, 2)
-    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "0-0") == null)
-    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "1-0") == null)
-    assert(workerPartitionLocationInfo.getPrimaryLocation(shuffleKey, "2-0") eq location2)
-
-    workerPartitionLocationInfo.removePrimaryPartitions(
-      shuffleKey,
-      util.Collections.singletonList("2-0"))
-    assert(workerPartitionLocationInfo.isEmpty)
-  }
-
   private def mockPartition(partitionId: Int, epoch: Int): PartitionLocation = {
     new PartitionLocation(
       partitionId,

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -27,6 +27,7 @@ import scala.util.Random
 
 import com.google.common.collect.Lists
 import org.apache.hadoop.shaded.org.apache.commons.lang3.RandomStringUtils
+import org.roaringbitmap.RoaringBitmap
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.identity.UserIdentifier
@@ -461,6 +462,45 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
     assert(restoredPartitionLocation.equals(partitionLocation1))
   }
 
+  test("fromAndToPbPartitionLocation preserves lazy and peer bitmaps") {
+    val primary =
+      new PartitionLocation(10, 0, "host1", 10, 11, 12, 13, PartitionLocation.Mode.PRIMARY)
+    val replica =
+      new PartitionLocation(10, 0, "host2", 20, 21, 22, 23, PartitionLocation.Mode.REPLICA)
+    val primaryBitmap = new RoaringBitmap()
+    primaryBitmap.add(1)
+    val replicaBitmap = new RoaringBitmap()
+    replicaBitmap.add(2)
+    primary.setMapIdBitMap(primaryBitmap)
+    replica.setMapIdBitMap(replicaBitmap)
+    primary.setPeer(replica)
+    replica.setPeer(primary)
+
+    val restored = PbSerDeUtils.fromPbPartitionLocation(
+      PbSerDeUtils.toPbPartitionLocation(primary))
+
+    assert(restored.hasPeer)
+    assert(restored.getMapIdBitMap.contains(1))
+    assert(!restored.getMapIdBitMap.contains(2))
+    assert(restored.getPeer.getMapIdBitMap.contains(2))
+    assert(!restored.getPeer.getMapIdBitMap.contains(1))
+
+    val (packedPrimaries, _) = fromPbPackedPartitionLocationsPair(
+      toPbPackedPartitionLocationsPair(List(primary)))
+    val packedRestored = packedPrimaries.get(0)
+    assert(packedRestored.hasPeer)
+    assert(packedRestored.getMapIdBitMap.contains(1))
+    assert(!packedRestored.getMapIdBitMap.contains(2))
+    assert(packedRestored.getPeer.getMapIdBitMap.contains(2))
+    assert(!packedRestored.getPeer.getMapIdBitMap.contains(1))
+
+    val withoutBitmap =
+      new PartitionLocation(11, 0, "host3", 30, 31, 32, 33, PartitionLocation.Mode.PRIMARY)
+    val restoredWithoutBitmap = PbSerDeUtils.fromPbPartitionLocation(
+      PbSerDeUtils.toPbPartitionLocation(withoutBitmap))
+    assert(restoredWithoutBitmap.getMapIdBitMapIfPresent == null)
+  }
+
   test("fromAndToPbWorkerResource") {
     val pbWorkerResource = PbSerDeUtils.toPbWorkerResource(workerResource)
     val restoredWorkerResource = PbSerDeUtils.fromPbWorkerResource(pbWorkerResource)
@@ -694,6 +734,9 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
 
     assert(primaryLocations.zip(locs1.asScala).count(x => x._1 != x._2) == 0)
     assert(replicaLocations.zip(locs2.asScala).count(x => x._1 != x._2) == 0)
+    (locs1.asScala ++ locs2.asScala).foreach { loc =>
+      assert(loc.hasPeer)
+    }
 
     assert(packedWorkerResourceSize < workerResourceSize)
     log.info(s"Packed size : ${packedWorkerResourceSize} unpacked size :${workerResourceSize}")
@@ -703,6 +746,10 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
 
   test("serializationComparasion") {
     testSerializationPerformance(100)
+  }
+
+  test("packed partition location serde remains compact at scale") {
+    testSerializationPerformance(1000)
   }
 
   test("GetReduceFileGroup with primary and replica locations") {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/slotsalloc/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/slotsalloc/SlotsAllocator.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import scala.Tuple2;
 import scala.Tuple3;
 
-import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -550,7 +549,7 @@ public class SlotsAllocator {
         mode,
         peer,
         storageInfo,
-        new RoaringBitmap());
+        null);
   }
 
   private static void addLocation(

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
     <guava.version>33.1.0-jre</guava.version>
+    <jol.version>0.17</jol.version>
     <junit.version>4.13.2</junit.version>
     <leveldb.version>1.8</leveldb.version>
     <log4j2.version>2.25.4</log4j2.version>
@@ -795,6 +796,12 @@
         <version>${swagger-ui.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.openjdk.jol</groupId>
+        <artifactId>jol-core</artifactId>
+        <version>${jol.version}</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -57,6 +57,7 @@ object Dependencies {
   val junitInterfaceVersion = "0.13.3"
   // don't forget update `junitInterfaceVersion` when we upgrade junit
   val junitVersion = "4.13.2"
+  val jolVersion = "0.17"
   val leveldbJniVersion = "1.8"
   val log4j2Version = "2.25.4"
   val disruptorVersion = "3.4.4"
@@ -249,6 +250,7 @@ object Dependencies {
   // https://www.scala-sbt.org/1.x/docs/Testing.html
   val junitInterface = "com.github.sbt" % "junit-interface" % junitInterfaceVersion
   val junit = "junit" % "junit" % junitVersion
+  val jolCore = "org.openjdk.jol" % "jol-core" % jolVersion
   val mockitoCore = "org.mockito" % "mockito-core" % mockitoVersion
   val mockitoInline = "org.mockito" % "mockito-inline" % mockitoVersion
   val scalatestMockito = "org.mockito" %% "mockito-scala-scalatest" % scalatestMockitoVersion
@@ -706,6 +708,7 @@ object CelebornCommon {
         Dependencies.jacksonCore,
         Dependencies.jacksonDatabind,
         Dependencies.jacksonAnnotations,
+        Dependencies.jolCore % "test",
         Dependencies.log4jSlf4jImpl % "test",
         Dependencies.log4j12Api % "test",
         // SSL support

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/api/v1/ApiUtils.scala
@@ -159,7 +159,9 @@ object ApiUtils {
       case StorageInfo.Type.S3 =>
         locationData.storage(StorageEnum.S3)
     }
-    Option(partitionLocation.getMapIdBitMap).map(_.toString).foreach(locationData.mapIdBitMap)
+    Option(partitionLocation.getMapIdBitMapIfPresent)
+      .map(_.toString)
+      .foreach(locationData.mapIdBitMap)
     locationData
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

  This PR reduces the memory footprint of `PartitionLocation` metadata while preserving the existing wire protocol and public getter behavior.

  The main changes are:

  - Introduce an immutable, weakly interned `WorkerEndpoint` to share worker host and port information across partition locations.
  - Move the cached `host:pushPort` and `host:fetchPort` strings into the shared endpoint.
  - Lazily initialize `StorageInfo` and `RoaringBitmap` using thread-safe initialization.
  - Keep `getMapIdBitMap()` non-null for compatibility, and add a non-materializing accessor for serialization, HTTP API, and read-side inspection.
  - Avoid allocating empty bitmaps when locations are created by `LifecycleManager` and `SlotsAllocator`.
  - Preserve the current `storageTypes.head` selection behavior in `LifecycleManager`.
  - Keep string keys in `WorkerPartitionLocationInfo` to avoid parsing and boxing overhead on the Worker hot path.
  - Add allocation-free helpers for converting partition location IDs into packed `long` values.
  - Avoid materializing optional metadata from logging, protobuf serialization, HTTP rendering, and range-read paths.
  - Re-intern `WorkerEndpoint` instances after same-version Java deserialization.
  - Fix peer bitmap serialization so that the peer protobuf contains the peer's bitmap instead of the primary location's bitmap.
  - Make range reads fall back to the peer bitmap and fail open when bitmap metadata is unavailable.
  - Add JOL-based manual memory benchmarks and focused unit tests.

  No protobuf schema is changed by this PR.

  ### Why are the changes needed?

  A shuffle may contain millions of `PartitionLocation` instances. Previously, every instance independently retained:

  - Worker host and port fields.
  - Cached host/port strings.
  - An empty `StorageInfo`.
  - An empty `RoaringBitmap`.

  Most of this metadata is identical across locations or unused for the majority of their lifetime. The eager allocations therefore contribute significant heap usage and GC pressure on the Master, Worker, and client.

  The JOL benchmark includes both the live location graph and the weak interner overhead:

| Scenario | Before | After, including interner | Reduction |
|---|---:|---:|---:|
| Allocator, 10,000 pairs | 4,383,504 bytes | 2,148,056 bytes | 51.00% |
| Allocator, 1,000,000 pairs | 424,143,504 bytes | 184,308,056 bytes | 56.55% |
| Packed decoded pair shape, 10,000 pairs | 3,752,304 bytes | 2,148,056 bytes | 42.75% |
| Packed decoded pair shape, 1,000,000 pairs | 375,200,304 bytes | 184,308,056 bytes | 50.88% |

  The additional serialization and range-read fixes are needed to ensure that lazy bitmap allocation does not introduce data loss, incorrect peer metadata, or compatibility regressions.

  ### Does this PR resolve a correctness bug?

  <!-- Check if yes. The `correctness` label will be added/removed automatically. -->
  - [x] Yes

  It fixes peer bitmap serialization and ensures that missing bitmap metadata does not cause an NPE or silently exclude a partition location during range reads.

  ### Does this PR introduce _any_ user-facing change?

  <!-- Check if yes. -->
  - [ ] Yes

  There are no configuration, wire-protocol, or intended behavioral changes for users.

  ### How was this patch tested?

  The following verification was completed:

  - Ran the `common`, `client`, and `master` module regression suites:
    - 366 JUnit tests, with 1 ignored.
    - 325 ScalaTest tests.
    - 691 tests in total, with no failures or errors.
  - Ran the final `PartitionLocationSuiteJ`:
    - 20 tests passed.
    - Covers lazy initialization, endpoint interning, endpoint setters, ID parsing, peer references, compatibility getters, and same-version Java serialization.
  - Ran Worker partition and storage regression suites:
    - 27 Java tests passed.
    - 9 Scala tests passed.
  - Ran the Spark 3.5 `LifecycleManagerReserveSlotsSuite` integration test:
    - 1 test passed.
    - All 11 reactor modules completed successfully.
  - Compiled the affected modules through SBT:
    - `celeborn-common/Test/compile`
    - `celeborn-service/Compile/compile`
  - Ran `spotless:check` and `git diff --check`.
  - Manually ran `PartitionLocationMemorySuiteJ` with JOL for both the 10,000-pair and 1,000,000-pair scenarios.
