### PR TITLE
[CELEBORN-XXXX][WIP] Mark CelebornShuffleHandle as reliably stored for per-shuffle DRA safety

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -51,4 +51,9 @@ class CelebornShuffleHandle[K, V, C](
     numMappers,
     dependency,
     null)
+
+  // Only created for shuffles stored on Celeborn workers (fallback uses SortShuffleManager), so
+  // their output survives executor loss. TODO(CELEBORN-XXXX): uncomment once
+  // ShuffleHandle.isReliablyStored ships in a released Spark (SPARK-59138); blocked on that PR.
+  // override def isReliablyStored: Boolean = true
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Adds a per-shuffle reliable-storage signal so Spark does not recompute a lost executor's map stages for shuffles whose data lives on Celeborn workers.
- On executor loss, Spark's `DAGScheduler` unregisters the executor's map outputs and recomputes the map stage. A `CelebornShuffleHandle` is only created for shuffles stored on Celeborn workers (fallback shuffles use Spark's `SortShuffleManager`), so their output survives executor loss and the recompute is wasteful.
- Overrides `ShuffleHandle.isReliablyStored` to return `true` on `CelebornShuffleHandle`; fallback shuffles keep Spark's `BaseShuffleHandle` (default `false`), so the mixed case is handled per shuffle.
- The override is committed commented out: `ShuffleHandle.isReliablyStored` does not exist in any released Spark, so enabling it would break compilation against the Spark versions Celeborn builds against.
- Blocked on the Spark-side PR (apache/spark#58437, SPARK-59138). Do not merge until that lands, ships in a release, and Celeborn's Spark dependency is bumped; then uncomment the override and update the JIRA IDs.
- Follow-up to CELEBORN-2451, which ties `supportsReliableStorage` to the `NEVER` fallback policy to stay DRA-safe. This PR lets AUTO fallback avoid the recompute penalty per shuffle.

### Why are the changes needed?

- Under DRA with AUTO fallback, losing an executor needlessly recomputes map stages whose output is safely stored on Celeborn workers.
- The app-global `supportsReliableStorage()` flag cannot express "this shuffle is on Celeborn, that one fell back to local disk," so it forces `NEVER` to be safe. Per-shuffle reliability removes that constraint.

### Does this PR resolve a correctness bug?

- [ ] Yes

### Does this PR introduce _any_ user-facing change?

- [ ] Yes

### How was this patch tested?

- Not yet exercised end-to-end: the override is commented out pending the Spark dependency.
- Once unblocked, validated against a Spark build carrying SPARK-59138 with a DRA + AUTO-fallback job that loses an executor, asserting the Celeborn-backed shuffle's map stage is not recomputed while a fallback shuffle's is.
