### PR TITLE
[CELEBORN-2455] Remove redundant synchronized in Dispatcher.postMessage

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Dispatcher.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Dispatcher.scala
@@ -171,9 +171,7 @@ private[celeborn] class Dispatcher(nettyEnv: NettyRpcEnv, rpcSource: RpcSource) 
       endpointName: String,
       message: InboxMessage,
       callbackIfStopped: Exception => Unit): Unit = {
-    val data = synchronized {
-      endpoints.get(endpointName)
-    }
+    val data = endpoints.get(endpointName)
     if (data != null) {
       data.inbox.waitOnFull()
     }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Remove the redundant `synchronized` block around the first `endpoints.get(endpointName)` read in `Dispatcher.postMessage`.


### Why are the changes needed?

 `endpoints` is a `ConcurrentHashMap`, so the read is already thread-safe.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?
Existing UTs.
