### PR TITLE
[CELEBORN-2390] Add celeborn-web service to docker-compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,6 +57,28 @@ services:
       start_period: 40s
     restart: unless-stopped
 
+  celeborn-web:
+    image: nginx:alpine
+    container_name: celeborn-web
+    hostname: celeborn-web
+    ports:
+      - "9095:9095"   # Celeborn Web UI
+    volumes:
+      - ../web/dist:/usr/share/nginx/html:ro
+      - ./web/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - celeborn-net
+    depends_on:
+      celeborn-master:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9095/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+    restart: unless-stopped
+
   celeborn-worker:
     image: celeborn:dev
     command: /opt/celeborn/sbin/start-worker.sh

--- a/docker/web/nginx.conf
+++ b/docker/web/nginx.conf
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server {
+    listen 9095;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # API proxy: forward /api/* to Celeborn master /api/v1/*
+    location /api/ {
+        proxy_pass http://celeborn-master:9098/api/v1/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Serve static assets and fallback to index.html for SPA routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a `celeborn-web` service to the local docker-compose cluster so users can access the Celeborn Web UI at http://localhost:9095 without additional backend code.

The implementation uses a lightweight `nginx:alpine` container to:
- Serve the built frontend assets from `web/dist/`.
- Proxy `/api/*` requests to the Celeborn master's native `/api/v1/*` REST API.

This keeps the `web/` module untouched and avoids introducing a separate Java backend service.

## Why are the changes needed?

Currently, the local docker-compose cluster (`docker/docker-compose.yaml`) only starts the Celeborn master and worker services. Users who want to view cluster status through the Web UI have to manually build and serve the frontend, or run a separate backend service, which increases the barrier for local development and testing.


## How was this patch tested?
1. Started the local cluster:
   ```bash
   cd docker
   docker compose -f docker-compose.yaml up -d 
   ```
2. Verified the Web UI loads at http://localhost:9095 (HTTP 200).
<img width="2456" height="1168" alt="image" src="https://github.com/user-attachments/assets/70cfb821-12bf-4336-80e0-097cea79923e" />


