### PR TITLE
[CELEBORN-2458] Invalidate transport client after push timeout

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -350,8 +350,7 @@ public class TransportClient implements Closeable {
     this.timedOut = true;
   }
 
-  /** Invalidate this client and asynchronously close its channel. */
-  public void invalidate() {
+  private void invalidate() {
     this.timedOut = true;
     channel.close();
   }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -220,7 +220,7 @@ public class TransportClient implements Closeable {
 
     long requestId = requestId();
     long dueTime = System.currentTimeMillis() + pushDataTimeout;
-    PushRequestInfo info = new PushRequestInfo(dueTime, callback);
+    PushRequestInfo info = new PushRequestInfo(dueTime, callback, this::invalidate);
     handler.addPushRequest(requestId, info);
     pushData.requestId = requestId;
     PushChannelListener listener = new PushChannelListener(requestId, rpcSendoutCallback);
@@ -237,7 +237,7 @@ public class TransportClient implements Closeable {
 
     long requestId = requestId();
     long dueTime = System.currentTimeMillis() + pushDataTimeout;
-    PushRequestInfo info = new PushRequestInfo(dueTime, callback);
+    PushRequestInfo info = new PushRequestInfo(dueTime, callback, this::invalidate);
     handler.addPushRequest(requestId, info);
     pushMergedData.requestId = requestId;
 
@@ -348,6 +348,12 @@ public class TransportClient implements Closeable {
   /** Mark this channel as having timed out. */
   public void timeOut() {
     this.timedOut = true;
+  }
+
+  /** Invalidate this client and asynchronously close its channel. */
+  public void invalidate() {
+    this.timedOut = true;
+    channel.close();
   }
 
   @VisibleForTesting

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -139,6 +139,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
           if (info.channelFuture != null) {
             info.channelFuture.cancel(true);
           }
+          info.handleTimeout();
           String module = conf.getModuleName();
           // When module name equals to DATA_MODULE, mean shuffle client push data, else means
           // do data replication.

--- a/common/src/main/java/org/apache/celeborn/common/write/PushRequestInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/PushRequestInfo.java
@@ -25,13 +25,25 @@ public class PushRequestInfo {
   public ChannelFuture channelFuture;
   public long dueTime;
   public RpcResponseCallback callback;
+  private final Runnable timeoutHandler;
 
   public PushRequestInfo(long dueTime, RpcResponseCallback callback) {
+    this(dueTime, callback, null);
+  }
+
+  public PushRequestInfo(long dueTime, RpcResponseCallback callback, Runnable timeoutHandler) {
     this.dueTime = dueTime;
     this.callback = callback;
+    this.timeoutHandler = timeoutHandler;
   }
 
   public void setChannelFuture(ChannelFuture future) {
     this.channelFuture = future;
+  }
+
+  public void handleTimeout() {
+    if (timeoutHandler != null) {
+      timeoutHandler.run();
+    }
   }
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
@@ -185,6 +185,18 @@ public class TransportClientFactorySuiteJ {
   }
 
   @Test
+  public void neverReturnInvalidatedClients() throws IOException, InterruptedException {
+    TransportClientFactory factory = context.createClientFactory();
+    TransportClient c1 = factory.createClient(getLocalHost(), server1.getPort());
+    c1.invalidate();
+
+    TransportClient c2 = factory.createClient(getLocalHost(), server1.getPort());
+    assertNotSame(c1, c2);
+    assertTrue(c2.isActive());
+    factory.close();
+  }
+
+  @Test
   public void closeBlockClientsWithFactory() throws IOException, InterruptedException {
     TransportClientFactory factory = context.createClientFactory();
     TransportClient c1 = factory.createClient(getLocalHost(), server1.getPort());

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
@@ -25,7 +25,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
@@ -35,12 +38,19 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
+import org.apache.celeborn.common.network.protocol.PushData;
+import org.apache.celeborn.common.network.protocol.RequestMessage;
+import org.apache.celeborn.common.network.protocol.RpcResponse;
 import org.apache.celeborn.common.network.server.BaseMessageHandler;
 import org.apache.celeborn.common.network.server.TransportServer;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.network.util.TransportFrameDecoder;
+import org.apache.celeborn.common.protocol.TransportModuleConstants;
+import org.apache.celeborn.common.protocol.message.StatusCode;
 import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.util.ThreadUtils;
 
@@ -185,15 +195,80 @@ public class TransportClientFactorySuiteJ {
   }
 
   @Test
-  public void neverReturnInvalidatedClients() throws IOException, InterruptedException {
-    TransportClientFactory factory = context.createClientFactory();
-    TransportClient c1 = factory.createClient(getLocalHost(), server1.getPort());
-    c1.invalidate();
+  public void replaceClientAfterPushTimeout() throws Exception {
+    AtomicBoolean respond = new AtomicBoolean(false);
+    BaseMessageHandler handler =
+        new BaseMessageHandler() {
+          @Override
+          public void receive(TransportClient client, RequestMessage message) {
+            PushData pushData = (PushData) message;
+            if (respond.get()) {
+              client
+                  .getChannel()
+                  .writeAndFlush(
+                      new RpcResponse(
+                          pushData.requestId, new NioManagedBuffer(ByteBuffer.allocate(0))));
+            }
+          }
 
-    TransportClient c2 = factory.createClient(getLocalHost(), server1.getPort());
-    assertNotSame(c1, c2);
-    assertTrue(c2.isActive());
-    factory.close();
+          @Override
+          public boolean checkRegistered() {
+            return true;
+          }
+        };
+    TransportConf conf =
+        new TransportConf(TransportModuleConstants.REPLICATE_MODULE, new CelebornConf());
+
+    try (TransportContext timeoutContext = new TransportContext(conf, handler);
+        TransportServer timeoutServer = timeoutContext.createServer();
+        TransportClientFactory factory = timeoutContext.createClientFactory()) {
+      TransportClient timedOutClient =
+          factory.createClient(getLocalHost(), timeoutServer.getPort());
+      RpcResponseCallback timedOutCallback = mock(RpcResponseCallback.class);
+      RpcResponseCallback outstandingCallback = mock(RpcResponseCallback.class);
+      timedOutClient.pushData(
+          new PushData(
+              (byte) 0,
+              "shuffleKey",
+              "partitionId-1",
+              new NioManagedBuffer(ByteBuffer.allocate(1))),
+          0,
+          timedOutCallback);
+      timedOutClient.pushData(
+          new PushData(
+              (byte) 0,
+              "shuffleKey",
+              "partitionId-2",
+              new NioManagedBuffer(ByteBuffer.allocate(1))),
+          TimeUnit.MINUTES.toMillis(1),
+          outstandingCallback);
+
+      timedOutClient.getHandler().failExpiredPushRequest();
+
+      Mockito.verify(timedOutCallback, Mockito.after(200).times(1))
+          .onFailure(
+              Mockito.argThat(
+                  error ->
+                      error.getMessage().startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())));
+      Mockito.verify(outstandingCallback, Mockito.after(200).times(1)).onFailure(Mockito.any());
+      assertFalse(timedOutClient.isActive());
+
+      respond.set(true);
+      TransportClient replacementClient =
+          factory.createClient(getLocalHost(), timeoutServer.getPort());
+      assertNotSame(timedOutClient, replacementClient);
+      RpcResponseCallback successCallback = mock(RpcResponseCallback.class);
+      replacementClient.pushData(
+          new PushData(
+              (byte) 0,
+              "shuffleKey",
+              "partitionId-3",
+              new NioManagedBuffer(ByteBuffer.allocate(1))),
+          TimeUnit.SECONDS.toMillis(5),
+          successCallback);
+      Mockito.verify(successCallback, Mockito.timeout(5000)).onSuccess(Mockito.any());
+      Mockito.verify(successCallback, Mockito.never()).onFailure(Mockito.any());
+    }
   }
 
   @Test

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
@@ -245,13 +245,12 @@ public class TransportClientFactorySuiteJ {
 
       timedOutClient.getHandler().failExpiredPushRequest();
 
-      Mockito.verify(timedOutCallback, Mockito.after(200).times(1))
+      Mockito.verify(timedOutCallback, Mockito.timeout(5000).times(1))
           .onFailure(
               Mockito.argThat(
                   error ->
                       error.getMessage().startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())));
-      Mockito.verify(outstandingCallback, Mockito.after(200).times(1)).onFailure(Mockito.any());
-      assertFalse(timedOutClient.isActive());
+      Mockito.verify(outstandingCallback, Mockito.timeout(5000).times(1)).onFailure(Mockito.any());
 
       respond.set(true);
       TransportClient replacementClient =

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
@@ -18,22 +18,20 @@
 package org.apache.celeborn.common.network;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.nio.ByteBuffer;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.local.LocalChannel;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
 import org.apache.celeborn.common.network.client.ChunkReceivedCallback;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
-import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportResponseHandler;
 import org.apache.celeborn.common.network.protocol.*;
 import org.apache.celeborn.common.protocol.TransportModuleConstants;
@@ -182,41 +180,29 @@ public class TransportResponseHandlerSuiteJ {
   }
 
   @Test
-  public void invalidateClientAfterPushTimeout() {
-    Channel channel = mock(Channel.class);
-    ChannelFuture closeFuture = mock(ChannelFuture.class);
-    when(channel.isOpen()).thenReturn(true);
-    when(channel.close()).thenReturn(closeFuture);
-
+  public void invokeTimeoutHandlerBeforePushFailureCallback() {
     TransportResponseHandler handler =
         new TransportResponseHandler(
             Utils.fromCelebornConf(
                 new CelebornConf(), TransportModuleConstants.REPLICATE_MODULE, 8),
-            channel);
-    TransportClient client = new TransportClient(channel, handler);
+            new LocalChannel());
+    Runnable timeoutHandler = mock(Runnable.class);
     RpcResponseCallback callback = mock(RpcResponseCallback.class);
-    doAnswer(
-            invocation -> {
-              assertFalse(client.isActive());
-              return null;
-            })
-        .when(callback)
-        .onFailure(any());
     PushRequestInfo info =
-        new PushRequestInfo(System.currentTimeMillis() - 1, callback, client::invalidate);
+        new PushRequestInfo(System.currentTimeMillis() - 1, callback, timeoutHandler);
     ChannelFuture pushFuture = mock(ChannelFuture.class);
     info.setChannelFuture(pushFuture);
     handler.addPushRequest(12345, info);
 
-    assertTrue(client.isActive());
     handler.failExpiredPushRequest();
 
-    assertFalse(client.isActive());
     verify(pushFuture).cancel(true);
-    verify(channel).close();
-    verify(callback)
+    InOrder timeoutOrder = inOrder(timeoutHandler, callback);
+    timeoutOrder.verify(timeoutHandler).run();
+    timeoutOrder
+        .verify(callback)
         .onFailure(
-            argThat(
+            Mockito.<Throwable>argThat(
                 error ->
                     error.getMessage().startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())));
     assertEquals(0, handler.numOutstandingRequests());

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
@@ -18,10 +18,13 @@
 package org.apache.celeborn.common.network;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.nio.ByteBuffer;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.local.LocalChannel;
 import org.junit.Test;
@@ -30,9 +33,11 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
 import org.apache.celeborn.common.network.client.ChunkReceivedCallback;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
+import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportResponseHandler;
 import org.apache.celeborn.common.network.protocol.*;
 import org.apache.celeborn.common.protocol.TransportModuleConstants;
+import org.apache.celeborn.common.protocol.message.StatusCode;
 import org.apache.celeborn.common.read.FetchRequestInfo;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.common.write.PushRequestInfo;
@@ -173,6 +178,47 @@ public class TransportResponseHandlerSuiteJ {
 
     handler.handle(new RpcFailure(12345, "oh no"));
     verify(callback, times(1)).onFailure(any());
+    assertEquals(0, handler.numOutstandingRequests());
+  }
+
+  @Test
+  public void invalidateClientAfterPushTimeout() {
+    Channel channel = mock(Channel.class);
+    ChannelFuture closeFuture = mock(ChannelFuture.class);
+    when(channel.isOpen()).thenReturn(true);
+    when(channel.close()).thenReturn(closeFuture);
+
+    TransportResponseHandler handler =
+        new TransportResponseHandler(
+            Utils.fromCelebornConf(
+                new CelebornConf(), TransportModuleConstants.REPLICATE_MODULE, 8),
+            channel);
+    TransportClient client = new TransportClient(channel, handler);
+    RpcResponseCallback callback = mock(RpcResponseCallback.class);
+    doAnswer(
+            invocation -> {
+              assertFalse(client.isActive());
+              return null;
+            })
+        .when(callback)
+        .onFailure(any());
+    PushRequestInfo info =
+        new PushRequestInfo(System.currentTimeMillis() - 1, callback, client::invalidate);
+    ChannelFuture pushFuture = mock(ChannelFuture.class);
+    info.setChannelFuture(pushFuture);
+    handler.addPushRequest(12345, info);
+
+    assertTrue(client.isActive());
+    handler.failExpiredPushRequest();
+
+    assertFalse(client.isActive());
+    verify(pushFuture).cancel(true);
+    verify(channel).close();
+    verify(callback)
+        .onFailure(
+            argThat(
+                error ->
+                    error.getMessage().startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())));
     assertEquals(0, handler.numOutstandingRequests());
   }
 }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
@@ -39,7 +39,8 @@ class PushDataTimeoutTest extends AnyFunSuite
     logInfo("test initialized, setup celeborn mini cluster")
     val workerConf = Map(
       CelebornConf.TEST_CLIENT_PUSH_PRIMARY_DATA_TIMEOUT.key -> "true",
-      CelebornConf.TEST_WORKER_PUSH_REPLICA_DATA_TIMEOUT.key -> "true")
+      CelebornConf.TEST_WORKER_PUSH_REPLICA_DATA_TIMEOUT.key -> "true",
+      CelebornConf.WORKER_REPLICATE_FAST_FAIL_DURATION.key -> "10m")
     // required at least 4 workers, the reason behind this requirement is that when replication is
     // enabled, there is a possibility that two workers might be added to the excluded list due to
     // primary/replica timeout issues, then there are not enough workers to do replication if
@@ -53,6 +54,7 @@ class PushDataTimeoutTest extends AnyFunSuite
     PushDataHandler.pushReplicaDataTimeoutTested.set(false)
     PushDataHandler.pushPrimaryMergeDataTimeoutTested.set(false)
     PushDataHandler.pushReplicaMergeDataTimeoutTested.set(false)
+    workerInfos.keys.foreach(_.unavailablePeers.clear())
   }
 
   override def afterEach(): Unit = {
@@ -87,6 +89,7 @@ class PushDataTimeoutTest extends AnyFunSuite
       assert(PushDataHandler.pushPrimaryDataTimeoutTested.get())
       if (enabled) {
         assert(PushDataHandler.pushReplicaDataTimeoutTested.get())
+        assert(workerInfos.keys.exists(!_.unavailablePeers.isEmpty))
       }
     }
   }
@@ -116,6 +119,7 @@ class PushDataTimeoutTest extends AnyFunSuite
       assert(PushDataHandler.pushPrimaryMergeDataTimeoutTested.get())
       if (enabled) {
         assert(PushDataHandler.pushReplicaMergeDataTimeoutTested.get())
+        assert(workerInfos.keys.exists(!_.unavailablePeers.isEmpty))
       }
     }
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -352,6 +352,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
                 workerSource.incCounter(WorkerSource.REPLICATE_DATA_WRITE_FAIL_COUNT)
                 callbackWithTimer.onFailure(e)
               } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())) {
+                unavailablePeers.put(peerWorker, System.currentTimeMillis())
                 workerSource.incCounter(WorkerSource.REPLICATE_DATA_TIMEOUT_COUNT)
                 callbackWithTimer.onFailure(e)
               } else if (ExceptionUtils.connectFail(e.getMessage)) {
@@ -734,6 +735,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
                 workerSource.incCounter(WorkerSource.REPLICATE_DATA_WRITE_FAIL_COUNT)
                 pushMergedDataCallback.onFailure(e)
               } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_REPLICA.name())) {
+                unavailablePeers.put(peerWorker, System.currentTimeMillis())
                 workerSource.incCounter(WorkerSource.REPLICATE_DATA_TIMEOUT_COUNT)
                 pushMergedDataCallback.onFailure(e)
               } else if (ExceptionUtils.connectFail(e.getMessage)) {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -568,11 +568,7 @@ private[celeborn] class Worker(
     checkFastFailTask = forwardMessageScheduler.scheduleWithFixedDelay(
       new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {
-          unavailablePeers.entrySet().forEach { entry: JMap.Entry[WorkerInfo, Long] =>
-            if (System.currentTimeMillis() - entry.getValue > replicaFastFailDuration) {
-              unavailablePeers.remove(entry.getKey)
-            }
-          }
+          removeExpiredUnavailablePeers(System.currentTimeMillis())
         }
       },
       0,
@@ -847,6 +843,14 @@ private[celeborn] class Worker(
         }
       })
     }
