### PR TITLE
[CELEBORN-2456] Fix wrong isAssignableFrom direction in Basic/Bearer authenticationSupported

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/AuthenticationFilter.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/AuthenticationFilter.scala
@@ -113,6 +113,11 @@ class AuthenticationFilter(conf: CelebornConf, serviceName: String) extends Filt
 
   override def init(filterConfig: FilterConfig): Unit = {
     initAuthHandlers()
+    if (authSchemes.nonEmpty && authSchemeHandlers.isEmpty) {
+      throw new ServletException(
+        s"No authentication handler registered for the configured schemes" +
+          s" ${authSchemes.mkString(", ")}, refusing to serve requests without authentication")
+    }
   }
 
   private[celeborn] def getMatchedHandler(authorization: String): Option[AuthenticationHandler] = {

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BasicAuthenticationHandler.scala
@@ -43,8 +43,7 @@ class BasicAuthenticationHandler(providerClass: String) extends AuthenticationHa
   override def authenticationSupported: Boolean = {
     Option(providerClass).exists { _ =>
       try {
-        Class.forName(providerClass).isAssignableFrom(classOf[PasswdAuthenticationProvider])
-        true
+        classOf[PasswdAuthenticationProvider].isAssignableFrom(Class.forName(providerClass))
       } catch {
         case _: Throwable => false
       }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/authentication/BearerAuthenticationHandler.scala
@@ -42,8 +42,7 @@ class BearerAuthenticationHandler(providerClass: String)
   override def authenticationSupported: Boolean = {
     Option(providerClass).exists { _ =>
       try {
-        Class.forName(providerClass).isAssignableFrom(classOf[TokenAuthenticationProvider])
-        true
+        classOf[TokenAuthenticationProvider].isAssignableFrom(Class.forName(providerClass))
       } catch {
         case _: Throwable => false
       }

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/AuthenticationHandlerSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/authentication/AuthenticationHandlerSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.server.common.http.authentication
+
+import javax.servlet.ServletException
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.server.common.Service
+
+class AuthenticationHandlerSuite extends CelebornFunSuite {
+
+  test("basic handler supports providers implementing PasswdAuthenticationProvider") {
+    assert(new BasicAuthenticationHandler(
+      classOf[UserDefinedPasswordAuthenticationProviderImpl].getName).authenticationSupported)
+    assert(!new BasicAuthenticationHandler(
+      classOf[UserDefineTokenAuthenticationProviderImpl].getName).authenticationSupported)
+    assert(!new BasicAuthenticationHandler("non.existent.Provider").authenticationSupported)
+  }
+
+  test("bearer handler supports providers implementing TokenAuthenticationProvider") {
+    assert(new BearerAuthenticationHandler(
+      classOf[UserDefineTokenAuthenticationProviderImpl].getName).authenticationSupported)
+    assert(!new BearerAuthenticationHandler(
+      classOf[UserDefinedPasswordAuthenticationProviderImpl].getName).authenticationSupported)
+    assert(!new BearerAuthenticationHandler("non.existent.Provider").authenticationSupported)
+  }
+
+  test("fail fast when no handler registered for the configured schemes") {
+    val conf = new CelebornConf()
+    conf.set(CelebornConf.MASTER_HTTP_AUTH_SUPPORTED_SCHEMES, Seq("BASIC"))
+    conf.set(CelebornConf.MASTER_HTTP_AUTH_BASIC_PROVIDER, "non.existent.Provider")
+    intercept[ServletException] {
+      new AuthenticationFilter(conf, Service.MASTER).init(null)
+    }
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?

 Fix the reversed `isAssignableFrom` direction in `BasicAuthenticationHandler` and `BearerAuthenticationHandler` (its result was also discarded, making the check a no-op), and fail fast in `AuthenticationFilter.init` when schemes are configured but no handler is registered.



### Why are the changes needed?

The broken check lets invalid providers pass startup validation; if the provider class cannot be loaded and it is the only configured scheme, all requests are silently served without authentication.

### Does this PR resolve a correctness bug?

<!-- Check if yes. The `correctness` label will be added/removed automatically. -->
- [ ] Yes

### Does this PR introduce _any_ user-facing change?

<!-- Check if yes. -->
- [ ] Yes


### How was this patch tested?
Added `AuthenticationHandlerSuite`
