### PR TITLE
[CELEBORN-2454] Add config celeborn.master.ha.ratis.raft.server.close.threshold and docs for Ratis JvmPauseMonitor

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -801,6 +801,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def haMasterRatisLogInstallSnapshotEnabled: Boolean =
     get(HA_MASTER_RATIS_LOG_INSTALL_SNAPSHOT_ENABLED)
   def haMasterRatisRpcRequestTimeout: Long = get(HA_MASTER_RATIS_RPC_REQUEST_TIMEOUT)
+  def haMasterRatisCloseThreshold: Long = get(HA_MASTER_RATIS_CLOSE_THRESHOLD)
   def haMasterRatisRetryCacheExpiryTime: Long = get(HA_MASTER_RATIS_SERVER_RETRY_CACHE_EXPIRY_TIME)
   def haMasterRatisRpcTimeoutMin: Long = get(HA_MASTER_RATIS_RPC_TIMEOUT_MIN)
   def haMasterRatisRpcTimeoutMax: Long = get(HA_MASTER_RATIS_RPC_TIMEOUT_MAX)
@@ -2966,6 +2967,17 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefaultString("3s")
+
+  val HA_MASTER_RATIS_CLOSE_THRESHOLD: ConfigEntry[Long] =
+    buildConf("celeborn.master.ha.ratis.raft.server.close.threshold")
+      .categories("ha")
+      .version("0.7.0")
+      .doc("Threshold for the Ratis JvmPauseMonitor to close the local raft server after " +
+        "a JVM/host pause, e.g. long GC, VM live migration or jmap -F. Maps to Ratis " +
+        "raft.server.close.threshold. Once exceeded, the master leaves the raft group " +
+        "until the process is restarted.")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("60s")
 
   val HA_MASTER_RATIS_SERVER_RETRY_CACHE_EXPIRY_TIME: ConfigEntry[Long] =
     buildConf("celeborn.master.ha.ratis.raft.server.retrycache.expirytime")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2971,7 +2971,7 @@ object CelebornConf extends Logging {
   val HA_MASTER_RATIS_CLOSE_THRESHOLD: ConfigEntry[Long] =
     buildConf("celeborn.master.ha.ratis.raft.server.close.threshold")
       .categories("ha")
-      .version("0.7.0")
+      .version("1.0.0")
       .doc("Threshold for the Ratis JvmPauseMonitor to close the local raft server after " +
         "a JVM/host pause, e.g. long GC, VM live migration or jmap -F. Maps to Ratis " +
         "raft.server.close.threshold. Once exceeded, the master leaves the raft group " +

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -27,6 +27,7 @@ license: |
 | celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 
 | celeborn.master.ha.node.&lt;id&gt;.ratis.port | 9872 | false | Ratis port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.ratis.port | 
 | celeborn.master.ha.ratis.raft.rpc.type | netty | false | RPC type for Ratis, available options: netty, grpc. | 0.3.0 | celeborn.ha.master.ratis.raft.rpc.type | 
+| celeborn.master.ha.ratis.raft.server.close.threshold | 60s | false | Threshold for the Ratis JvmPauseMonitor to close the local raft server after a JVM/host pause, e.g. long GC, VM live migration or jmap -F. Maps to Ratis raft.server.close.threshold. Once exceeded, the master leaves the raft group until the process is restarted. | 0.7.0 |  | 
 | celeborn.master.ha.ratis.raft.server.storage.dir | /tmp/ratis | false | Root storage directory to hold RaftServer data. | 0.3.0 | celeborn.ha.master.ratis.raft.server.storage.dir | 
 | celeborn.master.ha.ratis.raft.server.storage.startup.option | RECOVER | false | Startup option of RaftServer storage. Available options: RECOVER, FORMAT. | 0.5.0 |  | 
 <!--end-include-->

--- a/docs/configuration/ha.md
+++ b/docs/configuration/ha.md
@@ -27,7 +27,7 @@ license: |
 | celeborn.master.ha.node.&lt;id&gt;.port | 9097 | false | Port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.port | 
 | celeborn.master.ha.node.&lt;id&gt;.ratis.port | 9872 | false | Ratis port to bind of master node <id> in HA mode. | 0.3.0 | celeborn.ha.master.node.&lt;id&gt;.ratis.port | 
 | celeborn.master.ha.ratis.raft.rpc.type | netty | false | RPC type for Ratis, available options: netty, grpc. | 0.3.0 | celeborn.ha.master.ratis.raft.rpc.type | 
-| celeborn.master.ha.ratis.raft.server.close.threshold | 60s | false | Threshold for the Ratis JvmPauseMonitor to close the local raft server after a JVM/host pause, e.g. long GC, VM live migration or jmap -F. Maps to Ratis raft.server.close.threshold. Once exceeded, the master leaves the raft group until the process is restarted. | 0.7.0 |  | 
+| celeborn.master.ha.ratis.raft.server.close.threshold | 60s | false | Threshold for the Ratis JvmPauseMonitor to close the local raft server after a JVM/host pause, e.g. long GC, VM live migration or jmap -F. Maps to Ratis raft.server.close.threshold. Once exceeded, the master leaves the raft group until the process is restarted. | 1.0.0 |  | 
 | celeborn.master.ha.ratis.raft.server.storage.dir | /tmp/ratis | false | Root storage directory to hold RaftServer data. | 0.3.0 | celeborn.ha.master.ratis.raft.server.storage.dir | 
 | celeborn.master.ha.ratis.raft.server.storage.startup.option | RECOVER | false | Startup option of RaftServer storage. Available options: RECOVER, FORMAT. | 0.5.0 |  | 
 <!--end-include-->

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -112,6 +112,12 @@ celeborn.worker.replicate.fastFail.duration 240s
 celeborn.worker.monitor.disk.enabled false
 ```
 
+Note: In an HA cluster, each master runs a Ratis JvmPauseMonitor. If the JVM or the host is paused
+longer than `celeborn.master.ha.ratis.raft.server.close.threshold` (default 60s), the local raft
+server is closed and the master leaves the raft group; the process must be restarted to recover.
+Avoid operations that suspend the JVM for a long time on production masters, e.g. `jmap -F` or
+heap dumps, and prefer low-intrusion diagnostics like `jcmd <pid> GC.class_histogram`.
+
 Flink engine related configurations:
 ```properties
 # If you are using Celeborn for flink, these settings will be needed.

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -374,6 +374,10 @@ public class HARaftServer {
         TimeDuration.valueOf(conf.haMasterRatisRpcRequestTimeout(), TimeUnit.SECONDS);
     RaftServerConfigKeys.Rpc.setRequestTimeout(properties, serverRequestTimeout);
 
+    // Set the threshold for JvmPauseMonitor to close the local raft server
+    RaftServerConfigKeys.setCloseThreshold(
+        properties, TimeDuration.valueOf(conf.haMasterRatisCloseThreshold(), TimeUnit.SECONDS));
+
     // Set timeout for server retry cache entry
     TimeDuration retryCacheExpiryTime =
         TimeDuration.valueOf(conf.haMasterRatisRetryCacheExpiryTime(), TimeUnit.SECONDS);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a config `celeborn.master.ha.ratis.raft.server.close.threshold` (default 60s) for the Ratis `raft.server.close.threshold`, and document the JvmPauseMonitor behavior in the deploy guide.

### Why are the changes needed?
Related PR: https://github.com/apache/celeborn/pull/3838

Ratis `JvmPauseMonitor` closes the local RaftServer when a JVM pause exceeds `raft.server.close.threshold` (default 60s), e.g. caused by `jmap -F`, long GC, or disk I/O hang. Today this threshold can only be set via the generic `celeborn.ratis.*` custom config passthrough, which is undocumented and easy to miss — operators hit the unexpected master shutdown without knowing why or how to tune it.


### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?
Existing master HA tests pass.  