+
+  private[worker] def removeExpiredUnavailablePeers(currentTime: Long): Unit = {
+    unavailablePeers.entrySet().forEach { entry: JMap.Entry[WorkerInfo, Long] =>
+      if (currentTime - entry.getValue > replicaFastFailDuration) {
+        unavailablePeers.remove(entry.getKey)
+      }
+    }
+  }
 
   private def removeAppResourceConsumption(applicationIds: Iterable[String]): Unit = {
     applicationIds.foreach { applicationId => removeAppResourceConsumption(applicationId) }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/WorkerSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.client.MasterClient
 import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.meta.WorkerInfo
 import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.message.ControlMessages.CommitFilesResponse
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -130,6 +131,28 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach with MiniClusterFe
       }
     }
     Assert.assertEquals(1, allWriters.size())
+  }
+
+  test("remove expired unavailable peers") {
+    conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, "/tmp")
+    conf.set(CelebornConf.WORKER_REPLICATE_FAST_FAIL_DURATION.key, "100ms")
+    worker = new Worker(conf, workerArgs)
+    val expiredPeer =
+      new WorkerInfo("expired", 1, 2, 3, 4, -1, new util.HashMap(), null)
+    val activePeer =
+      new WorkerInfo("active", 5, 6, 7, 8, -1, new util.HashMap(), null)
+    val currentTime = System.currentTimeMillis()
+    worker.unavailablePeers.put(expiredPeer, currentTime - 101)
+    worker.unavailablePeers.put(activePeer, currentTime)
+
+    worker.removeExpiredUnavailablePeers(currentTime)
+
+    assert(!worker.unavailablePeers.containsKey(expiredPeer))
+    assert(worker.unavailablePeers.containsKey(activePeer))
+
+    worker.removeExpiredUnavailablePeers(currentTime + 101)
+
+    assert(worker.unavailablePeers.isEmpty)
   }
 
   test("handle top resource consumption") {


### PR DESCRIPTION
## Problem

A push request timeout leaves the pooled `TransportClient` eligible for reuse while its Netty channel still reports active. After a Worker restart or Pod IP replacement, long-running applications can therefore repeatedly send replica pushes over a stale connection and receive `PUSH_DATA_TIMEOUT_REPLICA`.

JIRA: [CELEBORN-2458](https://issues.apache.org/jira/browse/CELEBORN-2458)

## Fix

- Invalidate and asynchronously close the transport client when a push request expires.
- Ensure `TransportClientFactory` creates a fresh connection for the next request.
- Temporarily add a timed-out replica peer to `unavailablePeers`, reusing the existing replica fast-fail duration.
- Preserve higher-level retry/revive semantics rather than replaying the payload in the transport layer.
- Keep connection invalidation private to the transport implementation.

## Verification

- Added a pooled-client test with multiple outstanding pushes, exactly-once callbacks, connection replacement, and a successful push over the new channel.
- Added Spark integration assertions for normal and merged replica timeouts populating `unavailablePeers`.
- Added Worker coverage for fast-fail expiration and subsequent peer recovery.
- `TransportResponseHandlerSuiteJ` and `TransportClientFactorySuiteJ`: passed.
- `WorkerSuite`: 7 passed.
- `PushDataTimeoutTest` with Spark 3.5: 5 passed.
- Spark 3.5 `common`, `worker`, and `spark-it` package build: passed.